### PR TITLE
STM32 LPTICKER with LPTIM optimisation

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -38,6 +38,10 @@
 #include "lp_ticker_api.h"
 #include "mbed_error.h"
 
+#if !defined(LPTICKER_DELAY_TICKS) || (LPTICKER_DELAY_TICKS < 3)
+#warning "lpticker_delay_ticks value should be set to 3"
+#endif
+
 LPTIM_HandleTypeDef LptimHandle;
 
 const ticker_info_t *lp_ticker_get_info()
@@ -145,6 +149,12 @@ void lp_ticker_init(void)
 
     __HAL_LPTIM_ENABLE_IT(&LptimHandle, LPTIM_IT_CMPM);
     HAL_LPTIM_Counter_Start(&LptimHandle, 0xFFFF);
+
+    /* Need to write a compare value in order to get LPTIM_FLAG_CMPOK in set_interrupt */
+    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+    __HAL_LPTIM_COMPARE_SET(&LptimHandle, 0);
+    while (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == RESET) {
+    }
 }
 
 static void LPTIM1_IRQHandler(void)
@@ -191,12 +201,12 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
     LptimHandle.Instance = LPTIM1;
     irq_handler = (void (*)(void))lp_ticker_irq_handler;
 
-    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-    __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
     /* CMPOK is set by hardware to inform application that the APB bus write operation to the LPTIM_CMP register has been successfully completed */
     /* Any successive write before the CMPOK flag be set, will lead to unpredictable results */
-    while (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == RESET) {
-    }
+    /* LPTICKER_DELAY_TICKS value prevents OS to call this set interrupt function before CMPOK */
+    MBED_ASSERT(__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == SET);
+    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+    __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
 
     lp_ticker_clear_interrupt();
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2233,6 +2233,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0744"],
         "device_has_add": [
             "ANALOGOUT",
@@ -2395,6 +2396,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
@@ -2431,6 +2433,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
@@ -2646,6 +2649,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "macros_add": ["USBHOST_OTHER"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0816"],
@@ -2691,6 +2695,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "macros_add": [
             "TRANSACTION_QUEUE_SIZE_SPI=2",
             "USBHOST_OTHER",
@@ -2743,6 +2748,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "supported_form_factors": ["ARDUINO"],
         "macros_add": ["USBHOST_OTHER"],
         "detect_code": ["0818"],
@@ -2902,6 +2908,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0770"],
         "device_has_add": [
             "ANALOGOUT",
@@ -2932,6 +2939,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0779"],
         "device_has_add": [
             "ANALOGOUT",
@@ -2990,6 +2998,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0765"],
         "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": [
@@ -3047,6 +3056,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0827"],
         "macros_add": [
             "USBHOST_OTHER",
@@ -3433,6 +3443,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0815"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
@@ -3476,6 +3487,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0817"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
@@ -3509,6 +3521,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
         "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
@@ -3540,6 +3553,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0820"],
         "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": [
@@ -6844,6 +6858,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0822"],
         "device_has_add": [
             "ANALOGOUT",
@@ -6874,6 +6889,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0823"],
         "device_has_add": [
             "ANALOGOUT",
@@ -6908,6 +6924,7 @@
                 "value": 1
             }
         },
+        "overrides": { "lpticker_delay_ticks": 3 },
         "detect_code": ["0776"],
         "device_has_add": [
             "ANALOGOUT",


### PR DESCRIPTION
### Description

This patches fixes #8714 

lp_ticker_set_interrupt implementation causes some IRQ latency and then UART character loss.

Delay in lp_ticker_set_interrupt was added to ensure that we can't write LPTIM_CMP registers too often.
This delay is now removed, thanks to the LPTICKER_DELAY_TICKS feature which guarantee a minimum delay beween lp_ticker_set_interrupt calls.

@mfatiga @c1728p9 @kjbracey-arm @LMESTM 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

