### PR TITLE
SD-driver size optimization for bootloader

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -449,6 +449,7 @@ end:
 
 int SDBlockDevice::program(const void *b, bd_addr_t addr, bd_size_t size)
 {
+#if MBED_CONF_SD_WRITE_ENABLED
     if (!is_valid_program(addr, size)) {
         return SD_BLOCK_DEVICE_ERROR_PARAMETER;
     }
@@ -514,10 +515,13 @@ int SDBlockDevice::program(const void *b, bd_addr_t addr, bd_size_t size)
          */
         _spi.write(SPI_STOP_TRAN);
     }
-
     _deselect();
     unlock();
     return status;
+#else
+    debug_if(SD_DBG, "Write not supported in this configuration!\n");
+    return SD_BLOCK_DEVICE_ERROR_UNSUPPORTED;
+#endif
 }
 
 int SDBlockDevice::read(void *b, bd_addr_t addr, bd_size_t size)
@@ -582,6 +586,7 @@ bool SDBlockDevice::_is_valid_trim(bd_addr_t addr, bd_size_t size)
 
 int SDBlockDevice::trim(bd_addr_t addr, bd_size_t size)
 {
+#if MBED_CONF_SD_WRITE_ENABLED
     if (!_is_valid_trim(addr, size)) {
         return SD_BLOCK_DEVICE_ERROR_PARAMETER;
     }
@@ -614,8 +619,14 @@ int SDBlockDevice::trim(bd_addr_t addr, bd_size_t size)
     }
     status = _cmd(CMD38_ERASE, 0x0);
     unlock();
+
     return status;
+#else
+    debug_if(SD_DBG, "Erase not supported in this configuration!\n");
+    return  SD_BLOCK_DEVICE_ERROR_UNSUPPORTED;
+#endif
 }
+
 
 bd_size_t SDBlockDevice::get_read_size() const
 {
@@ -945,7 +956,6 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
 
 uint8_t SDBlockDevice::_write(const uint8_t *buffer, uint8_t token, uint32_t length)
 {
-
     uint32_t crc = (~0);
     uint8_t response = 0xFF;
 

--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -9,7 +9,8 @@
         "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
         "INIT_FREQUENCY": 100000,
-        "CRC_ENABLED": 1
+        "crc-enabled": 1,
+        "write-enabled" : 1
     },
     "target_overrides": {
         "DISCO_F051R8": {


### PR DESCRIPTION
### Description

Bootloader does not need write at all, it can be overriden in that
configuration.

Changing the names to lower-case to match the typical
mbed_lib.json namings (they are not typically upper case).


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

