### PR TITLE
W7500x target ADC 6 and 7 not implemented

### DIFF
--- a/targets/TARGET_WIZNET/TARGET_W7500x/analogin_api.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/analogin_api.c
@@ -82,6 +82,12 @@ static inline uint16_t adc_read(analogin_t *obj)
         case PC_10:
             adc_ch = ADC_CH5;
             break;
+        case PC_09:
+            adc_ch = ADC_CH6;
+            break;
+        case PC_08:
+            adc_ch = ADC_CH7;
+            break;            
         default:
             return 0;
     }


### PR DESCRIPTION
### Description

On W7500x targets, ADC 6 and 7 is not implemented. 
This simple fix implements them.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

