### PR TITLE
Cellular: Update cellular debug prints

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
@@ -185,12 +185,12 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_registration_params)
     reg_params._periodic_tau = 3;
 
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.get_registration_params(CellularNetwork::C_EREG, reg_params));
-    EXPECT_TRUE(reg_params._status == CellularNetwork::StatusNotAvailable);
+    EXPECT_TRUE(reg_params._status == CellularNetwork::NotRegistered);
     EXPECT_TRUE(reg_params._act == CellularNetwork::RAT_UNKNOWN);
     EXPECT_TRUE(reg_params._cell_id == -1 && reg_params._active_time == -1 && reg_params._periodic_tau == -1);
 
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.get_registration_params(CellularNetwork::C_GREG, reg_params));
-    EXPECT_TRUE(reg_params._status == CellularNetwork::StatusNotAvailable);
+    EXPECT_TRUE(reg_params._status == CellularNetwork::NotRegistered);
     EXPECT_TRUE(reg_params._act == CellularNetwork::RAT_UNKNOWN);
     EXPECT_TRUE(reg_params._cell_id == -1);
 
@@ -201,12 +201,12 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_registration_params)
     reg_params._periodic_tau = 3;
 
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == nw.get_registration_params(CellularNetwork::C_EREG, reg_params));
-    EXPECT_TRUE(reg_params._status == CellularNetwork::StatusNotAvailable);
+    EXPECT_TRUE(reg_params._status == CellularNetwork::NotRegistered);
     EXPECT_TRUE(reg_params._act == CellularNetwork::RAT_UNKNOWN);
     EXPECT_TRUE(reg_params._cell_id == -1 && reg_params._active_time == -1 && reg_params._periodic_tau == -1);
     // Check get_registration_params without specifying the registration type
     EXPECT_TRUE(NSAPI_ERROR_OK == cn.get_registration_params(reg_params_check));
-    EXPECT_TRUE(reg_params_check._status == CellularNetwork::StatusNotAvailable);
+    EXPECT_TRUE(reg_params_check._status == CellularNetwork::NotRegistered);
     EXPECT_TRUE(reg_params_check._act == CellularNetwork::RAT_UNKNOWN);
     EXPECT_TRUE(reg_params_check._cell_id == -1 && reg_params_check._active_time == -1 && reg_params_check._periodic_tau == -1);
 }
@@ -497,7 +497,7 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_signal_quality)
     ATHandler_stub::int_value = 1;
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
     EXPECT_TRUE(NSAPI_ERROR_OK == cn.get_signal_quality(rs, ber));
-    EXPECT_TRUE(rs == 1 && ber == 1);
+    EXPECT_TRUE(rs == -111 && ber == 1);
 }
 
 TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_3gpp_error)

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -79,7 +79,8 @@ public:
         AttachedEmergencyOnly,
         RegisteredCSFBNotPreferredHome,
         RegisteredCSFBNotPreferredRoaming,
-        AlreadyRegistered = 11 // our our definition when modem says that we are not registered but we have active PDP Context
+        AlreadyRegistered = 11, // our definition when modem says that we are not registered but we have active PDP Context
+        RegistrationStatusMax
     };
 
     /* Network registration type */
@@ -107,7 +108,8 @@ public:
         RAT_E_UTRAN,
         RAT_CATM1,
         RAT_NB1,
-        RAT_UNKNOWN
+        RAT_UNKNOWN,
+        RAT_MAX = 11 // to reserve string array
     };
 
     // 3GPP TS 27.007 - 7.3 PLMN selection +COPS
@@ -342,7 +344,7 @@ public:
      */
     virtual bool is_active_context() = 0;
 
-    /** Gets current network registration parameters:
+    /** Gets the latest received registration parameters from the network:
      *  type, status, access technology, cell_id, lac, active_time, periodic_tau.
      *
      *  @param reg_params   see registration_params_t
@@ -351,7 +353,7 @@ public:
      */
     virtual nsapi_error_t get_registration_params(registration_params_t &reg_params) = 0;
 
-    /** Gets the network registration parameters based on required registration type:
+    /** Gets the current network registration parameters from the network with type:
     *   status, access technology, cell_id, lac, active_time, periodic_tau.
     *
     *  @param type         see RegistrationType values

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -524,7 +524,7 @@ private:
     bool find_urc_handler(const char *prefix);
 
     // print contents of a buffer to trace log
-    void debug_print(char *p, int len);
+    void debug_print(const char *p, int len);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -365,5 +365,17 @@ void AT_CellularDevice::modem_debug_on(bool on)
 
 nsapi_error_t AT_CellularDevice::init_module()
 {
+#if MBED_CONF_MBED_TRACE_ENABLE
+    CellularInformation *information = open_information();
+    if (information) {
+        char *pbuf = new char[100];
+        nsapi_error_t ret = information->get_model(pbuf, sizeof(*pbuf));
+        close_information();
+        if (ret == NSAPI_ERROR_OK) {
+            tr_info("Model %s", pbuf);
+        }
+        delete[] pbuf;
+    }
+#endif
     return NSAPI_ERROR_OK;
 }

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -117,7 +117,7 @@ private:
     void urc_cgev();
 
     void read_reg_params_and_compare(RegistrationType type);
-    void read_reg_params(registration_params_t &reg_params);
+    void read_reg_params(RegistrationType type, registration_params_t &reg_params);
 
     // Returns active time(Table 10.5.163/3GPP TS 24.008: GPRS Timer 2 information element) in seconds
     int calculate_active_time(const char *active_time_string, int active_time_length);

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -182,6 +182,8 @@ protected:
     nsapi_ip_stack_t _stack_type;
 
 private:
+    int find_socket_index(nsapi_socket_t handle);
+
     // mutex for write/read to a _socket array, needed when multiple threads may open sockets simultaneously
     PlatformMutex _socket_mutex;
 };

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -157,7 +157,7 @@ void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr)
 {
     if (ev >= NSAPI_EVENT_CELLULAR_STATUS_BASE && ev <= NSAPI_EVENT_CELLULAR_STATUS_END) {
         cell_callback_data_t *ptr_data = (cell_callback_data_t *)ptr;
-        tr_debug("Device: network_callback called with event: %d, err: %d, data: %d", ev, ptr_data->error, ptr_data->status_data);
+        tr_debug("callback: %d, err: %d, data: %d", ev, ptr_data->error, ptr_data->status_data);
         cellular_connection_status_t cell_ev = (cellular_connection_status_t)ev;
         if (cell_ev == CellularRegistrationStatusChanged && _state_machine) {
             // broadcast only network registration changes to state machine
@@ -180,7 +180,7 @@ void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr)
             }
         }
     } else {
-        tr_debug("Device: network_callback called with event: %d, ptr: %d", ev, ptr);
+        tr_debug("callback: %d, ptr: %d", ev, ptr);
         if (ev == NSAPI_EVENT_CONNECTION_STATUS_CHANGE && ptr == NSAPI_STATUS_DISCONNECTED) {
             // we have been disconnected, reset state machine so that application can start connect sequence again
             if (_state_machine) {


### PR DESCRIPTION
### Description

Cellular traces need to be improved:
- Removed unnecessary prints.
- Tracing more in DEBUG level.
- Read/write bytes not printed on big packets.
- Signal quality (RSSI) traced to log network problems.
- Dismissed AT data is traced.
- Modem type and firmware version are traced.

Network registration returns NotRegistered instead of previous StatusNotAvailable (which is not part of 3GPP TS 27.007).

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

