### PR TITLE
Apply GitHub style to exporter matrix

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -69,7 +69,7 @@ To export this project please <a href='http://mbed.org/compiler/?import=http://m
 """
 
 def mcu_ide_list():
-    """Shows list of exportable ides 
+    """Shows list of exportable ides
 
     """
     supported_ides = sorted(EXPORTERS.keys())
@@ -84,10 +84,10 @@ def mcu_ide_matrix(verbose_html=False):
     """
     supported_ides = sorted(EXPORTERS.keys())
     # Only use it in this function so building works without extra modules
-    from prettytable import PrettyTable, ALL
+    from prettytable import PrettyTable, ALL, HEADER
 
     # All tests status table print
-    table_printer = PrettyTable(["Platform"] + supported_ides)
+    table_printer = PrettyTable(["Platform"] + supported_ides, junction_char="|", hrules=HEADER)
     # Align table
     for col in supported_ides:
         table_printer.align[col] = "c"
@@ -107,15 +107,12 @@ def mcu_ide_matrix(verbose_html=False):
             row.append(text)
         table_printer.add_row(row)
 
-    table_printer.border = True
-    table_printer.vrules = ALL
-    table_printer.hrules = ALL
     # creates a html page in a shorter format suitable for readme.md
     if verbose_html:
         result = table_printer.get_html_string()
     else:
         result = table_printer.get_string()
-    result += "\n"
+    result += "\n\n"
     result += "Total IDEs: %d\n"% (len(supported_ides))
     if verbose_html:
         result += "<br>"

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -84,7 +84,7 @@ def mcu_ide_matrix(verbose_html=False):
     """
     supported_ides = sorted(EXPORTERS.keys())
     # Only use it in this function so building works without extra modules
-    from prettytable import PrettyTable, ALL, HEADER
+    from prettytable import PrettyTable, HEADER
 
     # All tests status table print
     table_printer = PrettyTable(["Platform"] + supported_ides, junction_char="|", hrules=HEADER)


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR changes the table output produced by `mbed export -S` from this...
![screen shot 2018-12-06 at 10 38 03 am](https://user-images.githubusercontent.com/6963725/49597895-082b9880-f943-11e8-9382-32305d00903e.png)
To this...
![screen shot 2018-12-06 at 10 37 30 am](https://user-images.githubusercontent.com/6963725/49597901-0c57b600-f943-11e8-9c99-910e8e8e962d.png)

Which allows simple copy/paste in github style table markdown (similar to PR #7720), for example...

| Platform              | cces | cmake_gcc_arm | codeblocks | e2studio | eclipse_armc5 | eclipse_gcc_arm | eclipse_iar | embitz | gnuarmeclipse | iar | make_armc5 | make_armc6 | make_gcc_arm | make_iar | mcuxpresso | netbeans | qtcreator | sw4stm32 | uvision5 | uvision6 | vscode_armc5 | vscode_gcc_arm | vscode_iar |
|-----------------------|------|---------------|------------|----------|---------------|-----------------|-------------|--------|---------------|-----|------------|------------|--------------|----------|------------|----------|-----------|----------|----------|----------|--------------|----------------|------------|
| ARCH_BLE              |  -   |       x       |     -      |    x     |       x       |        x        |      -      |   -    |       x       |  -  |     x      |     -      |      x       |    -     |     -      |    x     |     x     |    -     |    x     |    -     |      x       |       x        |     -      |
| ARCH_BLE_BOOT         |  -   |       x       |     -      |    x     |       x       |        x        |      -      |   -    |       x       |  -  |     x      |     -      |      x       |    -     |     -      |    x     |     x     |    -     |    x     |    -     |      x       |       x        |     -      |
| ARCH_BLE_OTA          |  -   |       x       |     -      |    x     |       x       |        x        |      -      |   -    |       x       |  -  |     x      |     -      |      x       |    -     |     -      |    x     |     x     |    -     |    x     |    -     |      x       |       x        |     -      |

And it just looks cleaner and is easier to read.

I also added another "\n" blank space in between the end of the table and the table information (total IDEs, platforms, etc.)

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

