### PR TITLE
Nuvoton: Fix mbedtls crypto ECC AC management failed

### DIFF
--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
@@ -684,7 +684,7 @@ NU_STATIC int internal_run_eccop(const mbedtls_ecp_group *grp,
     CRPT->ECC_CTL = (grp->pbits << CRPT_ECC_CTL_CURVEM_Pos) | eccop | CRPT_ECC_CTL_FSEL_Msk | CRPT_ECC_CTL_START_Msk;
     ecc_done = crypto_ecc_wait();
 
-    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_SSL_HW_ACCEL_FAILED);
+    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED);
 
     /* (X1, Y1) hold the normalized result. */
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(&R->X, (uint32_t *) CRPT->ECC_X1, NU_ECC_BIGNUM_MAXWORD));
@@ -792,7 +792,7 @@ NU_STATIC int internal_run_modop(mbedtls_mpi *r,
     CRPT->ECC_CTL = (pbits << CRPT_ECC_CTL_CURVEM_Pos) | (ECCOP_MODULE | modop) | CRPT_ECC_CTL_FSEL_Msk | CRPT_ECC_CTL_START_Msk;
     ecc_done = crypto_ecc_wait();
 
-    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_SSL_HW_ACCEL_FAILED);
+    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED);
 
     /* X1 holds the result. */
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(r, (uint32_t *) CRPT->ECC_X1, NU_ECC_BIGNUM_MAXWORD));

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
@@ -53,6 +53,7 @@
  *        would be defined in mbedtls/ecp.h from ecp.c for our inclusion */
 #define ECP_SHORTWEIERSTRASS
 
+#include "mbedtls/ssl.h"
 #include "mbedtls/ecp_internal.h"
 #include "mbed_toolchain.h"
 #include "mbed_assert.h"
@@ -632,10 +633,9 @@ NU_STATIC int internal_run_eccop(const mbedtls_ecp_group *grp,
     crypto_ecc_prestart();
     CRPT->ECC_CTL = (grp->pbits << CRPT_ECC_CTL_CURVEM_Pos) | eccop | CRPT_ECC_CTL_FSEL_Msk | CRPT_ECC_CTL_START_Msk;
     ecc_done = crypto_ecc_wait();
-    
-    /* FIXME: Better error code for ECC accelerator error */
-    MBEDTLS_MPI_CHK(ecc_done ? 0 : -1);
-    
+
+    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_SSL_HW_ACCEL_FAILED);
+
     /* (X1, Y1) hold the normalized result. */
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(&R->X, (uint32_t *) CRPT->ECC_X1, NU_ECC_BIGNUM_MAXWORD));
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(&R->Y, (uint32_t *) CRPT->ECC_Y1, NU_ECC_BIGNUM_MAXWORD));
@@ -726,10 +726,9 @@ NU_STATIC int internal_run_modop(mbedtls_mpi *r,
     crypto_ecc_prestart();
     CRPT->ECC_CTL = (pbits << CRPT_ECC_CTL_CURVEM_Pos) | (ECCOP_MODULE | modop) | CRPT_ECC_CTL_FSEL_Msk | CRPT_ECC_CTL_START_Msk;
     ecc_done = crypto_ecc_wait();
-    
-    /* FIXME: Better error code for ECC accelerator error */
-    MBEDTLS_MPI_CHK(ecc_done ? 0 : -1);
-    
+
+    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_SSL_HW_ACCEL_FAILED);
+
     /* X1 holds the result. */
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(r, (uint32_t *) CRPT->ECC_X1, NU_ECC_BIGNUM_MAXWORD));
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.c
@@ -249,7 +249,11 @@ static bool crypto_submodule_acquire(uint16_t *submodule_avail)
 static void crypto_submodule_release(uint16_t *submodule_avail)
 {
     uint16_t expectedCurrentValue = 0;
-    while (! core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 1));
+    while (! core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 1)) {
+        /* On failure, 'expectedCurrentValue' would be set to 'submodule_avail', so we
+         * need to re-initialize it. */
+        expectedCurrentValue = 0;
+    }
 }
 
 static void crypto_submodule_prestart(volatile uint16_t *submodule_done)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.c
@@ -216,7 +216,11 @@ static bool crypto_submodule_acquire(uint16_t *submodule_avail)
 static void crypto_submodule_release(uint16_t *submodule_avail)
 {
     uint16_t expectedCurrentValue = 0;
-    while (! core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 1));
+    while (! core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 1)) {
+        /* On failure, 'expectedCurrentValue' would be set to 'submodule_avail', so we
+         * need to re-initialize it. */
+        expectedCurrentValue = 0;
+    }
 }
 
 static void crypto_submodule_prestart(volatile uint16_t *submodule_done)


### PR DESCRIPTION
### Description

In mbed-os 5.11, Mbed TLS doesn't guarantee `mbedtls_internal_ecp_init()`/`mbedtls_internal_ecp_free()`
are paired. When they are not paired, system would hang in Nuvoton's ECC AC management. This PR majorly tries to release the limit by narrwoing ECC AC open period to just real ECC AC operation. With this modification, pairing `mbedtls_internal_ecp_init()`/`mbedtls_internal_ecp_free()` is not required, for example, multiple `mbedtls_internal_ecp_init()` and finally one `mbedtls_internal_ecp_free()` is allowed.

#### Related target

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M487/NUMAKER_IOT_M487

#### Related issue

#8927

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

