### PR TITLE
Cellular: add radio access technology as configurable in json

### DIFF
--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -385,7 +385,7 @@ bool CellularStateMachine::device_ready()
 
 #ifdef MBED_CONF_CELLULAR_RADIO_ACCESS_TECHNOLOGY
     MBED_ASSERT(MBED_CONF_CELLULAR_RADIO_ACCESS_TECHNOLOGY >= CellularNetwork::RAT_GSM &&
-            MBED_CONF_CELLULAR_RADIO_ACCESS_TECHNOLOGY < CellularNetwork::RAT_UNKNOWN);
+                MBED_CONF_CELLULAR_RADIO_ACCESS_TECHNOLOGY < CellularNetwork::RAT_UNKNOWN);
     nsapi_error_t err = _network->set_access_technology((CellularNetwork::RadioAccessTechnology)MBED_CONF_CELLULAR_RADIO_ACCESS_TECHNOLOGY);
     if (err != NSAPI_ERROR_OK && err != NSAPI_ERROR_UNSUPPORTED) {
         tr_warning("Failed to set access technology to %d", MBED_CONF_CELLULAR_RADIO_ACCESS_TECHNOLOGY);

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -12,6 +12,10 @@
         "debug-at": {
             "help": "Enable AT debug prints",
             "value": false
+        },
+        "radio-access-technology": {
+            "help": "Radio access technology to use. Value in integer: GSM=0, GSM_COMPACT=1, UTRAN=2, EGPRS=3, HSDPA=4, HSUPA=5, HSDPA_HSUPA=6, E_UTRAN=7, CATM1=8 ,NB1=9",
+            "value": null
         }
     }
 }


### PR DESCRIPTION
Added radio access technology as configurable item in cellular mbed_lib.json.

Issue: https://github.com/ARMmbed/mbed-os-example-cellular/issues/87

@AriParkkila @mirelachirica please review

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

