### PR TITLE
SPI and deep sleep fixes for FUTURE_SEQUANA target.

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/i2c_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/i2c_api.c
@@ -264,7 +264,7 @@ static int i2c_convert_status(cy_en_scb_i2c_status_t status)
 /*
  * Callback function to handle into and out of deep sleep state transitions.
  */
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
 static cy_en_syspm_status_t i2c_pm_callback(cy_stc_syspm_callback_params_t *callback_params)
 {
     cy_stc_syspm_callback_params_t params = *callback_params;
@@ -273,7 +273,7 @@ static cy_en_syspm_status_t i2c_pm_callback(cy_stc_syspm_callback_params_t *call
 
     return Cy_SCB_I2C_DeepSleepCallback(&params);
 }
-#endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#endif // DEVICE_SLEEP && DEVICE_LPTICKER
 
 
 void i2c_init(i2c_t *obj_in, PinName sda, PinName scl)
@@ -300,7 +300,7 @@ void i2c_init(i2c_t *obj_in, PinName sda, PinName scl)
         i2c_init_clock(obj, I2C_DEFAULT_SPEED);
         i2c_init_pins(obj);
         i2c_init_peripheral(obj);
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
         obj->pm_callback_handler.callback = i2c_pm_callback;
         obj->pm_callback_handler.type = CY_SYSPM_DEEPSLEEP;
         obj->pm_callback_handler.skipMode = 0;
@@ -310,7 +310,7 @@ void i2c_init(i2c_t *obj_in, PinName sda, PinName scl)
         if (!Cy_SysPm_RegisterCallback(&obj->pm_callback_handler)) {
             error("PM callback registration failed!");
         }
-#endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#endif // DEVICE_SLEEP && DEVICE_LPTICKER
     } else {
         error("I2C pinout mismatch. Requested pins Rx and Tx can't be used for the same I2C communication.");
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/objects.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/objects.h
@@ -86,7 +86,7 @@ struct serial_s {
     bool                        tx_pending;
     cy_israddress               async_handler;
 #endif // DEVICE_SERIAL_ASYNCH
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
     cy_stc_syspm_callback_params_t pm_callback_params;
     cy_stc_syspm_callback_t     pm_callback_handler;
 #endif
@@ -124,7 +124,7 @@ struct spi_s {
     void                                *tx_buffer;
     uint32_t                            tx_buffer_size;
 #endif // DEVICE_SPI_ASYNCH
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
     cy_stc_syspm_callback_params_t      pm_callback_params;
     cy_stc_syspm_callback_t             pm_callback_handler;
 #endif
@@ -160,7 +160,7 @@ struct i2c_s {
     uint16_t                            events;
     uint32_t                            handler;
 #endif // DEVICE_I2C_ASYNCH
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
     cy_stc_syspm_callback_params_t      pm_callback_params;
     cy_stc_syspm_callback_t             pm_callback_handler;
 #endif
@@ -178,7 +178,7 @@ struct pwmout_s {
     uint32_t period;
     uint32_t pulse_width;
     uint32_t prescaler;
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
     cy_stc_syspm_callback_params_t      pm_callback_params;
     cy_stc_syspm_callback_t             pm_callback_handler;
 #endif

--- a/targets/TARGET_Cypress/TARGET_PSOC6/pwmout_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/pwmout_api.c
@@ -120,7 +120,7 @@ static void pwm_start(pwmout_t *obj, uint32_t new_period, uint32_t new_pulse_wid
 /*
  * Callback handler to restart the timer after deep sleep.
  */
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
 static cy_en_syspm_status_t pwm_pm_callback(cy_stc_syspm_callback_params_t *callback_params)
 {
     pwmout_t *obj = (pwmout_t *)callback_params->context;
@@ -145,7 +145,7 @@ static cy_en_syspm_status_t pwm_pm_callback(cy_stc_syspm_callback_params_t *call
 
     return CY_SYSPM_SUCCESS;
 }
-#endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#endif // DEVICE_SLEEP && DEVICE_LPTICKER
 
 
 void pwmout_init(pwmout_t *obj, PinName pin)
@@ -198,17 +198,17 @@ void pwmout_init(pwmout_t *obj, PinName pin)
         obj->period = 0;
         obj->pulse_width = 0;
         obj->prescaler = 0;
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER
         obj->pm_callback_handler.callback = pwm_pm_callback;
         obj->pm_callback_handler.type = CY_SYSPM_DEEPSLEEP;
-        obj->pm_callback_handler.skipMode = CY_SYSPM_SKIP_CHECK_READY | CY_SYSPM_SKIP_CHECK_FAIL;
+        obj->pm_callback_handler.skipMode = 0;
         obj->pm_callback_handler.callbackParams = &obj->pm_callback_params;
         obj->pm_callback_params.base = obj->base;
         obj->pm_callback_params.context = obj;
         if (!Cy_SysPm_RegisterCallback(&obj->pm_callback_handler)) {
             error("PM callback registration failed!");
         }
-#endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#endif // DEVICE_SLEEP && DEVICE_LPTICKER
 
     } else {
         error("PWM OUT pinout mismatch.");

--- a/targets/TARGET_Cypress/TARGET_PSOC6/serial_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/serial_api.c
@@ -345,7 +345,7 @@ static void serial_init_peripheral(serial_obj_t *obj)
     Cy_SCB_UART_Enable(obj->base);
 }
 
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER && SERIAL_PM_CALLBACK_ENABLED
 static cy_en_syspm_status_t serial_pm_callback(cy_stc_syspm_callback_params_t *params)
 {
     serial_obj_t *obj = (serial_obj_t *)params->context;
@@ -393,7 +393,7 @@ static cy_en_syspm_status_t serial_pm_callback(cy_stc_syspm_callback_params_t *p
     }
     return status;
 }
-#endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#endif // DEVICE_SLEEP && DEVICE_LPTICKER
 
 void serial_init(serial_t *obj_in, PinName tx, PinName rx)
 {
@@ -425,7 +425,7 @@ void serial_init(serial_t *obj_in, PinName tx, PinName rx)
             //Cy_GPIO_Write(Cy_GPIO_PortToAddr(CY_PORT(P13_6)), CY_PIN(P13_6), 1);
             serial_init_pins(obj);
             //Cy_GPIO_Write(Cy_GPIO_PortToAddr(CY_PORT(P13_6)), CY_PIN(P13_6), 0);
-#if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#if DEVICE_SLEEP && DEVICE_LPTICKER && SERIAL_PM_CALLBACK_ENABLED
             obj->pm_callback_handler.callback = serial_pm_callback;
             obj->pm_callback_handler.type = CY_SYSPM_DEEPSLEEP;
             obj->pm_callback_handler.skipMode = 0;
@@ -435,7 +435,7 @@ void serial_init(serial_t *obj_in, PinName tx, PinName rx)
             if (!Cy_SysPm_RegisterCallback(&obj->pm_callback_handler)) {
                 error("PM callback registration failed!");
             }
-#endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
+#endif // DEVICE_SLEEP && DEVICE_LPTICKER
             if (is_stdio) {
                 memcpy(&stdio_uart, obj_in, sizeof(serial_t));
                 stdio_uart_inited = true;

--- a/targets/TARGET_Cypress/TARGET_PSOC6/spi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/spi_api.c
@@ -170,16 +170,36 @@ static cy_en_sysclk_status_t spi_init_clock(spi_obj_t *obj, uint32_t frequency)
  */
 static void spi_init_pins(spi_obj_t *obj)
 {
-    if (cy_reserve_io_pin(obj->pin_sclk) ||
-            cy_reserve_io_pin(obj->pin_mosi) ||
-            cy_reserve_io_pin(obj->pin_miso) ||
-            cy_reserve_io_pin(obj->pin_ssel)) {
+    bool conflict = false;
+    conflict = cy_reserve_io_pin(obj->pin_sclk);
+    if (!conflict) {
+        pin_function(obj->pin_sclk, pinmap_function(obj->pin_sclk, PinMap_SPI_SCLK));
+    }
+    if (obj->pin_mosi != NC) {
+        if (!cy_reserve_io_pin(obj->pin_mosi)) {
+            pin_function(obj->pin_mosi, pinmap_function(obj->pin_mosi, PinMap_SPI_MOSI));
+        } else {
+            conflict = true;
+        }
+    }
+    if (obj->pin_miso != NC) {
+        if (!cy_reserve_io_pin(obj->pin_miso)) {
+            pin_function(obj->pin_miso, pinmap_function(obj->pin_miso, PinMap_SPI_MISO));
+        } else {
+            conflict = true;
+        }
+    }
+    if (obj->pin_ssel != NC) {
+        if (!cy_reserve_io_pin(obj->pin_ssel)) {
+            pin_function(obj->pin_ssel, pinmap_function(obj->pin_ssel, PinMap_SPI_SSEL));
+        } else {
+            conflict = true;
+        }
+    }
+    if (conflict) {
         error("SPI pin reservation conflict.");
     }
-    pin_function(obj->pin_sclk, pinmap_function(obj->pin_sclk, PinMap_SPI_SCLK));
-    pin_function(obj->pin_mosi, pinmap_function(obj->pin_mosi, PinMap_SPI_MOSI));
-    pin_function(obj->pin_miso, pinmap_function(obj->pin_miso, PinMap_SPI_MISO));
-    pin_function(obj->pin_ssel, pinmap_function(obj->pin_ssel, PinMap_SPI_SSEL));
+
     // Pin configuration in PinMap defaults to Master mode; revert for Slave.
     if (obj->ms_mode == CY_SCB_SPI_SLAVE) {
         pin_mode(obj->pin_sclk, PullNone);
@@ -276,7 +296,7 @@ void spi_init(spi_t *obj_in, PinName mosi, PinName miso, PinName sclk, PinName s
         }
 #endif // DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
     } else {
-        error("Serial pinout mismatch. Requested pins Rx and Tx can't be used for the same Serial communication.");
+        error("SPI pinout mismatch. Requested Rx and Tx pins can't be used for the same SPI communication.");
     }
 }
 
@@ -367,9 +387,10 @@ int spi_master_block_write(spi_t *obj_in, const char *tx_buffer, int tx_length, 
             ++rx_count;
         }
     }
-    // Read any ramaining bytes from the fifo.
+    // Read any remaining bytes from the fifo.
     while (rx_count < rx_length) {
         *rx_buffer++ = (char)Cy_SCB_SPI_Read(obj->base);
+        ++rx_count;
     }
     // Clean up if we have read less bytes than available.
     Cy_SCB_SPI_ClearRxFifo(obj->base);


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

1. Proper handling of (NC) in the SPI initialization to allow only a subset SPI pins to be used for communication (e.g. no SS pin or tx-only SPI mode).

2. DEVICE_LOWPOWERTIMER was renamed into DEVICE_LPTICKER in one of the prevoius Mbed OS releases. This was missed in a few places in Sequana code.

3. Better handling of deep sleep entry in hal_deepsleep()

4. Cypress Power Manager deep sleep callback removed from HAL serial driver. Callbacks are not strictly necessary, serial works anyway, but having them breaks assumed timing dependencies in HAL sleep tests - serial callback handling delays deep sleep mode entry more than allowed in these tests.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

