### PR TITLE
Enable stats reporting with a flag in targets.json

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -13,6 +13,7 @@
         "public": false,
         "default_lib": "std",
         "bootloader_supported": false,
+        "static_memory_defines": true,
         "config": {
             "console-uart-flow-control": {
                 "help": "Console hardware flow control. Options: null, RTS, CTS, RTSCTS.",
@@ -6501,6 +6502,7 @@
     "MCU_NRF52832": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
+        "static_memory_defines": false,
         "macros": [
             "BOARD_PCA10040",
             "NRF52",
@@ -6620,6 +6622,7 @@
     "MCU_NRF52840": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
+        "static_memory_defines": false,
         "macros": [
             "BOARD_PCA10056",
             "NRF52840_XXAA",

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -761,6 +761,8 @@ class mbedToolchain:
 
         try:
             # Add all available ROM regions to build profile
+            if not getattr(self.target, "static_memory_defines", False):
+                raise ConfigException()
             rom_available_regions = self.config.get_all_active_memories(ROM_ALL_MEMORIES)
             for key, value in rom_available_regions.items():
                 rom_start, rom_size = value
@@ -773,6 +775,8 @@ class mbedToolchain:
             pass
         try:
             # Add all available RAM regions to build profile
+            if not getattr(self.target, "static_memory_defines", False):
+                raise ConfigException()
             ram_available_regions = self.config.get_all_active_memories(RAM_ALL_MEMORIES)
             for key, value in ram_available_regions.items():
                 ram_start, ram_size = value


### PR DESCRIPTION
### Description

PR #8607 will cause problems for the NRF52832 and the NRF52840
in the online compiler starting with 5.10.2. This PR prevents this problem
by using a toggle in `targets.json` to enable these new defines for every
target except for the NRF52832 and NRF52840.


Update: BLE + Softdevice + NRF528XX is currently broken in master, and this will work around it for the time being by not enabling the memory-reporting for the NRF528XX targets.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change