### PR TITLE
Cellular: Fix bc95 to accept only RAT_NB1

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularNetwork.cpp
@@ -36,8 +36,8 @@ AT_CellularNetwork::RegistrationMode QUECTEL_BC95_CellularNetwork::has_registrat
 nsapi_error_t QUECTEL_BC95_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)
 {
     if (opRat != RAT_NB1) {
-        //TODO: Set as unknown or force to NB1?
-        _op_act = RAT_UNKNOWN;
+        // only rat that is supported by this modem
+        _op_act = RAT_NB1;
         return NSAPI_ERROR_UNSUPPORTED;
     }
 


### PR DESCRIPTION
Fixed TODO comment by correct implementation:

RAT_NB1 is the only rat that bc95 supports so this fix prevents changing it some other.

@AriParkkila  please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

