### PR TITLE
Nuvoton: Refine UART init/deinit

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/objects.h
@@ -46,8 +46,6 @@ struct analogin_s {
 
 struct serial_s {
     UARTName uart;
-    PinName pin_tx;
-    PinName pin_rx;
     
     uint32_t baudrate;
     uint32_t databits;

--- a/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
@@ -221,8 +221,19 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
 
-        // Configure the UART module and set its baudrate
-        serial_baud(obj, 9600);
+        // Configure baudrate
+        int baudrate = 9600;
+        if (obj->serial.uart == STDIO_UART) {
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_STDIO_BAUD_RATE;
+#endif
+        } else {
+#if MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE;
+#endif            
+        }
+        serial_baud(obj, baudrate);
+
         // Configure data bits, parity, and stop bits
         serial_format(obj, 8, ParityNone, 1);
     }

--- a/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
@@ -200,35 +200,33 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
 
     if (! var->ref_cnt) {
-        do {
-            /* Reset module
-             *
-             * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
-             */
-            SYS_ResetModule_S(modinit->rsetidx);
+        /* Reset module
+         *
+         * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
+         */
+        SYS_ResetModule_S(modinit->rsetidx);
 
-            /* Select IP clock source
-             *
-             * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
-             */
-            CLK_SetModuleClock_S(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
-            
-            /* Enable IP clock
-             *
-             * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
-             */
-            CLK_EnableModuleClock_S(modinit->clkidx);
+        /* Select IP clock source
+         *
+         * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
+         */
+        CLK_SetModuleClock_S(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
 
-            pinmap_pinout(tx, PinMap_UART_TX);
-            pinmap_pinout(rx, PinMap_UART_RX);
-        } while (0);
+        /* Enable IP clock
+         *
+         * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
+         */
+        CLK_EnableModuleClock_S(modinit->clkidx);
+
+        pinmap_pinout(tx, PinMap_UART_TX);
+        pinmap_pinout(rx, PinMap_UART_RX);
+
+        // Configure the UART module and set its baudrate
+        serial_baud(obj, 9600);
+        // Configure data bits, parity, and stop bits
+        serial_format(obj, 8, ParityNone, 1);
     }
     var->ref_cnt ++;
-
-    // Configure the UART module and set its baudrate
-    serial_baud(obj, 9600);
-    // Configure data bits, parity, and stop bits
-    serial_format(obj, 8, ParityNone, 1);
 
     obj->serial.vec = var->vec;
     obj->serial.irq_en = 0;

--- a/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
@@ -222,9 +222,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
             pinmap_pinout(tx, PinMap_UART_TX);
             pinmap_pinout(rx, PinMap_UART_RX);
         } while (0);
-
-        obj->serial.pin_tx = tx;
-        obj->serial.pin_rx = rx;
     }
     var->ref_cnt ++;
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/serial_api.c
@@ -250,10 +250,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
 #endif
 
-    // For stdio management
-    if (obj->serial.uart == STDIO_UART) {
+    /* With support for checking H/W UART initialized or not, we allow serial_init(&stdio_uart)
+     * calls in even though H/W UART 'STDIO_UART' has initialized. When serial_init(&stdio_uart)
+     * calls in, we only need to set the 'stdio_uart_inited' flag. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 
     if (var->ref_cnt) {
@@ -302,7 +304,9 @@ void serial_free(serial_t *obj)
         var->obj = NULL;
     }
 
-    if (obj->serial.uart == STDIO_UART) {
+    /* Clear the 'stdio_uart_inited' flag when serial_free(&stdio_uart) calls in. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 0;
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/objects.h
@@ -50,8 +50,6 @@ struct analogin_s {
 
 struct serial_s {
     UARTName uart;
-    PinName pin_tx;
-    PinName pin_rx;
     
     uint32_t baudrate;
     uint32_t databits;

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -172,7 +172,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     if (! var->ref_cnt) {
         // Reset this module
         SYS_ResetModule(modinit->rsetidx);
-    
+
         // Select IP clock source
         CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
         // Enable IP clock
@@ -180,14 +180,14 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
+
+        // Configure the UART module and set its baudrate
+        serial_baud(obj, 9600);
+        // Configure data bits, parity, and stop bits
+        serial_format(obj, 8, ParityNone, 1);
     }
     var->ref_cnt ++;
-    
-    // Configure the UART module and set its baudrate
-    serial_baud(obj, 9600);
-    // Configure data bits, parity, and stop bits
-    serial_format(obj, 8, ParityNone, 1);
-    
+
     obj->serial.vec = var->vec;
     obj->serial.irq_en = 0;
     

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -181,8 +181,19 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
 
-        // Configure the UART module and set its baudrate
-        serial_baud(obj, 9600);
+        // Configure baudrate
+        int baudrate = 9600;
+        if (obj->serial.uart == STDIO_UART) {
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_STDIO_BAUD_RATE;
+#endif
+        } else {
+#if MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE;
+#endif            
+        }
+        serial_baud(obj, baudrate);
+
         // Configure data bits, parity, and stop bits
         serial_format(obj, 8, ParityNone, 1);
     }

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -180,9 +180,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
-    
-        obj->serial.pin_tx = tx;
-        obj->serial.pin_rx = rx;
     }
     var->ref_cnt ++;
     

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -210,12 +210,14 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
 #endif
 
-    // For stdio management
-    if (obj->serial.uart == STDIO_UART) {
+    /* With support for checking H/W UART initialized or not, we allow serial_init(&stdio_uart)
+     * calls in even though H/W UART 'STDIO_UART' has initialized. When serial_init(&stdio_uart)
+     * calls in, we only need to set the 'stdio_uart_inited' flag. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
-    
+
     if (var->ref_cnt) {
         // Mark this module to be inited.
         int i = modinit - uart_modinit_tab;
@@ -256,11 +258,13 @@ void serial_free(serial_t *obj)
     if (var->obj == obj) {
         var->obj = NULL;
     }
-    
-    if (obj->serial.uart == STDIO_UART) {
+
+    /* Clear the 'stdio_uart_inited' flag when serial_free(&stdio_uart) calls in. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 0;
     }
-    
+
     if (! var->ref_cnt) {
         // Mark this module to be deinited.
         int i = modinit - uart_modinit_tab;

--- a/targets/TARGET_NUVOTON/TARGET_M480/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/objects.h
@@ -50,8 +50,6 @@ struct analogin_s {
 
 struct serial_s {
     UARTName uart;
-    PinName pin_tx;
-    PinName pin_rx;
     
     uint32_t baudrate;
     uint32_t databits;

--- a/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
@@ -211,8 +211,19 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
 
-        // Configure the UART module and set its baudrate
-        serial_baud(obj, 9600);
+        // Configure baudrate
+        int baudrate = 9600;
+        if (obj->serial.uart == STDIO_UART) {
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_STDIO_BAUD_RATE;
+#endif
+        } else {
+#if MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE;
+#endif            
+        }
+        serial_baud(obj, baudrate);
+
         // Configure data bits, parity, and stop bits
         serial_format(obj, 8, ParityNone, 1);
     }

--- a/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
@@ -240,10 +240,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
 #endif
 
-    // For stdio management
-    if (obj->serial.uart == STDIO_UART) {
+    /* With support for checking H/W UART initialized or not, we allow serial_init(&stdio_uart)
+     * calls in even though H/W UART 'STDIO_UART' has initialized. When serial_init(&stdio_uart)
+     * calls in, we only need to set the 'stdio_uart_inited' flag. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 
     if (var->ref_cnt) {
@@ -289,7 +291,9 @@ void serial_free(serial_t *obj)
         var->obj = NULL;
     }
 
-    if (obj->serial.uart == STDIO_UART) {
+    /* Clear the 'stdio_uart_inited' flag when serial_free(&stdio_uart) calls in. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 0;
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
@@ -212,9 +212,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
             pinmap_pinout(tx, PinMap_UART_TX);
             pinmap_pinout(rx, PinMap_UART_RX);
         } while (0);
-
-        obj->serial.pin_tx = tx;
-        obj->serial.pin_rx = rx;
     }
     var->ref_cnt ++;
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/serial_api.c
@@ -200,25 +200,23 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
 
     if (! var->ref_cnt) {
-        do {
-            // Reset this module
-            SYS_ResetModule(modinit->rsetidx);
+        // Reset this module
+        SYS_ResetModule(modinit->rsetidx);
 
-            // Select IP clock source
-            CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
-            // Enable IP clock
-            CLK_EnableModuleClock(modinit->clkidx);
+        // Select IP clock source
+        CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
+        // Enable IP clock
+        CLK_EnableModuleClock(modinit->clkidx);
 
-            pinmap_pinout(tx, PinMap_UART_TX);
-            pinmap_pinout(rx, PinMap_UART_RX);
-        } while (0);
+        pinmap_pinout(tx, PinMap_UART_TX);
+        pinmap_pinout(rx, PinMap_UART_RX);
+
+        // Configure the UART module and set its baudrate
+        serial_baud(obj, 9600);
+        // Configure data bits, parity, and stop bits
+        serial_format(obj, 8, ParityNone, 1);
     }
     var->ref_cnt ++;
-
-    // Configure the UART module and set its baudrate
-    serial_baud(obj, 9600);
-    // Configure data bits, parity, and stop bits
-    serial_format(obj, 8, ParityNone, 1);
 
     obj->serial.vec = var->vec;
     obj->serial.irq_en = 0;

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/objects.h
@@ -46,8 +46,6 @@ struct analogin_s {
 
 struct serial_s {
     UARTName uart;
-    PinName pin_tx;
-    PinName pin_rx;
     
     uint32_t baudrate;
     uint32_t databits;

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
@@ -146,8 +146,19 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
 
-        // Configure the UART module and set its baudrate
-        serial_baud(obj, 9600);
+        // Configure baudrate
+        int baudrate = 9600;
+        if (obj->serial.uart == STDIO_UART) {
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_STDIO_BAUD_RATE;
+#endif
+        } else {
+#if MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE;
+#endif            
+        }
+        serial_baud(obj, baudrate);
+
         // Configure data bits, parity, and stop bits
         serial_format(obj, 8, ParityNone, 1);
     }

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
@@ -145,9 +145,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
-    
-        obj->serial.pin_tx = tx;
-        obj->serial.pin_rx = rx;
     }
     var->ref_cnt ++;
     

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
@@ -175,12 +175,14 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
 #endif
 
-    // For stdio management
-    if (obj->serial.uart == STDIO_UART) {
+    /* With support for checking H/W UART initialized or not, we allow serial_init(&stdio_uart)
+     * calls in even though H/W UART 'STDIO_UART' has initialized. When serial_init(&stdio_uart)
+     * calls in, we only need to set the 'stdio_uart_inited' flag. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
-    
+
     if (var->ref_cnt) {
         // Mark this module to be inited.
         int i = modinit - uart_modinit_tab;
@@ -221,11 +223,13 @@ void serial_free(serial_t *obj)
     if (var->obj == obj) {
         var->obj = NULL;
     }
-    
-    if (obj->serial.uart == STDIO_UART) {
+
+    /* Clear the 'stdio_uart_inited' flag when serial_free(&stdio_uart) calls in. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 0;
     }
-    
+
     if (! var->ref_cnt) {
         // Mark this module to be deinited.
         int i = modinit - uart_modinit_tab;

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/serial_api.c
@@ -137,7 +137,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     if (! var->ref_cnt) {
         // Reset this module
         SYS_ResetModule(modinit->rsetidx);
-    
+
         // Select IP clock source
         CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
         // Enable IP clock
@@ -145,17 +145,17 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
+
+        // Configure the UART module and set its baudrate
+        serial_baud(obj, 9600);
+        // Configure data bits, parity, and stop bits
+        serial_format(obj, 8, ParityNone, 1);
     }
     var->ref_cnt ++;
-    
-    // Configure the UART module and set its baudrate
-    serial_baud(obj, 9600);
-    // Configure data bits, parity, and stop bits
-    serial_format(obj, 8, ParityNone, 1);
-    
+
     obj->serial.vec = var->vec;
     obj->serial.irq_en = 0;
-    
+
 #if DEVICE_SERIAL_ASYNCH
     obj->serial.dma_usage_tx = DMA_USAGE_NEVER;
     obj->serial.dma_usage_rx = DMA_USAGE_NEVER;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/objects.h
@@ -50,8 +50,6 @@ struct analogin_s {
 
 struct serial_s {
     UARTName uart;
-    PinName pin_tx;
-    PinName pin_rx;
     
     uint32_t baudrate;
     uint32_t databits;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -202,7 +202,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     if (! var->ref_cnt) {
         // Reset this module
         SYS_ResetModule(modinit->rsetidx);
-    
+
         // Select IP clock source
         CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
         // Enable IP clock
@@ -210,14 +210,14 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
+
+        // Configure the UART module and set its baudrate
+        serial_baud(obj, 9600);
+        // Configure data bits, parity, and stop bits
+        serial_format(obj, 8, ParityNone, 1);
     }
     var->ref_cnt ++;
-    
-    // Configure the UART module and set its baudrate
-    serial_baud(obj, 9600);
-    // Configure data bits, parity, and stop bits
-    serial_format(obj, 8, ParityNone, 1);
-    
+
     obj->serial.vec = var->vec;
     obj->serial.irq_en = 0;
     

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -211,8 +211,19 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
 
-        // Configure the UART module and set its baudrate
-        serial_baud(obj, 9600);
+        // Configure baudrate
+        int baudrate = 9600;
+        if (obj->serial.uart == STDIO_UART) {
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_STDIO_BAUD_RATE;
+#endif
+        } else {
+#if MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
+            baudrate = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE;
+#endif            
+        }
+        serial_baud(obj, baudrate);
+
         // Configure data bits, parity, and stop bits
         serial_format(obj, 8, ParityNone, 1);
     }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -210,9 +210,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
         pinmap_pinout(tx, PinMap_UART_TX);
         pinmap_pinout(rx, PinMap_UART_RX);
-    
-        obj->serial.pin_tx = tx;
-        obj->serial.pin_rx = rx;
     }
     var->ref_cnt ++;
     

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -240,12 +240,14 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
 #endif
 
-    // For stdio management
-    if (obj->serial.uart == STDIO_UART) {
+    /* With support for checking H/W UART initialized or not, we allow serial_init(&stdio_uart)
+     * calls in even though H/W UART 'STDIO_UART' has initialized. When serial_init(&stdio_uart)
+     * calls in, we only need to set the 'stdio_uart_inited' flag. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
-    
+
     if (var->ref_cnt) {
         // Mark this module to be inited.
         int i = modinit - uart_modinit_tab;
@@ -286,11 +288,13 @@ void serial_free(serial_t *obj)
     if (var->obj == obj) {
         var->obj = NULL;
     }
-    
-    if (obj->serial.uart == STDIO_UART) {
+
+    /* Clear the 'stdio_uart_inited' flag when serial_free(&stdio_uart) calls in. */
+    if (((uintptr_t) obj) == ((uintptr_t) &stdio_uart)) {
+        MBED_ASSERT(obj->serial.uart == STDIO_UART);
         stdio_uart_inited = 0;
     }
-    
+
     if (! var->ref_cnt) {
         // Mark this module to be deinited.
         int i = modinit - uart_modinit_tab;


### PR DESCRIPTION
### Description

This PR refines UART init/deinit, especially when there are multiple `serial_t` structs sharing the same H/W UART. It includes:
1. Remove unused `pin_tx`/`pin_rx` fields from `serial_s` struct
1. Avoid re-configuring the shared H/W UART in `serial_init()`
1. Check configuration option for default UART baudrate setting
1. Fix init/deinit time of `stdio_uart`

#### Targets

- NUMAKER_PFM_NANO130
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487/NUMAKER_IOT_M487
- NUMAKER_PFM_M2351


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

