### PR TITLE
[DO NOT MERGE] Testing `master` in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 [mbed-travis-release-svg]: https://travis-ci.org/ARMmbed/mbed-os.svg?branch=latest
 [mbed-coveralls-tools]: https://coveralls.io/github/ARMmbed/mbed-os?branch=master
 [mbed-coveralls-tools-svg]: https://coveralls.io/repos/github/ARMmbed/mbed-os/badge.svg?branch=master
-[mbed-waffle]: https://waffle.io/ARMmbed/mbed-os
-[mbed-waffle-svg]: https://badge.waffle.io/ARMmbed/mbed-os.svg?columns=all
 
 Arm Mbed OS is an open source embedded operating system designed specifically for the "things" in the Internet of Things. It includes all the features you need to develop a connected product based on an Arm Cortex-M microcontroller, including security, connectivity, an RTOS and drivers for sensors and I/O devices.
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -43,7 +43,6 @@ from ..memap import MemapParser
 from ..config import (ConfigException, RAM_ALL_MEMORIES, ROM_ALL_MEMORIES)
 
 
-#Disables multiprocessing if set to higher number than the host machine CPUs
 CPU_COUNT_MIN = 1
 CPU_COEF = 1
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

#### Investigating Cloud Client CI failures 

This PR is a baseline to make sure any recent merges into master didn't break things.

The following PRs are affected, and _would_ otherwise be ready for merge:
- #8690 
- #8771 
- #8779 
- #8795

#### The issue

The following PRs all saw the following similar error:
```
Link: mbed-cloud-client-example_application
Link: /usr/local/ARM_Compiler_5.06u6/bin/armlink --via ./BUILD/K66F/ARM/.link_options.txt
[DEBUG] Return: 0
[DEBUG] Errors: "/tmp/apNGV1", line 125 (column 3): Warning: L6312W: Empty Execution region description for region RW_IRAM1
[DEBUG] Errors: Finished: 0 information, 1 warning and 0 error messages.
Elf2Bin: mbed-cloud-client-example_application
FromELF: /usr/local/ARM_Compiler_5.06u6/bin/fromelf --bin -o ./BUILD/K66F/ARM/mbed-cloud-client-example_application.bin ./BUILD/K66F/ARM/mbed-cloud-client-example_application.elf
[DEBUG] Return: 0
Merging Regions
  Filling region bootloader with /builds/ws/mbed-os-ci_cloud-client-test/mbed-cloud-client-example/mbed-os/features/FEATURE_BOOTLOADER/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/mbed-bootloader-k66f-block_device-sotp-v3_4_0.bin
  Padding region bootloader with 0x6c4 bytes
Traceback (most recent call last):
  File "/builds/ws/mbed-os-ci_cloud-client-test/mbed-cloud-client-example/mbed-os/tools/make.py", line 73, in wrapped_build_project
    src_dir, build_dir, mcu, *args, **kwargs
  File "/builds/ws/mbed-os-ci_cloud-client-test/mbed-cloud-client-example/mbed-os/tools/build_api.py", line 551, in build_project
    merge_region_list(region_list, res, notify)
  File "/builds/ws/mbed-os-ci_cloud-client-test/mbed-cloud-client-example/mbed-os/tools/build_api.py", line 422, in merge_region_list
    _fill_header(region_list, region).tofile(header_filename, format='hex')
  File "/builds/ws/mbed-os-ci_cloud-client-test/mbed-cloud-client-example/mbed-os/tools/build_api.py", line 392, in _fill_header
    header.puts(start, struct.pack(fmt, zlib.crc32(ih.tobinarray())))
error: integer out of range for 'L' format code
[mbed] ERROR: "/usr/bin/python" returned error.
```

#### Expectation

Am expecting this to fail.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
    [x] None

