### PR TITLE
Fix traceback when running mbed test

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -749,7 +749,7 @@ class Config(object):
         if start > rom_start + rom_size:
             raise ConfigException("Not enough memory on device to fit all "
                                   "application regions")
-    
+
     @staticmethod
     def _find_sector(address, sectors):
         target_size = -1
@@ -762,13 +762,13 @@ class Config(object):
         if (target_size < 0):
             raise ConfigException("No valid sector found")
         return target_start, target_size
-        
+
     @staticmethod
     def _align_floor(address, sectors):
         target_start, target_size = Config._find_sector(address, sectors)
         sector_num = (address - target_start) // target_size
         return target_start + (sector_num * target_size)
-    
+
     @staticmethod
     def _align_ceiling(address, sectors):
         target_start, target_size = Config._find_sector(address, sectors)
@@ -778,7 +778,7 @@ class Config(object):
     @property
     def report(self):
         return {'app_config': self.app_config_location,
-                'library_configs': map(relpath, self.processed_configs.keys())}
+                'library_configs': list(map(relpath, self.processed_configs.keys()))}
 
     def _generate_linker_overrides(self, rom_start, rom_size):
         if self.target.mbed_app_start is not None:


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This should fix #8619.

The issue came down to the use of the Python function `map()` and that being present in a data structure that is serialized to json. Turns out, you can't serialize the output of `map()`! (Hence the error). This wraps the call to map in `list()` to force it to be serializable.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

