### PR TITLE
Add cellular statemachine unit tests

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/unittest.cmake
@@ -25,6 +25,7 @@ set(unittest-test-sources
   stubs/AT_CellularDevice_stub.cpp
   stubs/AT_CellularStack_stub.cpp
   stubs/AT_CellularNetwork_stub.cpp
+  stubs/AT_CellularPower_stub.cpp
   stubs/CellularDevice_stub.cpp
   stubs/CellularStateMachine_stub.cpp
   stubs/equeue_stub.c

--- a/UNITTESTS/features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gtest/gtest.h"
+#include <string.h>
+
+#include "CellularDevice.h"
+#include "AT_CellularDevice_stub.h"
+#include "FileHandle_stub.h"
+#include "AT_CellularPower_stub.h"
+#include "AT_CellularNetwork_stub.h"
+#include "myCellularDevice.h"
+#include "Thread_stub.h"
+#include "cmsis_os2.h"
+#include "equeue_stub.h"
+
+using namespace mbed;
+
+enum UT_CellularState {
+    UT_STATE_INIT = 0,
+    UT_STATE_POWER_ON,
+    UT_STATE_DEVICE_READY,
+    UT_STATE_SIM_PIN,
+    UT_STATE_REGISTERING_NETWORK,
+    UT_STATE_MANUAL_REGISTERING_NETWORK,
+    UT_STATE_ATTACHING_NETWORK,
+    UT_STATE_MAX_FSM_STATE
+};
+
+// AStyle ignored as the definition is not clear due to preprocessor usage
+// *INDENT-OFF*
+class TestCellularStateMachine : public testing::Test {
+protected:
+
+    void SetUp()
+    {
+        Thread_stub::osStatus_value = osOK;
+        AT_CellularPower_stub::fail_counter = 0;
+    }
+
+    void TearDown()
+    {
+    }
+};
+
+static void cellular_callback(nsapi_event_t ev, intptr_t ptr)
+{
+
+}
+
+namespace mbed {
+
+class UT_CellularStateMachine {
+
+public:
+
+    UT_CellularStateMachine() {
+        _state_machine = NULL;
+    }
+
+    ~UT_CellularStateMachine() {
+        delete _state_machine;
+        _state_machine = NULL;
+    }
+
+    CellularStateMachine *create_state_machine(CellularDevice &device, events::EventQueue &queue)
+    {
+        _state_machine = new CellularStateMachine(device, queue);
+        return _state_machine;
+    }
+
+    void delete_state_machine() {
+        delete _state_machine;
+        _state_machine = NULL;
+    }
+
+    void set_cellular_callback(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+    {
+        _state_machine->set_cellular_callback(status_cb);
+    }
+
+    nsapi_error_t start_dispatch()
+    {
+        return _state_machine->start_dispatch();
+    }
+
+    nsapi_error_t run_to_power_on()
+    {
+        return _state_machine->run_to_state(CellularStateMachine::STATE_POWER_ON);
+    }
+
+    nsapi_error_t run_to_device_ready()
+    {
+        return _state_machine->run_to_state(CellularStateMachine::STATE_DEVICE_READY);
+    }
+
+    nsapi_error_t run_to_device_sim_ready()
+    {
+        return _state_machine->run_to_state(CellularStateMachine::STATE_SIM_PIN);
+    }
+
+    nsapi_error_t run_to_device_registered()
+    {
+        return _state_machine->run_to_state(CellularStateMachine::STATE_REGISTERING_NETWORK);
+    }
+
+    nsapi_error_t run_to_device_attached()
+    {
+        return _state_machine->run_to_state(CellularStateMachine::STATE_ATTACHING_NETWORK);
+    }
+
+    void stop()
+    {
+        _state_machine->stop();
+    }
+
+    void set_sim_pin(const char *sim_pin)
+    {
+        _state_machine->set_sim_pin(sim_pin);
+    }
+
+    void set_retry_timeout_array(uint16_t *timeout, int array_len)
+    {
+        _state_machine->set_retry_timeout_array(timeout, array_len);
+    }
+
+    void set_plmn(const char *plmn)
+    {
+        _state_machine->set_plmn(plmn);
+    }
+
+    bool get_current_status(UT_CellularState &current_state, UT_CellularState &target_state)
+    {
+        return _state_machine->get_current_status((CellularStateMachine::CellularState&)current_state,
+                (CellularStateMachine::CellularState&)target_state);
+    }
+
+    void cellular_event_changed(nsapi_event_t ev, intptr_t ptr)
+    {
+        _state_machine->cellular_event_changed(ev, ptr);
+    }
+
+    void reset()
+    {
+        _state_machine->reset();
+    }
+    void ready_urc_cb()
+    {
+        _state_machine->device_ready_cb();
+    }
+
+    CellularStateMachine * _state_machine;
+};
+}
+
+TEST_F(TestCellularStateMachine, test_create_delete)
+{
+    UT_CellularStateMachine ut;
+    FileHandle_stub fh1;
+
+    CellularDevice *dev = new myCellularDevice(&fh1);
+    EXPECT_TRUE(dev);
+
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    ut.delete_state_machine();
+
+    delete dev;
+    dev = NULL;
+}
+
+TEST_F(TestCellularStateMachine, test_setters)
+{
+    UT_CellularStateMachine ut;
+    FileHandle_stub fh1;
+
+    CellularDevice *dev = new myCellularDevice(&fh1);
+    EXPECT_TRUE(dev);
+
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    ut.set_cellular_callback(&cellular_callback);
+
+    ut.set_sim_pin(NULL);
+    ut.set_sim_pin("1234");
+    ut.set_plmn(NULL);
+    ut.set_plmn("12345");
+
+    uint16_t timeout[20] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20};
+    ut.set_retry_timeout_array(timeout, 10); // test max length
+    ut.set_retry_timeout_array(timeout, 20); // test too big array
+    ut.set_retry_timeout_array(0, 10); // null array
+
+    ut.delete_state_machine();
+
+    delete dev;
+    dev = NULL;
+}
+
+TEST_F(TestCellularStateMachine, test_start_dispatch)
+{
+    UT_CellularStateMachine ut;
+    FileHandle_stub fh1;
+
+    CellularDevice *dev = new myCellularDevice(&fh1);
+    EXPECT_TRUE(dev);
+
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    nsapi_error_t err = ut.start_dispatch();
+    ASSERT_EQ(NSAPI_ERROR_OK, err);
+    ut.delete_state_machine();
+
+    Thread_stub::osStatus_value = osErrorNoMemory;
+    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    err = ut.start_dispatch();
+    ASSERT_EQ(NSAPI_ERROR_NO_MEMORY, err);
+    ut.delete_state_machine();
+
+    delete dev;
+    dev = NULL;
+}
+
+TEST_F(TestCellularStateMachine, test_stop)
+{
+    UT_CellularStateMachine ut;
+    FileHandle_stub fh1;
+
+    CellularDevice *dev = new AT_CellularDevice(&fh1);
+    EXPECT_TRUE(dev);
+
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+
+    ut.stop(); // nothing created, run through
+    ut.delete_state_machine();
+
+    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    nsapi_error_t err = ut.start_dispatch();
+    ASSERT_EQ(NSAPI_ERROR_OK, err);
+
+    ut.stop(); // thread is created, now stop will delete it
+    ut.delete_state_machine();
+
+    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    err = ut.start_dispatch();
+    ASSERT_EQ(NSAPI_ERROR_OK, err);
+
+    ut.set_cellular_callback(&cellular_callback);
+
+    struct equeue_event ptr;
+    equeue_stub.void_ptr = &ptr;
+    equeue_stub.call_cb_immediately = true;
+
+    AT_CellularPower_stub::fail_counter = 1;
+
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_power_on());
+
+    ut.stop(); // thread and power are created, now stop will delete them
+    ut.delete_state_machine();
+
+    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+    err = ut.start_dispatch();
+    ASSERT_EQ(NSAPI_ERROR_OK, err);
+
+    ut.set_cellular_callback(&cellular_callback);
+    AT_CellularPower_stub::fail_counter = 1;
+
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_ready());
+
+    ut.stop(); // thread and network are created, now stop will delete them
+    ut.delete_state_machine();
+
+    delete dev;
+    dev = NULL;
+}
+
+TEST_F(TestCellularStateMachine, test_run_to_state)
+{
+    UT_CellularStateMachine ut;
+    FileHandle_stub fh1;
+
+    CellularDevice *dev = new AT_CellularDevice(&fh1);
+    EXPECT_TRUE(dev);
+
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    EXPECT_TRUE(stm);
+
+    nsapi_error_t err = ut.start_dispatch();
+    ASSERT_EQ(NSAPI_ERROR_OK, err);
+
+    struct equeue_event ptr;
+    equeue_stub.void_ptr = 0;
+    equeue_stub.call_cb_immediately = false;
+    ASSERT_EQ(NSAPI_ERROR_NO_MEMORY, ut.run_to_power_on());
+    ut.reset();
+
+    equeue_stub.void_ptr = &ptr;
+    equeue_stub.call_cb_immediately = true;
+
+    ut.set_cellular_callback(&cellular_callback);
+    AT_CellularPower_stub::fail_counter = 0;
+
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_power_on());
+    UT_CellularState current_state;
+    UT_CellularState target_state;
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_POWER_ON, current_state);
+    ASSERT_EQ(UT_STATE_POWER_ON, target_state);
+    ut.reset();
+
+    AT_CellularPower_stub::set_at_fail_counter = 1;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, current_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, target_state);
+    ut.ready_urc_cb();
+    ut.reset();
+
+    AT_CellularPower_stub::fail_counter = 1;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, current_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, target_state);
+    ut.reset();
+
+     AT_CellularPower_stub::fail_counter = 2;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, current_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, target_state);
+    ut.reset();
+
+     AT_CellularPower_stub::fail_counter = 3;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, current_state);
+    ASSERT_EQ(UT_STATE_DEVICE_READY, target_state);
+    ut.reset();
+
+    AT_CellularDevice_stub::init_module_failure_count = 1;
+    AT_CellularPower_stub::fail_counter = 0;
+    AT_CellularNetwork_stub::set_registration_urc_fail_counter = 4;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_sim_ready());
+    (void) ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, current_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, target_state);
+    ut.reset();
+
+    AT_CellularDevice_stub::pin_needed = true;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_sim_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, current_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, target_state);
+    ut.reset();
+
+    ut.set_sim_pin("1234");
+    AT_CellularDevice_stub::pin_needed = true;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_sim_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, current_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, target_state);
+    ut.reset();
+
+    ut.set_sim_pin("1234");
+    AT_CellularDevice_stub::pin_needed = true;
+    AT_CellularDevice_stub::set_pin_failure_count = 1;
+    AT_CellularDevice_stub::get_sim_failure_count = 1;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_sim_ready());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, current_state);
+    ASSERT_EQ(UT_STATE_SIM_PIN, target_state);
+    ut.reset();
+
+    cell_callback_data_t data;
+    data.status_data = CellularNetwork::RegisteredHomeNetwork;
+    AT_CellularNetwork_stub::get_registration_params_fail_counter = 10;
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_registered());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_REGISTERING_NETWORK, current_state);
+    ASSERT_EQ(UT_STATE_REGISTERING_NETWORK, target_state);
+    ut.cellular_event_changed((nsapi_event_t)CellularRegistrationStatusChanged, (intptr_t)&data);
+    ut.reset();
+
+    // manual registering
+    ut.set_plmn("12345");
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_registered());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_MANUAL_REGISTERING_NETWORK, current_state);
+    ASSERT_EQ(UT_STATE_MANUAL_REGISTERING_NETWORK, target_state);
+    ut.cellular_event_changed((nsapi_event_t)CellularRegistrationStatusChanged, (intptr_t)&data);
+    ut.reset();
+
+    ut.set_plmn(0);
+    ASSERT_EQ(NSAPI_ERROR_OK, ut.run_to_device_attached());
+    (void)ut.get_current_status(current_state, target_state);
+    ASSERT_EQ(UT_STATE_ATTACHING_NETWORK, current_state);
+    ASSERT_EQ(UT_STATE_ATTACHING_NETWORK, target_state);
+    ut.reset();
+
+    ut.delete_state_machine();
+
+    delete dev;
+    dev = NULL;
+}
+
+
+
+
+

--- a/UNITTESTS/features/cellular/framework/device/cellularstatemachine/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellularstatemachine/unittest.cmake
@@ -1,0 +1,43 @@
+
+####################
+# UNIT TESTS
+####################
+
+# Add test specific include paths
+set(unittest-includes ${unittest-includes}
+    /features/cellular/framework/device/cellularstatemachine
+  ../features/cellular/framework/device
+  ../features/cellular/framework/common
+)
+
+# Source files
+set(unittest-sources
+  ../features/cellular/framework/device/CellularStateMachine.cpp
+)
+
+# Test files
+set(unittest-test-sources
+  features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
+  stubs/FileHandle_stub.cpp
+  stubs/CellularDevice_stub.cpp
+  stubs/EventQueue_stub.cpp
+  stubs/mbed_assert_stub.c
+  stubs/UARTSerial_stub.cpp
+  stubs/SerialBase_stub.cpp
+  stubs/ATHandler_stub.cpp
+  stubs/AT_CellularNetwork_stub.cpp
+  stubs/AT_CellularPower_stub.cpp
+  stubs/AT_CellularBase_stub.cpp
+  stubs/AT_CellularContext_stub.cpp
+  stubs/AT_CellularDevice_stub.cpp
+  stubs/Semaphore_stub.cpp
+  stubs/NetworkInterface_stub.cpp
+  stubs/Thread_stub.cpp
+  stubs/Mutex_stub.cpp
+  stubs/EventQueue_stub.cpp
+  stubs/equeue_stub.c
+)
+
+# defines
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMDMRTS=PTC0 -DMDMCTS=PTC1 -DMDMTXD=NC -DMDMRXD=NC -DMBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE=115200 -DCELLULAR_DEVICE=myCellularDevice -DDEVICE_SERIAL_FC=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMDMRTS=PTC0 -DMDMCTS=PTC1 -DMDMTXD=NC -DMDMRXD=NC -DMBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE=115200 -DCELLULAR_DEVICE=myCellularDevice -DDEVICE_SERIAL_FC=1")

--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -15,13 +15,23 @@
  * limitations under the License.
  */
 
-#include "AT_CellularDevice.h"
+#include "AT_CellularDevice_stub.h"
 #include "AT_CellularNetwork.h"
+#include "AT_CellularPower.h"
+#include "AT_CellularContext.h"
 #include "ATHandler.h"
 
 const int DEFAULT_AT_TIMEOUT = 1000;
 
 using namespace mbed;
+
+
+int AT_CellularDevice_stub::failure_count = 0;
+nsapi_error_t AT_CellularDevice_stub::nsapi_error_value = 0;
+int AT_CellularDevice_stub::init_module_failure_count = 0;
+int AT_CellularDevice_stub::set_pin_failure_count = 0;
+int AT_CellularDevice_stub::get_sim_failure_count = 0;
+bool AT_CellularDevice_stub::pin_needed = false;
 
 AT_CellularDevice::AT_CellularDevice(FileHandle *fh) : CellularDevice(fh), _network(0), _sms(0),
     _power(0), _information(0), _context_list(0), _default_timeout(DEFAULT_AT_TIMEOUT),
@@ -33,6 +43,8 @@ AT_CellularDevice::AT_CellularDevice(FileHandle *fh) : CellularDevice(fh), _netw
 
 AT_CellularDevice::~AT_CellularDevice()
 {
+    delete _network;
+    delete _power;
     delete _atHandlers;
 }
 
@@ -55,7 +67,8 @@ void delete_context(CellularContext *context)
 
 CellularNetwork *AT_CellularDevice::open_network(FileHandle *fh)
 {
-    return new AT_CellularNetwork(*_atHandlers);
+    _network = new AT_CellularNetwork(*_atHandlers);
+    return _network;
 }
 
 CellularSMS *AT_CellularDevice::open_sms(FileHandle *fh)
@@ -65,7 +78,8 @@ CellularSMS *AT_CellularDevice::open_sms(FileHandle *fh)
 
 CellularPower *AT_CellularDevice::open_power(FileHandle *fh)
 {
-    return NULL;
+    _power = new AT_CellularPower(*_atHandlers);
+    return _power;
 }
 
 CellularInformation *AT_CellularDevice::open_information(FileHandle *fh)
@@ -146,7 +160,11 @@ void AT_CellularDevice::modem_debug_on(bool on)
 
 nsapi_error_t AT_CellularDevice::is_ready()
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularDevice_stub::init_module_failure_count) {
+        AT_CellularDevice_stub::init_module_failure_count--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularDevice_stub::nsapi_error_value;
 }
 
 nsapi_error_t AT_CellularDevice::set_ready_cb(mbed::Callback<void()> callback)
@@ -161,25 +179,53 @@ nsapi_error_t AT_CellularDevice::set_power_save_mode(int periodic_time, int acti
 
 nsapi_error_t AT_CellularDevice::init()
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularDevice_stub::init_module_failure_count) {
+        AT_CellularDevice_stub::init_module_failure_count--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularDevice_stub::nsapi_error_value;
 }
 
 nsapi_error_t AT_CellularDevice::reset()
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularDevice_stub::init_module_failure_count) {
+        AT_CellularDevice_stub::init_module_failure_count--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularDevice_stub::nsapi_error_value;
 }
 
 nsapi_error_t AT_CellularDevice::shutdown()
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularDevice_stub::init_module_failure_count) {
+        AT_CellularDevice_stub::init_module_failure_count--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularDevice_stub::nsapi_error_value;
 }
 
 nsapi_error_t AT_CellularDevice::set_pin(const char *sim_pin)
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularDevice_stub::set_pin_failure_count) {
+        AT_CellularDevice_stub::set_pin_failure_count--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularDevice_stub::nsapi_error_value;
 }
 
 nsapi_error_t AT_CellularDevice::get_sim_state(SimState &state)
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularDevice_stub::get_sim_failure_count) {
+        AT_CellularDevice_stub::get_sim_failure_count--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+
+    if (AT_CellularDevice_stub::pin_needed) {
+        AT_CellularDevice_stub::pin_needed = false;
+        state = SimStatePinNeeded;
+    } else {
+        state = SimStateReady;
+    }
+
+    return AT_CellularDevice_stub::nsapi_error_value;
 }

--- a/UNITTESTS/stubs/AT_CellularDevice_stub.h
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) , Arm Limited and affiliates.
+ * Copyright (c) 2018, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef AT_CELLULARDEVICE_STUB_H_
+#define AT_CELLULARDEVICE_STUB_H_
 
-#include "Thread_stub.h"
+#include "AT_CellularDevice.h"
 
-using namespace rtos;
-
-osStatus Thread_stub::osStatus_value = osOK;
-
-osStatus Thread::wait_until(uint64_t millisec)
-{
-    return 0;
+namespace AT_CellularDevice_stub {
+extern int failure_count;
+extern nsapi_error_t nsapi_error_value;
+extern int init_module_failure_count;
+extern int set_pin_failure_count;
+extern int get_sim_failure_count;
+extern bool pin_needed;
 }
 
-osStatus Thread::terminate()
-{
-    return 0;
-}
 
-osStatus Thread::start(mbed::Callback<void()> task)
-{
-    return Thread_stub::osStatus_value;
-}
-
-void Thread::constructor(osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name)
-{
-}
-
-Thread::~Thread()
-{
-}
+#endif /* AT_CELLULARDEVICE_STUB_H_ */

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "AT_CellularNetwork.h"
+#include "AT_CellularNetwork_stub.h"
 #include "CellularNetwork.h"
 #include "CellularUtil.h"
 #include "CellularLog.h"
@@ -24,6 +24,13 @@
 
 using namespace mbed;
 using namespace mbed_cellular_util;
+
+
+
+nsapi_error_t AT_CellularNetwork_stub::nsapi_error_value = 0;
+int AT_CellularNetwork_stub::fail_counter = 0;
+int AT_CellularNetwork_stub::set_registration_urc_fail_counter = 0;
+int AT_CellularNetwork_stub::get_registration_params_fail_counter = 0;
 
 AT_CellularNetwork::AT_CellularNetwork(ATHandler &atHandler) : AT_CellularBase(atHandler)
 {
@@ -44,6 +51,10 @@ nsapi_connection_status_t AT_CellularNetwork::get_connection_status() const
 
 nsapi_error_t AT_CellularNetwork::set_registration_urc(RegistrationType type, bool urc_on)
 {
+    if (AT_CellularNetwork_stub::set_registration_urc_fail_counter) {
+        AT_CellularNetwork_stub::set_registration_urc_fail_counter--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
     return NSAPI_ERROR_OK;
 }
 
@@ -60,6 +71,12 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
 
 nsapi_error_t AT_CellularNetwork::get_registration_params(RegistrationType type, registration_params_t &reg_params)
 {
+    if (AT_CellularNetwork_stub::get_registration_params_fail_counter) {
+        AT_CellularNetwork_stub::get_registration_params_fail_counter--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+
+    reg_params._status = CellularNetwork::RegisteredHomeNetwork;
     return NSAPI_ERROR_OK;
 }
 
@@ -148,7 +165,7 @@ nsapi_error_t AT_CellularNetwork::get_operator_names(operator_names_list &op_nam
 
 bool AT_CellularNetwork::is_active_context()
 {
-    return true;
+    return false;
 }
 
 nsapi_error_t AT_CellularNetwork::set_receive_period(int mode, EDRXAccessTechnology act_type, uint8_t edrx_value)

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.h
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) , Arm Limited and affiliates.
+ * Copyright (c) 2018, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef AT_CELLULARNETWORK_STUB_H_
+#define AT_CELLULARNETWORK_STUB_H_
 
-#include "Thread_stub.h"
+#include "AT_CellularNetwork.h"
 
-using namespace rtos;
-
-osStatus Thread_stub::osStatus_value = osOK;
-
-osStatus Thread::wait_until(uint64_t millisec)
-{
-    return 0;
+namespace AT_CellularNetwork_stub {
+extern nsapi_error_t nsapi_error_value;
+extern int fail_counter;
+extern int set_registration_urc_fail_counter;
+extern int get_registration_params_fail_counter;
 }
 
-osStatus Thread::terminate()
-{
-    return 0;
-}
 
-osStatus Thread::start(mbed::Callback<void()> task)
-{
-    return Thread_stub::osStatus_value;
-}
-
-void Thread::constructor(osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name)
-{
-}
-
-Thread::~Thread()
-{
-}
+#endif /* AT_CELLULARNETWORK_STUB_H_ */

--- a/UNITTESTS/stubs/AT_CellularPower_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularPower_stub.cpp
@@ -15,12 +15,16 @@
  * limitations under the License.
  */
 
-#include "AT_CellularPower.h"
+#include "AT_CellularPower_stub.h"
 #include "CellularUtil.h"
 #include "CellularLog.h"
 
 using namespace mbed_cellular_util;
 using namespace mbed;
+
+nsapi_error_t AT_CellularPower_stub::nsapi_error_value = 0;
+int AT_CellularPower_stub::fail_counter = 0;
+int AT_CellularPower_stub::set_at_fail_counter = 0;
 
 AT_CellularPower::AT_CellularPower(ATHandler &at) : AT_CellularBase(at)
 {
@@ -32,10 +36,18 @@ AT_CellularPower::~AT_CellularPower()
 
 nsapi_error_t AT_CellularPower::on()
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularPower_stub::fail_counter) {
+        AT_CellularPower_stub::fail_counter--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularPower_stub::nsapi_error_value;
 }
 
 nsapi_error_t AT_CellularPower::off()
 {
-    return NSAPI_ERROR_OK;
+    if (AT_CellularPower_stub::fail_counter) {
+        AT_CellularPower_stub::fail_counter--;
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    return AT_CellularPower_stub::nsapi_error_value;
 }

--- a/UNITTESTS/stubs/AT_CellularPower_stub.h
+++ b/UNITTESTS/stubs/AT_CellularPower_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) , Arm Limited and affiliates.
+ * Copyright (c) 2018, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef AT_CELLULARPOWER_STUB_H_
+#define AT_CELLULARPOWER_STUB_H_
 
-#include "Thread_stub.h"
+#include "AT_CellularPower.h"
 
-using namespace rtos;
-
-osStatus Thread_stub::osStatus_value = osOK;
-
-osStatus Thread::wait_until(uint64_t millisec)
-{
-    return 0;
+namespace AT_CellularPower_stub {
+extern nsapi_error_t nsapi_error_value;
+extern int fail_counter;
+extern int set_at_fail_counter;
 }
 
-osStatus Thread::terminate()
-{
-    return 0;
-}
-
-osStatus Thread::start(mbed::Callback<void()> task)
-{
-    return Thread_stub::osStatus_value;
-}
-
-void Thread::constructor(osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name)
-{
-}
-
-Thread::~Thread()
-{
-}
+#endif /* AT_CELLULARPOWER_STUB_H_ */

--- a/UNITTESTS/stubs/Thread_stub.h
+++ b/UNITTESTS/stubs/Thread_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) , Arm Limited and affiliates.
+ * Copyright (c) 2018, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef THREAD_STUB_H_
+#define THREAD_STUB_H_
 
-#include "Thread_stub.h"
+#include "Thread.h"
 
-using namespace rtos;
-
-osStatus Thread_stub::osStatus_value = osOK;
-
-osStatus Thread::wait_until(uint64_t millisec)
-{
-    return 0;
+namespace Thread_stub {
+extern osStatus osStatus_value;
 }
 
-osStatus Thread::terminate()
-{
-    return 0;
-}
-
-osStatus Thread::start(mbed::Callback<void()> task)
-{
-    return Thread_stub::osStatus_value;
-}
-
-void Thread::constructor(osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name)
-{
-}
-
-Thread::~Thread()
-{
-}
+#endif /* THREAD_STUB_H_ */

--- a/UNITTESTS/target_h/cmsis_os2.h
+++ b/UNITTESTS/target_h/cmsis_os2.h
@@ -24,7 +24,7 @@
 typedef int32_t                  osStatus;
 
 #define osOK 0
-
+#define osErrorNoMemory -5
 
 
 //These are from cmsis_os2.h

--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -670,8 +670,6 @@ void CellularStateMachine::set_cellular_callback(mbed::Callback<void(nsapi_event
 
 bool CellularStateMachine::check_is_target_reached()
 {
-    tr_debug("check_is_target_reached(): target state %s, _state: %s, _cb_data.error: %d, _event_id: %d,_is_retry: %d", get_state_string(_target_state), get_state_string(_state), _cb_data.error, _event_id, _is_retry);
-
     if (((_target_state == _state || _target_state < _next_state) && _cb_data.error == NSAPI_ERROR_OK && !_is_retry) ||
             _event_id == STM_STOPPED) {
         if (_target_state != _state && _target_state < _next_state) {
@@ -733,7 +731,7 @@ void CellularStateMachine::device_ready_cb()
     }
 }
 
-void CellularStateMachine::set_retry_timeout_array(uint16_t *timeout, int array_len)
+void CellularStateMachine::set_retry_timeout_array(const uint16_t timeout[], int array_len)
 {
     if (!timeout || array_len <= 0) {
         tr_warn("set_retry_timeout_array, timeout array null or invalid length");

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -99,7 +99,7 @@ private:
      *  @param timeout      timeout array using seconds
      *  @param array_len    length of the array
      */
-    void set_retry_timeout_array(uint16_t *timeout, int array_len);
+    void set_retry_timeout_array(const uint16_t timeout[], int array_len);
 
     /** Sets the operator plmn which is used when registering to a network specified by plmn. If plmn is not set then automatic
      *  registering is used when registering to a cellular network. Does not start any operations.

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -42,6 +42,7 @@ private:
     // friend of CellularDevice so that it's the only way to close/delete this class.
     friend class CellularDevice;
     friend class AT_CellularDevice;
+    friend class UT_CellularStateMachine; // for unit tests
     /** Constructor
      *
      * @param device    reference to CellularDevice
@@ -98,7 +99,7 @@ private:
      *  @param timeout      timeout array using seconds
      *  @param array_len    length of the array
      */
-    void set_retry_timeout_array(uint16_t timeout[], int array_len);
+    void set_retry_timeout_array(uint16_t *timeout, int array_len);
 
     /** Sets the operator plmn which is used when registering to a network specified by plmn. If plmn is not set then automatic
      *  registering is used when registering to a cellular network. Does not start any operations.


### PR DESCRIPTION
### Description

- added unit tests for cellular state machine
- fix possible crash which was found while making unit tests: _sim_pin is now a pointer and it's length was checked with strlen because it used to be an array. If _sim_pin was null strlen crashed. Replaced strlen with NULL check.
- fix state machine to stop in all required states, this was also found when making unit tests

@AriParkkila @mirelachirica please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

