### PR TITLE
Initialize the interface at the construction

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -178,8 +178,19 @@ bool LoWPANNDInterface::getRouterIpAddress(char *address, int8_t len)
 #if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == LOWPAN && DEVICE_802_15_4_PHY
 MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
 {
-    static LoWPANNDInterface lowpan(&NanostackRfPhy::get_default_instance());
-
-    return &lowpan;
+    static bool inited;
+    static LoWPANNDInterface interface;
+    singleton_lock();
+    if (!inited) {
+        nsapi_error_t result = interface.initialize(&NanostackRfPhy::get_default_instance());
+        if (result != 0) {
+            tr_error("LoWPANND initialize failed: %d", error);
+            singleton_unlock();
+            return NULL;
+        }
+        inited = true;
+    }
+    singleton_unlock();
+    return &interface;
 }
 #endif

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -269,10 +269,22 @@ mesh_error_t Nanostack::ThreadInterface::device_pskd_set(const char *pskd)
 
 #define THREAD 0x2345
 #if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == THREAD && DEVICE_802_15_4_PHY
+
 MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
 {
-    static ThreadInterface thread(&NanostackRfPhy::get_default_instance());
-
-    return &thread;
+    static bool inited;
+    static ThreadInterface interface;
+    singleton_lock();
+    if (!inited) {
+        nsapi_error_t result = interface.initialize(&NanostackRfPhy::get_default_instance());
+        if (result != 0) {
+            tr_error("Thread initialize failed: %d", error);
+            singleton_unlock();
+            return NULL;
+        }
+        inited = true;
+    }
+    singleton_unlock();
+    return &interface;
 }
 #endif

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -178,8 +178,19 @@ bool WisunInterface::getRouterIpAddress(char *address, int8_t len)
 #if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == WISUN && DEVICE_802_15_4_PHY
 MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
 {
-    static WisunInterface wisun(&NanostackRfPhy::get_default_instance());
-
-    return &wisun;
+    static bool inited;
+    static WisunInterface interface;
+    singleton_lock();
+    if (!inited) {
+        nsapi_error_t result = interface.initialize(&NanostackRfPhy::get_default_instance());
+        if (result != 0) {
+            tr_error("Wi-SUN initialize failed: %d", error);
+            singleton_unlock();
+            return NULL;
+        }
+        inited = true;
+    }
+    singleton_unlock();
+    return &interface;
 }
 #endif


### PR DESCRIPTION
 and make sure that it's done only once.

### Description
Interface is initialized at construction.
This will make it possible to read mac-address before mesh.connect()

Tested locally that correction is working with mbed-os-example-mesh-minimal and K66F

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

