### PR TITLE
Fix build of library archive with Arm Compiler 6

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -454,7 +454,7 @@ class ARMC6(ARM_STD):
                      self.flags['common'] + self.flags['cxx'])
         self.asm = [join(TOOLCHAIN_PATHS["ARMC6"], "armasm")] + self.flags['asm']
         self.ld = [join(TOOLCHAIN_PATHS["ARMC6"], "armlink")] + self.flags['ld']
-        self.ar = [join(TOOLCHAIN_PATHS["ARMC6"], "armar")]
+        self.ar = join(TOOLCHAIN_PATHS["ARMC6"], "armar")
         self.elf2bin = join(TOOLCHAIN_PATHS["ARMC6"], "fromelf")
 
     def _get_toolchain_labels(self):


### PR DESCRIPTION
### Description

The 'archive' method of the toolchain class 'ARM' expects that self.ar
is a string, but the constructor of the class 'ARMC6' initializes it
with a list. This patch fixes the issue.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

