### PR TITLE
Revert "Merge pull request #8272 from NXPmicro/Ensure_RTC_OSC_Start"

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/mbed_overrides.c
@@ -17,37 +17,12 @@
 
 #define CRC16
 #include "crc.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -57,6 +32,13 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Provide ethernet devices with a semi-unique MAC address from the UUID
@@ -73,7 +55,7 @@ void mbed_mac_address(char *mac)
 
     // generate three CRC16's using different slices of the UUID
     MAC[0] = crcSlow((const uint8_t *)UID, 8);  // most significant half-word
-    MAC[1] = crcSlow((const uint8_t *)UID, 12);
+    MAC[1] = crcSlow((const uint8_t *)UID, 12); 
     MAC[2] = crcSlow((const uint8_t *)UID, 16); // least significant half word
 
     // The network stack expects an array of 6 bytes

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/mbed_overrides.c
@@ -14,37 +14,12 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -54,6 +29,13 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Set the UART clock source

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_UBRIDGE/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_UBRIDGE/mbed_overrides.c
@@ -17,18 +17,13 @@
 #include "fsl_smc.h"
 #include "fsl_rcm.h"
 #include "fsl_pmc.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 //!< this contains the wakeup source
 rcm_reset_source_t kinetisResetSource;
 
 // called before main
-void mbed_sdk_init()
-{
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
+void mbed_sdk_init() {
     SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
 
     // check the power mode source
@@ -41,26 +36,6 @@ void mbed_sdk_init()
 
     BOARD_BootClockRUN();
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -70,6 +45,13 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Set the UART clock source

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/TARGET_FRDM/mbed_overrides.c
@@ -15,40 +15,22 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
     /* Set the TPM clock source to be IRC48M, do not change as TPM2 is used for the usticker */
     CLOCK_SetTpmClock(1U);
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/TARGET_FRDM/mbed_overrides.c
@@ -15,40 +15,22 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
     /* Set the TPM clock source to be IRC48M, do not change as TPM2 is used for the usticker */
     CLOCK_SetTpmClock(1U);
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_FRDM/mbed_overrides.c
@@ -15,38 +15,20 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_USENSE/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_USENSE/mbed_overrides.c
@@ -17,18 +17,13 @@
 #include "fsl_smc.h"
 #include "fsl_rcm.h"
 #include "fsl_pmc.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 //!< this contains the wakeup source
 rcm_reset_source_t kinetisResetSource;
 
 // called before main
-void mbed_sdk_init()
-{
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
+void mbed_sdk_init() {
     SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
 
     // check the power mode source
@@ -40,27 +35,6 @@ void mbed_sdk_init()
     }
 
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -71,6 +45,15 @@ void NMI_Handler(void)
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
 }
+
+#if DEVICE_RTC || DEVICE_LPTICKER
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
+}
+#endif
 
 // Set the UART clock source
 void serial_clock_init(void)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/mbed_overrides.c
@@ -14,38 +14,20 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/mbed_overrides.c
@@ -14,40 +14,22 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
     /* Set the TPM clock source to be OSCERCLK, do not change as TPM2 is used for the usticker */
     CLOCK_SetTpmClock(2U);
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/TARGET_FRDM/mbed_overrides.c
@@ -15,39 +15,21 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
     pin_function(PTA2, 1);          //By default the GREEN LED is enabled. This disables it
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -58,4 +40,3 @@ void NMI_Handler(void)
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
 }
-

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_RO359B/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_RO359B/mbed_overrides.c
@@ -17,37 +17,12 @@
 
 #define CRC16
 #include "crc.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -57,5 +32,12 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
@@ -17,37 +17,12 @@
 
 #define CRC16
 #include "crc.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -57,6 +32,13 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Provide ethernet devices with a semi-unique MAC address from the UUID
@@ -73,7 +55,7 @@ void mbed_mac_address(char *mac)
 
     // generate three CRC16's using different slices of the UUID
     MAC[0] = crcSlow((const uint8_t *)UID, 8);  // most significant half-word
-    MAC[1] = crcSlow((const uint8_t *)UID, 12);
+    MAC[1] = crcSlow((const uint8_t *)UID, 12); 
     MAC[2] = crcSlow((const uint8_t *)UID, 16); // least significant half word
 
     // The network stack expects an array of 6 bytes

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/mbed_overrides.c
@@ -14,36 +14,19 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
-#include "fsl_rtc.h"
+
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
+}
 
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_MTS_GAMBIT/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_MTS_GAMBIT/mbed_overrides.c
@@ -14,36 +14,16 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
-
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/mbed_overrides.c
@@ -17,37 +17,12 @@
 
 #define CRC16
 #include "crc.h"
-#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    rtc_config_t rtc_basic_config;
-    uint32_t u32cTPR_counter = 0;
-
     BOARD_BootClockRUN();
-
-    CLOCK_EnableClock(kCLOCK_Rtc0);
-
-    /* Check if the Rtc oscillator is enabled */
-    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
-        /* Setup the 32K RTC OSC */
-        RTC_Init(RTC, &rtc_basic_config);
-
-        /* Enable the RTC 32KHz oscillator */
-        RTC->CR |= RTC_CR_OSCE_MASK;
-
-        /* Start the RTC time counter */
-        RTC_StartTimer(RTC);
-
-        /* Verify TPR register reaches 4096 counts */
-        while (u32cTPR_counter < 4096) {
-            u32cTPR_counter = RTC->TPR;
-        }
-        /* 32kHz Oscillator is ready. */
-        RTC_Deinit(RTC);
-    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -57,6 +32,13 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Provide ethernet devices with a semi-unique MAC address from the UUID
@@ -73,7 +55,7 @@ void mbed_mac_address(char *mac)
 
     // generate three CRC16's using different slices of the UUID
     MAC[0] = crcSlow((const uint8_t *)UID, 8);  // most significant half-word
-    MAC[1] = crcSlow((const uint8_t *)UID, 12);
+    MAC[1] = crcSlow((const uint8_t *)UID, 12); 
     MAC[2] = crcSlow((const uint8_t *)UID, 16); // least significant half word
 
     // The network stack expects an array of 6 bytes
@@ -93,4 +75,6 @@ void mbed_mac_address(char *mac)
     mac[0] &= 0xFE; // force bit 0 to a "0" = Unicast
 
 }
+
+
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -33,6 +33,8 @@ const ticker_info_t* lp_ticker_get_info()
 
 static bool lp_ticker_inited = false;
 
+extern void rtc_setup_oscillator(RTC_Type *base);
+
 static void lptmr_isr(void)
 {
     LPTMR_ClearStatusFlags(LPTMR0, kLPTMR_TimerCompareFlag);
@@ -50,6 +52,9 @@ void lp_ticker_init(void)
         /* Setup high resolution clock - LPTMR */
         LPTMR_GetDefaultConfig(&lptmrConfig);
 
+        /* Setup the RTC 32KHz oscillator */
+        CLOCK_EnableClock(kCLOCK_Rtc0);
+        rtc_setup_oscillator(RTC);
         /* Use 32kHz drive */
         CLOCK_SetXtal32Freq(OSC32K_CLK_HZ);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
@@ -21,6 +21,8 @@
 #include "fsl_rtc.h"
 #include "PeripheralPins.h"
 
+extern void rtc_setup_oscillator(RTC_Type *base);
+
 static bool rtc_time_set = false;
 
 void rtc_init(void)
@@ -30,6 +32,8 @@ void rtc_init(void)
     RTC_GetDefaultConfig(&rtcConfig);
     RTC_Init(RTC, &rtcConfig);
 
+    /* Setup the RTC 32KHz oscillator */
+    rtc_setup_oscillator(RTC);
     RTC_StartTimer(RTC);
 }
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This reverts commit 3d859ca1d64e6f56b7af83a963df5f9f8782db40, reversing changes made to 03f4623b801f869057abe9753f98f8d9be919898.

One set of CI issues that have been blocking PRs this week have revolved around lp_ticker activity with the K64F, K22F, and K82F devices in our Test CI.

We don't yet know how to exactly put the devices in a bad state, but we did transplant a device that _was_ in a bad state into a local debugging env and found that the lp_ticker was in a bad state. Since the particular timer used in the Kinetis devices is only reset on POR and currently our CI does not have the ability to power cycle devices, once the devices were put into a bad state, they would fail lp_ticker tests until the devices were power cycled. Special thanks to @deepikabhavnani for looking at the transplanted device.

Part of what makes reproduction of the issue difficult is that our CI has a load-balancing feature where the Test CI can run tests on different devices of the same board. This allows us to 1) run tests in parallel, and 2) swap out boards if one is disabled, but the downside is that from a device's point of view, the tests aren't run in sequence; the order that tests are run are undeterministic. @studavekar is looking into disabling this in the short term to see if this helps aleviate issues.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

