### PR TITLE
STM32L4: fix trng clock setting

### DIFF
--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -37,15 +37,6 @@ void trng_init(trng_t *obj)
         error("Only 1 RNG instance supported\r\n");
     }
 
-#if defined(TARGET_STM32L4)
-    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
-
-    /*Select PLLQ output as RNG clock source */
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RNG;
-    PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_PLL;
-    HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
-#endif
-
     /* RNG Peripheral clock enable */
     __HAL_RCC_RNG_CLK_ENABLE();
 


### PR DESCRIPTION
### Description

Remove the TRNG clock setting for STM32L4 devices in the trng_api.c file to solve the conflict with USB clock setting.

Fix #8864

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

