### PR TITLE
Adding arch option instead MCPU for no dsp and no fpu support

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -63,7 +63,7 @@ class GCC(mbedToolchain):
         elif target.core.startswith("Cortex-M33F"):
             self.cpu = ["-mcpu=cortex-m33+nodsp"]
         elif target.core.startswith("Cortex-M33"):
-            self.cpu = ["-mcpu=cortex-m33+nodsp+nofp"]
+            self.cpu = ["-march=armv8-m.main"]
         else:
             self.cpu = ["-mcpu={}".format(target.core.lower())]
 


### PR DESCRIPTION
### Description

Cortex-M33 has optional floating point and DSP, the mcpu option by default enables optional features. To disable optional features we need to add +nodsp +nofp.

But nofp is supported after 8.x version of toolchain. Hence to get this we will have to use -march option instead of -mcpu

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
