### PR TITLE
Add MBED_ALL_STATS_ENABLED to config system

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -72,6 +72,12 @@
             "value": null
         },
 
+        "all-stats-enabled": {
+            "macro_name": "MBED_ALL_STATS_ENABLED",
+            "help": "Set to 1 to enable all platform stats. When enabled the functions mbed_stats_*_get returns non-zero data. See mbed_stats.h for more information",
+            "value": null
+        },
+
         "sys-stats-enabled": {
             "macro_name": "MBED_SYS_STATS_ENABLED",
             "help": "Set to 1 to enable system stats. When enabled the function mbed_stats_sys_get returns non-zero data. See mbed_stats.h for more information",
@@ -106,6 +112,7 @@
             "help": "HTTP URL string for ARM Mbed-OS Error Decode microsite",
             "value": "\"\\nFor more info, visit: https://armmbed.github.io/mbedos-error/?error=0x%08X\""
         },
+
         "cthunk_count_max": {
             "help": "The maximum CThunk objects used at the same time. This must be greater than 0 and less 256",
             "value": 8

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -31,12 +31,24 @@ extern "C" {
 #endif
 
 #ifdef MBED_ALL_STATS_ENABLED
+
+#ifndef MBED_SYS_STATS_ENABLED
 #define MBED_SYS_STATS_ENABLED      1
+#endif
+#ifndef MBED_STACK_STATS_ENABLED
 #define MBED_STACK_STATS_ENABLED    1
+#endif
+#ifndef MBED_CPU_STATS_ENABLED
 #define MBED_CPU_STATS_ENABLED      1
+#endif
+#ifndef MBED_HEAP_STATS_ENABLED
 #define MBED_HEAP_STATS_ENABLED     1
+#endif
+#ifndef MBED_THREAD_STATS_ENABLED
 #define MBED_THREAD_STATS_ENABLED   1
 #endif
+
+#endif // MBED_ALL_STATS_ENABLED
 
 /** Maximum memory regions reported by mbed-os memory statistics */
 #define MBED_MAX_MEM_REGIONS     4


### PR DESCRIPTION
### Description
Add `MBED_ALL_STATS_ENABLED` to the config system. Added define guards in mbed_stats.h to both disallow accidental conflicting redefines (which will generate a warning without the new guards), and to allow:

```JSON
 "platform.all-stats-enabled": true,          
 "platform.cpu-stats-enabled": false          
```

to enable all stats **but** the CPU ones.

May get a merge conflict with https://github.com/ARMmbed/mbed-os/pull/8734 after the rollup PR gets in, will fix when we get there.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

