### PR TITLE
Fix a few bugs in TDBStore and KV config

### DIFF
--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -572,6 +572,12 @@ int _storage_config_TDB_INTERNAL()
         return MBED_ERROR_INVALID_ARGUMENT;
     }
 
+    ret = kvstore_config.internal_bd->deinit();
+    if (ret != MBED_SUCCESS) {
+        tr_error("KV Config: Fail to deinit internal BlockDevice.");
+        return MBED_ERROR_FAILED_OPERATION;
+    }
+
     static TDBStore tdb_internal(kvstore_config.internal_bd);
     kvstore_config.internal_store = &tdb_internal;
 
@@ -737,7 +743,7 @@ int _storage_config_tdb_external_common()
 
     if (_calculate_blocksize_match_tdbstore(kvstore_config.external_bd) != MBED_SUCCESS) {
         tr_error("KV Config: Can not create TDBStore with less then 2 sector.");
-        return MBED_ERROR_INVALID_ARGUMENT;
+        return MBED_ERROR_INVALID_SIZE;
     }
 
     static TDBStore tdb_external(kvstore_config.external_bd);

--- a/features/storage/kvstore/kv_map/KVMap.cpp
+++ b/features/storage/kvstore/kv_map/KVMap.cpp
@@ -78,8 +78,6 @@ exit:
 
 void KVMap::deinit_partition(kv_map_entry_t *partition)
 {
-    free(partition->partition_name);
-
     if (partition->kv_config == NULL) {
         return;
     }
@@ -88,20 +86,13 @@ void KVMap::deinit_partition(kv_map_entry_t *partition)
         partition->kv_config->external_store->deinit();
     }
 
+    // TODO: this should be removed after FS APIs are standardized
     if (partition->kv_config->external_fs != NULL) {
         partition->kv_config->external_fs->unmount();
     }
 
-    if (partition->kv_config->external_bd != NULL) {
-        partition->kv_config->external_bd->deinit();
-    }
-
     if (partition->kv_config->internal_store != NULL) {
         partition->kv_config->internal_store->deinit();
-    }
-
-    if (partition->kv_config->internal_bd != NULL) {
-        partition->kv_config->internal_bd->deinit();
     }
 
     if (partition->kv_config->kvstore_main_instance != NULL) {


### PR DESCRIPTION
### Description
This PR fixes a few bugs in TDBStore and KV config. 
1. Don't initialize TDBStore if already initialized.
2. When reading a TDBStore record, make sure size calculation don't wrap around (can happen in a corrupt record).
3. Fix a few problems in KV config init and deinit logic.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

