### PR TITLE
travis: fix coding style for remaining 2 files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ matrix:
       after_success:
         # run astyle for all files on the branch
         - git checkout -- .
-        - find -regex '.*\.\(h\|c\|hpp\|cpp\)' -type f | fgrep -v -f .astyleignore | xargs -n 100 -I {} bash -c "astyle -n --options=.astylerc \"{}\"" > astyle-branch.out;
+        - find -regex '.*\.\(h\|c\|hpp\|cpp\)$' -type f | fgrep -v -f .astyleignore | xargs -n 100 -I {} bash -c "astyle -n --options=.astylerc \"{}\"" > astyle-branch.out;
         # update status if we succeeded, compare with master if possible
         - |
           CURR=$(cat astyle-branch.out | grep Formatted | wc -l)

--- a/TESTS/network/wifi/wifi_connect_params_null.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_null.cpp
@@ -30,7 +30,7 @@ void wifi_connect_params_null(void)
     error = wifi->connect(NULL, NULL);
     wifi->disconnect();
     TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
-    error =  wifi->connect("", "");   
+    error =  wifi->connect("", "");
     wifi->disconnect();
     TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
 }

--- a/TESTS/network/wifi/wifi_connect_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure.cpp
@@ -32,7 +32,7 @@ void wifi_connect_secure(void)
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security()));
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
-    
+
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->disconnect());
 }
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

While updating travis script, there landed 2 files that needs fixing the coding style. This PR is to address this. I'll update PR with these files, first need to check if I found them locally, so running  travis here with debug msg added.

Update: files located and fixed, ready for review

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

