### PR TITLE
NUCLEO_F030/F070: remove ADC_VBAT pin definition

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/PinNames.h
@@ -117,7 +117,6 @@ typedef enum {
     // ADC internal channels
     ADC_TEMP = 0xF0,
     ADC_VREF = 0xF1,
-    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/PinNames.h
@@ -115,7 +115,6 @@ typedef enum {
     // ADC internal channels
     ADC_TEMP = 0xF0,
     ADC_VREF = 0xF1,
-    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,


### PR DESCRIPTION
### Description

Remove the ADC_VBAT pin in PinNames.h (function not available in those devices).

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

