### PR TITLE
Ensure macros and parameters with the same name are not repeated.

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -1095,8 +1095,8 @@ class Config(object):
     def _parameters_and_config_macros_to_macros(params, macros):
         """ Return the macro definitions generated for a dictionary of
         ConfigParameters and a dictionary of ConfigMacros (as returned by
-        get_config_data). The ConfigMacros override any matching macros set by
-        the ConfigParameters.
+        get_config_data). The ConfigParameters override any matching macros set
+        by the ConfigMacros.
 
         Positional arguments:
         params - a dictionary mapping a name to a ConfigParameter
@@ -1105,14 +1105,14 @@ class Config(object):
         Return: a list of strings that are the C pre-processor macros
         """
         all_macros = {
-            p.macro_name: p.value for p in params.values() if p.value is not None
-        }
-
-        config_macros = {
             m.macro_name: m.macro_value for m in macros.values()
         }
 
-        all_macros.update(config_macros)
+        parameter_macros = {
+            p.macro_name: p.value for p in params.values() if p.value is not None
+        }
+
+        all_macros.update(parameter_macros)
         macro_list = []
         for name, value in all_macros.items():
             # If the macro does not have a value, just append the name.

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -650,21 +650,21 @@ class Config(object):
         raise ConfigException(exception_text)
 
     def get_all_active_memories(self, memory_list):
-        """Get information of all available rom/ram memories in the form of dictionary 
-        {Memory: [start_addr, size]}. Takes in the argument, a list of all available 
+        """Get information of all available rom/ram memories in the form of dictionary
+        {Memory: [start_addr, size]}. Takes in the argument, a list of all available
         regions within the ram/rom memory"""
         # Override rom_start/rom_size
         #
         # This is usually done for a target which:
         # 1. Doesn't support CMSIS pack, or
         # 2. Supports TrustZone and user needs to change its flash partition
-        
+
         available_memories = {}
         # Counter to keep track of ROM/RAM memories supported by target
         active_memory_counter = 0
         # Find which memory we are dealing with, RAM/ROM
         active_memory = 'ROM' if any('ROM' in mem_list for mem_list in memory_list) else 'RAM'
-        
+
         try:
             cmsis_part = self._get_cmsis_part()
         except ConfigException:
@@ -683,7 +683,7 @@ class Config(object):
 
         present_memories = set(cmsis_part['memory'].keys())
         valid_memories = set(memory_list).intersection(present_memories)
-        
+
         for memory in valid_memories:
             mem_start, mem_size = self._get_mem_specs(
                 [memory],
@@ -709,7 +709,7 @@ class Config(object):
             mem_start = int(mem_start, 0)
             mem_size = int(mem_size, 0)
             available_memories[memory] = [mem_start, mem_size]
-        
+
         return available_memories
 
     @property
@@ -1092,17 +1092,37 @@ class Config(object):
                                       "' doesn't have a value")
 
     @staticmethod
-    def parameters_to_macros(params):
-        """ Encode the configuration parameters as C macro definitions.
+    def _parameters_and_config_macros_to_macros(params, macros):
+        """ Return the macro definitions generated for a dictionary of
+        ConfigParameters and a dictionary of ConfigMacros (as returned by
+        get_config_data). The ConfigMacros override any matching macros set by
+        the ConfigParameters.
 
         Positional arguments:
         params - a dictionary mapping a name to a ConfigParameter
+        macros - a dictionary mapping a name to a ConfigMacro
 
-        Return: a list of strings that encode the configuration parameters as
-        C pre-processor macros
+        Return: a list of strings that are the C pre-processor macros
         """
-        return ['%s=%s' % (m.macro_name, m.value) for m in params.values()
-                if m.value is not None]
+        all_macros = {
+            p.macro_name: p.value for p in params.values() if p.value is not None
+        }
+
+        config_macros = {
+            m.macro_name: m.macro_value for m in macros.values()
+        }
+
+        all_macros.update(config_macros)
+        macro_list = []
+        for name, value in all_macros.items():
+            # If the macro does not have a value, just append the name.
+            # Otherwise, append the macro as NAME=VALUE
+            if value is None:
+                macro_list.append(name)
+            else:
+                macro_list.append("%s=%s" % (name, value))
+
+        return macro_list
 
     @staticmethod
     def config_macros_to_macros(macros):
@@ -1126,8 +1146,7 @@ class Config(object):
         """
         params, macros = config[0], config[1]
         Config._check_required_parameters(params)
-        return Config.config_macros_to_macros(macros) + \
-            Config.parameters_to_macros(params)
+        return Config._parameters_and_config_macros_to_macros(params, macros)
 
     def get_config_data_macros(self):
         """ Convert a Config object to a list of C macros

--- a/tools/test/config/config_test.py
+++ b/tools/test/config/config_test.py
@@ -199,8 +199,7 @@ def test_basic_regions(target, overrides):
 
 def test_parameters_and_config_macros_to_macros():
     """
-    Test that checks that parameter-generated macros get overriden with
-    explicitly set macros
+    Test that checks that parameter-generated macros override set macros
     """
 
     params = {
@@ -224,4 +223,4 @@ def test_parameters_and_config_macros_to_macros():
     }
 
     macro_list = Config._parameters_and_config_macros_to_macros(params, macros)
-    assert macro_list == ["CUSTOM_MACRO_NAME=2"]
+    assert macro_list == ["CUSTOM_MACRO_NAME=1"]

--- a/tools/test/config/config_test.py
+++ b/tools/test/config/config_test.py
@@ -25,7 +25,7 @@ from hypothesis.strategies import sampled_from
 from os.path import join, isfile, dirname, abspath
 from tools.build_api import get_config
 from tools.targets import set_targets_json_location, Target, TARGET_NAMES
-from tools.config import ConfigException, Config
+from tools.config import ConfigException, Config, ConfigParameter, ConfigMacro
 
 def compare_config(cfg, expected):
     """Compare the output of config against a dictionary of known good results
@@ -196,3 +196,32 @@ def test_basic_regions(target, overrides):
                 assert r.size >= 0
     except ConfigException:
         pass
+
+def test_parameters_and_config_macros_to_macros():
+    """
+    Test that checks that parameter-generated macros get overriden with
+    explicitly set macros
+    """
+
+    params = {
+        "test_lib.parameter_with_macro": ConfigParameter(
+            "parameter_with_macro",
+            {
+                "macro_name": "CUSTOM_MACRO_NAME",
+                "value": 1
+            },
+            "test_lib",
+            "library"
+        )
+    }
+
+    macros = {
+        "CUSTOM_MACRO_NAME": ConfigMacro(
+            "CUSTOM_MACRO_NAME=2",
+            "dummy",
+            "application"
+        )
+    }
+
+    macro_list = Config._parameters_and_config_macros_to_macros(params, macros)
+    assert macro_list == ["CUSTOM_MACRO_NAME=2"]


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Should fix #8931.

This covers the case when a macro is set with the same name as a
parameter. Previously, the macro would be repeated on the command line,
which causes certain toolchains to break (ex. IAR assembler). Now the
config system will override the parameter's value with the macro's
value.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
