### PR TITLE
Update mbed-coap to version 4.7.2

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [v4.7.2](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.2) 
+
+- Fix handling of duplicate blockwise ACK's
+    CoAP data buffer was not added into duplication info store when creating response for blockwise request.
+    This leads to case where whole bootstrap flow just timeouts if received any duplicate messages during blockwise operation.
+    Fixes error: IOTCLT-3188 - UDP connection fails for lost ACK sending
+
+- Remove error trace when building reset message without options
+    This makes it possible to build the reset message without allocating option or getting error message.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.7.1...v4.7.2)
+
 ## [v4.7.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.1) 
 
 - Fix CoAP stored blockwise message release and list continue

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/source/sn_coap_builder.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_builder.c
@@ -547,7 +547,10 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
     /* * * * Check if Options are used at all  * * * */
     if (src_coap_msg_ptr->uri_path_ptr == NULL && src_coap_msg_ptr->token_ptr == NULL &&
             src_coap_msg_ptr->content_format == COAP_CT_NONE && src_coap_msg_ptr->options_list_ptr == NULL) {
-        tr_error("sn_coap_builder_options_build - options not used!");
+        /* If the empty message is confirmable it is CoAP ping. */
+        if (src_coap_msg_ptr->msg_type != COAP_MSG_TYPE_CONFIRMABLE) {
+            tr_error("sn_coap_builder_options_build - options not used!");
+        }
         return 0;
     }
 


### PR DESCRIPTION
### Description

 - Fix handling of duplicate blockwise ACK's
    CoAP data buffer was not added into duplication info store when creating response for blockwise request.
    This leads to case where whole bootstrap flow just timeouts if received any duplicate messages during blockwise operation.
    Fixes error: IOTCLT-3188 - UDP connection fails for lost ACK sending

 - Remove error trace when building reset message without options
    This makes it possible to build the reset message without allocating option or getting error message.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

