### PR TITLE
Update Ticker wrapper to handle early interrupts

### DIFF
--- a/hal/LowPowerTickerWrapper.cpp
+++ b/hal/LowPowerTickerWrapper.cpp
@@ -33,7 +33,12 @@ void LowPowerTickerWrapper::irq_handler(ticker_irq_handler_type handler)
 {
     core_util_critical_section_enter();
 
-    if (_pending_fire_now || _match_check(_intf->read()) || _suspended) {
+    // This code no longer filters out early interrupts. Instead it
+    // passes them through to the next layer and ignores further interrupts
+    // until the next call to set_interrrupt or fire_interrupt (when not suspended).
+    // This is to ensure that the device doesn't get stuck in sleep due to an
+    // early low power ticker interrupt that was ignored.
+    if (_pending_fire_now || _pending_match || _suspended) {
         _timeout.detach();
         _pending_timeout = false;
         _pending_match = false;


### PR DESCRIPTION
### Description

Update the LowPowerTickerWrapper class to handle rather than ignore early low power ticker interrupts. This ensures that devices don't get stuck in sleep due to a ignored early low power ticker interrupt.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

