### PR TITLE
Add the port for the ACONNO ACN52832 module on MTB's form factor

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/PinNames.h
@@ -1,0 +1,158 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  3
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+    p31 = 31,
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_26 = p26,
+    P0_27 = p27,
+    P0_28 = p28,
+    P0_29 = p29,
+    P0_30 = p30,
+    P0_31 = p31,
+
+    LED1    = p25,
+    LED2    = p26,
+    LED3    = p27,
+
+    AIN0 = p2,
+    AIN1 = p3,
+    AIN2 = p4,
+
+    GP0 = p19,
+    GP1 = p20,
+    GP2 = p28,
+    GP3 = p29,
+    GP4 = p30,
+    GP5 = p31,
+    GP6 = p5,
+    GP7 = p6,
+    GP8 = p7,
+
+    RX_PIN_NUMBER  = p12,
+    TX_PIN_NUMBER  = p11,
+    CTS_PIN_NUMBER = p9,
+    RTS_PIN_NUMBER = p8,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+    STDIO_UART_TX = TX_PIN_NUMBER,
+    STDIO_UART_RX = RX_PIN_NUMBER,
+    STDIO_UART_CTS = CTS_PIN_NUMBER,
+    STDIO_UART_RTS = RTS_PIN_NUMBER,
+
+    SPI_MOSI = p16,
+    SPI_MISO = p17,
+    SPI_SCK  = p18,
+
+    USER_BUTTON = GP0,
+
+    I2C_SDA = p14,
+    I2C_SCL = p15,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/PinNames.h
@@ -104,9 +104,9 @@ typedef enum {
     GP2 = p28,
     GP3 = p29,
     GP4 = p30,
-    GP5 = p31,
-    GP6 = p5,
-    GP7 = p6,
+    GP5 = p31, // LCD-A0
+    GP6 = p5,  // LCD-RESET
+    GP7 = p6,  // LCD-CS
     GP8 = p7,
 
     RX_PIN_NUMBER  = p12,
@@ -125,6 +125,7 @@ typedef enum {
     SPI_MOSI = p16,
     SPI_MISO = p17,
     SPI_SCK  = p18,
+    SPI_CS   = p10,
 
     USER_BUTTON = GP0,
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/PinNames.h
@@ -1,18 +1,9 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2006-2018 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/********************************************************************************
+ * \copyright
+ * \copyright
+ * Copyright 2018-2018, ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
 
 #ifndef MBED_PINNAMES_H
 #define MBED_PINNAMES_H

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/device.h
@@ -1,0 +1,38 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include "objects.h"
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/TARGET_MTB_ACONNO_ACN52832/device.h
@@ -1,37 +1,12 @@
-// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
-// Check the 'features' section of the target description in 'targets.json' for more details.
-/* mbed Microcontroller Library
- * Copyright (c) 2006-2018 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/********************************************************************************
+ * \copyright
+ * \copyright
+ * Copyright 2018-2018, ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #include "objects.h"
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6571,6 +6571,11 @@
             "WSF_MAX_HANDLERS=10"
         ]
     },
+    "MTB_ACONNO_ACN52832": {
+        "inherits": ["MCU_NRF52832"],
+        "release_versions": ["5"],
+        "device_name": "nRF52832_xxAA"
+    },
     "SDT52832B": {
         "inherits": ["MCU_NRF52832"],
         "release_versions": ["5"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6571,11 +6571,6 @@
             "WSF_MAX_HANDLERS=10"
         ]
     },
-    "MTB_ACONNO_ACN52832": {
-        "inherits": ["MCU_NRF52832"],
-        "release_versions": ["5"],
-        "device_name": "nRF52832_xxAA"
-    },
     "SDT52832B": {
         "inherits": ["MCU_NRF52832"],
         "release_versions": ["5"],
@@ -6608,6 +6603,11 @@
         "release_versions": ["5"],
         "device_name": "nRF52832_xxAA",
         "detect_code": ["0466"]
+    },
+    "MTB_ACONNO_ACN52832": {
+        "inherits": ["MCU_NRF52832"],
+        "release_versions": ["5"],
+        "device_name": "nRF52832_xxAA"
     },
     "DELTA_DFBM_NQ620": {
         "supported_form_factors": ["ARDUINO"],


### PR DESCRIPTION
### Description

This PR add support for the ACONNO ACN52832 module's MTB.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change


### Attachments
[aconno_acn52832_iar.txt](https://github.com/ARMmbed/mbed-os/files/2611918/aconno_acn52832_iar.txt)
[aconno_acn52832_arm.txt](https://github.com/ARMmbed/mbed-os/files/2611919/aconno_acn52832_arm.txt)
[aconno_acn52832_gcc_arm.txt](https://github.com/ARMmbed/mbed-os/files/2611920/aconno_acn52832_gcc_arm.txt)

### CC
@cmonr @0xc0170 @ashok-rao 