### PR TITLE
M2351 RAM / ROM defines updated

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_MICRO/M2351.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_MICRO/M2351.sct
@@ -10,40 +10,53 @@
  *   Secure:        32KiB
  *   Non-secure:    64KiB
  */
+
+#ifndef MBED_ROM_SIZE_S
+#define MBED_ROM_SIZE_S      (0x40000)
+#endif
+
+#ifndef MBED_RAM_SIZE_S
+#define MBED_RAM_SIZE_S      (0x8000)
+#endif
+
+#ifndef NU_TZ_NSC_SIZE
+#define NU_TZ_NSC_SIZE       (0x1000)
+#endif
+
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      0x10040000
+#define MBED_APP_START        (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       0x40000
+#define MBED_APP_SIZE         (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
 #endif
 
-#ifndef MBED_RAM_START
-#define MBED_RAM_START      0x30008000
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START    (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
 #endif
 
-#ifndef MBED_RAM_SIZE
-#define MBED_RAM_SIZE       0x10000
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE      (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
 #else
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      0x0
+#define MBED_APP_START          MBED_ROM_START
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       0x40000
+#define MBED_APP_SIZE           MBED_ROM_SIZE_S
 #endif
 
-#ifndef MBED_RAM_START
-#define MBED_RAM_START      0x20000000
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START      MBED_RAM_START
 #endif
 
-#ifndef MBED_RAM_SIZE
-#define MBED_RAM_SIZE       0x8000
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE       MBED_RAM_SIZE_S
 #endif
 
 #endif
@@ -55,12 +68,7 @@
  * 3. Greentea NVSTORE uses last 2 sectors or 4KiB x 2 for its test. Avoid this range.
  * 4. NSC region size defaults to 4KiB if not defined.
  */
-#ifndef NU_TZ_NSC_START
-#define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE - 0x2000 - NU_TZ_NSC_SIZE)
-#endif
-#ifndef NU_TZ_NSC_SIZE
-#define NU_TZ_NSC_SIZE          0x1000
-#endif
+#define NU_TZ_NSC_START     (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
 
 /* Initial/ISR stack size */
 #if (! defined(NU_INITIAL_STACK_SIZE))
@@ -83,7 +91,7 @@ LR_IROM1    MBED_APP_START
         .ANY (+RO)
     }
 
-    ARM_LIB_STACK   MBED_RAM_START  EMPTY   NU_INITIAL_STACK_SIZE
+    ARM_LIB_STACK   MBED_RAM_APP_START    EMPTY   NU_INITIAL_STACK_SIZE
     {
     }
 
@@ -101,13 +109,13 @@ LR_IROM1    MBED_APP_START
         .ANY (+RW +ZI)
     }
 
-    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_START + MBED_RAM_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
+    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
     {
     }
 }
 
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= MBED_RAM_START + MBED_RAM_SIZE)
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= MBED_RAM_APP_START + MBED_RAM_APP_SIZE)
 
 #else
 
@@ -139,7 +147,7 @@ LR_IROM1 MBED_APP_START
         .ANY (+RW +ZI)
     }
 
-    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_START + MBED_RAM_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
+    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
     {
     }
 }
@@ -160,6 +168,6 @@ ScatterAssert(LoadLimit(LR_IROM1) <= NU_TZ_NSC_START)
 ScatterAssert(LoadLimit(LR_IROM_NSC) <= (NU_TZ_NSC_START + NU_TZ_NSC_SIZE))
 /* By IDAU, 0~0x4000 is secure. NSC can only locate in 0x4000~0x10000000 */
 ScatterAssert(LoadBase(LR_IROM_NSC) >= 0x4000)
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_START + MBED_RAM_SIZE))
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_APP_START + MBED_RAM_APP_SIZE))
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_MICRO/M2351.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_MICRO/M2351.sct
@@ -12,33 +12,33 @@
  */
 
 #ifndef MBED_ROM_SIZE_S
-#define MBED_ROM_SIZE_S      (0x40000)
+#define MBED_ROM_SIZE_S         (0x40000)
 #endif
 
 #ifndef MBED_RAM_SIZE_S
-#define MBED_RAM_SIZE_S      (0x8000)
+#define MBED_RAM_SIZE_S         (0x8000)
 #endif
 
 #ifndef NU_TZ_NSC_SIZE
-#define NU_TZ_NSC_SIZE       (0x1000)
+#define NU_TZ_NSC_SIZE          (0x1000)
 #endif
 
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
 #ifndef MBED_APP_START
-#define MBED_APP_START        (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
+#define MBED_APP_START          (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE         (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
+#define MBED_APP_SIZE           (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_RAM_APP_START
-#define MBED_RAM_APP_START    (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
+#define MBED_RAM_APP_START      (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
 #endif
 
 #ifndef MBED_RAM_APP_SIZE
-#define MBED_RAM_APP_SIZE      (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
+#define MBED_RAM_APP_SIZE       (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
 #else
@@ -68,14 +68,14 @@
  * 3. Greentea NVSTORE uses last 2 sectors or 4KiB x 2 for its test. Avoid this range.
  * 4. NSC region size defaults to 4KiB if not defined.
  */
-#define NU_TZ_NSC_START     (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
+#define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
 
 /* Initial/ISR stack size */
 #if (! defined(NU_INITIAL_STACK_SIZE))
 #if defined(DOMAIN_NS) && DOMAIN_NS
-#define NU_INITIAL_STACK_SIZE       0x800
+#define NU_INITIAL_STACK_SIZE   0x800
 #else
-#define NU_INITIAL_STACK_SIZE       0x800
+#define NU_INITIAL_STACK_SIZE   0x800
 #endif
 #endif
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_STD/M2351.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_STD/M2351.sct
@@ -12,33 +12,33 @@
  */
 
 #ifndef MBED_ROM_SIZE_S
-#define MBED_ROM_SIZE_S      (0x40000)
+#define MBED_ROM_SIZE_S         (0x40000)
 #endif
 
 #ifndef MBED_RAM_SIZE_S
-#define MBED_RAM_SIZE_S      (0x8000)
+#define MBED_RAM_SIZE_S         (0x8000)
 #endif
 
 #ifndef NU_TZ_NSC_SIZE
-#define NU_TZ_NSC_SIZE       (0x1000)
+#define NU_TZ_NSC_SIZE          (0x1000)
 #endif
 
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
 #ifndef MBED_APP_START
-#define MBED_APP_START        (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
+#define MBED_APP_START          (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE         (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
+#define MBED_APP_SIZE           (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_RAM_APP_START
-#define MBED_RAM_APP_START    (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
+#define MBED_RAM_APP_START      (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
 #endif
 
 #ifndef MBED_RAM_APP_SIZE
-#define MBED_RAM_APP_SIZE     (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
+#define MBED_RAM_APP_SIZE       (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
 #else
@@ -68,14 +68,14 @@
  * 3. Greentea NVSTORE uses last 2 sectors or 4KiB x 2 for its test. Avoid this range.
  * 4. NSC region size defaults to 4KiB if not defined.
  */
-#define NU_TZ_NSC_START     (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
+#define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
 
 /* Initial/ISR stack size */
 #if (! defined(NU_INITIAL_STACK_SIZE))
 #if defined(DOMAIN_NS) && DOMAIN_NS
-#define NU_INITIAL_STACK_SIZE       0x800
+#define NU_INITIAL_STACK_SIZE   0x800
 #else
-#define NU_INITIAL_STACK_SIZE       0x800
+#define NU_INITIAL_STACK_SIZE   0x800
 #endif
 #endif
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_STD/M2351.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_STD/M2351.sct
@@ -10,40 +10,53 @@
  *   Secure:        32KiB
  *   Non-secure:    64KiB
  */
+
+#ifndef MBED_ROM_SIZE_S
+#define MBED_ROM_SIZE_S      (0x40000)
+#endif
+
+#ifndef MBED_RAM_SIZE_S
+#define MBED_RAM_SIZE_S      (0x8000)
+#endif
+
+#ifndef NU_TZ_NSC_SIZE
+#define NU_TZ_NSC_SIZE       (0x1000)
+#endif
+
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      0x10040000
+#define MBED_APP_START        (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       0x40000
+#define MBED_APP_SIZE         (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
 #endif
 
-#ifndef MBED_RAM_START
-#define MBED_RAM_START      0x30008000
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START    (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
 #endif
 
-#ifndef MBED_RAM_SIZE
-#define MBED_RAM_SIZE       0x10000
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE     (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
 #else
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      0x0
+#define MBED_APP_START          MBED_ROM_START
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       0x40000
+#define MBED_APP_SIZE           MBED_ROM_SIZE_S
 #endif
 
-#ifndef MBED_RAM_START
-#define MBED_RAM_START      0x20000000
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START      MBED_RAM_START
 #endif
 
-#ifndef MBED_RAM_SIZE
-#define MBED_RAM_SIZE       0x8000
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE       MBED_RAM_SIZE_S
 #endif
 
 #endif
@@ -55,12 +68,7 @@
  * 3. Greentea NVSTORE uses last 2 sectors or 4KiB x 2 for its test. Avoid this range.
  * 4. NSC region size defaults to 4KiB if not defined.
  */
-#ifndef NU_TZ_NSC_START
-#define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE - 0x2000 - NU_TZ_NSC_SIZE)
-#endif
-#ifndef NU_TZ_NSC_SIZE
-#define NU_TZ_NSC_SIZE          0x1000
-#endif
+#define NU_TZ_NSC_START     (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
 
 /* Initial/ISR stack size */
 #if (! defined(NU_INITIAL_STACK_SIZE))
@@ -83,7 +91,7 @@ LR_IROM1    MBED_APP_START
         .ANY (+RO)
     }
 
-    ARM_LIB_STACK   MBED_RAM_START  EMPTY   NU_INITIAL_STACK_SIZE
+    ARM_LIB_STACK   MBED_RAM_APP_START    EMPTY   NU_INITIAL_STACK_SIZE
     {
     }
 
@@ -101,13 +109,13 @@ LR_IROM1    MBED_APP_START
         .ANY (+RW +ZI)
     }
 
-    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_START + MBED_RAM_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
+    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
     {
     }
 }
 
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= MBED_RAM_START + MBED_RAM_SIZE)
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= MBED_RAM_APP_START + MBED_RAM_APP_SIZE)
 
 #else
 
@@ -139,7 +147,7 @@ LR_IROM1 MBED_APP_START
         .ANY (+RW +ZI)
     }
 
-    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_START + MBED_RAM_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
+    ARM_LIB_HEAP    AlignExpr(+0, 16) EMPTY (MBED_RAM_APP_START + MBED_RAM_APP_SIZE - AlignExpr(ImageLimit(RW_IRAM1), 16))
     {
     }
 }
@@ -160,6 +168,6 @@ ScatterAssert(LoadLimit(LR_IROM1) <= NU_TZ_NSC_START)
 ScatterAssert(LoadLimit(LR_IROM_NSC) <= (NU_TZ_NSC_START + NU_TZ_NSC_SIZE))
 /* By IDAU, 0~0x4000 is secure. NSC can only locate in 0x4000~0x10000000 */
 ScatterAssert(LoadBase(LR_IROM_NSC) >= 0x4000)
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_START + MBED_RAM_SIZE))
+ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= (MBED_RAM_APP_START + MBED_RAM_APP_SIZE))
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/M2351.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/M2351.ld
@@ -79,9 +79,6 @@ StackSize = 0x800;
 #ifndef NU_TZ_NSC_START
 #define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE - 0x2000 - NU_TZ_NSC_SIZE)
 #endif
-#ifndef NU_TZ_NSC_SIZE
-#define NU_TZ_NSC_SIZE          0x1000
-#endif
 
 
 #if defined(DOMAIN_NS) && DOMAIN_NS

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/M2351.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/M2351.ld
@@ -12,40 +12,53 @@
  *   Secure:        32KiB
  *   Non-secure:    64KiB
  */
+
+#ifndef MBED_ROM_SIZE_S
+#define MBED_ROM_SIZE_S      (0x40000)
+#endif
+
+#ifndef MBED_RAM_SIZE_S
+#define MBED_RAM_SIZE_S      (0x8000)
+#endif
+
+#ifndef NU_TZ_NSC_SIZE
+#define NU_TZ_NSC_SIZE       (0x1000)
+#endif
+
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      0x10040000
+#define MBED_APP_START      (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       0x40000
+#define MBED_APP_SIZE       (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
 #endif
 
-#ifndef MBED_RAM_START
-#define MBED_RAM_START      0x30008000
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START  (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
 #endif
 
-#ifndef MBED_RAM_SIZE
-#define MBED_RAM_SIZE       0x10000
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE   (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
 #else
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      0x0
+#define MBED_APP_START      MBED_ROM_START
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       0x40000
+#define MBED_APP_SIZE       MBED_ROM_SIZE_S
 #endif
 
-#ifndef MBED_RAM_START
-#define MBED_RAM_START      0x20000000
+#ifndef MBED_RAM_APP_START
+#define MBED_RAM_APP_START  MBED_RAM_START
 #endif
 
-#ifndef MBED_RAM_SIZE
-#define MBED_RAM_SIZE       0x8000
+#ifndef MBED_RAM_APP_SIZE
+#define MBED_RAM_APP_SIZE   MBED_RAM_SIZE_S
 #endif
 
 #endif
@@ -77,7 +90,7 @@ MEMORY
 {
   VECTORS (rx)          : ORIGIN = MBED_APP_START,          LENGTH = 0x00000400
   FLASH (rx)            : ORIGIN = MBED_APP_START + 0x400,  LENGTH = MBED_APP_SIZE - 0x400
-  RAM_INTERN (rwx)      : ORIGIN = MBED_RAM_START,          LENGTH = MBED_RAM_SIZE
+  RAM_INTERN (rwx)      : ORIGIN = MBED_RAM_APP_START,      LENGTH = MBED_RAM_APP_SIZE
 }
 
 #else
@@ -87,7 +100,7 @@ MEMORY
   VECTORS (rx)          : ORIGIN = MBED_APP_START,          LENGTH = 0x00000400
   FLASH (rx)            : ORIGIN = MBED_APP_START + 0x400,  LENGTH = NU_TZ_NSC_START - MBED_APP_START - 0x400
   NSC_FLASH (rx)        : ORIGIN = NU_TZ_NSC_START,         LENGTH = NU_TZ_NSC_SIZE
-  RAM_INTERN (rwx)      : ORIGIN = MBED_RAM_START,          LENGTH = MBED_RAM_SIZE
+  RAM_INTERN (rwx)      : ORIGIN = MBED_RAM_APP_START,      LENGTH = MBED_RAM_APP_SIZE
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
@@ -18,21 +18,28 @@ if (! isdefinedsymbol(NU_TZ_NSC_SIZE)) {
 if (isdefinedsymbol(DOMAIN_NS)) {
 
     if (! isdefinedsymbol(MBED_APP_START)) {
-        define symbol MBED_APP_START                = 0x10040000;
+        define symbol MBED_APP_START                = (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S);
     }
 
     if (! isdefinedsymbol(MBED_APP_SIZE)) {
-        define symbol MBED_APP_SIZE                 = 0x40000;
+        define symbol MBED_APP_SIZE                 = (MBED_ROM_SIZE  - MBED_ROM_SIZE_S);
     }
 
+    if (! isdefinedsymbol(MBED_RAM_APP_START)) {
+        define symbol MBED_RAM_APP_START            = (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S);
+    }
+
+    if (! isdefinedsymbol(MBED_RAM_APP_SIZE)) {
+        define symbol MBED_RAM_APP_SIZE             = (MBED_RAM_SIZE - MBED_RAM_SIZE_S);
+    }
 
     /*-Specials-*/
     define symbol __ICFEDIT_intvec_start__          = MBED_APP_START;
     /*-Memory Regions-*/
     define symbol __ICFEDIT_region_ROM_start__      = MBED_APP_START;
     define symbol __ICFEDIT_region_ROM_end__        = MBED_APP_START + MBED_APP_SIZE - 1;
-    define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_START + MBED_RAM_SIZE_S;
-    define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_START + MBED_RAM_SIZE - 1;
+    define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_APP_START;
+    define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 1;
     
     /*-Sizes-*/
     define symbol __ICFEDIT_size_cstack__           = 0x800;
@@ -41,11 +48,19 @@ if (isdefinedsymbol(DOMAIN_NS)) {
 } else {
 
     if (! isdefinedsymbol(MBED_APP_START)) {
-        define symbol MBED_APP_START                = 0x0;
+        define symbol MBED_APP_START                = MBED_ROM_START;
     }
 
     if (! isdefinedsymbol(MBED_APP_SIZE)) {
-        define symbol MBED_APP_SIZE                 = 0x40000;
+        define symbol MBED_APP_SIZE                 = MBED_ROM_SIZE_S;
+    }
+
+    if (! isdefinedsymbol(MBED_RAM_APP_START)) {
+        define symbol MBED_RAM_APP_START            = MBED_RAM_START;
+    }
+
+    if (! isdefinedsymbol(MBED_RAM_APP_SIZE)) {
+        define symbol MBED_RAM_APP_SIZE             = MBED_RAM_SIZE_S;
     }
 
     /* Requirements for NSC location
@@ -68,8 +83,8 @@ if (isdefinedsymbol(DOMAIN_NS)) {
     define symbol __ICFEDIT_region_ROM_end__        = MBED_APP_START + MBED_APP_SIZE - 1;
     define symbol __ICFEDIT_region_NSCROM_start__   = NU_TZ_NSC_START;
     define symbol __ICFEDIT_region_NSCROM_end__     = NU_TZ_NSC_START + NU_TZ_NSC_SIZE - 1;
-    define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_START;
-    define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_START + MBED_RAM_SIZE_S - 1;
+    define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_APP_START;
+    define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 1;
 
     /*-Sizes-*/
     define symbol __ICFEDIT_size_cstack__           = 0x800;

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
@@ -2,6 +2,19 @@
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
 
+
+if (! isdefinedsymbol(MBED_RAM_SIZE_S)) {
+    define symbol MBED_RAM_SIZE_S   = 0x8000;
+}
+
+if (! isdefinedsymbol(MBED_ROM_SIZE_S)) {
+    define symbol MBED_ROM_SIZE_S   = 0x40000;
+}
+
+if (! isdefinedsymbol(NU_TZ_NSC_SIZE)) {
+    define symbol NU_TZ_NSC_SIZE   = 0x1000;
+}
+
 if (isdefinedsymbol(DOMAIN_NS)) {
 
     if (! isdefinedsymbol(MBED_APP_START)) {
@@ -18,7 +31,7 @@ if (isdefinedsymbol(DOMAIN_NS)) {
     /*-Memory Regions-*/
     define symbol __ICFEDIT_region_ROM_start__      = MBED_APP_START;
     define symbol __ICFEDIT_region_ROM_end__        = MBED_APP_START + MBED_APP_SIZE - 1;
-    define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_START;
+    define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_START + MBED_RAM_SIZE_S;
     define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_START + MBED_RAM_SIZE - 1;
     
     /*-Sizes-*/
@@ -46,9 +59,6 @@ if (isdefinedsymbol(DOMAIN_NS)) {
         define symbol NU_TZ_NSC_START               = MBED_APP_START + MBED_APP_SIZE - 0x2000 - NU_TZ_NSC_SIZE;
     }
     define exported symbol __NU_TZ_NSC_start__      = NU_TZ_NSC_START;
-    if (! isdefinedsymbol(NU_TZ_NSC_SIZE)) {
-        define symbol NU_TZ_NSC_SIZE                = 0x1000;
-    }
     define exported symbol __NU_TZ_NSC_size__       = NU_TZ_NSC_SIZE;
 
     /*-Specials-*/
@@ -59,7 +69,7 @@ if (isdefinedsymbol(DOMAIN_NS)) {
     define symbol __ICFEDIT_region_NSCROM_start__   = NU_TZ_NSC_START;
     define symbol __ICFEDIT_region_NSCROM_end__     = NU_TZ_NSC_START + NU_TZ_NSC_SIZE - 1;
     define symbol __ICFEDIT_region_IRAM_start__     = MBED_RAM_START;
-    define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_START + MBED_RAM_SIZE - 1;
+    define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_START + MBED_RAM_SIZE_S - 1;
 
     /*-Sizes-*/
     define symbol __ICFEDIT_size_cstack__           = 0x800;

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/partition_M2351.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/partition_M2351.h
@@ -11,17 +11,16 @@
 #ifndef PARTITION_M2351
 #define PARTITION_M2351
 
-#ifndef MBED_ROM_SIZE
-    #define NU_TZ_SECURE_FLASH_SIZE     0x40000
-#else
-    #define NU_TZ_SECURE_FLASH_SIZE     MBED_ROM_SIZE
+#ifndef MBED_ROM_SIZE_S
+#define MBED_ROM_SIZE_S      (0x40000)
 #endif
 
-#ifndef APPLICATION_RAM_SIZE
-    #define NU_TZ_SECURE_SRAM_SIZE      0x8000
-#else
-    #define NU_TZ_SECURE_SRAM_SIZE      APPLICATION_RAM_SIZE
+#ifndef MBED_RAM_SIZE_S
+#define MBED_RAM_SIZE_S      (0x8000)
 #endif
+
+#define NU_TZ_SECURE_FLASH_SIZE     MBED_ROM_SIZE_S
+#define NU_TZ_SECURE_SRAM_SIZE      MBED_RAM_SIZE_S
 
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
@@ -25,8 +25,12 @@
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 
+#ifndef MBED_ROM_SIZE_S
+#define MBED_ROM_SIZE_S         (0x40000)
+#endif
+
 #define NU_SECURE_FLASH_START       (MBED_ROM_START)
-#define NU_SECURE_FLASH_SIZE        (MBED_ROM_SIZE / 2)
+#define NU_SECURE_FLASH_SIZE        (MBED_ROM_SIZE_S)
 
 // This is a flash algo binary blob. It is PIC (position independent code) that should be stored in RAM
 // NOTE: On ARMv7-M/ARMv8-M, instruction fetches are always little-endian.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
@@ -25,16 +25,8 @@
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 
-#ifndef MBED_ROM_START
-#define MBED_ROM_START      0x0
-#endif
-
-#ifndef MBED_ROM_SIZE
-#define MBED_ROM_SIZE       0x40000
-#endif
-
-#define NU_SECURE_FLASH_START       MBED_ROM_START
-#define NU_SECURE_FLASH_SIZE        MBED_ROM_SIZE
+#define NU_SECURE_FLASH_START       (MBED_ROM_START)
+#define NU_SECURE_FLASH_SIZE        (MBED_ROM_SIZE / 2)
 
 // This is a flash algo binary blob. It is PIC (position independent code) that should be stored in RAM
 // NOTE: On ARMv7-M/ARMv8-M, instruction fetches are always little-endian.
@@ -121,7 +113,7 @@ static const flash_target_config_t flash_target_config_ns = {
                                                             // Here page_size is program unit, which is different
                                                             // than FMC definition.
     .flash_start = NS_OFFSET + NU_SECURE_FLASH_SIZE,
-    .flash_size = 0x80000 - NU_SECURE_FLASH_SIZE,
+    .flash_size = MBED_ROM_SIZE - NU_SECURE_FLASH_SIZE,
     .sectors = sectors_info_ns,
     .sector_info_count = sizeof(sectors_info_ns) / sizeof(sector_info_t)
 };

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7205,10 +7205,6 @@
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
             }
         },
-        "mbed_rom_start": "0x10040000",
-        "mbed_rom_size": "0x40000",
-        "mbed_ram_start": "0x30008000",
-        "mbed_ram_size": "0x10000",
         "inherits": ["Target"],
         "device_has": [
             "USTICKER",


### PR DESCRIPTION
### Description
RAM/ROM sizes in tools were updated to report entire device size, and in M2351 they were used earlier to report secure/non-secure partition size.

M2351 files are updated to take full RAM/ROM device size and derive secure and non-secure partition size based on that.

Commit for this PR: cb51f191d33887bdafe1c21d4f1d6f7c02348e8c
Other commits are from PR : https://github.com/ARMmbed/mbed-os/pull/8607

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Dependent on https://github.com/ARMmbed/mbed-os/pull/8607

CC @ARMmbed/team-nuvoton 
