### PR TITLE
Setting K64F to use KVStore FileSystem configuration

### DIFF
--- a/features/storage/kvstore/conf/mbed_lib.json
+++ b/features/storage/kvstore/conf/mbed_lib.json
@@ -12,7 +12,7 @@
     },
     "target_overrides": {
         "K64F": {
-            "storage_type": "TDB_INTERNAL"
+            "storage_type": "FILESYSTEM"
         },
         "K66F": {
             "storage_type": "TDB_INTERNAL"


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR change the default KVStore configuration of K64F to FILESYSTEM means, that KVStore will work over filesystem using the FileSystemStore implementation and SecureStore implementation.
Previously PR has changed it to TDB_INTERNAL, which was a mistake.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

