### PR TITLE
Reports NSAPI_STATUS_CONNECTING when trying to reconnect

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -47,6 +47,7 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
       _packets_end(&_packets),
       _heap_usage(0),
       _connect_error(0),
+      _disconnect(false),
       _fail(false),
       _sock_already(false),
       _closed(false),
@@ -308,6 +309,7 @@ nsapi_error_t ESP8266::connect(const char *ap, const char *passPhrase)
 bool ESP8266::disconnect(void)
 {
     _smutex.lock();
+    _disconnect = true;
     bool done = _parser.send("AT+CWQAP") && _parser.recv("OK\n");
     _smutex.unlock();
 
@@ -1035,7 +1037,12 @@ void ESP8266::_oob_connection_status()
         if (strcmp(status, "GOT IP\n") == 0) {
             _conn_status = NSAPI_STATUS_GLOBAL_UP;
         } else if (strcmp(status, "DISCONNECT\n") == 0) {
-            _conn_status = NSAPI_STATUS_DISCONNECTED;
+            if (_disconnect) {
+                _conn_status = NSAPI_STATUS_DISCONNECTED;
+                _disconnect = false;
+            } else {
+                _conn_status = NSAPI_STATUS_CONNECTING;
+            }
         } else if (strcmp(status, "CONNECTED\n") == 0) {
             _conn_status = NSAPI_STATUS_CONNECTING;
         } else {

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -428,6 +428,7 @@ private:
 
     // OOB state variables
     int _connect_error;
+    bool _disconnect;
     bool _fail;
     bool _sock_already;
     bool _closed;


### PR DESCRIPTION
### Description
ESP8266 does try to reconnect on its own. The app should now get that information and doesn't need to start the connect procedure from scratch. Hence the driver must return NSAPI_STATUS_CONNECTING if the application hasn't called disconnect.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

