### PR TITLE
STM32 LPTICKER with LPTIM : reduce clock feature

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -44,9 +44,9 @@ const ticker_info_t *lp_ticker_get_info()
 {
     static const ticker_info_t info = {
 #if MBED_CONF_TARGET_LSE_AVAILABLE
-        LSE_VALUE,
+        LSE_VALUE / MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK,
 #else
-        LSI_VALUE,
+        LSI_VALUE / MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK,
 #endif
         16
     };
@@ -119,7 +119,17 @@ void lp_ticker_init(void)
     LptimHandle.Instance = LPTIM1;
     LptimHandle.State = HAL_LPTIM_STATE_RESET;
     LptimHandle.Init.Clock.Source = LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC;
+#if defined(MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK)
+#if (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 4)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV4;
+#elif (MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK == 2)
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV2;
+#else
     LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV1;
+#endif
+#else
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV1;
+#endif /* MBED_CONF_TARGET_LPTICKER_LPTIM_CLOCK */
 
     LptimHandle.Init.Trigger.Source = LPTIM_TRIGSOURCE_SOFTWARE;
     LptimHandle.Init.OutputPolarity = LPTIM_OUTPUTPOLARITY_HIGH;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1712,6 +1712,10 @@
                 "help": "https://os.mbed.com/docs/latest/porting/low-power-ticker.html",
                 "value": 1,
                 "macro_name": "LPTICKER_DELAY_TICKS"
+            },
+            "lpticker_lptim_clock": {
+                "help": "Default value for LPTIM clock (lpticker_lptim == 1). Value is the dividing factor. Choose 1, 2 or 4",
+                "value": 1
             }
         },
         "device_has": [


### PR DESCRIPTION
### Description


This fix follows https://github.com/ARMmbed/mbed-os/issues/7156#issuecomment-435883069
@rohithreddykota-npsc

Default behavior is not changed : Frequency is 32768 Hz with a 16 bits timer
This provides:
- a 30us precision
- and a sleep time about 2s


You have now the possibility to divide frequency by 4

- Precision becomes around 132us
- Sleep time is now about 8s

Add:
- in targets.json file:
         "overrides": { "lpticker_lptim_clock": 4 },

- in your local mbed_app.json file:
    "target_overrides": {
xxx
            "target.lpticker_lptim_clock": 4




@c1728p9 @LMESTM 


### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

