### PR TITLE
Add NUCLEO_L4R5ZI_P target

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7199,6 +7199,10 @@
         "device_name": "STM32L4R5ZI",
         "bootloader_supported": true
     },
+    "NUCLEO_L4R5ZI_P": {
+        "inherits": ["NUCLEO_L4R5ZI"],
+        "detect_code": ["0781"]
+    },
     "VBLUNO52": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52832"],


### PR DESCRIPTION
### Description

https://os.mbed.com/platforms/ST-Nucleo-L4R5ZI-P/

This board contains an External SMPS to generate Vcore logic supply (only available on '-P' suffixed boards).

This board is using the same MBED configuration as NUCLEO_L4R5ZI

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

