### PR TITLE
fix-tests-netsocket-udp not all modems are able to send empty packets

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -715,9 +715,8 @@ Call `UDPSocket::sendto()` with invalid parameters.
 3.  Call `UDPSocket:sendto( "", 0, NULL, 0);`
 4.  Call `UDPSocket:sendto(NULL, 9, "hello", 5);`
 5.  Call `UDPSocket:sendto(NULL, 0, "hello", 5);`
-6.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9,NULL, 0);`
-7.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`
-8.  destroy the socket
+6.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`
+7.  destroy the socket
 
 **Expected result:**
 

--- a/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
@@ -32,7 +32,6 @@ void UDPSOCKET_SENDTO_INVALID()
     TEST_ASSERT(sock.sendto(NULL, 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 0, NULL, 0) < 0);
-    TEST_ASSERT_EQUAL(0, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, NULL, 0));
     TEST_ASSERT_EQUAL(5, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, "hello", 5));
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());


### PR DESCRIPTION
### Description
Not all modems are capable of sending empty UDP packets so lets remove the check for that scenario


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

