### PR TITLE
Fix uninitialized handler pointer in FastModels ethernet driver

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/drivers/lan91c111.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/drivers/lan91c111.c
@@ -18,7 +18,7 @@
 #include "lan91c111.h"
 #include <stddef.h>
 
-static lan91_handle_t *lan91c111_handle;
+static lan91_handle_t lan91c111_handle;
 
 void LAN91_init(void)
 {
@@ -95,8 +95,8 @@ void read_MACaddr(uint8_t *addr)
 void LAN91_SetCallback(lan91_callback_t callback, void *userData)
 {
     /* Set callback and userData. */
-    lan91c111_handle->callback = callback;
-    lan91c111_handle->userData = userData;
+    lan91c111_handle.callback = callback;
+    lan91c111_handle.userData = userData;
 }
 
 
@@ -216,8 +216,8 @@ void ETHERNET_Handler(void)
     if ((LREG(uint8_t, B2_IST) & IST_RCV) != 0) {
         LREG(uint8_t,  B2_MSK) = 0;
         /* Callback function. */
-        if (lan91c111_handle->callback) {
-            lan91c111_handle->callback(LAN91_RxEvent, lan91c111_handle->userData);
+        if (lan91c111_handle.callback) {
+            lan91c111_handle.callback(LAN91_RxEvent, lan91c111_handle.userData);
         }
     }
 }


### PR DESCRIPTION
### Description

This is the fix for ARMmbed/mbed-os-example-sockets#104.
This is fixed the bug of uninitialized handler pointer, which didn't expose until we got MPU enabled in mbed OS. 

cc @ashok-rao @TacoGrandeTX @MarceloSalazar 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

