### PR TITLE
Revert "Turn off MPU on targets failing OOB"

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4087,8 +4087,7 @@
         "macros_add": [
             "MBEDTLS_CONFIG_HW_SUPPORT",
             "HSE_VALUE=12000000",
-            "GNSSBAUD=9600",
-            "MBED_MPU_CUSTOM"
+            "GNSSBAUD=9600"
         ],
         "overrides": { "lse_available": 0 },
         "device_has_add": [
@@ -4096,7 +4095,8 @@
             "EMAC",
             "SERIAL_FC",
             "TRNG",
-            "FLASH"
+            "FLASH",
+            "MPU"
         ],
         "public": false,
         "device_name": "STM32F437VG",
@@ -7239,7 +7239,7 @@
             }
         },
         "inherits": ["Target"],
-        "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "LPTICKER_DELAY_TICKS=3", "MBED_MPU_CUSTOM"],
+        "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "LPTICKER_DELAY_TICKS=3"],
         "device_has": [
             "USTICKER",
             "LPTICKER",
@@ -7265,7 +7265,8 @@
             "TRNG",
             "FLASH",
             "CAN",
-            "EMAC"
+            "EMAC",
+            "MPU"
         ],
         "release_versions": ["5"],
         "bootloader_supported": true,


### PR DESCRIPTION
### Description

The cause of the pelion-enablement test failures for Nuvoton boards is not caused by or related to the MPU so this patch re-enables the MPU for these boards.

The change which initially disabled the MPU is:
b217c5fe4de3d451653971cee394a84c14c40174


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

