### PR TITLE
Mbed os 5.11.0 oob: fix fault exception issue

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -319,10 +319,9 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
     _at.unlock();
 
     if (ret_val >= 0) {
-        if(addr){
+        if (addr) {
             tr_info("Socket %d recv %d bytes from %s port %d", find_socket_index(socket), ret_val, addr->get_ip_address(), addr->get_port());
-        }
-        else{
+        } else {
             tr_info("Socket %d recv %d bytes", find_socket_index(socket), ret_val);
         }
     } else if (ret_val != NSAPI_ERROR_WOULD_BLOCK) {

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -307,7 +307,12 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
 
         _at.unlock();
         if (ret_val != NSAPI_ERROR_OK) {
-            tr_error("Socket %d create %s error %d", find_socket_index(socket), addr->get_ip_address(), ret_val);
+            if(addr){
+                tr_error("Socket %d create %s error %d", find_socket_index(socket), addr->get_ip_address(), ret_val);
+            }
+            else{
+                tr_error("Socket %d create error %d", find_socket_index(socket), ret_val);
+            }
             return ret_val;
         }
     }
@@ -319,7 +324,12 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
     _at.unlock();
 
     if (ret_val >= 0) {
-        tr_info("Socket %d recv %d bytes from %s port %d", find_socket_index(socket), ret_val, addr->get_ip_address(), addr->get_port());
+        if(addr){
+            tr_info("Socket %d recv %d bytes from %s port %d", find_socket_index(socket), ret_val, addr->get_ip_address(), addr->get_port());
+        }
+        else{
+            tr_info("Socket %d recv %d bytes", find_socket_index(socket), ret_val);
+        }
     } else if (ret_val != NSAPI_ERROR_WOULD_BLOCK) {
         tr_error("Socket %d recv error %d", find_socket_index(socket), ret_val);
     }

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -307,12 +307,7 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
 
         _at.unlock();
         if (ret_val != NSAPI_ERROR_OK) {
-            if(addr){
-                tr_error("Socket %d create %s error %d", find_socket_index(socket), addr->get_ip_address(), ret_val);
-            }
-            else{
-                tr_error("Socket %d create error %d", find_socket_index(socket), ret_val);
-            }
+            tr_error("Socket %d create error %d", find_socket_index(socket), ret_val);
             return ret_val;
         }
     }


### PR DESCRIPTION
### Description
Fix the fault exception issue in socket_recvfrom().
It is caused by the usage of null pointer as SocketAddress *addr.
e.g. socket_recv() -> socket_recvfrom(handle, NULL, data, size);

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

