### PR TITLE
Disable SecureStore if custom MBEDTLS config disables required features

### DIFF
--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -27,8 +27,8 @@
 
 #define SECURESTORE_ENABLED 1
 
-// Whole class is not supported if entropy or device key are not enabled
-#if !defined(MBEDTLS_ENTROPY_C) || !DEVICEKEY_ENABLED
+// Whole class is not supported if entropy, device key or required mbed TLS features are not enabled
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CIPHER_MODE_CTR) || !defined(MBEDTLS_CMAC_C) || !DEVICEKEY_ENABLED
 #undef SECURESTORE_ENABLED
 #define SECURESTORE_ENABLED 0
 #endif


### PR DESCRIPTION
### Description
SecureStore class depends on the MBED TLS AES CTR encryption and CMAC calculation features. These features are enabled by default by SecureStore itself. This PR disables SecureStore if the user overrides the MBED TLS configuration and excludes these features (otherwise we'll get a compilation error).

Resolves [#8865](https://github.com/ARMmbed/mbed-os/issues/8865)

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

