### PR TITLE
Bugfix restrict send size; namespace fixes; ATCmdParser::read return value fix

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -27,8 +27,6 @@
 
 #define TRACE_GROUP  "ESPA" // ESP8266 AT layer
 
-using namespace mbed;
-
 #define ESP8266_DEFAULT_BAUD_RATE   115200
 #define ESP8266_ALL_SOCKET_IDS      -1
 

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -955,7 +955,7 @@ void ESP8266::_oob_tcp_data_hdlr()
         return;
     }
 
-    if (!_parser.read(_sock_i[_sock_active_id].tcp_data, len)) {
+    if (_parser.read(_sock_i[_sock_active_id].tcp_data, len) == -1) {
         return;
     }
 

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -550,6 +550,9 @@ bool ESP8266::dns_lookup(const char *name, char *ip)
 
 nsapi_error_t ESP8266::send(int id, const void *data, uint32_t amount)
 {
+    // +CIPSEND supports up to 2048 bytes at a time
+    amount = amount > 2048 ? 2048 : amount;
+
     //May take a second try if device is busy
     for (unsigned i = 0; i < 2; i++) {
         _smutex.lock();

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -241,7 +241,7 @@ const char *ESP8266Interface::get_ip_address()
     }
 
     const char *ip_buff = _esp.ip_addr();
-    if (!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
+    if (!ip_buff || strcmp(ip_buff, "0.0.0.0") == 0) {
         return NULL;
     }
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

* Drops std:: because string.h is included
* Truncates data to be send to modem to 2048 bytes - AT command set restriction
* Dropping duplicate "using namespace mbed;" - one already on the line 33
* Fixes return value check when calling ATCmdParser::read() 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

