### PR TITLE
LoRaWANTimer UT fixed

### DIFF
--- a/UNITTESTS/features/lorawan/lorawantimer/unittest.cmake
+++ b/UNITTESTS/features/lorawan/lorawantimer/unittest.cmake
@@ -37,3 +37,6 @@ set(unittest-test-sources
   stubs/equeue_stub.c
 )
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNDEBUG=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG=1")
+


### PR DESCRIPTION
### Description

LoRaWAN_Timer unittest was segfaulting, this is fixed now


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

