### PR TITLE
Add socket stat logging state change update

### DIFF
--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -288,6 +288,8 @@ TCPSocket *TCPSocket::accept(nsapi_error_t *error)
 
         if (0 == ret) {
             connection = new TCPSocket(this, socket, address);
+            _socket_stats.stats_update_peer(connection, address);
+            _socket_stats.stats_update_socket_state(connection, SOCK_CONNECTED);
             break;
         } else if ((_timeout == 0) || (ret != NSAPI_ERROR_WOULD_BLOCK)) {
             break;


### PR DESCRIPTION
### Description

TCPServer was deprecated and the accept call was added to TCPSocket. Add state change update to that call for Socket stats reporting.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

