### PR TITLE
Fix cellular backward compatibility

### DIFF
--- a/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.h
@@ -22,10 +22,13 @@ using namespace mbed;
 MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, use CellularBase::get_default_instance() instead.")
 class OnboardCellularInterface : public CellularBase {
 public:
-    OnboardCellularInterface()
+    OnboardCellularInterface(bool debug = false)
     {
         context = CellularContext::get_default_instance();
         MBED_ASSERT(context != NULL);
+        CellularDevice *dev = CellularDevice::get_default_instance();
+        MBED_ASSERT(dev != NULL);
+        dev->modem_debug_on(debug);
     }
 public: // from NetworkInterface
     virtual nsapi_error_t set_blocking(bool blocking)


### PR DESCRIPTION
Fixed cellular backward compatibility by adding boolean to OnboardCellularInterface wrapper.

https://github.com/ARMmbed/mbed-os-cliapp was not compiling as it used debug flag in constructor.

@VeijoPesonen @kjbracey-arm please review.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

