### PR TITLE
Fix wrong PIN config for RTL8195AM platform

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -202,7 +202,7 @@
             "SPI_MOSI": "D11",
             "SPI_MISO": "D12",
             "SPI_CLK": "D13",
-            "SPI_CS": "D9"
+            "SPI_CS": "D10"
         },
         "NUCLEO_F207ZG": {
              "SPI_MOSI": "PC_12",


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Merge from https://github.com/ARMmbed/sd-driver/pull/110


For realtek RTL8195AM platform - the correct PIN for SPI-CS should be D10.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [v ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

