### PR TITLE
Deprecate TCP/UDPSocket open-calling constructors

### DIFF
--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -62,7 +62,8 @@ TEST_F(TestTCPSocket, constructor)
 
 TEST_F(TestTCPSocket, constructor_parameters)
 {
-    TCPSocket socketParam = TCPSocket(dynamic_cast<NetworkStack *>(&stack));
+    TCPSocket socketParam = TCPSocket();
+    socketParam.open(dynamic_cast<NetworkStack *>(&stack));
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socketParam.connect(a), NSAPI_ERROR_OK);
 }

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -42,8 +42,14 @@ public:
      *  network interface.
      *
      *  @param stack    Network stack as target for socket
+     *
+     *  @deprecated since mbed-os-5.11
      */
     template <typename S>
+    MBED_DEPRECATED_SINCE("mbed-os-5.11",
+                          "The TCPSocket(S *stack) constructor is deprecated."
+                          "It discards the open() call return value."
+                          "Use another constructor and call open() explicitly, instead.")
     TCPSocket(S *stack)
     {
         open(stack);

--- a/features/netsocket/TLSSocket.h
+++ b/features/netsocket/TLSSocket.h
@@ -45,22 +45,6 @@ public:
      */
     virtual ~TLSSocket();
 
-    /** Create a socket on a network interface
-     *
-     *  Creates and opens a socket on the network stack of the given
-     *  network interface.
-     *  If hostname is also given, user is not required to call set_hostname() later.
-     *
-     *  @param stack    Network stack as target for socket
-     *  @param hostname Hostname used for certificate verification
-     */
-    template <typename S>
-    TLSSocket(S *stack, const char *hostname = NULL) : TLSSocketWrapper(&tcp_socket, hostname)
-    {
-        nsapi_error_t ret = tcp_socket.open(stack);
-        MBED_ASSERT(ret == NSAPI_ERROR_OK);
-    }
-
     /** Opens a socket
      *
      *  Creates a network socket on the network stack of the given

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -41,8 +41,13 @@ public:
      *
      *  @tparam S    Type of the Network stack.
      *  @param stack Network stack as target for socket.
+     *  @deprecated since mbed-os-5.11
      */
     template <typename S>
+    MBED_DEPRECATED_SINCE("mbed-os-5.11",
+                          "The UDPSocket(S *stack) constructor is deprecated"
+                          "It discards the open() call return value."
+                          "Use another constructor and call open() explicitly, instead.")
     UDPSocket(S *stack)
     {
         open(stack);


### PR DESCRIPTION


### Description

Updated Doxygen, removed the only one call of the deprecated constructor from the tests.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

