### PR TITLE
[Seeed Arch MAX] Add Mbed OS 5 support

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3273,14 +3273,17 @@
         "macros_add": ["USB_STM_HAL"],
         "config": {
             "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI | USE_PLL_MSI",
                 "value": "USE_PLL_HSE_XTAL",
                 "macro_name": "CLOCK_SOURCE"
             }
         },
         "release_versions": ["2", "5"],
         "overrides": {"lse_available": 0},
-        "device_name": "STM32F407VG"
+        "device_name": "STM32F407VG",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "WIO_3G": {
         "inherits": ["FAMILY_STM32"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3259,16 +3259,27 @@
         "inherits": ["FAMILY_STM32"],
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "program_cycle_s": 2,
         "extra_labels_add": [
             "STM32F4",
             "STM32F407",
             "STM32F407xG",
-            "STM32F407VG"
+            "STM32F407VG",
+            "STM_EMAC"
         ],
-        "device_has_add": ["ANALOGOUT", "TRNG", "FLASH", "MPU"],
-        "release_versions": ["2"],
+        "device_has_add": ["ANALOGOUT", "TRNG", "FLASH", "EMAC", "MPU"],
+        "device_has_remove": ["LPTICKER"],
+        "macros_add": ["USB_STM_HAL"],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_HSE_XTAL",
+                "macro_name": "CLOCK_SOURCE"
+            }
+        },
+        "release_versions": ["2", "5"],
+        "overrides": {"lse_available": 0},
         "device_name": "STM32F407VG"
     },
     "WIO_3G": {


### PR DESCRIPTION
### Description

Add Mbed OS 5 support for Seeed Arch MAX target.

### Test result

[ARM](https://github.com/ARMmbed/mbed-os/files/2604774/arch_max-arm.txt)
[GCC_ARM](https://github.com/ARMmbed/mbed-os/files/2604776/arch_max-gcc_arm.txt)
[IAR](https://github.com/ARMmbed/mbed-os/files/2604777/arch_max-iar.txt)

RTC related test cases failed.  I believe this is same issue here: https://github.com/ARMmbed/mbed-os/issues/8196

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

cc @MarceloSalazar @ytsuboi 