### PR TITLE
Fix unsigned packing bug in merge_regions #8544

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -388,7 +388,7 @@ def _fill_header(region_list, current_region):
             else:
                 ih = intelhex_offset(region_dict[data].filename, offset=region_dict[data].start)
             if subtype.startswith("CRCITT32"):
-                fmt = {"CRCITT32be": ">l", "CRCITT32le": "<l"}[subtype]
+                fmt = {"CRCITT32be": ">L", "CRCITT32le": "<L"}[subtype]
                 header.puts(start, struct.pack(fmt, zlib.crc32(ih.tobinarray())))
             elif subtype.startswith("SHA"):
                 if subtype == "SHA256":


### PR DESCRIPTION
### Description

There is a randomly occuring bug at the `merge_regions` build stage which throws depending on computed CRC32 value. If 32-bit ( instead of 31-bit ) value is calculated, merge fails as follows:

```
Merging Regions
  Filling region bootloader with /opt/m/mbed/compiletest/cloud-2.0/mbed-os/features/FEATURE_BOOTLOADER/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_UBLOX_EVK_ODIN_W2/mbed-bootloader-sotp-v3_4_0.bin
  Padding region bootloader with 0x684 bytes
Traceback (most recent call last):
  File "/opt/m/mbed/compiletest/cloud-2.0/mbed-os/tools/make.py", line 293, in <module>
    ignore=options.ignore
  File "/opt/m/mbed/compiletest/cloud-2.0/mbed-os/tools/build_api.py", line 552, in build_project
    merge_region_list(region_list, res, notify)
  File "/opt/m/mbed/compiletest/cloud-2.0/mbed-os/tools/build_api.py", line 427, in merge_region_list
    _fill_header(region_list, region).tofile(header_filename, format='hex')
  File "/opt/m/mbed/compiletest/cloud-2.0/mbed-os/tools/build_api.py", line 397, in _fill_header
    header.puts(start, struct.pack(fmt, zlib.crc32(ih.tobinarray())))
struct.error: 'l' format requires -2147483648 <= number <= 2147483647
```

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

