### PR TITLE
mbed_fault_handler: fix build warning

### DIFF
--- a/cmsis/TARGET_CORTEX_M/mbed_fault_handler.c
+++ b/cmsis/TARGET_CORTEX_M/mbed_fault_handler.c
@@ -18,6 +18,7 @@
 #define __STDC_FORMAT_MACROS
 #endif
 #include <inttypes.h>
+#include <string.h>
 
 #include "device.h"
 #include "mbed_error.h"


### PR DESCRIPTION
Fixes the following build warning:

```
BUILD\NRF52840_DK\GCC_ARM\mbed-os\cmsis\TARGET_CORTEX_M\mbed_fault_handler.o
.\mbed-os\cmsis\TARGET_CORTEX_M\mbed_fault_handler.c
[Warning] mbed_fault_handler.c@149,5: implicit declaration
of function 'memcpy' [-Wimplicit-function-declaration]
```
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

