### PR TITLE
Fix C++11 build with Arm Compiler 6

### DIFF
--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
@@ -301,7 +301,11 @@ typedef enum {
     S2LP_STATE_SYNTH_SETUP  = 0x50
 } s2lp_states_e;
 
+#if defined __cplusplus && __cplusplus >= 201103
+typedef enum : uint8_t {
+#else
 typedef enum {
+#endif
     S2LP_CMD_TX = 0x60,
     S2LP_CMD_RX,
     S2LP_CMD_READY,

--- a/features/frameworks/nanostack-libservice/mbed-client-libservice/ns_types.h
+++ b/features/frameworks/nanostack-libservice/mbed-client-libservice/ns_types.h
@@ -121,7 +121,15 @@ typedef int_fast32_t int_fast24_t;
 #define alignas(n) __align(n)
 #define __alignas_is_defined 1
 #elif (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L) || (defined __cplusplus && __cplusplus >= 201103L)
-#include <stdalign.h>
+# if defined __ARMCC_VERSION && __ARMCC_VERSION < 6120000
+    /* Workaround for Arm Compiler versions prior to 6.12 */
+#   if !defined __cplusplus
+#     define alignas _Alignas
+#   endif
+#   define __alignas_is_defined 1
+# else
+#   include <stdalign.h>
+# endif
 #elif defined __GNUC__
 #define alignas(n) __attribute__((__aligned__(n)))
 #define __alignas_is_defined 1


### PR DESCRIPTION
### Description

Currently there are two issues which prevent building Mbed OS with
-std=gnu++11 when using Arm Compiler 6:
* NanostackRfPhys2lp.cpp contains a narrowing conversion in a braced
  initializer list
* ns_types.h includes <stdalign.h> which Arm Compiler 6 does not
  proivde

This patch fixes both issues. The first one is fixed by adding an
explicit cast. The second issue is worked around by avoiding the
<stdalign.h> header (alignas is a keyword in C++, so we don't actually
need to #include the header to use it).

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

