### PR TITLE
Bugfix-tests-network-wifi drop the assumption about more than one SSID

### DIFF
--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -62,31 +62,23 @@ Case cases[] = {
     Case("WIFI-CONNECT-NOCREDENTIALS", wifi_connect_nocredentials),
     Case("WIFI-SET-CREDENTIAL", wifi_set_credential),
     Case("WIFI-SET-CHANNEL", wifi_set_channel),
+    Case("WIFI-CONNECT-PARAMS-NULL", wifi_connect_params_null),
+    Case("WIFI-SCAN-NULL", wifi_scan_null),
+#if defined(MBED_CONF_APP_WIFI_SECURE_SSID) || defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
+    Case("WIFI-SCAN", wifi_scan),
+#endif
 #if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
     Case("WIFI-GET-RSSI", wifi_get_rssi),
-#endif
-    Case("WIFI-CONNECT-PARAMS-NULL", wifi_connect_params_null),
-#if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
     Case("WIFI-CONNECT-PARAMS-VALID-UNSECURE", wifi_connect_params_valid_unsecure),
+    Case("WIFI-CONNECT", wifi_connect),
+    Case("WIFI-CONNECT-DISCONNECT-REPEAT", wifi_connect_disconnect_repeat),
 #endif
 #if defined(MBED_CONF_APP_WIFI_SECURE_SSID)
     Case("WIFI-CONNECT-PARAMS-VALID-SECURE", wifi_connect_params_valid_secure),
     Case("WIFI-CONNECT-PARAMS-CHANNEL", wifi_connect_params_channel),
     Case("WIFI-CONNECT-PARAMS-CHANNEL-FAIL", wifi_connect_params_channel_fail),
-#endif
-#if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
-    Case("WIFI-CONNECT", wifi_connect),
-#endif
-#if defined(MBED_CONF_APP_WIFI_SECURE_SSID)
     Case("WIFI-CONNECT-SECURE", wifi_connect_secure),
     Case("WIFI-CONNECT-SECURE-FAIL", wifi_connect_secure_fail),
-#endif
-#if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
-    Case("WIFI-CONNECT-DISCONNECT-REPEAT", wifi_connect_disconnect_repeat),
-#endif
-    Case("WIFI-SCAN-NULL", wifi_scan_null),
-#if defined(MBED_CONF_APP_WIFI_SECURE_SSID) || defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
-    Case("WIFI-SCAN", wifi_scan),
 #endif
 };
 

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -85,7 +85,7 @@ Case cases[] = {
     Case("WIFI-CONNECT-DISCONNECT-REPEAT", wifi_connect_disconnect_repeat),
 #endif
     Case("WIFI-SCAN-NULL", wifi_scan_null),
-#if defined(MBED_CONF_APP_WIFI_SECURE_SSID) && defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
+#if defined(MBED_CONF_APP_WIFI_SECURE_SSID) || defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
     Case("WIFI-SCAN", wifi_scan),
 #endif
 };

--- a/TESTS/network/wifi/wifi_scan.cpp
+++ b/TESTS/network/wifi/wifi_scan.cpp
@@ -24,8 +24,6 @@
 
 using namespace utest::v1;
 
-#if defined(MBED_CONF_APP_WIFI_SECURE_SSID) && defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
-
 void wifi_scan(void)
 {
     WiFiInterface *wifi = get_interface();
@@ -33,7 +31,7 @@ void wifi_scan(void)
     WiFiAccessPoint ap[MBED_CONF_APP_MAX_SCAN_SIZE];
 
     int size = wifi->scan(ap, MBED_CONF_APP_MAX_SCAN_SIZE);
-    TEST_ASSERT(size >= 2);
+    TEST_ASSERT(size >= 1);
 
     bool secure_found = false;
     bool unsecure_found = false;
@@ -49,17 +47,19 @@ void wifi_scan(void)
         nsapi_security_t security = ap[i].get_security();
         int8_t rssi = ap[i].get_rssi();
         TEST_ASSERT_INT8_WITHIN(-10, -100, rssi);
+#if defined(MBED_CONF_APP_WIFI_SECURE_SSID)
         if (strcmp(MBED_CONF_APP_WIFI_SECURE_SSID, ssid) == 0) {
             secure_found = true;
             TEST_ASSERT_EQUAL_INT(get_security(), security);
         }
+#endif
+#if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
         if (strcmp(MBED_CONF_APP_WIFI_UNSECURE_SSID, ssid) == 0) {
             unsecure_found = true;
             TEST_ASSERT_EQUAL_INT(NSAPI_SECURITY_NONE, security);
         }
+#endif
     }
     // Finding one SSID is enough
     TEST_ASSERT_TRUE(secure_found || unsecure_found);
 }
-
-#endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID) && defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)

--- a/TESTS/network/wifi/wifi_scan_null.cpp
+++ b/TESTS/network/wifi/wifi_scan_null.cpp
@@ -26,6 +26,6 @@ using namespace utest::v1;
 void wifi_scan_null(void)
 {
     WiFiInterface *wifi = get_interface();
-    TEST_ASSERT(wifi->scan(NULL, 0) >= 2);
+    TEST_ASSERT(wifi->scan(NULL, 0) >= 1);
 }
 


### PR DESCRIPTION
### Description
When running test cases tests-network-wifi we shouldn't assume there is more than one SSID in our vicinity. E.g., in a case that a device under test is in a RF shield box.


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

