### PR TITLE
Coverity fixes.

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/ethernet_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/ethernet_tasklet.c
@@ -228,8 +228,18 @@ static void enet_tasklet_poll_network_status(void *param)
  */
 void enet_tasklet_configure_and_connect_to_network(void)
 {
-    arm_nwk_interface_up(tasklet_data_ptr->network_interface_id);
-    enet_tasklet_network_state_changed(MESH_BOOTSTRAP_STARTED);
+    int8_t status;
+
+    status = arm_nwk_interface_up(tasklet_data_ptr->network_interface_id);
+    if (status >= 0) {
+        tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_STARTED;
+        tr_info("Start Bootstrap");
+        enet_tasklet_network_state_changed(MESH_BOOTSTRAP_STARTED);
+    } else {
+        tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
+        tr_err("Bootstrap start failed, %d", status);
+        enet_tasklet_network_state_changed(MESH_BOOTSTRAP_START_FAILED);
+    }
 }
 
 /*

--- a/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
@@ -256,7 +256,7 @@ int8_t wisun_tasklet_connect(mesh_interface_cb callback, int8_t nwk_interface_id
         re_connecting = false;
     }
 
-    memset(wisun_tasklet_data_ptr, 0, sizeof(wisun_tasklet_data_ptr));
+    memset(wisun_tasklet_data_ptr, 0, sizeof(wisun_tasklet_data_str_t));
     wisun_tasklet_data_ptr->mesh_api_cb = callback;
     wisun_tasklet_data_ptr->network_interface_id = nwk_interface_id;
     wisun_tasklet_data_ptr->tasklet_state = TASKLET_STATE_INITIALIZED;


### PR DESCRIPTION
### Description

These issues has been found by coverity.
Return value of arm_nwk_interface_up() needs to be checked at ethernet_tasklet.c.
Incorrect expression (SIZEOF_MISMATCH) at wisun_tasklet.c

### Pull request type


    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

