### PR TITLE
BLE: suppress scan timeout if we disabled scanning

### DIFF
--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -726,6 +726,7 @@ private:
     ble::address_t _random_static_identity_address;
     bool _random_address_rotating;
 
+    bool _scan_enabled;
     mbed::Timeout _advertising_timeout;
     mbed::Timeout _scan_timeout;
     mbed::Ticker _address_rotation_ticker;

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -2387,9 +2387,6 @@ ble_error_t GenericGap::stopAdvertising(advertising_handle_t handle)
     ble_error_t status;
 
     if (is_extended_advertising_available()) {
-
-        _active_sets.clear(handle);
-
         status = _pal_gap.extended_advertising_enable(
             /*enable ? */ false,
             /* number of advertising sets */ 1,
@@ -2399,7 +2396,6 @@ ble_error_t GenericGap::stopAdvertising(advertising_handle_t handle)
         );
 
         if (status) {
-            _active_sets.set(handle);
             return status;
         }
     } else {
@@ -2407,17 +2403,16 @@ ble_error_t GenericGap::stopAdvertising(advertising_handle_t handle)
             return BLE_ERROR_INVALID_PARAM;
         }
 
-        _active_sets.clear(handle);
-
         status = _pal_gap.advertising_enable(false);
 
         if (status) {
-            _active_sets.set(handle);
             return status;
         }
 
         _advertising_timeout.detach();
     }
+
+    _active_sets.clear(handle);
 
     return status;
 }
@@ -2746,10 +2741,6 @@ void GenericGap::on_advertising_set_terminated(
     uint8_t number_of_completed_extended_advertising_events
 )
 {
-    if (!_active_sets.get(advertising_handle)) {
-        return;
-    }
-
     _active_sets.clear(advertising_handle);
 
     if (!_eventHandler) {


### PR DESCRIPTION
### Description

Currently a scan timeout will be called even if we have stopped scanning due to a stopScan call or connect. This suppresses the call.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

