### PR TITLE
DO NOT MERGE: targets: K64F: Disable PSA by default

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1447,8 +1447,7 @@
             "KPSDK_MCUS",
             "KPSDK_CODE",
             "MCU_K64F",
-            "Freescale_EMAC",
-            "PSA"
+            "Freescale_EMAC"
         ],
         "is_disk_virtual": true,
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "MBEDTLS_PSA_CRYPTO_C"],


### PR DESCRIPTION
### Description

PSA is available on an opt-in basis. Add the PSA label to your target
via the Mbed configuration system in order to access PSA APIs. For
example, use `"target.extra_labels_add": ["PSA"]` in your mbed_app.json.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

