### PR TITLE
STM32 : Add default deep sleep latency of 3ms

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1719,6 +1719,9 @@
                 "value": 1
             }
         },
+        "overrides": {
+            "deep-sleep-latency": 3
+        },
         "device_has": [
             "USTICKER",
             "LPTICKER",


### PR DESCRIPTION
### Description

Feature has been introduced in #8223 
Discussion on ST impacts started there:  https://github.com/ARMmbed/mbed-os/pull/8223#issuecomment-436989116

@c1728p9 @LMESTM 

Here is some quick measurement between the end of deep sleep (CPU) and the end of hal_deepsleep function:
-	NUCLEO_F401 : 824 us
-	NUCLEO_L476 : 2.04 ms
-	NUCLEO_L073 : 1.02 ms

So we propose to set as default value a deep sleep latency of 2ms.

Value can be overwritten in your target anyway:

"overrides": { "deep-sleep-latency": 5 },
or "overrides": { "deep-sleep-latency": 0 },


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

