### PR TITLE
Add socket send timeout to tcp socket greentea tests.

### DIFF
--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -100,6 +100,8 @@ nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock)
         return err;
     }
 
+    sock.set_timeout(100000); //100 s
+
     return sock.connect(tcp_addr);
 }
 


### PR DESCRIPTION
### Description

TCP socket send is blocking by default with no timeout. If connectivity is lost, the tests would hang forever. I added a 100 s timeout setting at the beginning of every test to make sure that send returns with a timeout instead of hanging the whole suite in case of connectivity issues.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

