### PR TITLE
More MPU work

### DIFF
--- a/hal/mpu/mbed_mpu_v7m.c
+++ b/hal/mpu/mbed_mpu_v7m.c
@@ -163,7 +163,7 @@ void mbed_mpu_init()
             0,                          // IsShareable
             1,                          // IsCacheable
             0,                          // IsBufferable
-            ~0U,                        // SubRegionDisable
+            0U,                         // SubRegionDisable
             ARM_MPU_REGION_SIZE_512MB)  // Size
     );
 

--- a/hal/mpu/mbed_mpu_v7m.c
+++ b/hal/mpu/mbed_mpu_v7m.c
@@ -45,7 +45,7 @@ MBED_STATIC_ASSERT(
 void mbed_mpu_init()
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     const uint32_t regions = (MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
     if (regions < 4) {
@@ -178,40 +178,40 @@ void mbed_mpu_init()
         (1 << MPU_CTRL_ENABLE_Pos);                 // Enable MPU
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 void mbed_mpu_free()
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     // Disable the MPU
     MPU->CTRL = 0;
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 void mbed_mpu_enable_rom_wn(bool enable)
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     MPU->RNR = 0;
     MPU->RASR = (MPU->RASR & ~MPU_RASR_ENABLE_Msk) | (enable ? MPU_RASR_ENABLE_Msk : 0);
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 void mbed_mpu_enable_ram_xn(bool enable)
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     MPU->RNR = 1;
     MPU->RASR = (MPU->RASR & ~MPU_RASR_ENABLE_Msk) | (enable ? MPU_RASR_ENABLE_Msk : 0);
@@ -223,8 +223,8 @@ void mbed_mpu_enable_ram_xn(bool enable)
     MPU->RASR = (MPU->RASR & ~MPU_RASR_ENABLE_Msk) | (enable ? MPU_RASR_ENABLE_Msk : 0);
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 #endif

--- a/hal/mpu/mbed_mpu_v7m.c
+++ b/hal/mpu/mbed_mpu_v7m.c
@@ -15,7 +15,6 @@
  */
 #include "hal/mpu_api.h"
 #include "platform/mbed_assert.h"
-#include "platform/mbed_error.h"
 #include "cmsis.h"
 
 #if ((__ARM_ARCH_7M__ == 1U) || (__ARM_ARCH_7EM__ == 1U) || (__ARM_ARCH_6M__ == 1U)) && \
@@ -48,9 +47,10 @@ void mbed_mpu_init()
     __DMB();
 
     const uint32_t regions = (MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
-    if (regions < 4) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_EINVAL), "Device is not capable of supporting an MPU - remove DEVICE_MPU for device_has.");
-    }
+
+    // Our MPU setup requires 4 regions - if this assert is hit, remove
+    // DEVICE_MPU from device_has
+    MBED_ASSERT(regions >= 4);
 
     // Disable the MCU
     MPU->CTRL = 0;

--- a/hal/mpu/mbed_mpu_v7m.c
+++ b/hal/mpu/mbed_mpu_v7m.c
@@ -74,13 +74,12 @@ void mbed_mpu_init()
      * 0xE0000000 - 0xFFFFFFFF     System          No
      */
 
-    // Select region 1 and used it for the WT rom region
-    // - RAM 0x00000000 to MBED_MPU_ROM_END
-    MPU->RNR = 0;
-    // Set address to 0
-    MPU->RBAR = 0;
-    // Configure and enable region
-    MPU->RASR =
+    // Select region 0 and use it for the WT read-only rom region
+    // - Code 0x00000000 to MBED_MPU_ROM_END
+    ARM_MPU_SetRegion(
+        ARM_MPU_RBAR(
+            0,                          // Region
+            0x00000000),                // Base
         ARM_MPU_RASR(
             0,                          // DisableExec
             ARM_MPU_AP_RO,              // AccessPermission
@@ -97,16 +96,15 @@ void mbed_mpu_init()
             ((MBED_MPU_ROM_END >= 0x14000000) ? 0 : (1 << 5)) |
             ((MBED_MPU_ROM_END >= 0x18000000) ? 0 : (1 << 6)) |
             ((MBED_MPU_ROM_END >= 0x1C000000) ? 0 : (1 << 7)),
-            ARM_MPU_REGION_SIZE_512MB   // Size
-        );
+            ARM_MPU_REGION_SIZE_512MB)  // Size
+    );
 
-    // Select region 1 and used it for the WT rom region
-    // - RAM MBED_MPU_ROM_END + 1 to 0x1FFFFFFF
-    MPU->RNR = 1;
-    // Set address to 0
-    MPU->RBAR = 0;
-    // Configure and enable region
-    MPU->RASR =
+    // Select region 1 and use it for a WT ram region in the Code area
+    // - Code MBED_MPU_ROM_END + 1 to 0x1FFFFFFF
+    ARM_MPU_SetRegion(
+        ARM_MPU_RBAR(
+            1,                          // Region
+            0x00000000),                // Base
         ARM_MPU_RASR(
             1,                          // DisableExec
             ARM_MPU_AP_FULL,            // AccessPermission
@@ -123,17 +121,16 @@ void mbed_mpu_init()
             ((MBED_MPU_RAM_START <= 0x18000000) ? 0 : (1 << 5)) |
             ((MBED_MPU_RAM_START <= 0x1C000000) ? 0 : (1 << 6)) |
             ((MBED_MPU_RAM_START <= 0x20000000) ? 0 : (1 << 7)),
-            ARM_MPU_REGION_SIZE_512MB   // Size
-        );
+            ARM_MPU_REGION_SIZE_512MB)  // Size
+    );
 
-    // Select region 2 and used it for WBWA ram regions
+    // Select region 2 and use it for WBWA ram regions
     // - SRAM 0x20000000 to 0x3FFFFFFF
     // - RAM  0x60000000 to 0x7FFFFFFF
-    MPU->RNR = 2;
-    // Set address to 0
-    MPU->RBAR = 0;
-    // Configure and enable region
-    MPU->RASR =
+    ARM_MPU_SetRegion(
+        ARM_MPU_RBAR(
+            2,                          // Region
+            0x00000000),                // Base
         ARM_MPU_RASR(
             1,                          // DisableExec
             ARM_MPU_AP_FULL,            // AccessPermission
@@ -150,16 +147,15 @@ void mbed_mpu_init()
             (1 << 5) |     // Disable Sub-region
             (1 << 6) |     // Disable Sub-region
             (1 << 7),      // Disable Sub-region
-            ARM_MPU_REGION_SIZE_4GB     // Size
-        );
+            ARM_MPU_REGION_SIZE_4GB)    // Size
+    );
 
-    // Select region 3 and used it for the WT ram region
-    // - RAM RAM 0x80000000 to 0x9FFFFFFF
-    MPU->RNR = 3;
-    // Set address
-    MPU->RBAR = 0x80000000;
-    // Configure and enable region
-    MPU->RASR =
+    // Select region 3 and use it for the WT ram region
+    // - RAM 0x80000000 to 0x9FFFFFFF
+    ARM_MPU_SetRegion(
+        ARM_MPU_RBAR(
+            3,                          // Region
+            0x80000000),                // Base
         ARM_MPU_RASR(
             1,                          // DisableExec
             ARM_MPU_AP_FULL,            // AccessPermission
@@ -168,8 +164,8 @@ void mbed_mpu_init()
             1,                          // IsCacheable
             0,                          // IsBufferable
             ~0U,                        // SubRegionDisable
-            ARM_MPU_REGION_SIZE_512MB   // Size
-        );
+            ARM_MPU_REGION_SIZE_512MB)  // Size
+    );
 
     // Enable the MPU
     MPU->CTRL =

--- a/hal/mpu/mbed_mpu_v8m.c
+++ b/hal/mpu/mbed_mpu_v8m.c
@@ -35,7 +35,7 @@ MBED_STATIC_ASSERT(MBED_MPU_ROM_END == 0x1fffffff, "Changing MBED_MPU_ROM_END fo
 void mbed_mpu_init()
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     const uint32_t regions = (MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
     if (regions < 4) {
@@ -127,40 +127,40 @@ void mbed_mpu_init()
         (1 << MPU_CTRL_ENABLE_Pos);                 // Enable MPU
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 void mbed_mpu_free()
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     // Disable the MCU
     MPU->CTRL = 0;
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 void mbed_mpu_enable_rom_wn(bool enable)
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     MPU->RNR = 0;
     MPU->RLAR = (MPU->RLAR & ~MPU_RLAR_EN_Msk) | (enable ? MPU_RLAR_EN_Msk : 0);
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 void mbed_mpu_enable_ram_xn(bool enable)
 {
     // Flush memory writes before configuring the MPU.
-    __DSB();
+    __DMB();
 
     MPU->RNR = 1;
     MPU->RLAR = (MPU->RLAR & ~MPU_RLAR_EN_Msk) | (enable ? MPU_RLAR_EN_Msk : 0);
@@ -172,8 +172,8 @@ void mbed_mpu_enable_ram_xn(bool enable)
     MPU->RLAR = (MPU->RLAR & ~MPU_RLAR_EN_Msk) | (enable ? MPU_RLAR_EN_Msk : 0);
 
     // Ensure changes take effect
-    __ISB();
     __DSB();
+    __ISB();
 }
 
 #endif

--- a/hal/mpu/mbed_mpu_v8m.c
+++ b/hal/mpu/mbed_mpu_v8m.c
@@ -15,7 +15,6 @@
  */
 #include "hal/mpu_api.h"
 #include "platform/mbed_assert.h"
-#include "platform/mbed_error.h"
 #include "cmsis.h"
 
 #if ((__ARM_ARCH_8M_BASE__ == 1U) || (__ARM_ARCH_8M_MAIN__ == 1U)) && \
@@ -38,9 +37,10 @@ void mbed_mpu_init()
     __DMB();
 
     const uint32_t regions = (MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
-    if (regions < 4) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_HAL, MBED_ERROR_CODE_EINVAL), "Device is not capable of supporting an MPU - remove DEVICE_MPU for device_has.");
-    }
+
+    // Our MPU setup requires 4 regions - if this assert is hit, remove
+    // DEVICE_MPU from device_has
+    MBED_ASSERT(regions >= 4);
 
     // Disable the MCU
     MPU->CTRL = 0;

--- a/platform/mbed_application.c
+++ b/platform/mbed_application.c
@@ -19,7 +19,7 @@
 #include <stdarg.h>
 #include "device.h"
 #include "platform/mbed_application.h"
-#include "hal/mpu_api.h"
+#include "platform/mbed_mpu_mgmt.h"
 
 #if MBED_APPLICATION_SUPPORT
 
@@ -69,7 +69,7 @@ void mbed_start_application(uintptr_t address)
     SysTick->CTRL = 0x00000000;
     powerdown_nvic();
     powerdown_scb(address);
-    mbed_mpu_free();
+    mbed_mpu_manager_deinit();
 
     sp = *((void **)address + 0);
     pc = *((void **)address + 1);

--- a/platform/mbed_mpu_mgmt.h
+++ b/platform/mbed_mpu_mgmt.h
@@ -35,6 +35,8 @@ extern "C" {
 
 #define mbed_mpu_manager_init() mbed_mpu_init()
 
+#define mbed_mpu_manager_deinit() mbed_mpu_free()
+
 /** Lock ram execute never mode off
  *
  * This disables the MPU's execute never ram protection and allows
@@ -86,6 +88,8 @@ void mbed_mpu_manager_unlock_rom_write(void);
 #else
 
 #define mbed_mpu_manager_init() (void)0
+
+#define mbed_mpu_manager_deinit() (void)0
 
 #define mbed_mpu_manager_lock_ram_execution() (void)0
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7474,6 +7474,9 @@
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
             }
         },
+        "overrides": {
+            "mpu-rom-end": "0x1fffffff"
+        },
         "inherits": ["Target"],
         "device_has": [
             "USTICKER",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6678,6 +6678,9 @@
                 "value": 0
             }
         },
+        "overrides": {
+            "mpu-rom-end": "0x1fffffff"
+        },
         "OUTPUT_EXT": "hex",
         "is_disk_virtual": true,
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -32,8 +32,7 @@
             },
             "mpu-rom-end": {
                 "help": "Last address of ROM protected by the MPU",
-                "value": "0x0fffffff",
-                "macro_name": "MPU_ROM_END"
+                "value": "0x0fffffff"
             }
         }
     },


### PR DESCRIPTION
### Description

* Don't call HAL MPU free code when `platform.use-mpu` is turned off.
* Correct MPU synchronisation sequences.
* Reduce MPU code size further with a loop
* Use higher-level calls, fix ARMv8-M error 
* Assert number of regions, rather than error
* ARMv7-M: correctly protect 80000000 RAM region
* Fix target.mpu-rom-end setting, for ARMv8-M too
* nRF52840: Set mpu-rom-end to 0x1fffffff (to test this case)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

