### PR TITLE
Mbed TLS: Fix ECC hardware double initialization

### DIFF
--- a/features/mbedtls/src/ecp.c
+++ b/features/mbedtls/src/ecp.c
@@ -2393,11 +2393,6 @@ int mbedtls_ecp_muladd_restartable(
 
     mbedtls_ecp_point_init( &mP );
 
-#if defined(MBEDTLS_ECP_INTERNAL_ALT)
-    if( ( is_grp_capable = mbedtls_internal_ecp_grp_capable( grp ) ) )
-        MBEDTLS_MPI_CHK( mbedtls_internal_ecp_init( grp ) );
-#endif /* MBEDTLS_ECP_INTERNAL_ALT */
-
     ECP_RS_ENTER( ma );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
@@ -2425,6 +2420,12 @@ int mbedtls_ecp_muladd_restartable(
 mul2:
 #endif
     MBEDTLS_MPI_CHK( mbedtls_ecp_mul_shortcuts( grp, pR,  n, Q, rs_ctx ) );
+
+#if defined(MBEDTLS_ECP_INTERNAL_ALT)
+    if( ( is_grp_capable = mbedtls_internal_ecp_grp_capable( grp ) ) )
+        MBEDTLS_MPI_CHK( mbedtls_internal_ecp_init( grp ) );
+#endif /* MBEDTLS_ECP_INTERNAL_ALT */
+
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     if( rs_ctx != NULL && rs_ctx->ma != NULL )
         rs_ctx->ma->state = ecp_rsma_add;


### PR DESCRIPTION
### Description

We initialized the ECC hardware before calling
mbedtls_ecp_mul_shortcuts(). This in turn calls
mbedtls_ecp_mul_restartable(), which initializes and frees the hardware
too. This issue has been introduced by recent changes and caused some
accelerators to hang. 

We move the initialization after the mbedtle_ecp_mul_shortcuts() calls
to avoid double initialization.

### Integration

An identical fix has been submitted to the Mbed TLS repository:
https://github.com/ARMmbed/mbedtls/pull/2267

It has been reviewed and approved there and will be merged in the next Mbed TLS release.

### Testing

This issue has been raised in #8985 and I can't reproduce it. I have asked for manual testing of this fix there and waiting for a confirmation that this indeed resolves the problem.

### Pull request type

    [ x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change