### PR TITLE
Cordio Nordic memory optimizations

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/doc/PortingGuide.md
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/doc/PortingGuide.md
@@ -149,17 +149,26 @@ The functions `do_initialize` and `do_terminate` handle initialization and termi
 
 ##### Memory pool
 
-The function `get_buffer_pool_description` in the base class returns a buffer of 1040 bytes divided into different memory pools:
+Porters must override the `get_buffer_pool_description` function which should return a buffer pool to use by the Cordio stack.
+
+The function `get_default_buffer_pool_description` in the base class returns a buffer of 2250 bytes divided into different memory pools and can be used with most implementations:
 
 | Chunk size (bytes) | Number of chunks |
 |--------------------|------------------|
-| 16                 | 8                |
-| 32                 | 4                |
-| 64                 | 2                |
-| 128                | 2                |
+| 16                 | 16               |
+| 32                 | 16               |
+| 64                 | 8                |
+| 128                | 4                |
 | 272                | 1                |
 
-Porting overrides this function if the memory provided by the base class doesn't match what is required by the Bluetooth controller driver.
+**Example:**
+```
+buf_pool_desc_t CordioHCIDriver::get_buffer_pool_description()  {
+    return get_default_buffer_pool_description();
+}
+```
+
+If the memory provided by the base class doesn't match what is required by the Bluetooth controller driver, a custom pool can be returned.
 
 **Example:**
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/doc/PortingGuide.md
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/doc/PortingGuide.md
@@ -149,9 +149,9 @@ The functions `do_initialize` and `do_terminate` handle initialization and termi
 
 ##### Memory pool
 
-Porters must override the `get_buffer_pool_description` function which should return a buffer pool to use by the Cordio stack.
+Porters must override the `get_buffer_pool_description` function, which should return a buffer pool for the Cordio stack to use.
 
-The function `get_default_buffer_pool_description` in the base class returns a buffer of 2250 bytes divided into different memory pools and can be used with most implementations:
+The function `get_default_buffer_pool_description` in the base class returns a buffer of 2250 bytes divided into different memory pools, and most implementations can use it:
 
 | Chunk size (bytes) | Number of chunks |
 |--------------------|------------------|
@@ -168,7 +168,7 @@ buf_pool_desc_t CordioHCIDriver::get_buffer_pool_description()  {
 }
 ```
 
-If the memory provided by the base class doesn't match what is required by the Bluetooth controller driver, a custom pool can be returned.
+If the memory the base class provides doesn't match what the Bluetooth controller driver requires, a custom pool can be returned.
 
 **Example:**
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -78,7 +78,7 @@ void CordioHCIDriver::terminate()
     _transport_driver.terminate();
 }
 
-buf_pool_desc_t CordioHCIDriver::get_buffer_pool_description()
+buf_pool_desc_t CordioHCIDriver::get_default_buffer_pool_description()
 {
     static union {
         uint8_t buffer[2250];

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
@@ -128,7 +128,8 @@ public:
 
 protected:
     /**
-     * Return a defai;t set of memory pool which will be used by the Cordio stack
+     * Return a default set of memory pool which can be used by the Cordio stack
+     * This function can be used to implement get_buffer_pool_description().
      */
     buf_pool_desc_t get_default_buffer_pool_description();
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
@@ -128,7 +128,7 @@ public:
 
 protected:
     /**
-     * Return a default set of memory pool which can be used by the Cordio stack
+     * Return a default set of memory pool that the Cordio stack can use.
      * This function can be used to implement get_buffer_pool_description().
      */
     buf_pool_desc_t get_default_buffer_pool_description();

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
@@ -77,7 +77,7 @@ public:
     /**
      * Return the set of memory pool which will be used by the Cordio stack
      */
-    virtual buf_pool_desc_t get_buffer_pool_description();
+    virtual buf_pool_desc_t get_buffer_pool_description() = 0;
 
     /**
      * Initialize the HCI driver.
@@ -125,6 +125,12 @@ public:
      * @return The number of bytes which have been transmited.
      */
     uint16_t write(uint8_t type, uint16_t len, uint8_t *pData);
+
+protected:
+    /**
+     * Return a defai;t set of memory pool which will be used by the Cordio stack
+     */
+    buf_pool_desc_t get_default_buffer_pool_description();
 
 private:
     /**

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -330,9 +330,14 @@ void BLE::stack_setup()
         buf_pool_desc.pool_count, buf_pool_desc.pool_description
     );
 
-    // This assert will fail if we've either allocated too much or too little memory
-    // (bytes_used would be set to 0 in that case)
-    MBED_ASSERT(bytes_used == buf_pool_desc.buffer_size);
+    // Raise assert if not enough memory was allocated
+    MBED_ASSERT(bytes_used != 0);
+
+    // This warning will be raised if we've allocated too much memory
+    if(bytes_used < buf_pool_desc.buffer_size)
+    {
+        MBED_WARNING1(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_INVALID_SIZE), "Too much memory allocated for Cordio memory pool, reduce buf_pool_desc.buffer_size by value below.", buf_pool_desc.buffer_size - bytes_used);
+    }
 
     WsfTimerInit();
     SecInit();

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -330,7 +330,9 @@ void BLE::stack_setup()
         buf_pool_desc.pool_count, buf_pool_desc.pool_description
     );
 
-    MBED_ASSERT(bytes_used != 0);
+    // This assert will fail if we've either allocated too much or too little memory
+    // (bytes_used would be set to 0 in that case)
+    MBED_ASSERT(bytes_used == buf_pool_desc.buffer_size);
 
     WsfTimerInit();
     SecInit();

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO_ODIN_W2/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO_ODIN_W2/HCIDriver.cpp
@@ -41,6 +41,8 @@ public:
         service_pack_transfered(false) {
     };
 
+    virtual cordio::buf_pool_desc_t get_buffer_pool_description();
+
     virtual void do_initialize();
 
     virtual void do_terminate();
@@ -133,6 +135,13 @@ private:
 } // namespace odin_w2
 } // namespace vendor
 } // namespace ble
+
+
+ble::vendor::cordio::buf_pool_desc_t ble::vendor::odin_w2::HCIDriver::get_buffer_pool_description()
+{
+    // Use default buffer pool
+    return ble::vendor::cordio::CordioHCIDriver::get_default_buffer_pool_description();
+}
 
 void ble::vendor::odin_w2::HCIDriver::do_initialize()
 {

--- a/features/FEATURE_BLE/targets/TARGET_CYW4343X/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CYW4343X/HCIDriver.cpp
@@ -84,6 +84,12 @@ public:
         service_pack_transfered(false) {
     }
 
+    virtual cordio::buf_pool_desc_t get_buffer_pool_description()
+    {
+        // Use default buffer pool
+        return cordio::CordioHCIDriver::get_default_buffer_pool_description();
+    }
+
     virtual void do_initialize()
     {
         output_mode(bt_host_wake_name, 1);

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CY8C63XX/Psoc6BLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CY8C63XX/Psoc6BLE.cpp
@@ -46,6 +46,8 @@ private:
         BdAddress() : addr_type(0) {}
     };
 
+    virtual cordio::buf_pool_desc_t get_buffer_pool_description();
+
     /**
      * Initialize the chip.
      * The transport is up at that time.
@@ -62,6 +64,12 @@ private:
 private:
     BdAddress   bd_address;
 };
+
+cordio::buf_pool_desc_t Psoc6HCIDriver::get_buffer_pool_description()
+{
+    // Use default buffer pool
+    return ble::vendor::cordio::CordioHCIDriver::get_default_buffer_pool_description();
+}
 
 
 void Psoc6HCIDriver::do_initialize()

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -56,7 +56,11 @@ using namespace ble::vendor::nordic;
 using namespace ble::vendor::cordio;
 
 /*! \brief      Memory that should be reserved for the stack. */
+#if defined(NRF52840_XXAA)
 #define CORDIO_LL_MEMORY_FOOTPRINT  41906UL
+#else
+#define CORDIO_LL_MEMORY_FOOTPRINT  12768UL
+#endif
 
 /*! \brief      Typical implementation revision number (LlRtCfg_t::implRev). */
 #define LL_IMPL_REV             0x2303
@@ -107,7 +111,11 @@ const LlRtCfg_t NRFCordioHCIDriver::_ll_cfg = {
     /*maxScanReqRcvdEvt*/         4,
     /*maxExtScanDataLen*/         advDataLen,
     /* Connection */
+    #if defined(NRF52840_XXAA)
     /*maxConn*/          4,
+    #else
+    /*maxConn*/          2,
+    #endif
     /*numTxBufs*/          numTxBufs,
     /*numRxBufs*/          numRxBufs,
     /*maxAclLen*/          connDataLen,
@@ -117,7 +125,11 @@ const LlRtCfg_t NRFCordioHCIDriver::_ll_cfg = {
     /*dtmRxSyncMs*/          10000,
     /* PHY */
     /*phy2mSup*/          TRUE,
+    #if defined(NRF52840_XXAA)
     /*phyCodedSup*/          TRUE,
+    #else
+    /*phyCodedSup*/          FALSE,
+    #endif
     /*stableModIdxTxSup*/         TRUE,
     /*stableModIdxRxSup*/          TRUE
 };
@@ -184,7 +196,7 @@ NRFCordioHCIDriver::~NRFCordioHCIDriver()
 ble::vendor::cordio::buf_pool_desc_t NRFCordioHCIDriver::get_buffer_pool_description()
 {
     static union {
-        uint8_t buffer[ 17304 ];
+        uint8_t buffer[ 8920 ];
         uint64_t align;
     };
     static const wsfBufPoolDesc_t pool_desc[] = {

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -196,7 +196,11 @@ NRFCordioHCIDriver::~NRFCordioHCIDriver()
 ble::vendor::cordio::buf_pool_desc_t NRFCordioHCIDriver::get_buffer_pool_description()
 {
     static union {
+        #if defined(NRF52840_XXAA)
+        uint8_t buffer[ 17304 ];
+        #else
         uint8_t buffer[ 8920 ];
+        #endif
         uint64_t align;
     };
     static const wsfBufPoolDesc_t pool_desc[] = {


### PR DESCRIPTION
### Description

Fix for https://github.com/MarceloSalazar/mbed-os-example-ble-HeartRate/issues/2; JIRA: IOTPAN-315

This PR fixes two issues:
* The Cordio Link Layer initialisation requests too much memory on the NRF52832/810 platforms, we reduced memory requirements not these platforms
* When allocating a custom memory pool in a HCI Driver, the default pool is still allocated as it's statically allocated within part a virtual method (not eliminated but the linker) - to circumvent this we made this method pure virtual and still provided this default pool with a convenience method

HCI Drivers updated for the following platforms:
* Nordic NRF52
* ODIN-W2
* CYW4343X
* CY8X63XX
* ST BlueNRG-MS (outside of Mbed OS tree - associated PR:
https://github.com/ARMmbed/cordio-ble-x-nucleo-idb0xa1/pull/4)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change