### PR TITLE
[ESP8266] Adds support for controlling HW reset of the modem from the…

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -91,9 +91,18 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
 
 bool ESP8266::at_available()
 {
+    bool ready = false;
+
     _smutex.lock();
-    bool ready = _parser.send("AT")
-                 && _parser.recv("OK\n");
+    // Might take a while to respond after HW reset
+    for(int i = 0; i < 5; i++) {
+        ready = _parser.send("AT")
+                && _parser.recv("OK\n");
+        if (ready) {
+            break;
+        }
+        tr_debug("waiting AT response");
+    }
     _smutex.unlock();
 
     return ready;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -111,14 +111,14 @@ ESP8266Interface::~ESP8266Interface()
     }
 
     // Power down the modem
-    _rst_pin.assert();
+    _rst_pin.rst_assert();
 }
 
 ESP8266Interface::ResetPin::ResetPin(PinName rst_pin) : _rst_pin(mbed::DigitalOut(rst_pin, 1))
 {
 }
 
-void ESP8266Interface::ResetPin::assert()
+void ESP8266Interface::ResetPin::rst_assert()
 {
     if (_rst_pin.is_connected()) {
         _rst_pin = 0;
@@ -126,7 +126,7 @@ void ESP8266Interface::ResetPin::assert()
     }
 }
 
-void ESP8266Interface::ResetPin::deassert()
+void ESP8266Interface::ResetPin::rst_deassert()
 {
     if (_rst_pin.is_connected()) {
         // Notice that Pin7 CH_EN cannot be left floating if used as reset
@@ -270,7 +270,7 @@ int ESP8266Interface::disconnect()
     }
 
     // Power down the modem
-    _rst_pin.assert();
+    _rst_pin.rst_assert();
 
     return ret;
 }
@@ -377,11 +377,11 @@ nsapi_error_t ESP8266Interface::_init(void)
 
 void ESP8266Interface::_hw_reset()
 {
-    _rst_pin.assert();
+    _rst_pin.rst_assert();
     // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
     // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
     wait_us(200);
-    _rst_pin.deassert();
+    _rst_pin.rst_deassert();
 }
 
 nsapi_error_t ESP8266Interface::_startup(const int8_t wifi_mode)

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -109,6 +109,9 @@ ESP8266Interface::~ESP8266Interface()
     if (_oob_event_id) {
         _global_event_queue->cancel(_oob_event_id);
     }
+
+    // Power down the modem
+    _rst_pin.assert();
 }
 
 ESP8266Interface::ResetPin::ResetPin(PinName rst_pin) : _rst_pin(mbed::DigitalOut(rst_pin, 1))
@@ -119,9 +122,6 @@ void ESP8266Interface::ResetPin::assert()
 {
     if (_rst_pin.is_connected()) {
         _rst_pin = 0;
-        // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
-        // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
-        wait_us(200);
         tr_debug("HW reset asserted");
     }
 }
@@ -269,6 +269,9 @@ int ESP8266Interface::disconnect()
         }
     }
 
+    // Power down the modem
+    _rst_pin.assert();
+
     return ret;
 }
 
@@ -375,6 +378,9 @@ nsapi_error_t ESP8266Interface::_init(void)
 void ESP8266Interface::_hw_reset()
 {
     _rst_pin.assert();
+    // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
+    // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
+    wait_us(200);
     _rst_pin.deassert();
 }
 

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -353,7 +353,6 @@ private:
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
     void _hw_reset();
-    int _started;
     nsapi_error_t _startup(const int8_t wifi_mode);
 
     //sigio

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -18,6 +18,7 @@
 #define ESP8266_INTERFACE_H
 
 #if DEVICE_SERIAL && defined(MBED_CONF_EVENTS_PRESENT) && defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
+#include "drivers/DigitalOut.h"
 #include "ESP8266/ESP8266.h"
 #include "events/EventQueue.h"
 #include "events/mbed_shared_queues.h"
@@ -59,7 +60,7 @@ public:
      * @param rx        RX pin
      * @param debug     Enable debugging
      */
-    ESP8266Interface(PinName tx, PinName rx, bool debug = false, PinName rts = NC, PinName cts = NC);
+    ESP8266Interface(PinName tx, PinName rx, bool debug = false, PinName rts = NC, PinName cts = NC, PinName rst = NC);
 
     /**
      * @brief ESP8266Interface default destructor
@@ -320,6 +321,18 @@ private:
     ESP8266 _esp;
     void update_conn_state_cb();
 
+    // HW reset pin
+    class ResetPin {
+    public:
+        ResetPin(PinName rst_pin);
+        void assert();
+        void deassert();
+        bool is_connected();
+    private:
+        mbed::DigitalOut  _rst_pin;
+    } _rst_pin;
+
+
     // Credentials
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
     char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* The longest possible name; +1 for the \0 */
@@ -339,6 +352,7 @@ private:
     int _initialized;
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
+    void _hw_reset();
     int _started;
     nsapi_error_t _startup(const int8_t wifi_mode);
 

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -325,8 +325,8 @@ private:
     class ResetPin {
     public:
         ResetPin(PinName rst_pin);
-        void assert();
-        void deassert();
+        void rst_assert();
+        void rst_deassert();
         bool is_connected();
     private:
         mbed::DigitalOut  _rst_pin;

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -17,6 +17,10 @@
             "help": "CTS pin for serial connection, defaults to Not Connected",
             "value": null
         },
+        "rst": {
+            "help": "RESET pin for the modem, defaults to Not Connected",
+            "value": null
+        },
         "debug": {
             "help": "Enable debug logs. [true/false]",
             "value": false


### PR DESCRIPTION
… driver

While connecting will run HW reset for the modem if reset wire is attached to a know pin.

### Description

Brings possibility to use a known HW pin to attach the ESP8266 HW reset wire and to control it from the driver. Current implementation forces HW reset on each connect-call.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

