### PR TITLE
Fix incorrect #ifdefs on DEVICE_FOO macros

### DIFF
--- a/TESTS/mbed_hal/sleep/main.cpp
+++ b/TESTS/mbed_hal/sleep/main.cpp
@@ -95,7 +95,7 @@ void sleep_usticker_test()
     TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep());
 }
 
-#ifdef DEVICE_LPTICKER
+#if DEVICE_LPTICKER
 
 /* Test that wake-up time from sleep should be less than 10 ms and
  * low power ticker interrupt can wake-up target from sleep. */

--- a/TESTS/mbed_hal/sleep/sleep_test_utils.h
+++ b/TESTS/mbed_hal/sleep/sleep_test_utils.h
@@ -105,7 +105,7 @@ void us_ticker_isr(const ticker_data_t *const ticker_data)
     us_ticker_clear_interrupt();
 }
 
-#ifdef DEVICE_LPTICKER
+#if DEVICE_LPTICKER
 void lp_ticker_isr(const ticker_data_t *const ticker_data)
 {
     lp_ticker_clear_interrupt();

--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -21,7 +21,7 @@
 
 #include "mbed.h"
 
-#if !defined(MBED_CPU_STATS_ENABLED) || !defined(DEVICE_LPTICKER) || !defined(DEVICE_SLEEP)
+#if !defined(MBED_CPU_STATS_ENABLED) || !DEVICE_LPTICKER || !DEVICE_SLEEP
 #error [NOT_SUPPORTED] test not supported
 #endif
 

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#ifdef DEVICE_FLASH
+#if DEVICE_FLASH
 
 #include "FlashIAPBlockDevice.h"
 #include "mbed_critical.h"

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -17,7 +17,7 @@
 #ifndef MBED_FLASHIAP_BLOCK_DEVICE_H
 #define MBED_FLASHIAP_BLOCK_DEVICE_H
 
-#ifdef DEVICE_FLASH
+#if DEVICE_FLASH
 
 #include "FlashIAP.h"
 #include "BlockDevice.h"

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -136,7 +136,7 @@
  */
 
 /* If the target has no SPI support then SDCard is not supported */
-#ifdef DEVICE_SPI
+#if DEVICE_SPI
 
 #include "SDBlockDevice.h"
 #include "platform/mbed_debug.h"

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -18,7 +18,7 @@
 #define MBED_SD_BLOCK_DEVICE_H
 
 /* If the target has no SPI support then SDCard is not supported */
-#ifdef DEVICE_SPI
+#if DEVICE_SPI
 
 #include "BlockDevice.h"
 #include "drivers/SPI.h"

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/fopen/fopen.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/fopen/fopen.cpp
@@ -68,7 +68,7 @@ using namespace utest::v1;
  *      <<< lines removed >>>
  */
 
-#if defined(DEVICE_SPI) && ( defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) || (MBED_CONF_SD_FSFAT_SDCARD_INSTALLED))
+#if DEVICE_SPI && ( defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) || (MBED_CONF_SD_FSFAT_SDCARD_INSTALLED))
 static char fsfat_fopen_utest_msg_g[FSFAT_UTEST_MSG_BUF_SIZE];
 #define FSFAT_FOPEN_TEST_MOUNT_PT_NAME      "sd"
 #define FSFAT_FOPEN_TEST_MOUNT_PT_PATH      "/" FSFAT_FOPEN_TEST_MOUNT_PT_NAME

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_ANALOGIN) || defined(DOXYGEN_ONLY)
+#if DEVICE_ANALOGIN || defined(DOXYGEN_ONLY)
 
 #include "hal/analogin_api.h"
 #include "platform/SingletonPtr.h"

--- a/drivers/AnalogOut.h
+++ b/drivers/AnalogOut.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_ANALOGOUT) || defined(DOXYGEN_ONLY)
+#if DEVICE_ANALOGOUT || defined(DOXYGEN_ONLY)
 
 #include "hal/analogout_api.h"
 #include "platform/PlatformMutex.h"

--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_CAN) || defined(DOXYGEN_ONLY)
+#if DEVICE_CAN || defined(DOXYGEN_ONLY)
 
 #include "hal/can_api.h"
 #include "platform/Callback.h"

--- a/drivers/Ethernet.h
+++ b/drivers/Ethernet.h
@@ -20,7 +20,7 @@
 #include "platform/platform.h"
 #include "platform/NonCopyable.h"
 
-#if defined (DEVICE_ETHERNET) || defined(DOXYGEN_ONLY)
+#if DEVICE_ETHERNET || defined(DOXYGEN_ONLY)
 
 namespace mbed {
 /** \addtogroup drivers */

--- a/drivers/FlashIAP.cpp
+++ b/drivers/FlashIAP.cpp
@@ -29,7 +29,7 @@
 #include "platform/ScopedRomWriteLock.h"
 
 
-#ifdef DEVICE_FLASH
+#if DEVICE_FLASH
 
 namespace mbed {
 

--- a/drivers/FlashIAP.h
+++ b/drivers/FlashIAP.h
@@ -22,7 +22,7 @@
 #ifndef MBED_FLASHIAP_H
 #define MBED_FLASHIAP_H
 
-#if defined (DEVICE_FLASH) || defined(DOXYGEN_ONLY)
+#if DEVICE_FLASH || defined(DOXYGEN_ONLY)
 
 #include "flash_api.h"
 #include "platform/SingletonPtr.h"

--- a/drivers/I2C.h
+++ b/drivers/I2C.h
@@ -20,7 +20,7 @@
 #include "platform/platform.h"
 #include "hal/gpio_api.h"
 
-#if defined (DEVICE_I2C) || defined(DOXYGEN_ONLY)
+#if DEVICE_I2C || defined(DOXYGEN_ONLY)
 
 #include "hal/i2c_api.h"
 #include "platform/SingletonPtr.h"

--- a/drivers/I2CSlave.h
+++ b/drivers/I2CSlave.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_I2CSLAVE) || defined(DOXYGEN_ONLY)
+#if DEVICE_I2CSLAVE || defined(DOXYGEN_ONLY)
 
 #include "hal/i2c_api.h"
 

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
+#if DEVICE_INTERRUPTIN || defined(DOXYGEN_ONLY)
 
 #include "hal/gpio_api.h"
 #include "hal/gpio_irq_api.h"

--- a/drivers/LowPowerTimeout.h
+++ b/drivers/LowPowerTimeout.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_LPTICKER) || defined(DOXYGEN_ONLY)
+#if DEVICE_LPTICKER || defined(DOXYGEN_ONLY)
 
 #include "hal/lp_ticker_api.h"
 #include "drivers/LowPowerTicker.h"

--- a/drivers/LowPowerTimer.h
+++ b/drivers/LowPowerTimer.h
@@ -21,7 +21,7 @@
 #include "drivers/Timer.h"
 #include "platform/NonCopyable.h"
 
-#if defined (DEVICE_LPTICKER) || defined(DOXYGEN_ONLY)
+#if DEVICE_LPTICKER || defined(DOXYGEN_ONLY)
 
 #include "hal/lp_ticker_api.h"
 

--- a/drivers/MbedCRC.h
+++ b/drivers/MbedCRC.h
@@ -101,7 +101,7 @@ class MbedCRC {
 
 public:
     enum CrcMode {
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
         HARDWARE = 0,
 #endif
         TABLE = 1,
@@ -198,7 +198,7 @@ public:
         int32_t status = 0;
 
         switch (_mode) {
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
             case HARDWARE:
                 hal_crc_compute_partial((uint8_t *)buffer, size);
                 *crc = 0;
@@ -232,7 +232,7 @@ public:
     {
         MBED_ASSERT(crc != NULL);
 
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
         if (_mode == HARDWARE) {
             lock();
             crc_mbed_config_t config;
@@ -264,7 +264,7 @@ public:
     {
         MBED_ASSERT(crc != NULL);
 
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
         if (_mode == HARDWARE) {
             *crc = hal_crc_get_result();
             unlock();
@@ -316,7 +316,7 @@ private:
      */
     void lock()
     {
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
         if (_mode == HARDWARE) {
             mbed_crc_mutex->lock();
         }
@@ -327,7 +327,7 @@ private:
      */
     virtual void unlock()
     {
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
         if (_mode == HARDWARE) {
             mbed_crc_mutex->unlock();
         }
@@ -503,7 +503,7 @@ private:
     {
         MBED_STATIC_ASSERT(width <= 32, "Max 32-bit CRC supported");
 
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
         if (POLY_32BIT_REV_ANSI == polynomial) {
             _crc_table = (uint32_t *)Table_CRC_32bit_Rev_ANSI;
             _mode = TABLE;

--- a/drivers/PortIn.h
+++ b/drivers/PortIn.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_PORTIN) || defined(DOXYGEN_ONLY)
+#if DEVICE_PORTIN || defined(DOXYGEN_ONLY)
 
 #include "hal/port_api.h"
 #include "platform/mbed_critical.h"

--- a/drivers/PortInOut.h
+++ b/drivers/PortInOut.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_PORTINOUT) || defined(DOXYGEN_ONLY)
+#if DEVICE_PORTINOUT || defined(DOXYGEN_ONLY)
 
 #include "hal/port_api.h"
 #include "platform/mbed_critical.h"

--- a/drivers/PortOut.h
+++ b/drivers/PortOut.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_PORTOUT) || defined(DOXYGEN_ONLY)
+#if DEVICE_PORTOUT || defined(DOXYGEN_ONLY)
 
 #include "hal/port_api.h"
 #include "platform/mbed_critical.h"

--- a/drivers/PwmOut.h
+++ b/drivers/PwmOut.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_PWMOUT) || defined(DOXYGEN_ONLY)
+#if DEVICE_PWMOUT || defined(DOXYGEN_ONLY)
 #include "hal/pwmout_api.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_power_mgmt.h"

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_QSPI) || defined(DOXYGEN_ONLY)
+#if DEVICE_QSPI || defined(DOXYGEN_ONLY)
 
 #include "hal/qspi_api.h"
 #include "platform/PlatformMutex.h"

--- a/drivers/RawSerial.h
+++ b/drivers/RawSerial.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_SERIAL) || defined(DOXYGEN_ONLY)
+#if DEVICE_SERIAL || defined(DOXYGEN_ONLY)
 
 #include "mbed_toolchain.h"
 #include "drivers/SerialBase.h"

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_SPI) || defined(DOXYGEN_ONLY)
+#if DEVICE_SPI || defined(DOXYGEN_ONLY)
 
 #include "platform/PlatformMutex.h"
 #include "hal/spi_api.h"

--- a/drivers/SPISlave.h
+++ b/drivers/SPISlave.h
@@ -20,7 +20,7 @@
 #include "platform/platform.h"
 #include "platform/NonCopyable.h"
 
-#if defined (DEVICE_SPISLAVE) || defined(DOXYGEN_ONLY)
+#if DEVICE_SPISLAVE || defined(DOXYGEN_ONLY)
 
 #include "hal/spi_api.h"
 

--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_SERIAL) || defined(DOXYGEN_ONLY)
+#if DEVICE_SERIAL || defined(DOXYGEN_ONLY)
 
 #include "platform/Stream.h"
 #include "SerialBase.h"

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if defined (DEVICE_SERIAL) || defined(DOXYGEN_ONLY)
+#if DEVICE_SERIAL || defined(DOXYGEN_ONLY)
 
 #include "platform/Callback.h"
 #include "hal/serial_api.h"

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/trng.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/trng.c
@@ -18,7 +18,7 @@
   *
   */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <string.h>
 #include "trng_api.h"

--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -51,7 +51,7 @@ void generate_derived_key_consistency_32_byte_key_long_consistency_test(char *ke
  */
 int inject_dummy_rot_key()
 {
-#if !defined(DEVICE_TRNG)
+#if !DEVICE_TRNG
     uint32_t key[DEVICE_KEY_16BYTE / sizeof(uint32_t)];
 
     memcpy(key, "1234567812345678", DEVICE_KEY_16BYTE);

--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -259,7 +259,7 @@ int DeviceKey::generate_key_by_random(uint32_t *output, size_t size)
         return DEVICEKEY_INVALID_PARAM;
     }
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
     mbedtls_entropy_context *entropy = new mbedtls_entropy_context;
     mbedtls_entropy_init(entropy);
     memset(output, 0, size);

--- a/features/device_key/source/DeviceKey.h
+++ b/features/device_key/source/DeviceKey.h
@@ -24,7 +24,7 @@
 
 // Whole class is not supported if entropy is not enabled
 // Flash device is required as Device Key is currently depending on it
-#if !defined(DEVICE_FLASH) || !defined(COMPONENT_FLASHIAP)
+#if !DEVICE_FLASH || !defined(COMPONENT_FLASHIAP)
 #undef DEVICEKEY_ENABLED
 #define DEVICEKEY_ENABLED 0
 #endif

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -17,7 +17,7 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 

--- a/features/mbedtls/platform/src/mbed_trng.c
+++ b/features/mbedtls/platform/src/mbed_trng.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include "hal/trng_api.h"
 

--- a/features/storage/nvstore/source/nvstore.h
+++ b/features/storage/nvstore/source/nvstore.h
@@ -18,7 +18,7 @@
 #define MBED_NVSTORE_H
 
 // These addresses need to be configured according to board (in mbed_lib.json)
-#ifndef DEVICE_FLASH
+#if !DEVICE_FLASH
 #undef NVSTORE_ENABLED
 #define NVSTORE_ENABLED 0
 #endif

--- a/features/unsupported/tests/utest/general/general.cpp
+++ b/features/unsupported/tests/utest/general/general.cpp
@@ -64,7 +64,7 @@ TEST(C_String_Format, Sprintf_Negative_Integers)
     STRCMP_EQUAL(buffer, "-32768 -3214 -999 -100 -1 0 -1 -4231 -999 -4123 -32760 -99999");
 }
 
-#ifdef DEVICE_SEMIHOST
+#if DEVICE_SEMIHOST
 #include "mbed_semihost_api.h"
 
 TEST_GROUP(Device_Semihost)

--- a/hal/crc_api.h
+++ b/hal/crc_api.h
@@ -52,7 +52,7 @@ typedef struct crc_mbed_config {
     bool reflect_out;
 } crc_mbed_config_t;
 
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/itm_api.h
+++ b/hal/itm_api.h
@@ -20,7 +20,7 @@
 #ifndef MBED_ITM_API_H
 #define MBED_ITM_API_H
 
-#if defined(DEVICE_ITM)
+#if DEVICE_ITM
 
 #include <stdint.h>
 #include <stddef.h>

--- a/hal/mbed_itm_api.c
+++ b/hal/mbed_itm_api.c
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#if defined(DEVICE_ITM)
+#if DEVICE_ITM
 
 #include "hal/itm_api.h"
 #include "cmsis.h"
@@ -131,4 +131,4 @@ void mbed_itm_send_block(uint32_t port, const void *data, size_t len)
         }
     }
 }
-#endif // defined(DEVICE_ITM)
+#endif // DEVICE_ITM

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -36,13 +36,13 @@ static uint16_t deep_sleep_lock = 0U;
 static us_timestamp_t sleep_time = 0;
 static us_timestamp_t deep_sleep_time = 0;
 
-#if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LPTICKER)
+#if defined(MBED_CPU_STATS_ENABLED) && DEVICE_LPTICKER
 static ticker_data_t *sleep_ticker = NULL;
 #endif
 
 static inline us_timestamp_t read_us(void)
 {
-#if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LPTICKER)
+#if defined(MBED_CPU_STATS_ENABLED) && DEVICE_LPTICKER
     if (NULL == sleep_ticker) {
         sleep_ticker = (ticker_data_t *)get_lp_ticker_data();
     }

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -13,7 +13,7 @@
 #warning Statistics are currently not supported without the rtos.
 #endif
 
-#if defined(MBED_CPU_STATS_ENABLED) && (!defined(DEVICE_LPTICKER) || !defined(DEVICE_SLEEP))
+#if defined(MBED_CPU_STATS_ENABLED) && (!DEVICE_LPTICKER || !DEVICE_SLEEP)
 #warning CPU statistics are not supported without low power timer support.
 #endif
 
@@ -21,7 +21,7 @@ void mbed_stats_cpu_get(mbed_stats_cpu_t *stats)
 {
     MBED_ASSERT(stats != NULL);
     memset(stats, 0, sizeof(mbed_stats_cpu_t));
-#if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LPTICKER) && defined(DEVICE_SLEEP)
+#if defined(MBED_CPU_STATS_ENABLED) && DEVICE_LPTICKER && DEVICE_SLEEP
     stats->uptime = mbed_uptime();
     stats->idle_time = mbed_time_idle();
     stats->sleep_time = mbed_time_sleep();

--- a/rtos/TARGET_CORTEX/SysTimer.h
+++ b/rtos/TARGET_CORTEX/SysTimer.h
@@ -22,7 +22,7 @@
 #ifndef MBED_SYS_TIMER_H
 #define MBED_SYS_TIMER_H
 
-#if defined(DEVICE_LPTICKER) || defined(DOXYGEN_ONLY)
+#if DEVICE_LPTICKER || defined(DOXYGEN_ONLY)
 
 #include "platform/NonCopyable.h"
 #include "drivers/TimerEvent.h"

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -35,7 +35,7 @@ extern "C" {
 
     using namespace mbed;
 
-#if (defined(MBED_TICKLESS) && defined(DEVICE_LPTICKER))
+#if (defined(MBED_TICKLESS) && DEVICE_LPTICKER)
 
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
@@ -138,7 +138,7 @@ extern "C" {
         core_util_critical_section_exit();
     }
 
-#endif // (defined(MBED_TICKLESS) && defined(DEVICE_LPTICKER))
+#endif // (defined(MBED_TICKLESS) && DEVICE_LPTICKER)
 
     static void (*idle_hook_fptr)(void) = &default_idle_hook;
 


### PR DESCRIPTION
### Description

The DEVICE_FOO macros are predefined to be 0 or 1. There are a number of instances which incorrectly check if they are defined, rather than checking the value.

This PR addresses most (if not all) of these incorrect checks.

Fixes #8913 

Testing on master is blocked by #8912. A partial test on mbed-os-5.9.7 with Nucleo-F030R8 was successful.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

