### PR TITLE
ESP8266 disconnect returns ERROR_NO_CONNECTION

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -222,6 +222,11 @@ int ESP8266Interface::set_channel(uint8_t channel)
 
 int ESP8266Interface::disconnect()
 {
+    if (_conn_stat == NSAPI_STATUS_DISCONNECTED)
+    {
+        return NSAPI_ERROR_NO_CONNECTION;
+    }
+
     int ret = _esp.disconnect() ? NSAPI_ERROR_OK : NSAPI_ERROR_DEVICE_ERROR;
 
     if (ret == NSAPI_ERROR_OK) {


### PR DESCRIPTION
### Description

Even though I did not find an explicit statement on this, the disconnect in other implementations returns NSAPI_ERROR_NO_CONNECTION error in case it is called when no connection was established previously. This breaks some of our icetea wifi tests if we run them on K64F+ESP8266.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

