### PR TITLE
STM32L4: correct RNG clock source

### DIFF
--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -37,6 +37,21 @@ void trng_init(trng_t *obj)
         error("Only 1 RNG instance supported\r\n");
     }
 
+#if defined(RCC_PERIPHCLK_RNG)
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+
+    /*Select PLLQ output as RNG clock source */
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RNG;
+#if ((CLOCK_SOURCE) & USE_PLL_MSI)
+    PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_MSI;
+#else
+    PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_PLL;
+#endif
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
+        error("RNG clock configuration error\n");
+    }
+#endif
+
     /* RNG Peripheral clock enable */
     __HAL_RCC_RNG_CLK_ENABLE();
 


### PR DESCRIPTION
### Description

This is a proposition to replace #9029 

This fixes #8867 and #8864 

cc @juhoeskeli


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

