### PR TITLE
SMCC FOTA: bin name change

### DIFF
--- a/tools/targets/REALTEK_RTL8195AM.py
+++ b/tools/targets/REALTEK_RTL8195AM.py
@@ -176,7 +176,7 @@ def rtl8195a_elf2bin(t_self, image_elf, image_bin):
     image_map = ".".join(image_name + ['map'])
 
     ram1_bin = os.path.join(TOOLS_BOOTLOADERS, "REALTEK_RTL8195AM", "ram_1.bin")
-    ram2_bin = ".".join(image_name) + '-payload.bin'
+    ram2_bin = ".".join(image_name) + '_update.bin'
 
     entry = find_symbol(t_self.name, image_map, "PLAT_Start")
     segment = parse_load_segment(t_self.name, image_elf)


### PR DESCRIPTION

This PR modifies the name of the bin file generated for SMCC FOTA feature.

### Description

<!-- 
-->
  Modify name of the bin file from '-payload.bin' to '_update.bin' in REALTEK_RTL8195AM.py file to adapt the manifest tool requirment for the SMCC FOTA feature.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

