### PR TITLE
Fix PSA storage typo

### DIFF
--- a/components/TARGET_PSA/services/psa_prot_internal_storage/COMPONENT_PSA_SRV_IMPL/pits_impl.cpp
+++ b/components/TARGET_PSA/services/psa_prot_internal_storage/COMPONENT_PSA_SRV_IMPL/pits_impl.cpp
@@ -154,7 +154,7 @@ psa_its_status_t psa_its_get_impl(uint32_t pid, uint32_t uid, uint32_t data_offs
 
     if (kvstore_status == MBED_SUCCESS) {
         if (data_offset > kv_info.size) {
-            return PSA_PS_ERROR_OFFSET_INVALID;
+            return PSA_ITS_ERROR_OFFSET_INVALID;
         }
 
         // Verify (size + offset) does not wrap around

--- a/components/TARGET_PSA/services/psa_prot_internal_storage/psa_prot_internal_storage.h
+++ b/components/TARGET_PSA/services/psa_prot_internal_storage/psa_prot_internal_storage.h
@@ -57,7 +57,7 @@ typedef uint32_t psa_its_status_t;
 #define PSA_ITS_ERROR_BAD_POINTER               6   /**<    The operation failed because one of the provided pointers is invalid, for example is `NULL` or references memory the caller cannot access */
 #define PSA_ITS_ERROR_KEY_NOT_FOUND             7   /**<    The operation failed because the provided key value was not found in the storage */
 #define PSA_ITS_ERROR_INCORRECT_SIZE            8   /**<    The operation failed because the data associated with provided key is not the same size as `data_size` */
-#define PSA_PS_ERROR_OFFSET_INVALID             9   /**<    The operation failed because an offset was supplied that is invalid for the existing data associated with the uid. For example, offset + size is
+#define PSA_ITS_ERROR_OFFSET_INVALID            9   /**<    The operation failed because an offset was supplied that is invalid for the existing data associated with the uid. For example, offset + size is
                                                             past the end of the data */
 
 /**
@@ -98,7 +98,7 @@ psa_its_status_t psa_its_set(uint32_t uid, uint32_t data_length, const void *p_d
  * \retval      PSA_ITS_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
  * \retval      PSA_ITS_ERROR_BAD_POINTER        The operation failed because one of the provided pointers(`p_data`, `p_data_length`)
  *                                               is invalid. For example is `NULL` or references memory the caller cannot access
- * \retval      PSA_PS_ERROR_OFFSET_INVALID      The operation failed because an offset was supplied that is invalid for the existing data associated with the
+ * \retval      PSA_ITS_ERROR_OFFSET_INVALID     The operation failed because an offset was supplied that is invalid for the existing data associated with the
  *                                               uid. For example, offset + size is invalid,
  */
 psa_its_status_t psa_its_get(uint32_t uid, uint32_t data_offset,  uint32_t data_length, void *p_data);

--- a/features/mbedtls/mbed-crypto/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/psa_crypto.c
+++ b/features/mbedtls/mbed-crypto/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/psa_crypto.c
@@ -4249,7 +4249,7 @@ static psa_status_t its_to_psa_error( psa_its_status_t ret )
             return( PSA_ERROR_INSUFFICIENT_STORAGE );
 
         case PSA_ITS_ERROR_INVALID_KEY:
-        case PSA_PS_ERROR_OFFSET_INVALID:
+        case PSA_ITS_ERROR_OFFSET_INVALID:
         case PSA_ITS_ERROR_INCORRECT_SIZE:
         case PSA_ITS_ERROR_BAD_POINTER:
             return( PSA_ERROR_INVALID_ARGUMENT );

--- a/features/mbedtls/mbed-crypto/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/psa_crypto_storage_its.c
+++ b/features/mbedtls/mbed-crypto/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/psa_crypto_storage_its.c
@@ -52,7 +52,7 @@ static psa_status_t its_to_psa_error( psa_its_status_t ret )
             return( PSA_ERROR_INSUFFICIENT_STORAGE );
 
         case PSA_ITS_ERROR_INVALID_KEY:
-        case PSA_PS_ERROR_OFFSET_INVALID:
+        case PSA_ITS_ERROR_OFFSET_INVALID:
         case PSA_ITS_ERROR_INCORRECT_SIZE:
         case PSA_ITS_ERROR_BAD_POINTER:
             return( PSA_ERROR_INVALID_ARGUMENT );


### PR DESCRIPTION
### Description

Fix PSA_PS_ERROR_OFFSET_INVALID typo in both storage and crypto. These must be changed at the same time in order for each project's CI to remain green.

CC @alzix @dannybenor 

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

