### PR TITLE
STM32L4: before calling HAL_CRYP_DeInit initialize the Instance member

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/aes_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/aes_alt.c
@@ -56,13 +56,14 @@ static int aes_set_key(mbedtls_aes_context *ctx, const unsigned char *key, unsig
             return (MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
     }
 
+    ctx->hcryp_aes.Init.DataType = CRYP_DATATYPE_8B;
+    ctx->hcryp_aes.Instance = CRYP;
+
     /* Deinitializes the CRYP peripheral */
     if (HAL_CRYP_DeInit(&ctx->hcryp_aes) == HAL_ERROR) {
         return (HAL_ERROR);
     }
 
-    ctx->hcryp_aes.Init.DataType = CRYP_DATATYPE_8B;
-    ctx->hcryp_aes.Instance = CRYP;
     /* Enable CRYP clock */
     __HAL_RCC_CRYP_CLK_ENABLE();
 


### PR DESCRIPTION
### Description

Tested with wise 1570 (STM32L4) & cloud client. When function aes_set_key is called the function HAL_CRYP_DeInit calls macro __HAL_CRYP_DISABLE which dereferences null pointer (Instance). The target ends up HardFaulting. The issue was uncovered by the MPU overhaul change which was recently introduced.

To fix this, the Instance member should be initialized before calling HAL_CRYP_DeInit. This fixes the issue for workaround https://github.com/ARMmbed/mbed-os/pull/8922. 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

