### PR TITLE
Update mbed-coap to version 4.7.3

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v4.7.3](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.3) 
+
+- Do not store EMPTY response to blockwise list
+    An Empty message only contains the 4-byte header so it does not require any blockwise operations.
+    This will fix unneseccary message sending timeouts which leads mbed cloud client to do unnecessary
+    reconnections which increases the network traffic.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.7.2...v4.7.3)
+
 ## [v4.7.2](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.2) 
 
 - Fix handling of duplicate blockwise ACK's

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -564,7 +564,8 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         stored_blockwise_msg_ptr->param = param;
         stored_blockwise_msg_ptr->msg_id = stored_blockwise_msg_ptr->coap_msg_ptr->msg_id;
         ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_ptr);
-    } else if (src_coap_msg_ptr->msg_code <= COAP_MSG_CODE_REQUEST_DELETE) {
+    } else if (src_coap_msg_ptr->msg_code <= COAP_MSG_CODE_REQUEST_DELETE &&
+               src_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY) {
         /* Add message to linked list - response can be in blocks and we need header to build response.. */
         coap_blockwise_msg_s *stored_blockwise_msg_ptr;
 


### PR DESCRIPTION
### Description
EMPTY response should not be stored to blockwise list.
An Empty message only contains the 4-byte header so it does not require any blockwise operations.
This will fix unneseccary message sending timeouts which leads mbed cloud client to do unnecessary
reconnections which increases the network traffic.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

