### PR TITLE
memap.py: Cope with IAR 8 linker map

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -304,7 +304,7 @@ class _ArmccParser(_Parser):
 class _IarParser(_Parser):
     RE = re.compile(
         r'^\s+(.+)\s+(zero|const|ro code|inited|uninit)\s'
-        r'+0x(\w{8})\s+0x(\w+)\s+(.+)\s.+$')
+        r'+0x([\'\w]+)\s+0x(\w+)\s+(.+)\s.+$')
 
     RE_CMDLINE_FILE = re.compile(r'^#\s+(.+\.o)')
     RE_LIBRARY = re.compile(r'^(.+\.a)\:.+$')


### PR DESCRIPTION
### Description

IAR 8 linker map puts C++14-style apostrophe digit separators in its addresses, such as:

     .data   inited  0x2000'1ff0    0x4  mbed_rtx_idle.o [159]

Extend the regex pattern to allow this.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
