### PR TITLE
Add mbed_lib.json for Mbed Crypto

### DIFF
--- a/features/mbedtls/crypto/targets/TARGET_PSA/mbed_lib.json
+++ b/features/mbedtls/crypto/targets/TARGET_PSA/mbed_lib.json
@@ -1,0 +1,4 @@
+{
+    "name": "mbed-crypto",
+    "macros": ["MBEDTLS_PSA_HAS_ITS_IO"]
+}


### PR DESCRIPTION
### Description
This will enable the usage of PSA Secure Storage for PSA compliant platforms.

This PR depends on the PR for the upcoming mbedtls release for mbed-os version 5.11.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

