### PR TITLE
Change error code from NSAPI_ERROR_PARAMETER to NSAPI_ERROR_NO_CONNEC…

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -583,7 +583,7 @@ nsapi_error_t LWIP::Interface::bringdown()
 {
     // Check if we've connected
     if (connected == NSAPI_STATUS_DISCONNECTED) {
-        return NSAPI_ERROR_PARAMETER;
+        return NSAPI_ERROR_NO_CONNECTION;
     }
 
 #if LWIP_DHCP


### PR DESCRIPTION
Change error code from NSAPI_ERROR_PARAMETER to NSAPI_ERROR_NO_CONNECTION in a case were there wasn't connection.

### Description

Tested by running wifi connection tests

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

