### PR TITLE
Correct network status callbacks with ethernet and nanostack

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/NanostackEMACInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEMACInterface.cpp
@@ -7,6 +7,7 @@
 #include "nsdynmemLIB.h"
 #include "arm_hal_phy.h"
 #include "EMAC.h"
+#include "enet_tasklet.h"
 
 class EMACPhy : public NanostackEthernetPhy {
 public:
@@ -137,6 +138,7 @@ int8_t EMACPhy::phy_register()
 
         emac.set_memory_manager(memory_manager);
         emac.set_link_input_cb(mbed::callback(this, &EMACPhy::emac_phy_rx));
+        emac.set_link_state_cb(enet_tasklet_link_state_changed);
 
         if (!emac.power_up()) {
             return -1;

--- a/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
@@ -26,6 +26,7 @@ void enet_tasklet_init(void);
 uint8_t enet_tasklet_network_init(int8_t);
 int8_t enet_tasklet_connect(void (*)(mesh_connection_status_t mesh_status), int8_t nwk_interface_id);
 void enet_tasklet_disconnect();
+void enet_tasklet_link_state_changed(bool up);
 
 #ifdef __cplusplus
 }

--- a/features/nanostack/mbed-mesh-api/source/include/mesh_system.h
+++ b/features/nanostack/mbed-mesh-api/source/include/mesh_system.h
@@ -25,7 +25,11 @@ extern "C" {
 /*
  * Event type for connecting
  */
-#define APPL_EVENT_CONNECT 0x01
+enum {
+    APPL_EVENT_CONNECT = 0x01,
+    APPL_BACKHAUL_INTERFACE_PHY_DOWN,
+    APPL_BACKHAUL_INTERFACE_PHY_UP
+};
 
 /*
  * \brief Send application connect event to receiver tasklet to


### PR DESCRIPTION
Ethernet-tasklet needs to be registered for emac link state changes.
Ethernet-tasklet will then handle ethernet cable connection/disconnection events.

Tested locally with K64F and ethernet cable


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

