### PR TITLE
Migrate old memap file handling into toolchains

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -5,9 +5,9 @@ from __future__ import print_function, division, absolute_import
 
 from abc import abstractmethod, ABCMeta
 from sys import stdout, exit, argv, path
-from os import sep, rename, remove
+from os import sep
 from os.path import (basename, dirname, join, relpath, abspath, commonprefix,
-                     splitext, exists)
+                     splitext)
 
 # Be sure that the tools directory is in the search path
 ROOT = abspath(join(dirname(__file__), ".."))
@@ -25,7 +25,6 @@ from jinja2.environment import Environment
 
 from tools.utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
                          argparse_uppercase_type)
-from tools.settings import COMPARE_FIXED
 
 
 class _Parser(object):
@@ -831,11 +830,6 @@ class MemapParser(object):
                     self.old_modules = parser().parse_mapfile(old_input)
             except IOError:
                 self.old_modules = None
-            if not COMPARE_FIXED:
-                old_mapfile = "%s.old" % mapfile
-                if exists(old_mapfile):
-                    remove(old_mapfile)
-                rename(mapfile, old_mapfile)
             return True
 
         except IOError as error:

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -19,7 +19,7 @@ from __future__ import print_function, division, absolute_import
 import re
 import sys
 import json
-from os import stat, walk, getcwd, sep, remove, getenv
+from os import stat, walk, getcwd, sep, remove, getenv, rename, remove
 from copy import copy
 from time import time, sleep
 from shutil import copyfile
@@ -41,6 +41,7 @@ from ..notifier.term import TerminalNotifier
 from ..resources import FileType
 from ..memap import MemapParser
 from ..config import (ConfigException, RAM_ALL_MEMORIES, ROM_ALL_MEMORIES)
+from ..settings import COMPARE_FIXED
 
 
 #Disables multiprocessing if set to higher number than the host machine CPUs
@@ -617,7 +618,7 @@ class mbedToolchain:
         full_path = join(tmp_path, filename)
         elf = join(tmp_path, name + '.elf')
         bin = None if ext == 'elf' else full_path
-        map = join(tmp_path, name + '.map')
+        mapfile = join(tmp_path, name + '.map')
 
         objects = sorted(set(r.get_file_paths(FileType.OBJECT)))
         config_file = ([self.config.app_config_location]
@@ -634,6 +635,11 @@ class mbedToolchain:
         dependencies = objects + libraries + [linker_script] + config_file + hex_files
         dependencies.append(join(self.build_dir, self.PROFILE_FILE_NAME + "-ld"))
         if self.need_update(elf, dependencies):
+            if not COMPARE_FIXED and exists(mapfile):
+                old_mapfile = "%s.old" % mapfile
+                if exists(old_mapfile):
+                    remove(old_mapfile)
+                rename(mapfile, old_mapfile)
             needed_update = True
             self.progress("link", name)
             self.link(elf, objects, libraries, lib_dirs, linker_script)
@@ -644,7 +650,7 @@ class mbedToolchain:
             self.binary(r, elf, bin)
 
         # Initialize memap and process map file. This doesn't generate output.
-        self.mem_stats(map)
+        self.mem_stats(mapfile)
 
         self.notify.var("compile_succeded", True)
         self.notify.var("binary", filename)


### PR DESCRIPTION
### Description

This PR moves the old memap file handling required for differential
memap from within memap to the toolchain object. This has the 
advantage that we can do the `mv <app>.map <app>.map.old` the moment
before it is overwritten by the linker. This should allow multiple 
reruns of memap without modifying your build directory.


### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change