### PR TITLE
Revert "STM32L4: fix trng clock setting"

### DIFF
--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -37,6 +37,15 @@ void trng_init(trng_t *obj)
         error("Only 1 RNG instance supported\r\n");
     }
 
+#if defined(TARGET_STM32L4)
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+
+    /*Select PLLQ output as RNG clock source */
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RNG;
+    PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_PLL;
+    HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+#endif
+
     /* RNG Peripheral clock enable */
     __HAL_RCC_RNG_CLK_ENABLE();
 


### PR DESCRIPTION
Reverts ARMmbed/mbed-os#8867

@ARMmbed/team-st-mcd As noted in the PR itself, CI started failing because of this commit. I noticed TRNG tests were run for two L4 targets they did not fail, I am not certain why (opening this revert as the last resort, we shall fix this rather). Please review

cc @juhoeskeli