### PR TITLE
Realtek_RTL8195AM_NetworkSocket_Updates

### DIFF
--- a/tools/targets/REALTEK_RTL8195AM.py
+++ b/tools/targets/REALTEK_RTL8195AM.py
@@ -176,7 +176,7 @@ def rtl8195a_elf2bin(t_self, image_elf, image_bin):
     image_map = ".".join(image_name + ['map'])
 
     ram1_bin = os.path.join(TOOLS_BOOTLOADERS, "REALTEK_RTL8195AM", "ram_1.bin")
-    ram2_bin = ".".join(image_name) + '-payload.bin'
+    ram2_bin = ".".join(image_name) + '_update.bin'
 
     entry = find_symbol(t_self.name, image_map, "PLAT_Start")
     segment = parse_load_segment(t_self.name, image_elf)

--- a/tools/targets/REALTEK_RTL8195AM.py
+++ b/tools/targets/REALTEK_RTL8195AM.py
@@ -176,7 +176,7 @@ def rtl8195a_elf2bin(t_self, image_elf, image_bin):
     image_map = ".".join(image_name + ['map'])
 
     ram1_bin = os.path.join(TOOLS_BOOTLOADERS, "REALTEK_RTL8195AM", "ram_1.bin")
-    ram2_bin = ".".join(image_name) + '_update.bin'
+    ram2_bin = ".".join(image_name) + '-payload.bin'
 
     entry = find_symbol(t_self.name, image_map, "PLAT_Start")
     segment = parse_load_segment(t_self.name, image_elf)


### PR DESCRIPTION
This PR addresses the issue of [#8124](https://github.com/ARMmbed/mbed-os/issues/8124).
It updates and enriches the wifi connection error type to adapt the [Network Socket test plan](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md) requirement.
In the meantime, it increases the heap size that allows the transmission of larger packet size.
 
### Description

Increase heap size in lwipstack\mbed_lib.json.
Modify and enrich wifi connection error types in TARGET_AMEBA\RTWInterface.cpp
Add new parameters in TARGET_AMEBA\RTWInterface.h


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

