### PR TITLE
fixed wrong __StackTop calculation

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC15XX/device/TOOLCHAIN_GCC_ARM/LPC1549.ld
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/device/TOOLCHAIN_GCC_ARM/LPC1549.ld
@@ -145,7 +145,7 @@ SECTIONS
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(Ram0_16) + LENGTH(Ram0_16);
+    __StackTop = ORIGIN(Ram0_16) + LENGTH(Ram0_16) + LENGTH(Ram1_16) + LENGTH(Ram2_4);
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
     


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

StackTop calculation was not adjusted when ram size was increased by using al 3 ram regions.
This caused memory allocation failures althogh enough free heap was reported

The problem applies to GCC_ARM toolchain.
IAR and ARM toolchain setting looks fine, but I cannot verify this.
GCC_CR settings look also fine, but GCC_CR support has been removed already.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

