### PR TITLE
Greentea netsocket and network tests improvements

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -45,7 +45,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
         TEST_ASSERT(strlen(addr.get_ip_address()) > 1);
     }
 
-    semaphore.wait();
+    semaphore.wait(100);
 
     TEST_ASSERT(data.result == NSAPI_ERROR_OK);
 

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -30,7 +30,7 @@ nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock);
 int split2half_rmng_tcp_test_time(); // [s]
 
 namespace tcp_global {
-static const int TESTS_TIMEOUT = 960;
+static const int TESTS_TIMEOUT = 480;
 static const int TCP_OS_STACK_SIZE = 2048;
 
 static const int RX_BUFF_SIZE = 1220;

--- a/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
@@ -66,8 +66,8 @@ void TCPSOCKET_RECV_TIMEOUT()
                     TEST_FAIL();
                     goto CLEANUP;
                 }
-                printf("MBED: recv() took: %dms\n", timer.read_ms());
-                TEST_ASSERT_INT_WITHIN(50, 150, timer.read_ms());
+                printf("MBED: recv() took: %dus\n", timer.read_us());
+                TEST_ASSERT_INT_WITHIN(51, 150, (timer.read_us() + 500) / 1000);
                 continue;
             } else if (recvd < 0) {
                 printf("[pkt#%02d] network error %d\n", i, recvd);

--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -89,7 +89,8 @@ void NETWORKINTERFACE_STATUS()
         }
         TEST_ASSERT_EQUAL(NSAPI_STATUS_GLOBAL_UP, status);
 
-        net->disconnect();
+        err = net->disconnect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
 
         status = wait_status_callback();
         TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
@@ -123,7 +124,8 @@ void NETWORKINTERFACE_STATUS_NONBLOCK()
         }
         TEST_ASSERT_EQUAL(NSAPI_STATUS_GLOBAL_UP, status);
 
-        net->disconnect();
+        err = net->disconnect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
 
         status = wait_status_callback();
         TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
@@ -150,7 +152,8 @@ void NETWORKINTERFACE_STATUS_GET()
             wait(0.5);
         }
 
-        net->disconnect();
+        err = net->disconnect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
 
         TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, net->get_connection_status());
     }


### PR DESCRIPTION
### Description

Added smarter rounding of times in recv_timeout.
@VeijoPesonen , this is instead of just allowing an "off by one" error. Following @mtomczykmobica remark I checked that using milliseconds causes a dummy rounding of the real times:
```
[1542381389.86][CONN][RXD] MBED: recv() took: 143ms
[1542381389.90][CONN][RXD] MBED: recv() took: 143750us
[1542381390.54][CONN][RXD] MBED: recv() took: 100ms
[1542381390.57][CONN][RXD] MBED: recv() took: 100732us
```
So we thought it might be better to start with proper rounding and if that is not enough, we can introduce the "off by one" tolerance.

Reverted commit 88eea6a, reducing TESTS_TIMEOUT back to 480.

Introduced a 100ms timeout for waiting on asynchronous DNS resolution. (@VeijoPesonen , I checked that the DNS resolution takes up to 30 ms on my network, so I added some extra buffer beyond the 20 ms which you originally suggested.)

Improved error handling on disconnects.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

