### PR TITLE
mbedtls: Update Mbed TLS to 2.15.1

### DIFF
--- a/features/mbedtls/VERSION.txt
+++ b/features/mbedtls/VERSION.txt
@@ -1,2 +1,2 @@
-mbedtls-2.15.0
-mbedcrypto-0.1.0b
+mbedtls-2.15.1
+mbedcrypto-0.1.0b2

--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -27,7 +27,7 @@
 #
 
 # Set the mbed TLS release to import (this can/should be edited before import)
-MBED_TLS_RELEASE ?= mbedtls-2.15.0
+MBED_TLS_RELEASE ?= mbedtls-2.15.1
 
 # Translate between mbed TLS namespace and mbed namespace
 TARGET_PREFIX:=../

--- a/features/mbedtls/mbed-crypto/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/psa_crypto.c
+++ b/features/mbedtls/mbed-crypto/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/psa_crypto.c
@@ -3146,7 +3146,7 @@ static void psa_aead_abort( aead_operation_t *operation )
             mbedtls_ccm_free( &operation->ctx.ccm );
             break;
 #endif /* MBEDTLS_CCM_C */
-#if defined(MBEDTLS_CCM_C)
+#if defined(MBEDTLS_GCM_C)
         case PSA_ALG_GCM:
             mbedtls_gcm_free( &operation->ctx.gcm );
             break;
@@ -3259,6 +3259,7 @@ psa_status_t psa_aead_encrypt( psa_key_slot_t key,
     }
     tag = ciphertext + plaintext_length;
 
+#if defined(MBEDTLS_GCM_C)
     if( operation.core_alg == PSA_ALG_GCM )
     {
         status = mbedtls_to_psa_error(
@@ -3270,7 +3271,10 @@ psa_status_t psa_aead_encrypt( psa_key_slot_t key,
                                        plaintext, ciphertext,
                                        operation.tag_length, tag ) );
     }
-    else if( operation.core_alg == PSA_ALG_CCM )
+    else
+#endif /* MBEDTLS_GCM_C */
+#if defined(MBEDTLS_CCM_C)
+    if( operation.core_alg == PSA_ALG_CCM )
     {
         status = mbedtls_to_psa_error(
             mbedtls_ccm_encrypt_and_tag( &operation.ctx.ccm,
@@ -3282,6 +3286,7 @@ psa_status_t psa_aead_encrypt( psa_key_slot_t key,
                                          tag, operation.tag_length ) );
     }
     else
+#endif /* MBEDTLS_CCM_C */
     {
         return( PSA_ERROR_NOT_SUPPORTED );
     }
@@ -3339,6 +3344,7 @@ psa_status_t psa_aead_decrypt( psa_key_slot_t key,
     if( status != PSA_SUCCESS )
         return( status );
 
+#if defined(MBEDTLS_GCM_C)
     if( operation.core_alg == PSA_ALG_GCM )
     {
         status = psa_aead_unpadded_locate_tag( operation.tag_length,
@@ -3356,7 +3362,10 @@ psa_status_t psa_aead_decrypt( psa_key_slot_t key,
                                       tag, operation.tag_length,
                                       ciphertext, plaintext ) );
     }
-    else if( operation.core_alg == PSA_ALG_CCM )
+    else
+#endif /* MBEDTLS_GCM_C */
+#if defined(MBEDTLS_CCM_C)
+    if( operation.core_alg == PSA_ALG_CCM )
     {
         status = psa_aead_unpadded_locate_tag( operation.tag_length,
                                                ciphertext, ciphertext_length,
@@ -3374,6 +3383,7 @@ psa_status_t psa_aead_decrypt( psa_key_slot_t key,
                                       tag, operation.tag_length ) );
     }
     else
+#endif /* MBEDTLS_CCM_C */
     {
         return( PSA_ERROR_NOT_SUPPORTED );
     }


### PR DESCRIPTION
### Description

Update Mbed TLS to version 2.15.1. Fixes #8893.

Targeting Mbed OS 5.11.0rc2 in order to fix Client PR job

CC @sbutcher-arm

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change