### PR TITLE
Reduce default MBEDTLS_MPI_MAX_SIZE

### DIFF
--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -140,6 +140,8 @@ conf unset MBEDTLS_SSL_TRUNCATED_HMAC
 
 conf unset MBEDTLS_PLATFORM_TIME_TYPE_MACRO
 
+conf set MBEDTLS_MPI_MAX_SIZE     512
+
 # The following configurations are a needed for Mbed Crypto submodule.
 # They are related to the persistent key storage feature.
 conf set MBEDTLS_PSA_CRYPTO_STORAGE_C

--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -140,6 +140,10 @@ conf unset MBEDTLS_SSL_TRUNCATED_HMAC
 
 conf unset MBEDTLS_PLATFORM_TIME_TYPE_MACRO
 
+# The default size of MBEDTLS_MPI_MAX_SIZE is 1024 bytes.
+# In some cases, this value is set to stack buffers.
+# Reduce the maximal MBEDTLS_MPI_MAX_SIZE to 512 bytes,
+# which should fit RSA 4096 bit keys.
 conf set MBEDTLS_MPI_MAX_SIZE     512
 
 # The following configurations are a needed for Mbed Crypto submodule.


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Reduce the default size of `MBEDTLS_MPI_MAX_SIZE` to 512 bytes,
as the default 1024 consumes much stack, and supporting RSA 4096 bit
may suffice at the moment.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

