### PR TITLE
Cellular: Disable APN lookup by default on other but Ublox targets

### DIFF
--- a/features/cellular/TESTS/socket/udp/main.cpp
+++ b/features/cellular/TESTS/socket/udp/main.cpp
@@ -42,9 +42,9 @@
 
 #include "CellularContext.h"
 
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if MBED_CONF_CELLULAR_USE_APN_LOOKUP
 #include "APN_db.h"
-#endif //MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif
 
 #include "../../cellular_tests_common.h"
 

--- a/features/cellular/TESTS/socket/udp/template_mbed_app.json.txt
+++ b/features/cellular/TESTS/socket/udp/template_mbed_app.json.txt
@@ -25,8 +25,6 @@
     "target_overrides": {
         "*": {
             "nsapi.dns-response-wait-time": 30000,
-            "ppp-cell-iface.apn-lookup": false,
-            "cellular.use-apn-lookup": false,
             "target.features_add": ["LWIP"],
             "mbed-trace.enable": false,
             "lwip.ipv4-enabled": true,

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -32,11 +32,9 @@
 #include "nsapi_ppp.h"
 #endif
 
-#define USE_APN_LOOKUP (MBED_CONF_CELLULAR_USE_APN_LOOKUP || (NSAPI_PPP_AVAILABLE && MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP))
-
-#if USE_APN_LOOKUP
+#if MBED_CONF_CELLULAR_USE_APN_LOOKUP
 #include "APN_db.h"
-#endif //USE_APN_LOOKUP
+#endif
 
 using namespace mbed_cellular_util;
 using namespace mbed;
@@ -834,7 +832,7 @@ void AT_CellularContext::cellular_callback(nsapi_event_t ev, intptr_t ptr)
         cellular_connection_status_t st = (cellular_connection_status_t)ev;
         _cb_data.error = data->error;
         tr_debug("CellularContext: event %d, err %d, data %d", ev, data->error, data->status_data);
-#if USE_APN_LOOKUP
+#if MBED_CONF_CELLULAR_USE_APN_LOOKUP
         if (st == CellularSIMStatusChanged && data->status_data == CellularSIM::SimStateReady &&
                 _cb_data.error == NSAPI_ERROR_OK) {
             if (!_apn) {
@@ -861,7 +859,7 @@ void AT_CellularContext::cellular_callback(nsapi_event_t ev, intptr_t ptr)
                 _device->close_sim();
             }
         }
-#endif // USE_APN_LOOKUP
+#endif // MBED_CONF_CELLULAR_USE_APN_LOOKUP
 
         if (!_nw && st == CellularDeviceReady && data->error == NSAPI_ERROR_OK) {
             _nw = _device->open_network(_fh);

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -3,7 +3,7 @@
     "config": {
         "use-apn-lookup": {
             "help": "Use APN database lookup",
-            "value": true
+            "value": false
         },
         "random_max_start_delay": {
             "help": "Maximum random delay value used in start-up sequence in milliseconds",
@@ -16,6 +16,23 @@
         "radio-access-technology": {
             "help": "Radio access technology to use. Value in integer: GSM=0, GSM_COMPACT=1, UTRAN=2, EGPRS=3, HSDPA=4, HSUPA=5, HSDPA_HSUPA=6, E_UTRAN=7, CATM1=8 ,NB1=9",
             "value": null
+        }
+    },
+    "target_overrides": {
+        "UBLOX_C030_N211": {
+            "cellular.use-apn-lookup": true
+        },
+        "UBLOX_C030_R410M": {
+            "cellular.use-apn-lookup": true
+        },
+        "UBLOX_C030": {
+            "cellular.use-apn-lookup": true
+        },
+        "UBLOX_C027": {
+            "cellular.use-apn-lookup": true
+        },
+        "DRAGONFLY_L471QG": {
+            "cellular.use-apn-lookup": true
         }
     }
 }


### PR DESCRIPTION
### Description

Disabled APN lookup by default on other but Ublox targets, and also dropped dependency to ppp-cell-iface configuration.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [x] Breaking change

