### PR TITLE
[Wio 3G] Adding IAR exporting definition

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -129,6 +129,9 @@
     "STM32F439ZI": {
         "OGChipSelectEditMenu": "STM32F439ZI\tST STM32F439ZI"
     },
+    "STM32F439VI": {
+        "OGChipSelectEditMenu": "STM32F439VI\tST STM32F439VI"
+    },
     "LPC1768": {
         "OGChipSelectEditMenu": "LPC1768\tNXP LPC1768"
     },


### PR DESCRIPTION
### Description

Added exporting definition of STM32F439VI to enable exporting to EWARM.
Test result:
```
C:\mbed\Wio_3G-example-blinky>mbed export -i IAR -m WIO_3G
Scan: .
Scan: FEATURE_LWIP
```

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
