### PR TITLE
Fix a few SecureStore issues (following preliminary security review)

### DIFF
--- a/docs/design-documents/features/storage/KVStore/KVStore_design.md
+++ b/docs/design-documents/features/storage/KVStore/KVStore_design.md
@@ -82,7 +82,6 @@ class KVStore {
     enum create_flags {
         WRITE_ONCE_FLAG                     = (1 << 0),
         REQUIRE_CONFIDENTIALITY_FLAG        = (1 << 1),
-        REQUIRE_INTEGRITY_FLAG              = (1 << 2),
         REQUIRE_REPLAY_PROTECTION_FLAG      = (1 << 3),
     };
  
@@ -130,7 +129,6 @@ As mentioned above, each KVStore API has a parallel C-style API, used globally w
 enum kv_create_flags {
     KV_WRITE_ONCE_FLAG                      = (1 << 0),
     KV_REQUIRE_CONFIDENTIALITY_FLAG         = (1 << 1),
-    KV_REQUIRE_INTEGRITY_FLAG               = (1 << 2),
     KV_REQUIRE_REPLAY_PROTECTION_FLAG       = (1 << 3),
 };
  

--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -414,18 +414,6 @@ static void set_several_key_value_sizes()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
-//set key with ROLLBACK flag without AUTHENTICATION flag
-static void Sec_set_key_rollback_without_auth_flag()
-{
-    TEST_SKIP_UNLESS(kvstore != NULL);
-    if (kv_setup != SecStoreSet) {
-        return;
-    }
-
-    int res = kvstore->set(key, data, data_size, KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_INVALID_ARGUMENT, res);
-}
-
 //set key with ROLLBACK flag and retrieve it, set it again with no ROLBACK
 static void Sec_set_key_rollback_set_again_no_rollback()
 {
@@ -436,7 +424,7 @@ static void Sec_set_key_rollback_set_again_no_rollback()
         return;
     }
 
-    int res = kvstore->set(key_name, data, data_size, KVStore::REQUIRE_REPLAY_PROTECTION_FLAG | KVStore::REQUIRE_INTEGRITY_FLAG);
+    int res = kvstore->set(key_name, data, data_size, KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key_name, buffer, sizeof(buffer), &actual_size, 0);
@@ -479,7 +467,7 @@ static void Sec_set_key_auth()
         return;
     }
 
-    int res = kvstore->set(key, data, data_size, KVStore::REQUIRE_INTEGRITY_FLAG);
+    int res = kvstore->set(key, data, data_size, 0);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key, buffer, sizeof(buffer), &actual_size, 0);
@@ -768,7 +756,6 @@ template_case_t template_cases[] = {
     {"set_key_value_seventeen_byte_size", set_key_value_seventeen_byte_size, greentea_failure_handler},
     {"set_several_key_value_sizes", set_several_key_value_sizes, greentea_failure_handler},
 
-    {"Sec_set_key_rollback_without_auth_flag", Sec_set_key_rollback_without_auth_flag, greentea_failure_handler},
     {"Sec_set_key_rollback_set_again_no_rollback", Sec_set_key_rollback_set_again_no_rollback, greentea_failure_handler},
     {"Sec_set_key_encrypt", Sec_set_key_encrypt, greentea_failure_handler},
     {"Sec_set_key_auth", Sec_set_key_auth, greentea_failure_handler},

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -148,13 +148,13 @@ static void white_box_test()
         elapsed = timer.read_ms();
         printf("Elapsed time for reset is %d ms\n", elapsed);
 
-        result = sec_kv->set(key1, key1_val1, strlen(key1_val1), KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_INTEGRITY_FLAG);
+        result = sec_kv->set(key1, key1_val1, strlen(key1_val1), KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
-        result = sec_kv->set(key2, key2_val1, strlen(key2_val1), KVStore::REQUIRE_INTEGRITY_FLAG);
+        result = sec_kv->set(key2, key2_val1, strlen(key2_val1), 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
-        result = sec_kv->set(key2, key2_val2, strlen(key2_val2), KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_INTEGRITY_FLAG);
+        result = sec_kv->set(key2, key2_val2, strlen(key2_val2), KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = sec_kv->get(key2, get_buf, sizeof(get_buf), &actual_data_size);
@@ -163,18 +163,17 @@ static void white_box_test()
         TEST_ASSERT_EQUAL_STRING_LEN(key2_val2, get_buf, strlen(key2_val2));
 
         timer.reset();
-        result = sec_kv->set(key2, key2_val3, strlen(key2_val3), KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+        result = sec_kv->set(key2, key2_val3, strlen(key2_val3), KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
         elapsed = timer.read_ms();
         printf("Elapsed time for set is %d ms\n", elapsed);
 
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = sec_kv->set(key3, key3_val1, strlen(key3_val1),
-                             KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+                             KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
-        result = sec_kv->set(key3, key3_val2, strlen(key3_val2),
-                             KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
+        result = sec_kv->set(key3, key3_val2, strlen(key3_val2), KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_INVALID_ARGUMENT, result);
 
         result = sec_kv->get(key3, get_buf, sizeof(get_buf), &actual_data_size);
@@ -183,18 +182,16 @@ static void white_box_test()
         TEST_ASSERT_EQUAL_STRING_LEN(key3_val1, get_buf, strlen(key3_val1));
 
         for (int j = 0; j < 2; j++) {
-            result = sec_kv->set(key4, key4_val1, strlen(key4_val1),
-                                 KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+            result = sec_kv->set(key4, key4_val1, strlen(key4_val1), KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
             TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
-            result = sec_kv->set(key4, key4_val2, strlen(key4_val2),
-                                 KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+            result = sec_kv->set(key4, key4_val2, strlen(key4_val2), KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
             TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         }
 
         result = sec_kv->get_info(key3, &info);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
-        TEST_ASSERT_EQUAL(KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG, info.flags);
+        TEST_ASSERT_EQUAL(KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG, info.flags);
         TEST_ASSERT_EQUAL(strlen(key3_val1), info.size);
 
         result = ul_kv->get_info(key3, &info);
@@ -224,7 +221,7 @@ static void white_box_test()
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, result);
 
         result = sec_kv->set(key5, key5_val1, strlen(key5_val1),
-                             KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG | KVStore::WRITE_ONCE_FLAG);
+                             KVStore::REQUIRE_REPLAY_PROTECTION_FLAG | KVStore::WRITE_ONCE_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
 #ifndef NO_RBP_MODE
@@ -234,7 +231,7 @@ static void white_box_test()
 #endif
 
         result = sec_kv->set(key5, key5_val2, strlen(key5_val2),
-                             KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG | KVStore::WRITE_ONCE_FLAG);
+                             KVStore::REQUIRE_REPLAY_PROTECTION_FLAG | KVStore::WRITE_ONCE_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_WRITE_PROTECTED, result);
 
         result = sec_kv->remove(key5);
@@ -315,7 +312,7 @@ static void white_box_test()
         TEST_ASSERT_EQUAL_STRING_LEN(key4_val2, get_buf, strlen(key4_val2));
 
         result = sec_kv->set(key6, key6_val1, strlen(key6_val1),
-                             KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+                             KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
 #ifndef NO_RBP_MODE
@@ -326,7 +323,7 @@ static void white_box_test()
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = sec_kv->set(key6, key6_val2, strlen(key6_val2),
-                             KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+                             KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = ul_kv->set(key6, attack_buf, attack_size, 0);
@@ -342,7 +339,7 @@ static void white_box_test()
         int cmac_size = info.size;
         uint8_t *cmac = new uint8_t[cmac_size];
 
-        result = sec_kv->set(key7, key7_val1, strlen(key7_val1), KVStore::REQUIRE_INTEGRITY_FLAG);
+        result = sec_kv->set(key7, key7_val1, strlen(key7_val1), 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = ul_kv->get(key7, attack_buf, sizeof(attack_buf), &attack_size);
@@ -351,7 +348,7 @@ static void white_box_test()
         int data_offset = attack_size - cmac_size - strlen(key7_val1);
         TEST_ASSERT_EQUAL(0, strncmp(key7_val1, attack_buf + data_offset, strlen(key7_val1)));
 
-        result = sec_kv->set(key7, key7_val1, strlen(key7_val1), KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
+        result = sec_kv->set(key7, key7_val1, strlen(key7_val1), KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = ul_kv->get(key7, attack_buf, sizeof(attack_buf), &attack_size);

--- a/features/storage/kvstore/KVStore.h
+++ b/features/storage/kvstore/KVStore.h
@@ -32,7 +32,7 @@ public:
     enum create_flags {
         WRITE_ONCE_FLAG                     = (1 << 0),
         REQUIRE_CONFIDENTIALITY_FLAG        = (1 << 1),
-        REQUIRE_INTEGRITY_FLAG              = (1 << 2),
+        RESERVED_FLAG                       = (1 << 2),
         REQUIRE_REPLAY_PROTECTION_FLAG      = (1 << 3),
     };
 
@@ -54,7 +54,6 @@ public:
          * The Key flags, possible flags combination:
          * WRITE_ONCE_FLAG,
          * REQUIRE_CONFIDENTIALITY_FLAG,
-         * REQUIRE_INTEGRITY_FLAG,
          * REQUIRE_REPLAY_PROTECTION_FLAG
          */
         uint32_t flags;

--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -590,7 +590,7 @@ int _storage_config_TDB_INTERNAL()
         kvstore_config.internal_store;
 
     kvstore_config.flags_mask = ~(KVStore::REQUIRE_CONFIDENTIALITY_FLAG |
-                                  KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
+                                  KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
 
     KVMap &kv_map = KVMap::get_instance();
     ret = kv_map.init();

--- a/features/storage/kvstore/global_api/kvstore_global_api.h
+++ b/features/storage/kvstore/global_api/kvstore_global_api.h
@@ -27,7 +27,7 @@ typedef struct _opaque_kv_key_iterator *kv_iterator_t;
 
 #define KV_WRITE_ONCE_FLAG                      (1 << 0)
 #define KV_REQUIRE_CONFIDENTIALITY_FLAG         (1 << 1)
-#define KV_REQUIRE_INTEGRITY_FLAG               (1 << 2)
+#define KV_RESERVED_FLAG                        (1 << 2)
 #define KV_REQUIRE_REPLAY_PROTECTION_FLAG       (1 << 3)
 
 #define KV_MAX_KEY_LENGTH 128
@@ -44,7 +44,6 @@ typedef struct info {
      * The Key flags, possible flags combination:
      * WRITE_ONCE_FLAG,
      * REQUIRE_CONFIDENTIALITY_FLAG,
-     * REQUIRE_INTEGRITY_FLAG,
      * REQUIRE_REPLAY_PROTECTION_FLAG
      */
     uint32_t flags;

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -46,7 +46,7 @@ static const uint32_t derived_key_size  = 16;
 static const char *const enc_prefix  = "ENC";
 static const char *const auth_prefix = "AUTH";
 
-static const uint32_t security_flags = KVStore::REQUIRE_INTEGRITY_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG;
+static const uint32_t security_flags = KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG;
 
 typedef struct {
     uint16_t metadata_size;
@@ -190,11 +190,6 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         return MBED_ERROR_INVALID_ARGUMENT;
     }
 
-    // RP requires authentication
-    if ((create_flags & REQUIRE_REPLAY_PROTECTION_FLAG) && !(create_flags & REQUIRE_INTEGRITY_FLAG)) {
-        return MBED_ERROR_INVALID_ARGUMENT;
-    }
-
     *handle = static_cast<set_handle_t>(_inc_set_handle);
     ih = reinterpret_cast<inc_set_handle_t *>(*handle);
 
@@ -254,24 +249,22 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         memset(ih->metadata.iv, 0, iv_size);
     }
 
-    if (create_flags & REQUIRE_INTEGRITY_FLAG) {
-        os_ret = cmac_calc_start(ih->auth_ctx, key, _scratch_buf, scratch_buf_size);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto fail;
-        }
-        auth_started = true;
-        // Although name is not part of the data, we calculate CMAC on it as well
-        os_ret = cmac_calc_data(ih->auth_ctx, key, strlen(key));
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto fail;
-        }
-        os_ret = cmac_calc_data(ih->auth_ctx, &ih->metadata, sizeof(record_metadata_t));
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto fail;
-        }
+    os_ret = cmac_calc_start(ih->auth_ctx, key, _scratch_buf, scratch_buf_size);
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto fail;
+    }
+    auth_started = true;
+    // Although name is not part of the data, we calculate CMAC on it as well
+    os_ret = cmac_calc_data(ih->auth_ctx, key, strlen(key));
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto fail;
+    }
+    os_ret = cmac_calc_data(ih->auth_ctx, &ih->metadata, sizeof(record_metadata_t));
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto fail;
     }
 
     ih->offset_in_data = 0;
@@ -291,7 +284,7 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         goto fail;
     }
 
-    if (create_flags & REQUIRE_REPLAY_PROTECTION_FLAG) {
+    if (create_flags & (REQUIRE_REPLAY_PROTECTION_FLAG | WRITE_ONCE_FLAG)) {
         ih->key = new char[strlen(key) + 1];
         strcpy(ih->key, key);
     }
@@ -360,12 +353,10 @@ int SecureStore::set_add_data(set_handle_t handle, const void *value_data, size_
             dst_ptr = static_cast <const uint8_t *>(value_data);
         }
 
-        if (ih->metadata.create_flags & REQUIRE_INTEGRITY_FLAG) {
-            os_ret = cmac_calc_data(ih->auth_ctx, dst_ptr, chunk_size);
-            if (os_ret) {
-                ret = MBED_ERROR_FAILED_OPERATION;
-                goto fail;
-            }
+        os_ret = cmac_calc_data(ih->auth_ctx, dst_ptr, chunk_size);
+        if (os_ret) {
+            ret = MBED_ERROR_FAILED_OPERATION;
+            goto fail;
         }
 
         ret = _underlying_kv->set_add_data(ih->underlying_handle, dst_ptr, chunk_size);
@@ -387,9 +378,7 @@ fail:
         mbedtls_aes_free(&ih->enc_ctx);
     }
 
-    if (ih->metadata.create_flags & REQUIRE_INTEGRITY_FLAG) {
-        mbedtls_cipher_free(&ih->auth_ctx);
-    }
+    mbedtls_cipher_free(&ih->auth_ctx);
 
     // mark handle as invalid by clearing metadata size field in header
     ih->metadata.metadata_size = 0;
@@ -420,12 +409,10 @@ int SecureStore::set_finalize(set_handle_t handle)
         goto end;
     }
 
-    if (ih->metadata.create_flags & REQUIRE_INTEGRITY_FLAG) {
-        os_ret = cmac_calc_finish(ih->auth_ctx, cmac);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto end;
-        }
+    os_ret = cmac_calc_finish(ih->auth_ctx, cmac);
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto end;
     }
 
     ret = _underlying_kv->set_add_data(ih->underlying_handle, cmac, cmac_size);
@@ -438,9 +425,11 @@ int SecureStore::set_finalize(set_handle_t handle)
         goto end;
     }
 
-    if (_rbp_kv && (ih->metadata.create_flags & REQUIRE_REPLAY_PROTECTION_FLAG)) {
+    if (_rbp_kv && (ih->metadata.create_flags & (REQUIRE_REPLAY_PROTECTION_FLAG | WRITE_ONCE_FLAG))) {
         // In rollback protect case, we need to store CMAC in RBP store.
         // If it's also write once case, set write once flag in the RBP key as well.
+        // Use RBP storage also in write once case only - in order to prevent attacks removing
+        // a written once value from underlying KV.
         ret = _rbp_kv->set(ih->key, cmac, cmac_size, ih->metadata.create_flags & WRITE_ONCE_FLAG);
         delete[] ih->key;
         if (ret) {
@@ -455,9 +444,7 @@ end:
         mbedtls_aes_free(&ih->enc_ctx);
     }
 
-    if (ih->metadata.create_flags & REQUIRE_INTEGRITY_FLAG) {
-        mbedtls_cipher_free(&ih->auth_ctx);
-    }
+    mbedtls_cipher_free(&ih->auth_ctx);
 
     _mutex.unlock();
     return ret;
@@ -493,7 +480,9 @@ int SecureStore::remove(const char *key)
     _mutex.lock();
 
     int ret = do_get(key, 0, 0, 0, 0, &info);
-    if (ret) {
+    // Allow deleting key if read error is of our own errors
+    if ((ret != MBED_SUCCESS) && (ret != MBED_ERROR_AUTHENTICATION_FAILED) &&
+            (ret != MBED_ERROR_RBP_AUTHENTICATION_FAILED)) {
         goto end;
     }
 
@@ -570,30 +559,28 @@ int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_
     }
 
     // Another potential attack case - key hasn't got the RP flag set, but exists in the RBP KV
-    if (rbp_key_exists && !(create_flags & REQUIRE_REPLAY_PROTECTION_FLAG)) {
+    if (rbp_key_exists && !(create_flags & (REQUIRE_REPLAY_PROTECTION_FLAG |  WRITE_ONCE_FLAG))) {
         ret = MBED_ERROR_RBP_AUTHENTICATION_FAILED;
         goto end;
     }
 
-    if (create_flags & REQUIRE_INTEGRITY_FLAG) {
-        os_ret = cmac_calc_start(ih->auth_ctx, key, _scratch_buf, scratch_buf_size);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto end;
-        }
-        auth_started = true;
+    os_ret = cmac_calc_start(ih->auth_ctx, key, _scratch_buf, scratch_buf_size);
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto end;
+    }
+    auth_started = true;
 
-        // Although name is not part of the data, we calculate CMAC on it as well
-        os_ret = cmac_calc_data(ih->auth_ctx, key, strlen(key));
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto end;
-        }
-        os_ret = cmac_calc_data(ih->auth_ctx, &ih->metadata, sizeof(record_metadata_t));
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto end;
-        }
+    // Although name is not part of the data, we calculate CMAC on it as well
+    os_ret = cmac_calc_data(ih->auth_ctx, key, strlen(key));
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto end;
+    }
+    os_ret = cmac_calc_data(ih->auth_ctx, &ih->metadata, sizeof(record_metadata_t));
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto end;
     }
 
     if (create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
@@ -641,12 +628,10 @@ int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_
             goto end;
         }
 
-        if (create_flags & REQUIRE_INTEGRITY_FLAG) {
-            os_ret = cmac_calc_data(ih->auth_ctx, dest_buf, chunk_size);
-            if (os_ret) {
-                ret = MBED_ERROR_FAILED_OPERATION;
-                goto end;
-            }
+        os_ret = cmac_calc_data(ih->auth_ctx, dest_buf, chunk_size);
+        if (os_ret) {
+            ret = MBED_ERROR_FAILED_OPERATION;
+            goto end;
         }
 
         if (create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
@@ -672,35 +657,33 @@ int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_
         *actual_size = actual_data_size;
     }
 
-    if (create_flags & REQUIRE_INTEGRITY_FLAG) {
-        uint8_t calc_cmac[cmac_size], read_cmac[cmac_size];
-        os_ret = cmac_calc_finish(ih->auth_ctx, calc_cmac);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
-            goto end;
-        }
+    uint8_t calc_cmac[cmac_size], read_cmac[cmac_size];
+    os_ret = cmac_calc_finish(ih->auth_ctx, calc_cmac);
+    if (os_ret) {
+        ret = MBED_ERROR_FAILED_OPERATION;
+        goto end;
+    }
 
-        // Check with record CMAC
-        ret = _underlying_kv->get(key, read_cmac, cmac_size, 0,
-                                  ih->metadata.metadata_size + ih->metadata.data_size);
-        if (ret) {
-            goto end;
-        }
-        if (memcmp(calc_cmac, read_cmac, cmac_size) != 0) {
-            ret = MBED_ERROR_AUTHENTICATION_FAILED;
-            goto end;
-        }
+    // Check with record CMAC
+    ret = _underlying_kv->get(key, read_cmac, cmac_size, 0,
+                              ih->metadata.metadata_size + ih->metadata.data_size);
+    if (ret) {
+        goto end;
+    }
+    if (memcmp(calc_cmac, read_cmac, cmac_size) != 0) {
+        ret = MBED_ERROR_AUTHENTICATION_FAILED;
+        goto end;
+    }
 
-        // If rollback protect, check also CMAC stored in RBP store
-        if (create_flags & REQUIRE_REPLAY_PROTECTION_FLAG) {
-            if (!rbp_key_exists) {
-                ret = MBED_ERROR_RBP_AUTHENTICATION_FAILED;
-                goto end;
-            }
-            if (memcmp(calc_cmac, rbp_cmac, cmac_size) != 0) {
-                ret = MBED_ERROR_RBP_AUTHENTICATION_FAILED;
-                goto end;
-            }
+    // If rollback protect, check also CMAC stored in RBP store
+    if (_rbp_kv && (create_flags & (REQUIRE_REPLAY_PROTECTION_FLAG | WRITE_ONCE_FLAG))) {
+        if (!rbp_key_exists) {
+            ret = MBED_ERROR_RBP_AUTHENTICATION_FAILED;
+            goto end;
+        }
+        if (memcmp(calc_cmac, rbp_cmac, cmac_size) != 0) {
+            ret = MBED_ERROR_RBP_AUTHENTICATION_FAILED;
+            goto end;
         }
     }
 

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -27,8 +27,8 @@
 
 #define SECURESTORE_ENABLED 1
 
-// Whole class is not supported if entropy or device key are not enabled
-#if !defined(MBEDTLS_ENTROPY_C) || !DEVICEKEY_ENABLED
+// Whole class is not supported if entropy, device key or required mbed TLS features are not enabled
+#if !defined(MBEDTLS_ENTROPY_C) || !defined(MBEDTLS_CIPHER_MODE_CTR) || !defined(MBEDTLS_CMAC_C) || !DEVICEKEY_ENABLED
 #undef SECURESTORE_ENABLED
 #define SECURESTORE_ENABLED 0
 #endif


### PR DESCRIPTION
### Description
This PR includes a few fixes to SecureStore, following a preliminary security review.

These include:
- Remove the require integrity flag (authentication) - always authenticate
- Use RBP KV to store CMAC also in write once case
- Allow removing a key if reading it failed on RBP authentication error'
- Disable SecureStore if user disables MBED TLS AES CTR or CMAC in TLS config

Design docs modified as well.

Resolves [#8865](https://github.com/ARMmbed/mbed-os/issues/8865)

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

