### PR TITLE
Prefer QSPI Bus mode 1-4-4 as highest priority for QSPIFBlockDevice

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -421,7 +421,7 @@ int QSPIFBlockDevice::erase(bd_addr_t addr, bd_size_t in_size)
         if (_set_write_enable() != 0) {
             tr_error("QSPI Erase Device not ready - failed");
             erase_failed = true;
-            status = QSPIF_BD_ERROR_READY_FAILED;
+            status = QSPIF_BD_ERROR_WREN_FAILED;
             goto exit_point;
         }
 
@@ -1024,12 +1024,9 @@ int QSPIFBlockDevice::_sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table
                 //_inst_width = QSPI_CFG_BUS_QUAD;
                 _address_width = QSPI_CFG_BUS_QUAD;
                 _data_width = QSPI_CFG_BUS_QUAD;
-
-                break;
             }
         }
-
-
+        is_qpi_mode = false;
         examined_byte = basic_param_table_ptr[QSPIF_BASIC_PARAM_TABLE_FAST_READ_SUPPORT_BYTE];
         if (examined_byte & 0x40) {
             //  Fast Read 1-4-4 Supported

--- a/components/storage/blockdevice/COMPONENT_QSPIF/TESTS/block_device/qspif/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/TESTS/block_device/qspif/main.cpp
@@ -48,6 +48,10 @@ void basic_erase_program_read_test(QSPIFBlockDevice &blockD, bd_size_t block_siz
 {
     int err = 0;
     _mutex->lock();
+
+    static unsigned block_seed = 1;
+    srand(block_seed++);
+
     // Find a random block
     bd_addr_t block = (rand() * block_size) % blockD.size();
 


### PR DESCRIPTION
### Description

Prefer QSPI Bus mode 1-4-4 as highest priority for QSPIFBlockDevice.
QPI is not supported by all targets  and  requires register setup between each Read and Program/Erase commands, which might make the negligible advantage in sending the initial instruction become a disadvantage overall.

see issue: #8870 
https://github.com/ARMmbed/mbed-os/issues/8870#issuecomment-445746498

### Pull request type

    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

