### PR TITLE
Rapid-IoT: Add support for the KW41Z side of the platform

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PeripheralNames.h
@@ -1,0 +1,77 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PERIPHERALNAMES_H
+#define MBED_PERIPHERALNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    OSC32KCLK = 0
+} RTCName;
+
+typedef enum {
+    LPUART_0 = 0
+} UARTName;
+
+#define STDIO_UART_TX     USBTX
+#define STDIO_UART_RX     USBRX
+#define STDIO_UART        LPUART_0
+
+typedef enum {
+    I2C_0 = 0,
+    I2C_1 = 1,
+} I2CName;
+
+#define TPM_SHIFT   8
+typedef enum {
+    PWM_1  = (0 << TPM_SHIFT) | (0),  // TPM0 CH0
+    PWM_2  = (0 << TPM_SHIFT) | (1),  // TPM0 CH1
+    PWM_3  = (0 << TPM_SHIFT) | (2),  // TPM0 CH2
+    PWM_4  = (0 << TPM_SHIFT) | (3),  // TPM0 CH3
+    PWM_5  = (1 << TPM_SHIFT) | (0),  // TPM1 CH0
+    PWM_6  = (1 << TPM_SHIFT) | (1)   // TPM1 CH1
+} PWMName;
+
+#define ADC_INSTANCE_SHIFT           8
+#define ADC_B_CHANNEL_SHIFT          5
+typedef enum {
+    ADC0_SE1 = (0 << ADC_INSTANCE_SHIFT) | 1,
+    ADC0_SE2 = (0 << ADC_INSTANCE_SHIFT) | 2,
+    ADC0_SE3 = (0 << ADC_INSTANCE_SHIFT) | 3,
+    ADC0_SE4 = (0 << ADC_INSTANCE_SHIFT) | 4,
+    ADC0_SE5 = (0 << ADC_INSTANCE_SHIFT) | 5,
+} ADCName;
+
+typedef enum {
+    DAC_0 = 0
+} DACName;
+
+
+typedef enum {
+    SPI_0 = 0,
+    SPI_1 = 1,
+} SPIName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PeripheralPins.c
@@ -1,0 +1,137 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeripheralPins.h"
+
+/************RTC***************/
+const PinMap PinMap_RTC[] = {
+    {NC, OSC32KCLK, 0},
+};
+
+/************ADC***************/
+const PinMap PinMap_ADC[] = {
+    {PTB1,  ADC0_SE1, 0},
+    {PTB3,  ADC0_SE2, 0},
+    {PTB2,  ADC0_SE3, 0},
+    {PTB18, ADC0_SE4, 0},
+    {PTA19, ADC0_SE5, 0},
+    {NC   , NC       , 0}
+};
+
+/************DAC***************/
+const PinMap PinMap_DAC[] = {
+    {DAC0_OUT, DAC_0, 0},
+    {NC,       NC,    0}
+};
+
+/************I2C***************/
+const PinMap PinMap_I2C_SDA[] = {
+    {PTB1,  I2C_0, 3},
+    {PTB17, I2C_1, 3},
+    {PTC1, I2C_0, 3},
+    {PTC3, I2C_1, 3},
+    {PTC7, I2C_1, 3},
+    {PTC16, I2C_0, 3},
+    {PTC18, I2C_1, 3},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_I2C_SCL[] = {
+    {PTB0,  I2C_0, 3},
+    {PTB16, I2C_1, 3},
+    {PTB18, I2C_1, 3},
+    {PTC2, I2C_1, 3},
+    {PTC6, I2C_1, 3},
+    {PTC17, I2C_1, 3},
+    {PTC19, I2C_0, 3},
+    {NC   , NC   , 0}
+};
+
+/************UART***************/
+const PinMap PinMap_UART_TX[] = {
+    {PTC3,  LPUART_0, 4},
+    {PTC7,  LPUART_0, 4},
+    {PTC18, LPUART_0, 4},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_UART_RX[] = {
+    {PTC2,  LPUART_0, 4},
+    {PTC6,  LPUART_0, 4},
+    {PTC17, LPUART_0, 4},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_UART_CTS[] = {
+    {PTC4,  LPUART_0, 4},
+    {PTC19, LPUART_0, 4},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_UART_RTS[] = {
+    {PTC1,  LPUART_0, 4},
+    {PTC5,  LPUART_0, 4},
+    {PTC16, LPUART_0, 4},
+    {NC   , NC    , 0}
+};
+
+/************SPI***************/
+const PinMap PinMap_SPI_SCLK[] = {
+    {PTA18, SPI_1, 2},
+    {PTC16,  SPI_0, 2},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_MOSI[] = {
+    {PTA16, SPI_1, 2},
+    {PTC17,  SPI_0, 2},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_MISO[] = {
+    {PTA17, SPI_1, 2},
+    {PTC18,  SPI_0, 2},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_SSEL[] = {
+    {PTA1,  SPI_1, 2},
+    {PTA19, SPI_1, 2},
+    {PTC19,  SPI_0, 2},
+    {NC   , NC   , 0}
+};
+
+/************PWM***************/
+const PinMap PinMap_PWM[] = {
+    /* TPM 0 */
+    {PTA16, PWM_1, 5},
+    {PTB0,  PWM_2, 5},
+    {PTB1,  PWM_3, 5},
+    {PTA2,  PWM_4, 5},
+    {PTB18, PWM_1, 5},
+    {PTC3,  PWM_2, 5},
+    {PTC1,  PWM_3, 5},
+    {PTC16, PWM_4, 5},
+    /* TPM 1 */
+    {PTA0,  PWM_5, 5},
+    {PTA1,  PWM_6, 5},
+    {PTB2,  PWM_5, 5},
+    {PTB3,  PWM_6, 5},
+    {PTC4,  PWM_5, 5},
+    {PTC5,  PWM_6, 5},
+    {NC   , NC   , 0}
+};

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PinNames.h
@@ -1,0 +1,126 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define GPIO_PORT_SHIFT 12
+
+typedef enum {
+    PTA0  = (0 << GPIO_PORT_SHIFT | 0),
+    PTA1  = (0 << GPIO_PORT_SHIFT | 1),
+    PTA2  = (0 << GPIO_PORT_SHIFT | 2),
+    PTA16 = (0 << GPIO_PORT_SHIFT | 16),
+    PTA17 = (0 << GPIO_PORT_SHIFT | 17),
+    PTA18 = (0 << GPIO_PORT_SHIFT | 18),
+    PTA19 = (0 << GPIO_PORT_SHIFT | 19),
+    PTB0  = (1 << GPIO_PORT_SHIFT | 0),
+    PTB1  = (1 << GPIO_PORT_SHIFT | 1),
+    PTB2  = (1 << GPIO_PORT_SHIFT | 2),
+    PTB3  = (1 << GPIO_PORT_SHIFT | 3),
+    PTB16 = (1 << GPIO_PORT_SHIFT | 16),
+    PTB17 = (1 << GPIO_PORT_SHIFT | 17),
+    PTB18 = (1 << GPIO_PORT_SHIFT | 18),
+    PTC1  = (2 << GPIO_PORT_SHIFT | 1),
+    PTC2  = (2 << GPIO_PORT_SHIFT | 2),
+    PTC3  = (2 << GPIO_PORT_SHIFT | 3),
+    PTC4  = (2 << GPIO_PORT_SHIFT | 4),
+    PTC5  = (2 << GPIO_PORT_SHIFT | 5),
+    PTC6  = (2 << GPIO_PORT_SHIFT | 6),
+    PTC7  = (2 << GPIO_PORT_SHIFT | 7),
+    PTC16 = (2 << GPIO_PORT_SHIFT | 16),
+    PTC17 = (2 << GPIO_PORT_SHIFT | 17),
+    PTC18 = (2 << GPIO_PORT_SHIFT | 18),
+    PTC19 = (2 << GPIO_PORT_SHIFT | 19),
+
+    LED_RED   = PTC1,
+    LED_GREEN = PTA19,
+    LED_BLUE  = PTA18,
+
+    // mbed original LED naming
+    LED1 = LED_RED,
+    LED2 = LED_GREEN,
+    LED3 = LED_BLUE,
+    LED4 = LED_RED,
+
+    //Push buttons
+    SW3 = PTC4,
+    SW4 = PTC5,
+    // Standardized button names
+    BUTTON1 = SW3,
+    BUTTON2 = SW4,
+
+    // USB Pins
+    USBTX = PTC7,
+    USBRX = PTC6,
+
+    // Arduino Headers
+    D0 = PTC6,
+    D1 = PTC7,
+    D2 = PTC19,
+    D3 = PTC16,
+    D4 = PTC4,
+    D5 = PTC17,
+    D6 = PTC18,
+    D7 = PTA1,
+    D8 = PTA0,
+    D9 = PTC1,
+    D10 = PTA19,
+    D11 = PTA16,
+    D12 = PTA17,
+    D13 = PTA18,
+    D14 = PTC3,
+    D15 = PTC2,
+
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+
+    DAC0_OUT = PTB18,
+
+    A1 = DAC0_OUT,
+    A2 = PTB2,
+    A3 = PTB3,
+    A4 = PTB1,
+    A5 = PTB0,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp   = 2,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/device.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/device.h
@@ -1,0 +1,40 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+
+
+
+
+
+
+
+
+
+
+#define DEVICE_ID_LENGTH       24
+
+
+
+
+
+#include "objects.h"
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/fsl_clock_config.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/fsl_clock_config.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_common.h"
+#include "fsl_smc.h"
+#include "fsl_clock_config.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*! @brief Clock configuration structure. */
+typedef struct _clock_config
+{
+    mcg_config_t mcgConfig;       /*!< MCG configuration.      */
+    sim_clock_config_t simConfig; /*!< SIM configuration.      */
+    osc_config_t oscConfig;       /*!< OSC configuration.      */
+    uint32_t coreClock;           /*!< core clock frequency.   */
+} clock_config_t;
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/* Configuration for enter VLPR mode. Core clock = 4MHz. */
+const clock_config_t g_defaultClockConfigVlpr = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModeBLPI,            /* Work in BLPI mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /* MCGIRCLK enable. */
+            .ircs = kMCG_IrcFast,                /* Select IRC4M. */
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+
+            .frdiv = 5U,
+            .drs = kMCG_DrsLow,         /* Low frequency range */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25% */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC */
+        },
+    .simConfig =
+        {
+            .er32kSrc = 0U,         /* ERCLK32K selection, use OSC. */
+            .clkdiv1 = 0x00040000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig =
+        {
+            .freq = BOARD_XTAL0_CLK_HZ, /* Feed by RF XTAL_32M */
+            .workMode = kOSC_ModeExt,   /* Must work in external source mode. */
+        },
+    .coreClock = 4000000U, /* Core clock frequency */
+};
+
+/* Configuration for enter RUN mode. Core clock = 40MHz. */
+const clock_config_t g_defaultClockConfigRun = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModeFEE,             /* Work in FEE mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /* MCGIRCLK enable. */
+            .ircs = kMCG_IrcFast,                /* Select IRC4M. */
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+
+            .frdiv = 5U,
+            .drs = kMCG_DrsMid,         /* Middle frequency range */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25% */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC */
+        },
+    .simConfig =
+        {
+            .er32kSrc = 0U,         /* ERCLK32K selection, use OSC. */
+            .clkdiv1 = 0x00010000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig =
+        {
+            .freq = BOARD_XTAL0_CLK_HZ, /* Feed by RF XTAL_32M */
+            .workMode = kOSC_ModeExt,   /* Must work in external source mode. */
+        },
+    .coreClock = 40000000U, /* Core clock frequency */
+};
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. CLOCK_SetSimSafeDivs, to make sure core clock, bus clock, flexbus clock
+ *    and flash clock are in allowed range during clock mode switch.
+ *
+ * 2. Call CLOCK_Osc0Init to setup OSC clock, if it is used in target mode.
+ *
+ * 3. Set MCG configuration, MCG includes three parts: FLL clock, PLL clock and
+ *    internal reference clock(MCGIRCLK). Follow the steps to setup:
+ *
+ *    1). Call CLOCK_BootToXxxMode to set MCG to target mode.
+ *
+ *    2). If target mode is FBI/BLPI/PBI mode, the MCGIRCLK has been configured
+ *        correctly. For other modes, need to call CLOCK_SetInternalRefClkConfig
+ *        explicitly to setup MCGIRCLK.
+ *
+ *    3). Don't need to configure FLL explicitly, because if target mode is FLL
+ *        mode, then FLL has been configured by the function CLOCK_BootToXxxMode,
+ *        if the target mode is not FLL mode, the FLL is disabled.
+ *
+ *    4). If target mode is PEE/PBE/PEI/PBI mode, then the related PLL has been
+ *        setup by CLOCK_BootToXxxMode. In FBE/FBI/FEE/FBE mode, the PLL could
+ *        be enabled independently, call CLOCK_EnablePll0 explicitly in this case.
+ *
+ * 4. Call CLOCK_SetSimConfig to set the clock configuration in SIM.
+ */
+
+static void CLOCK_SYS_FllStableDelay(void)
+{
+    uint32_t i = 30000U;
+    while (i--)
+    {
+        __NOP();
+    }
+}
+
+void BOARD_BootClockVLPR(void)
+{
+    /* ERR010224 */
+    RSIM->RF_OSC_CTRL |= RSIM_RF_OSC_CTRL_RADIO_EXT_OSC_OVRD_EN_MASK;   /* Prevent XTAL_OUT_EN from generating XTAL_OUT request */
+
+    CLOCK_SetSimSafeDivs();
+
+    CLOCK_BootToBlpiMode(g_defaultClockConfigVlpr.mcgConfig.fcrdiv, g_defaultClockConfigVlpr.mcgConfig.ircs,
+                         g_defaultClockConfigVlpr.mcgConfig.irclkEnableMode);
+
+    CLOCK_SetSimConfig(&g_defaultClockConfigVlpr.simConfig);
+
+    SystemCoreClock = g_defaultClockConfigVlpr.coreClock;
+
+    SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
+    SMC_SetPowerModeVlpr(SMC);
+    while (SMC_GetPowerModeState(SMC) != kSMC_PowerStateVlpr)
+    {
+    }
+}
+
+void BOARD_BootClockRUN(void)
+{
+    BOARD_RfOscInit();
+
+    CLOCK_SetSimSafeDivs();
+
+    CLOCK_InitOsc0(&g_defaultClockConfigRun.oscConfig);
+    CLOCK_SetXtal0Freq(BOARD_XTAL0_CLK_HZ);
+    CLOCK_BootToFeeMode(kMCG_OscselOsc, g_defaultClockConfigRun.mcgConfig.frdiv,
+                        g_defaultClockConfigRun.mcgConfig.dmx32, g_defaultClockConfigRun.mcgConfig.drs,
+                        CLOCK_SYS_FllStableDelay);
+
+    CLOCK_SetInternalRefClkConfig(g_defaultClockConfigRun.mcgConfig.irclkEnableMode,
+                                  g_defaultClockConfigRun.mcgConfig.ircs, g_defaultClockConfigRun.mcgConfig.fcrdiv);
+
+    CLOCK_SetSimConfig(&g_defaultClockConfigRun.simConfig);
+
+    SystemCoreClock = g_defaultClockConfigRun.coreClock;
+}
+
+void BOARD_RfOscInit(void)
+{
+    uint32_t temp, tempTrim;
+    uint8_t revId;
+
+    /* Obtain REV ID from SIM */
+    temp = SIM->SDID;
+    revId = (uint8_t)((temp & SIM_SDID_REVID_MASK) >> SIM_SDID_REVID_SHIFT);
+
+    if(0 == revId)
+    {
+        tempTrim = RSIM->ANA_TRIM;
+        RSIM->ANA_TRIM |= RSIM_ANA_TRIM_BB_LDO_XO_TRIM_MASK;            /* Set max trim for BB LDO for XO */
+    }/* Workaround for Rev 1.0 XTAL startup and ADC analog diagnostics circuitry */
+
+    /* Turn on clocks for the XCVR */
+    /* Enable RF OSC in RSIM and wait for ready */
+    temp = RSIM->CONTROL;
+    temp &= ~RSIM_CONTROL_RF_OSC_EN_MASK;
+    RSIM->CONTROL = temp | RSIM_CONTROL_RF_OSC_EN(1);
+
+    /* ERR010224 */
+    RSIM->RF_OSC_CTRL |= RSIM_RF_OSC_CTRL_RADIO_EXT_OSC_OVRD_EN_MASK;   /* Prevent XTAL_OUT_EN from generating XTAL_OUT request */
+
+    while((RSIM->CONTROL & RSIM_CONTROL_RF_OSC_READY_MASK) == 0);       /* Wait for RF_OSC_READY */
+
+    if(0 == revId)
+    {
+        SIM->SCGC5 |= SIM_SCGC5_PHYDIG_MASK;
+        XCVR_TSM->OVRD0 |= XCVR_TSM_OVRD0_BB_LDO_ADCDAC_EN_OVRD_EN_MASK | XCVR_TSM_OVRD0_BB_LDO_ADCDAC_EN_OVRD_MASK; /* Force ADC DAC LDO on to prevent BGAP failure */
+
+        RSIM->ANA_TRIM = tempTrim;                                      /* Reset LDO trim settings */
+    }/* Workaround for Rev 1.0 XTAL startup and ADC analog diagnostics circuitry */
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/fsl_clock_config.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/fsl_clock_config.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+/*******************************************************************************
+ * DEFINITION
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ    32000000U
+#define BOARD_XTAL32K_CLK_HZ  32768U
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+void BOARD_BootClockVLPR(void);
+void BOARD_BootClockRUN(void);
+void BOARD_RfOscInit(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/mbed_overrides.c
@@ -1,0 +1,57 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gpio_api.h"
+#include "fsl_rtc.h"
+#include "fsl_clock_config.h"
+
+// called before main - implement here if board needs it otherwise, let
+//  the application override this if necessary
+void mbed_sdk_init()
+{
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
+    BOARD_BootClockRUN();
+    /* Set the TPM clock source to be OSCERCLK, do not change as TPM2 is used for the usticker */
+    CLOCK_SetTpmClock(2U);
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /*Init the RTC with default configuration*/
+        RTC_GetDefaultConfig(&rtc_basic_config);
+
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
+
+    CLOCK_DisableClock(kCLOCK_Rtc0);
+}

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1645,6 +1645,7 @@
         "macros": ["FSL_RTOS_MBED", "USE_EXTERNAL_RTC"],
         "default_toolchain": "ARM",
         "default_lib": "std",
+        "forced_reset_timeout": 7,
         "release_versions": ["2", "5"]
     },
     "RAPIDIOT_K64F": {
@@ -1684,8 +1685,44 @@
             "TRNG",
             "FLASH"
         ],
-        "forced_reset_timeout": 7,
         "device_name": "MK64FN1M0xxx12",
+        "bootloader_supported": true
+    },
+    "RAPIDIOT_KW41Z": {
+        "inherits": ["RAPIDIOT"],
+        "core": "Cortex-M0+",
+        "extra_labels": [
+            "Freescale",
+            "MCUXpresso_MCUS",
+            "KSDK2_MCUS",
+            "KW41Z"
+        ],
+        "macros_add": ["CPU_MKW41Z512VHT4"],
+        "is_disk_virtual": true,
+        "mbed_rom_start": "0x00004000",
+        "mbed_rom_size": "0x7C000",
+        "detect_code": ["0234"],
+        "device_has": [
+            "USTICKER",
+            "LPTICKER",
+            "ANALOGIN",
+            "ANALOGOUT",
+            "I2C",
+            "I2CSLAVE",
+            "INTERRUPTIN",
+            "PORTIN",
+            "PORTINOUT",
+            "PORTOUT",
+            "PWMOUT",
+            "SERIAL",
+            "SLEEP",
+            "SPI",
+            "SPISLAVE",
+            "TRNG",
+            "STDIO_MESSAGES",
+            "FLASH"
+        ],
+        "device_name": "MKW41Z512xxx4",
         "bootloader_supported": true
     },
     "K66F": {
@@ -1918,9 +1955,9 @@
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "IAR", "GCC_ARM"],
         "extra_labels": [
-            "NXP", 
-            "MCUXpresso_MCUS", 
-            "LPC", 
+            "NXP",
+            "MCUXpresso_MCUS",
+            "LPC",
             "NXP_EMAC"
         ],
         "is_disk_virtual": true,


### PR DESCRIPTION
### Description
Add support for the KW41Z side of the RapidIoT platform. This requires the latest DAPLink binary to be programmed on the RapidIoT platform, binary can be downloaded from the below link:
https://armmbed.github.io/DAPLink/

Also, the KW41Z side on RapidIoT does not have a serial port connected to the Debug terminal. Therefore a SerialPassThrough program should be flashed and running on the K64F side of RapidIoT platform for the mbed tests to pass. Attached is a binary for this PassThrough program.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

[RapidIoT_SerialPass.zip](https://github.com/ARMmbed/mbed-os/files/2667722/RapidIoT_SerialPass.zip)
