### PR TITLE
TARGET_MCUXpresso_MCUS: fix lp ticker init function

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -63,8 +63,7 @@ void lp_ticker_init(void)
 
         lp_ticker_inited = true;
     } else {
-        LPTMR_DisableInterrupts(LPTMR0, kLPTMR_TimerInterruptEnable);
-        NVIC_EnableIRQ(LPTMR0_IRQn);
+        lp_ticker_disable_interrupt();
     }
 }
 


### PR DESCRIPTION
### Description

When lp ticker is already initialised, then ticker init function should only disable ticker interrupt. In current implementation `NVIC_EnableIRQ(LPTMR0_IRQn);` is called incorrectly in this case.
To fix this issue we will call `lp_ticker_disable_interrupt();` when lp ticker is initialised.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

