### PR TITLE
Cellular: unified return value comments on API folder.

### DIFF
--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -225,7 +225,11 @@ public:
      *  For example, when multiple modules are supported in a single AT driver this function detects
      *  and adapts to an actual module at runtime.
      *
-     *  @return 0 on success
+     *  @return         NSAPI_ERROR_OK on success
+     *                  NSAPI_ERROR_NO_MEMORY on case of memory failure
+     *                  NSAPI_ERROR_UNSUPPORTED if current model is not detected
+     *                  NSAPI_ERROR_DEVICE_ERROR if model information could not be read
+     *
      */
     virtual nsapi_error_t init_module() = 0;
 

--- a/features/cellular/framework/API/CellularInformation.h
+++ b/features/cellular/framework/API/CellularInformation.h
@@ -80,7 +80,7 @@ public:
         IMEISV = 2, // IMEI and Software Version number
         SVN  = 3 // Software Version Number
     };
-    virtual nsapi_size_or_error_t get_serial_number(char *buf, size_t buf_size, SerialNumberType type = SN) = 0;
+    virtual nsapi_error_t get_serial_number(char *buf, size_t buf_size, SerialNumberType type = SN) = 0;
 };
 
 } // namespace mbed


### PR DESCRIPTION
### Description

_ Fixed cellular API folder to follow same syntax when defining doxygen return values.
 -CellularInformation had wrong return type (which is correct on deriving classes), fixed to correct return value. Does this make this Breaking change? Changed from nsapi_size_or_error_t to nsapi_error_t. Function implementation has returned only error codes.

@mirelachirica please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change