### PR TITLE
Fix long writes/reads stack overflowing

### DIFF
--- a/TESTS/nfc/eeprom/main.cpp
+++ b/TESTS/nfc/eeprom/main.cpp
@@ -66,7 +66,7 @@ typedef enum {
     TERMINATE            = 0xFF00
 } TestCommand_t;
 
-/* We group the command based on their fist byte to simplify step checking.
+/* We group the command based on their first byte to simplify step checking.
  * Individual conditions of a step are checked in the event so this doesn't
  * sacrifice any correctness checking */
 const size_t TEST_COMMAND_GROUP_MASK = 0xFF00;
@@ -359,7 +359,7 @@ public:
                 _driver->write_bytes(_address, _operation_data, _operation_size);
                 break;
             case ERASE_BYTES:
-                _driver->erase_bytes(_address, 4);
+                _driver->erase_bytes(_address, _operation_size);
                 break;
             case READ_SIZE:
                 _driver->read_size();
@@ -434,6 +434,7 @@ void write_read()
 
 void erase_bytes()
 {
+	abc
     driver_test->run_sequence(ERASE_TEST);
 }
 

--- a/TESTS/nfc/eeprom/main.cpp
+++ b/TESTS/nfc/eeprom/main.cpp
@@ -434,7 +434,6 @@ void write_read()
 
 void erase_bytes()
 {
-	abc
     driver_test->run_sequence(ERASE_TEST);
 }
 

--- a/features/nfc/nfc/NFCEEPROM.h
+++ b/features/nfc/nfc/NFCEEPROM.h
@@ -144,6 +144,7 @@ private:
 
     Delegate *_delegate;
     NFCEEPROMDriver *_driver;
+    events::EventQueue *_event_queue;
     bool _initialized;
 
     nfc_eeprom_operation_t _current_op;

--- a/features/nfc/source/nfc/NFCEEPROM.cpp
+++ b/features/nfc/source/nfc/NFCEEPROM.cpp
@@ -16,7 +16,6 @@
 
 #include "NFCEEPROM.h"
 #include "ndef/ndef.h"
-#include "Event.h"
 
 using namespace mbed;
 using namespace mbed::nfc;


### PR DESCRIPTION
### Description
Fix stack overflow crashes if using large message. NFC EEPROM wrapper not using recursion/stack anymore. All read/write/erase command follow-on blocks are now processed in the queue for large messages, since handling these were causing stack overflows if > about 2k of data.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

