### PR TITLE
Disable MPU on RT1050 due to memory map

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1845,7 +1845,8 @@
             "XIP_BOOT_HEADER_DCD_ENABLE=1",
             "SKIP_SYSCLK_INIT",
             "FSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE",
-            "SDRAM_IS_SHAREABLE"
+            "SDRAM_IS_SHAREABLE",
+            "MBED_MPU_CUSTOM"
         ],
         "inherits": ["Target"],
         "detect_code": ["0227"],
@@ -1867,8 +1868,7 @@
             "SERIAL",
             "SPI",
             "SPISLAVE",
-            "STDIO_MESSAGES",
-            "MPU"
+            "STDIO_MESSAGES"
         ],
         "release_versions": ["2", "5"],
         "features": ["LWIP"],


### PR DESCRIPTION
### Description

Disable the MPU on the RT1050 since this target has a memory map that is incompatible with the default MPU driver.

fixes #9024

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

