### PR TITLE
Add dependency configs to component build

### DIFF
--- a/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
+++ b/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
@@ -20,7 +20,7 @@
 #include "at24mac.h"
 #include "PinNames.h"
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "NanostackRfPhy.h"
 

--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -15,7 +15,7 @@
  */
 #include <string.h>
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "platform/arm_hal_interrupt.h"
 #include "nanostack/platform/arm_hal_phy.h"

--- a/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
@@ -17,10 +17,8 @@
 #ifndef NANOSTACK_PHY_MCR20A_H_
 #define NANOSTACK_PHY_MCR20A_H_
 
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && defined(MBED_CONF_RTOS_PRESENT)
 #include "mbed.h"
-
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
-
 #include "NanostackRfPhy.h"
 
 // Arduino pin defaults for convenience

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
@@ -15,7 +15,7 @@
  */
 #include "NanostackRfPhyMcr20a.h"
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "ns_types.h"
 #include "platform/arm_hal_interrupt.h"

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <string.h>
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && defined(MBED_CONF_RTOS_PRESENT)
 #include "platform/arm_hal_interrupt.h"
 #include "nanostack/platform/arm_hal_phy.h"
 #include "ns_types.h"

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.c
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.c
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "ns_types.h"
-#include "rf_configuration.h"
-#include "mbed_trace.h"
 
-#define TRACE_GROUP "rfcf"
+#include "rf_configuration.h"
 
 // Note that F_XO and F_DIG depends on the used clock frequency
 #define F_XO    50000000

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.h
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.h
@@ -16,6 +16,9 @@
 
 #ifndef RF_CONF_H_
 #define RF_CONF_H_
+
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/stm-s2lp-rf-driver/NanostackRfPhys2lp.h
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/stm-s2lp-rf-driver/NanostackRfPhys2lp.h
@@ -17,8 +17,8 @@
 #ifndef NANOSTACK_PHY_S2LP_H_
 #define NANOSTACK_PHY_S2LP_H_
 
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI  && defined(MBED_CONF_RTOS_PRESENT)
 #include "mbed.h"
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
 #include "NanostackRfPhy.h"
 
 // Uncomment to use testing gpios attached to TX/RX processes

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#ifdef MBED_CONF_NSAPI_PRESENT
+#if defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#ifdef MBED_CONF_NSAPI_PRESENT
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -1082,3 +1083,4 @@ nsapi_connection_status_t ESP8266::connection_status() const
 {
     return _conn_status;
 }
+#endif

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -17,7 +17,7 @@
 #ifndef ESP8266_H
 #define ESP8266_H
 
-#ifdef MBED_CONF_NSAPI_PRESENT
+#if defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
 #include <stdint.h>
 
 #include "drivers/UARTSerial.h"

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -17,6 +17,7 @@
 #ifndef ESP8266_H
 #define ESP8266_H
 
+#ifdef MBED_CONF_NSAPI_PRESENT
 #include <stdint.h>
 
 #include "drivers/UARTSerial.h"
@@ -454,5 +455,5 @@ private:
     nsapi_connection_status_t _conn_status;
     mbed::Callback<void()> _conn_stat_cb; // ESP8266Interface registered
 };
-
+#endif
 #endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#ifdef MBED_CONF_NSAPI_PRESENT
+#if defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
 
 #include <string.h>
 #include <stdint.h>

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#ifdef MBED_CONF_NSAPI_PRESENT
+
 #include <string.h>
 #include <stdint.h>
 
@@ -673,3 +675,4 @@ void ESP8266Interface::proc_oob_evnt()
         _esp.bg_process_oob(ESP8266_RECV_TIMEOUT, true);
     }
 }
+#endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -17,7 +17,7 @@
 #ifndef ESP8266_INTERFACE_H
 #define ESP8266_INTERFACE_H
 
-#ifdef MBED_CONF_NSAPI_PRESENT
+#if defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
 #include "ESP8266/ESP8266.h"
 #include "events/EventQueue.h"
 #include "events/mbed_shared_queues.h"

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -17,6 +17,7 @@
 #ifndef ESP8266_INTERFACE_H
 #define ESP8266_INTERFACE_H
 
+#ifdef MBED_CONF_NSAPI_PRESENT
 #include "ESP8266/ESP8266.h"
 #include "events/EventQueue.h"
 #include "events/mbed_shared_queues.h"
@@ -359,5 +360,5 @@ private:
     void proc_oob_evnt();
     void _oob2global_event_queue();
 };
-
+#endif
 #endif


### PR DESCRIPTION
### Description

Build dependency for components was not captured i.e. in case Network feature / RTOS is disabled (added to .mbedignore list), the build breaks. Resolving build issues in this PR.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

