### PR TITLE
Update the Watchdog & Reset_reason host test scripts

### DIFF
--- a/TESTS/host_tests/reset_reason.py
+++ b/TESTS/host_tests/reset_reason.py
@@ -68,13 +68,14 @@ class ResetReasonTest(BaseHostTest):
         super(ResetReasonTest, self).__init__()
         self.device_has_watchdog = None
         self.raw_reset_reasons = set()
-        cycle_s = self.get_config_item('program_cycle_s')
-        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+        self.program_cycle_s = DEFAULT_CYCLE_PERIOD
         self.test_steps_sequence = self.test_steps()
         # Advance the coroutine to it's first yield statement.
         self.test_steps_sequence.send(None)
 
     def setup(self):
+        cycle_s = self.get_config_item('program_cycle_s')
+        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
         self.register_callback(MSG_KEY_DEVICE_READY, self.cb_device_ready)
         self.register_callback(MSG_KEY_RESET_REASON_RAW, self.cb_reset_reason_raw)
         self.register_callback(MSG_KEY_RESET_REASON, self.cb_reset_reason)

--- a/TESTS/host_tests/sync_on_reset.py
+++ b/TESTS/host_tests/sync_on_reset.py
@@ -17,7 +17,7 @@ limitations under the License.
 import time
 from mbed_host_tests import BaseHostTest
 
-DEFAULT_CYCLE_PERIOD = 4.0
+DEFAULT_SYNC_DELAY = 4.0
 
 MSG_VALUE_DUMMY = '0'
 MSG_KEY_DEVICE_READY = 'ready'
@@ -47,11 +47,11 @@ class SyncOnReset(BaseHostTest):
     def __init__(self):
         super(SyncOnReset, self).__init__()
         self.test_case_num = 0
-        self.program_cycle_s = DEFAULT_CYCLE_PERIOD
+        self.sync_delay = DEFAULT_SYNC_DELAY
 
     def setup(self):
-        cycle_s = self.get_config_item('program_cycle_s')
-        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+        sync_delay = self.get_config_item('forced_reset_timeout')
+        self.sync_delay = sync_delay if sync_delay is not None else DEFAULT_SYNC_DELAY
         self.register_callback(MSG_KEY_DEVICE_READY, self.cb_device_ready)
         self.register_callback(MSG_KEY_DEVICE_RESET, self.cb_device_reset)
 
@@ -69,5 +69,5 @@ class SyncOnReset(BaseHostTest):
         except ValueError:
             pass
         self.test_case_num += 1
-        time.sleep(self.program_cycle_s)
+        time.sleep(self.sync_delay)
         self.send_kv(MSG_KEY_SYNC, MSG_VALUE_DUMMY)

--- a/TESTS/host_tests/sync_on_reset.py
+++ b/TESTS/host_tests/sync_on_reset.py
@@ -47,10 +47,11 @@ class SyncOnReset(BaseHostTest):
     def __init__(self):
         super(SyncOnReset, self).__init__()
         self.test_case_num = 0
-        cycle_s = self.get_config_item('program_cycle_s')
-        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+        self.program_cycle_s = DEFAULT_CYCLE_PERIOD
 
     def setup(self):
+        cycle_s = self.get_config_item('program_cycle_s')
+        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
         self.register_callback(MSG_KEY_DEVICE_READY, self.cb_device_ready)
         self.register_callback(MSG_KEY_DEVICE_RESET, self.cb_device_reset)
 

--- a/TESTS/host_tests/watchdog_reset.py
+++ b/TESTS/host_tests/watchdog_reset.py
@@ -49,8 +49,7 @@ class WatchdogReset(BaseHostTest):
         super(WatchdogReset, self).__init__()
         self.current_case = TestCaseData(0, CASE_DATA_INVALID)
         self.__handshake_timer = None
-        cycle_s = self.get_config_item('program_cycle_s')
-        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+        self.program_cycle_s = DEFAULT_CYCLE_PERIOD
         self.drop_heartbeat_messages = True
         self.hb_timestamps_us = []
 
@@ -94,6 +93,8 @@ class WatchdogReset(BaseHostTest):
         self.current_case = TestCaseData(self.current_case.index, dev_data)
 
     def setup(self):
+        cycle_s = self.get_config_item('program_cycle_s')
+        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
         self.register_callback(MSG_KEY_DEVICE_READY, self.cb_device_ready)
         self.register_callback(MSG_KEY_DEVICE_RESET, self.cb_device_reset)
         self.register_callback(MSG_KEY_HEARTBEAT, self.cb_heartbeat)


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Update the host test scripts used by Watchdog and Reset_reason HAL tests to use `forced_reset_timeout` config parameter instead of `program_cycle_s`. This is based on PR #8309, which explains such change refering to https://github.com/ARMmbed/htrun/blob/1c570ec77d8c5673dae55dc790302d86d712c36b/mbed_host_tests/__init__.py#L132-L144

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

