### PR TITLE
Cellular: Removed get_extended_signal_quality and changed get strength

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
@@ -464,24 +464,6 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_ciot_optimization_con
     EXPECT_TRUE(pref == CellularNetwork::PREFERRED_UE_OPT_NO_PREFERENCE);
 }
 
-TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_extended_signal_quality)
-{
-    EventQueue que;
-    FileHandle_stub fh1;
-    ATHandler at(&fh1, que, 0, ",");
-
-    AT_CellularNetwork cn(at);
-    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_DEVICE_ERROR;
-    int rx = -1, be = -1, rs = -1, ec = -1, rsrq = -1, rsrp = -1;
-    EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.get_extended_signal_quality(rx, be, rs, ec, rsrq, rsrp));
-    EXPECT_TRUE(rx == -1 && be == -1 && rs == -1 && ec == -1 && rsrq == -1 && rsrp == -1);
-
-    ATHandler_stub::int_value = 5;
-    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    EXPECT_TRUE(NSAPI_ERROR_OK == cn.get_extended_signal_quality(rx, be, rs, ec, rsrq, rsrp));
-    EXPECT_TRUE(rx == 5 && be == 5 && rs == 5 && ec == 5 && rsrq == 5 && rsrp == 5);
-}
-
 TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_signal_quality)
 {
     EventQueue que;
@@ -491,13 +473,14 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_signal_quality)
     AT_CellularNetwork cn(at);
     int rs = -1, ber = -1;
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_DEVICE_ERROR;
-    EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.get_signal_quality(rs, ber));
+    EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.get_signal_quality(rs, &ber));
     EXPECT_TRUE(rs == -1 && ber == -1);
 
     ATHandler_stub::int_value = 1;
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    EXPECT_TRUE(NSAPI_ERROR_OK == cn.get_signal_quality(rs, ber));
-    EXPECT_TRUE(rs == -111 && ber == 1);
+    EXPECT_TRUE(NSAPI_ERROR_OK == cn.get_signal_quality(rs, &ber));
+    EXPECT_EQ(rs, -111);
+    EXPECT_EQ(ber, 1);
 }
 
 TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_get_3gpp_error)

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -120,12 +120,7 @@ nsapi_error_t AT_CellularNetwork::get_ciot_optimization_config(Supported_UE_Opt 
     return NSAPI_ERROR_OK;
 }
 
-nsapi_error_t AT_CellularNetwork::get_extended_signal_quality(int &rxlev, int &ber, int &rscp, int &ecno, int &rsrq, int &rsrp)
-{
-    return NSAPI_ERROR_OK;
-}
-
-nsapi_error_t AT_CellularNetwork::get_signal_quality(int &rssi, int &ber)
+nsapi_error_t AT_CellularNetwork::get_signal_quality(int &rssi, int *ber)
 {
     return NSAPI_ERROR_OK;
 }

--- a/features/cellular/TESTS/api/cellular_network/main.cpp
+++ b/features/cellular/TESTS/api/cellular_network/main.cpp
@@ -180,32 +180,14 @@ static void test_other()
     TEST_ASSERT(nw->scan_plmn(operators, uplinkRate) == NSAPI_ERROR_OK);
     device->set_timeout(10 * 1000);
 
-    int rxlev = -1, ber = -1, rscp = -1, ecno = -1, rsrq = -1, rsrp = -1;
-    err = nw->get_extended_signal_quality(rxlev, ber, rscp, ecno, rsrq, rsrp);
-    TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
-    if (err == NSAPI_ERROR_DEVICE_ERROR) {
-        if (strcmp(devi, "QUECTEL_BG96") != 0 && strcmp(devi, "TELIT_HE910") != 0) {// QUECTEL_BG96 does not give any specific reason for device error
-            TEST_ASSERT((((AT_CellularNetwork *)nw)->get_device_error().errType == 3) &&   // 3 == CME error from the modem
-                        ((((AT_CellularNetwork *)nw)->get_device_error().errCode == 100) || // 100 == unknown command for modem
-                         (((AT_CellularNetwork *)nw)->get_device_error().errCode == 50)));  // 50 == incorrect parameters // seen in wise_1570 for not supported commands
-        }
-    } else {
-        // we should have some values which are not optional
-        TEST_ASSERT(rxlev >= 0 && ber >= 0 && rscp >= 0 && ecno >= 0 && rsrq >= 0 && rsrp >= 0);
-    }
-
     int rssi = -1;
-    ber = -1;
-    err = nw->get_signal_quality(rssi, ber);
+    int ber = -1;
+    err = nw->get_signal_quality(rssi, &ber);
     TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
     if (err == NSAPI_ERROR_DEVICE_ERROR) {
         TEST_ASSERT((((AT_CellularNetwork *)nw)->get_device_error().errType == 3) &&   // 3 == CME error from the modem
                     ((((AT_CellularNetwork *)nw)->get_device_error().errCode == 100) || // 100 == unknown command for modem
                      (((AT_CellularNetwork *)nw)->get_device_error().errCode == 50)));  // 50 == incorrect parameters // seen in wise_1570 for not supported commands
-    } else {
-        // test for values
-        TEST_ASSERT(rssi >= 0);
-        TEST_ASSERT(ber >= 0);
     }
 
     CellularNetwork::registration_params_t reg_params;

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -277,27 +277,17 @@ public:
     virtual nsapi_error_t get_ciot_optimization_config(Supported_UE_Opt &supported_opt,
                                                        Preferred_UE_Opt &preferred_opt) = 0;
 
-    /** Get extended signal quality parameters.
-     *
-     *  @param rxlev         signal strength level
-     *  @param ber           bit error rate
-     *  @param rscp          signal code power
-     *  @param ecno          ratio of the received energy per PN chip to the total received power spectral density
-     *  @param rsrq          signal received quality
-     *  @param rsrp          signal received power
-     *  @return              NSAPI_ERROR_OK on success
-     *                       NSAPI_ERROR_DEVICE_ERROR on other failures
-     */
-    virtual nsapi_error_t get_extended_signal_quality(int &rxlev, int &ber, int &rscp, int &ecno, int &rsrq, int &rsrp) = 0;
-
     /** Get signal quality parameters.
      *
-     *  @param rssi          signal strength level
-     *  @param ber           bit error rate
+     *  @param rssi          signal strength level as defined in 3GPP TS 27.007, range -113..-51 dBm or SignalQualityUnknown
+     *  @param ber           bit error rate as RXQUAL as defined in 3GPP TS 45.008, range 0..7 or SignalQualityUnknown
      *  @return              NSAPI_ERROR_OK on success
      *                       NSAPI_ERROR_DEVICE_ERROR on other failures
      */
-    virtual nsapi_error_t get_signal_quality(int &rssi, int &ber) = 0;
+    enum SignalQuality {
+        SignalQualityUnknown = 99
+    };
+    virtual nsapi_error_t get_signal_quality(int &rssi, int *ber = NULL) = 0;
 
     /** Get the last 3GPP error code
      *  @return see 3GPP TS 27.007 error codes

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -460,30 +460,7 @@ nsapi_error_t AT_CellularNetwork::get_ciot_optimization_config(Supported_UE_Opt 
     return _at.unlock_return_error();
 }
 
-nsapi_error_t AT_CellularNetwork::get_extended_signal_quality(int &rxlev, int &ber, int &rscp, int &ecno, int &rsrq, int &rsrp)
-{
-    _at.lock();
-
-    _at.cmd_start("AT+CESQ");
-    _at.cmd_stop();
-
-    _at.resp_start("+CESQ:");
-    rxlev = _at.read_int();
-    ber = _at.read_int();
-    rscp = _at.read_int();
-    ecno = _at.read_int();
-    rsrq = _at.read_int();
-    rsrp = _at.read_int();
-    _at.resp_stop();
-    if (rxlev < 0 || ber < 0 || rscp < 0 || ecno < 0 || rsrq < 0 || rsrp < 0) {
-        _at.unlock();
-        return NSAPI_ERROR_DEVICE_ERROR;
-    }
-
-    return _at.unlock_return_error();
-}
-
-nsapi_error_t AT_CellularNetwork::get_signal_quality(int &rssi, int &ber)
+nsapi_error_t AT_CellularNetwork::get_signal_quality(int &rssi, int *ber)
 {
     _at.lock();
 
@@ -491,18 +468,27 @@ nsapi_error_t AT_CellularNetwork::get_signal_quality(int &rssi, int &ber)
     _at.cmd_stop();
 
     _at.resp_start("+CSQ:");
-    rssi = _at.read_int();
-    ber = _at.read_int();
+    int t_rssi = _at.read_int();
+    int t_ber = _at.read_int();
     _at.resp_stop();
-    if (rssi < 0 || ber < 0) {
+    if (t_rssi < 0 || t_ber < 0) {
         _at.unlock();
         return NSAPI_ERROR_DEVICE_ERROR;
     }
 
-    if (rssi == 99) {
-        rssi = 0;
+    // RSSI value is returned in dBm with range from -51 to -113 dBm, see 3GPP TS 27.007
+    if (t_rssi == 99) {
+        rssi = SignalQualityUnknown;
     } else {
-        rssi = -113 + 2 * rssi;
+        rssi = -113 + 2 * t_rssi;
+    }
+
+    if (ber) {
+        if (t_ber == 99) {
+            *ber = SignalQualityUnknown;
+        } else {
+            *ber = t_ber;
+        }
     }
 
     return _at.unlock_return_error();

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -69,9 +69,7 @@ public: // CellularNetwork
     virtual nsapi_error_t get_ciot_optimization_config(Supported_UE_Opt &supported_opt,
                                                        Preferred_UE_Opt &preferred_opt);
 
-    virtual nsapi_error_t get_extended_signal_quality(int &rxlev, int &ber, int &rscp, int &ecno, int &rsrq, int &rsrp);
-
-    virtual nsapi_error_t get_signal_quality(int &rssi, int &ber);
+    virtual nsapi_error_t get_signal_quality(int &rssi, int *ber = NULL);
 
     virtual int get_3gpp_error();
 

--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -585,9 +585,8 @@ void CellularStateMachine::event()
 #if MBED_CONF_MBED_TRACE_ENABLE
     if (_network) {
         int rssi;
-        int ber;
-        if (_network->get_signal_quality(rssi, ber) == NSAPI_ERROR_OK) {
-            if (rssi == 0) {
+        if (_network->get_signal_quality(rssi) == NSAPI_ERROR_OK) {
+            if (rssi == CellularNetwork::SignalQualityUnknown) {
                 tr_info("RSSI unknown");
             } else {
                 tr_info("RSSI %d dBm", rssi);


### PR DESCRIPTION
### Description

Cellular get_signal_quality() was refined so that reading ber is optional, and unknown return value was changed from magic number to a symbolic constant.

Cellular get_extended_signal_quality() was removed because that's likely not needed in typical installations where get_signal_quality() with RSSI and BER should be good to use.

Created from #8918

### Pull request type

[ ] Fix
[ ] Refactor
[ ] Target update
[ ] Functionality change
[ ] Docs update
[ ] Test update
[x] Breaking change