### PR TITLE
DISCO_L072CZ: remove ADC_VBAT pin definition

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/PinNames.h
@@ -100,7 +100,6 @@ typedef enum {
     // ADC internal channels
     ADC_TEMP = 0xF0,
     ADC_VREF = 0xF1,
-    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,


### PR DESCRIPTION
### Description

Remove the ADC_VBAT pin in PinNames.h (function not available in this device).

Fixes #8809

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

