### PR TITLE
MODULE_UBLOX_ODIN_W2: disable MPU code until target properly supported

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3975,7 +3975,8 @@
             "MBEDTLS_DES_C",
             "MBEDTLS_MD4_C",
             "MBEDTLS_MD5_C",
-            "MBEDTLS_SHA1_C"
+            "MBEDTLS_SHA1_C",
+            "MBED_MPU_CUSTOM"
         ],
         "device_has_add": [
             "CAN",
@@ -3984,8 +3985,7 @@
             "FLASH",
             "WIFI",
             "SERIAL_FC",
-            "SERIAL",
-            "MPU"
+            "SERIAL"
         ],
         "features": ["BLE"],
         "device_has_remove": [],


### PR DESCRIPTION
### Description

The target and its derivatives started HardFaulting since the MPU overhaul commit (1821d376211ad5bf35cff43fbf68ddf2f5353b28). This was visible in network greentea tests and well as cloud connectivity tests. This is a workaround which disables the MPU code for the target. A proper fix would be target specific routines.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

