### PR TITLE
Fix issues in Cryptocell 310 shax_alt discovered by On Target Testing

### DIFF
--- a/features/cryptocell/FEATURE_CRYPTOCELL310/sha1_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/sha1_alt.c
@@ -25,7 +25,6 @@
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_sha1_context ) );
-
 }
 
 void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
@@ -64,10 +63,10 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
 int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
                              unsigned char output[20] )
 {
-    CRYSError_t CrysErr = CRYS_OK;
+    CRYSError_t crys_err = CRYS_OK;
     CRYS_HASH_Result_t crys_result = {0};
-    CrysErr = CRYS_HASH_Finish( &ctx->crys_hash_ctx, crys_result );
-    if( CrysErr == CRYS_OK )
+    crys_err = CRYS_HASH_Finish( &ctx->crys_hash_ctx, crys_result );
+    if( crys_err == CRYS_OK )
     {
         memcpy( output, crys_result, 20 );
         return ( 0 );

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/sha1_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/sha1_alt.c
@@ -21,6 +21,7 @@
 #include "mbedtls/sha1.h"
 #if defined(MBEDTLS_SHA1_ALT)
 #include <string.h>
+#include "mbedtls/platform.h"
 
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
 {
@@ -78,8 +79,6 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
 int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
                                    const unsigned char data[64] )
 {
-    if( CRYS_HASH_Update( &ctx->crys_hash_ctx, (uint8_t*)data, 64 ) != CRYS_OK )
-        return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
-    return ( 0 );
+    return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
 }
 #endif //MBEDTLS_SHA1_ALT

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/sha1_alt.h
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/sha1_alt.h
@@ -22,10 +22,6 @@
 #define __SHA1_ALT__
 #if defined(MBEDTLS_SHA1_ALT)
 #include "crys_hash.h"
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 /**
  * \brief          SHA-1 context structure
@@ -34,114 +30,6 @@ typedef struct
 {
     CRYS_HASHUserContext_t crys_hash_ctx;
 } mbedtls_sha1_context;
-
-/**
- * \brief          This function initializes a SHA-1 context.
- *
- * \param ctx      The SHA-1 context to initialize.
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
-
-/**
- * \brief          This function clears a SHA-1 context.
- *
- * \param ctx      The SHA-1 context to clear.
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
-
-/**
- * \brief          This function clones the state of a SHA-1 context.
- *
- * \param dst      The destination context.
- * \param src      The context to clone.
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
-                         const mbedtls_sha1_context *src );
-
-/**
- * \brief          This function starts a SHA-1 checksum calculation.
- *
- * \param ctx      The context to initialize.
- *
- * \return         \c 0 if successful
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
-
-/**
- * \brief          This function feeds an input buffer into an ongoing SHA-1
- *                 checksum calculation.
- *
- * \param ctx      The SHA-1 context.
- * \param input    The buffer holding the input data.
- * \param ilen     The length of the input data.
- *
- * \return         \c 0 if successful
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
-                             const unsigned char *input,
-                             size_t ilen );
-
-/**
- * \brief          This function finishes the SHA-1 operation, and writes
- *                 the result to the output buffer.
- *
- * \param ctx      The SHA-1 context.
- * \param output   The SHA-1 checksum result.
- *
- * \return         \c 0 if successful
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
-                             unsigned char output[20] );
-
-/**
- * \brief          SHA-1 process data block (internal use only)
- *
- * \param ctx      SHA-1 context
- * \param data     The data block being processed.
- *
- * \return         \c 0 if successful
- *
- * \warning        SHA-1 is considered a weak message digest and its use
- *                 constitutes a security risk. We recommend considering
- *                 stronger message digests instead.
- *
- */
-int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
-                                   const unsigned char data[64] );
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif //MBEDTLS_SHA1_ALT
 #endif //__SHA1_ALT__

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/sha256_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/sha256_alt.c
@@ -21,6 +21,7 @@
 #include "mbedtls/sha256.h"
 #if defined(MBEDTLS_SHA256_ALT)
 #include <string.h>
+#include "mbedtls/platform.h"
 
 void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
 {
@@ -53,9 +54,7 @@ int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 )
 int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
                                      const unsigned char data[64] )
 {
-    if( CRYS_HASH_Update( &ctx->crys_hash_ctx, (uint8_t*)data, 64 ) != CRYS_OK )
-        return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
-    return ( 0 );
+    return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
 }
 
 int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/sha256_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/sha256_alt.c
@@ -25,7 +25,6 @@
 void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
 {
     memset( ctx, 0, sizeof( mbedtls_sha256_context ) );
-
 }
 
 void mbedtls_sha256_free( mbedtls_sha256_context *ctx )
@@ -71,10 +70,10 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
 int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
                                unsigned char output[32] )
 {
-    CRYSError_t CrysErr = CRYS_OK;
+    CRYSError_t crys_err = CRYS_OK;
     CRYS_HASH_Result_t crys_result = {0};
-    CrysErr = CRYS_HASH_Finish( &ctx->crys_hash_ctx, crys_result );
-    if( CrysErr == CRYS_OK )
+    crys_err = CRYS_HASH_Finish( &ctx->crys_hash_ctx, crys_result );
+    if( crys_err == CRYS_OK )
     {
         memcpy( output, crys_result, 32 );
         return ( 0 );

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/sha256_alt.h
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/sha256_alt.h
@@ -24,10 +24,6 @@
 #if defined(MBEDTLS_SHA256_ALT)
 
 #include "crys_hash.h"
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 /**
  * \brief          SHA-256 context structure
@@ -36,86 +32,6 @@ typedef struct
 {
     CRYS_HASHUserContext_t crys_hash_ctx;
 } mbedtls_sha256_context;
-
-
-/**
- * \brief          This function initializes a SHA-256 context.
- *
- * \param ctx      The SHA-256 context to initialize.
- */
-void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
-
-/**
- * \brief          This function clears a SHA-256 context.
- *
- * \param ctx      The SHA-256 context to clear.
- */
-void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
-
-/**
- * \brief          This function clones the state of a SHA-256 context.
- *
- * \param dst      The destination context.
- * \param src      The context to clone.
- */
-void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
-                           const mbedtls_sha256_context *src );
-
-/**
- * \brief          This function starts a SHA-224 or SHA-256 checksum
- *                 calculation.
- *
- * \param ctx      The context to initialize.
- * \param is224    Determines which function to use.
- *                 <ul><li>0: Use SHA-256.</li>
- *                 <li>1: Use SHA-224.</li></ul>
- *
- * \return         \c 0 on success.
- */
-int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
-
-/**
- * \brief          This function feeds an input buffer into an ongoing
- *                 SHA-256 checksum calculation.
- *
- * \param ctx      SHA-256 context
- * \param input    buffer holding the data
- * \param ilen     length of the input data
- *
- * \return         \c 0 on success.
- */
-int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
-                               const unsigned char *input,
-                               size_t ilen );
-
-/**
- * \brief          This function finishes the SHA-256 operation, and writes
- *                 the result to the output buffer.
- *
- * \param ctx      The SHA-256 context.
- * \param output   The SHA-224 or SHA-256 checksum result.
- *
- * \return         \c 0 on success.
- */
-int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
-                               unsigned char output[32] );
-
-/**
- * \brief          This function processes a single data block within
- *                 the ongoing SHA-256 computation. This function is for
- *                 internal use only.
- *
- * \param ctx      The SHA-256 context.
- * \param data     The buffer holding one block of data.
- *
- * \return         \c 0 on success.
- */
-int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
-                                     const unsigned char data[64] );
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif // MBEDTLS_SHA256_ALT__
 #endif //__SHA256_ALT__


### PR DESCRIPTION
### Description

Initialize the Cryptocell context in the `mbedtls_shax_process()`
function, in case it wasn't initialized. The Process function can be
called without calling to the starts function. Discovered by
On Target Testing on the NRF52840_DK platform.

Note: This might have conflicts with #8643 , but not dependent on it.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

