### PR TITLE
Retrieve and store LoRaWAN sessions

### DIFF
--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -496,6 +496,21 @@ public:
      *                      LORAWAN_STATUS_NO_OP if the operation cannot be completed (nothing to cancel)
      */
     virtual lorawan_status_t cancel_sending(void) = 0;
+
+    /** Get the current session
+     *
+     * Retrieves the complete MAC session, including keys, frame counters, RX configuration
+     *
+     * @param loramac_protocol_params A pointer to a protocol parameters structure
+     * @return LORAWAN_STATUS_OK
+     */
+    virtual lorawan_status_t get_session(loramac_protocol_params*) = 0;
+
+    /** Set the current session
+     *
+     * Sets the complete MAC session, including keys, frame counters and RX configuration
+     */
+    virtual lorawan_status_t set_session(loramac_protocol_params*) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -181,3 +181,13 @@ lorawan_status_t LoRaWANInterface::set_device_class(const device_class_t device_
     Lock lock(*this);
     return _lw_stack.set_device_class(device_class);
 }
+
+lorawan_status_t LoRaWANInterface::get_session(loramac_protocol_params *params)
+{
+    return _lw_stack.get_session(params);
+}
+
+lorawan_status_t LoRaWANInterface::set_session(loramac_protocol_params *params)
+{
+    return _lw_stack.set_session(params);
+}

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -74,6 +74,8 @@ public:
     virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata &metadata);
     virtual lorawan_status_t get_backoff_metadata(int &backoff);
     virtual lorawan_status_t cancel_sending(void);
+    virtual lorawan_status_t get_session(loramac_protocol_params *params);
+    virtual lorawan_status_t set_session(loramac_protocol_params *params);
 
     void lock(void)
     {

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -389,6 +389,15 @@ public:
         _loramac.unlock();
     }
 
+    lorawan_status_t get_session(loramac_protocol_params *params)
+    {
+        return _loramac.get_session(params);
+    }
+
+    lorawan_status_t set_session(loramac_protocol_params *params) {
+        return _loramac.set_session(params);
+    }
+
 private:
     typedef mbed::ScopedLock<LoRaWANStack> Lock;
     /**

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -434,6 +434,19 @@ public:
     void unlock(void) { }
 #endif
 
+    /**
+     * @todo I think everything is serializable except for the multicast linked list
+     */
+    lorawan_status_t get_session(loramac_protocol_params *params) {
+        memcpy(params, &_params, sizeof(loramac_protocol_params));
+        return LORAWAN_STATUS_OK;
+    }
+
+    lorawan_status_t set_session(loramac_protocol_params *params) {
+        memcpy(&_params, params, sizeof(loramac_protocol_params));
+        return LORAWAN_STATUS_OK;
+    }
+
 private:
     /**
      * @brief   Queries the LoRaMAC the maximum possible FRMPayload size to send.


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This PR adds functions to retrieve and store the full LoRaWAN session state. This is very useful for:

* Deepsleep, can store the session in NVM and then stop retaining RAM.
* Altering between multiple sessions (e.g. both Class A and Class C, or multiple Class A sessions).
* All kinds of debug state, e.g. logging RX2 parameters without having to hack the stack.
* Reading device address of the current session.

I'm using this right now for the [LoRaWAN Update Client](https://github.com/armmbed/mbed-os-example-lorawan-fuota) to switch between normal class and multicast sessions.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

@hasnainvirk @AnttiKauppila 