### PR TITLE
Add new quick-start blinky example

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -16,6 +16,19 @@
       "auto-update" : true
     },
     {
+      "name": "mbed-os-quick-start-blinky",
+      "github": "https://github.com/ARMmbed/mbed-os-quick-start-blinky",
+      "mbed": [],
+      "test-repo-source": "github",
+      "features" : [],
+      "targets" : [],
+      "toolchains" : [],
+      "exporters": [],
+      "compile" : true,
+      "export": true,
+      "auto-update" : true
+    },
+    {
       "name": "mbed-os-example-tls",
       "github": "https://github.com/ARMmbed/mbed-os-example-tls",
       "mbed": [


### PR DESCRIPTION
### Description

Add the new Quick Start blinky application to the examples test page. Run on all available targets and toolchains by default.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

