### PR TITLE
Cellular: Fix ATHandler URC processing

### DIFF
--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -218,7 +218,7 @@ private:
     uint16_t _at_send_delay;
     uint64_t _last_response_stop;
 
-    bool _processing;
+    bool _oob_queued;
     int32_t _ref_count;
     bool _is_fh_usable;
 


### PR DESCRIPTION
### Description

Two closely related fixes to ATHandler:

- AT timeout for URC processing callback increased to one second
- URC processing flag to be set in RX event handler and cleared in process URC function

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

