### PR TITLE
Nuvoton: Fix crypto AC management

### DIFF
--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/aes/aes_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/aes/aes_alt.c
@@ -144,10 +144,9 @@ static void __nvt_aes_crypt( mbedtls_aes_context *ctx,
         error("Buffer for AES alter. DMA requires to be word-aligned and located in 0x20000000-0x2FFFFFFF region.");
     }
 
-    /* TODO: Change busy-wait to other means to release CPU */
     /* Acquire ownership of AES H/W */
-    while (! crypto_aes_acquire());
-    
+    crypto_aes_acquire();
+
     /* Init crypto module */
     crypto_init();
     /* Enable AES interrupt */

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/des/des_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/des/des_alt.c
@@ -349,10 +349,9 @@ static int mbedtls_des_docrypt(uint16_t keyopt, uint8_t key[3][MBEDTLS_DES_KEY_S
         error("Buffer for DES alter. DMA requires to be word-aligned and located in 0x20000000-0x2FFFFFFF region.");
     }
     
-    /* TODO: Change busy-wait to other means to release CPU */
     /* Acquire ownership of DES H/W */
-    while (! crypto_des_acquire());
-    
+    crypto_des_acquire();
+
     /* Init crypto module */
     crypto_init();
     /* Enable DES interrupt */

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/ecp/ecp_internal_alt.c
@@ -53,6 +53,7 @@
  *        would be defined in mbedtls/ecp.h from ecp.c for our inclusion */
 #define ECP_SHORTWEIERSTRASS
 
+#include "mbedtls/platform.h"
 #include "mbedtls/ecp_internal.h"
 #include "mbed_toolchain.h"
 #include "mbed_assert.h"
@@ -632,10 +633,9 @@ NU_STATIC int internal_run_eccop(const mbedtls_ecp_group *grp,
     crypto_ecc_prestart();
     CRPT->ECC_CTL = (grp->pbits << CRPT_ECC_CTL_CURVEM_Pos) | eccop | CRPT_ECC_CTL_FSEL_Msk | CRPT_ECC_CTL_START_Msk;
     ecc_done = crypto_ecc_wait();
-    
-    /* FIXME: Better error code for ECC accelerator error */
-    MBEDTLS_MPI_CHK(ecc_done ? 0 : -1);
-    
+
+    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED);
+
     /* (X1, Y1) hold the normalized result. */
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(&R->X, (uint32_t *) CRPT->ECC_X1, NU_ECC_BIGNUM_MAXWORD));
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(&R->Y, (uint32_t *) CRPT->ECC_Y1, NU_ECC_BIGNUM_MAXWORD));
@@ -726,10 +726,9 @@ NU_STATIC int internal_run_modop(mbedtls_mpi *r,
     crypto_ecc_prestart();
     CRPT->ECC_CTL = (pbits << CRPT_ECC_CTL_CURVEM_Pos) | (ECCOP_MODULE | modop) | CRPT_ECC_CTL_FSEL_Msk | CRPT_ECC_CTL_START_Msk;
     ecc_done = crypto_ecc_wait();
-    
-    /* FIXME: Better error code for ECC accelerator error */
-    MBEDTLS_MPI_CHK(ecc_done ? 0 : -1);
-    
+
+    MBEDTLS_MPI_CHK(ecc_done ? 0 : MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED);
+
     /* X1 holds the result. */
     MBEDTLS_MPI_CHK(internal_mpi_read_eccreg(r, (uint32_t *) CRPT->ECC_X1, NU_ECC_BIGNUM_MAXWORD));
 

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/sha/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/sha/sha1_alt.c
@@ -31,7 +31,7 @@
  */
 static void mbedtls_sha1_init_internal(mbedtls_sha1_context *ctx, int try_hw)
 {
-    if (try_hw && crypto_sha_acquire()) {
+    if (try_hw && crypto_sha_try_acquire()) {
         ctx->active_ctx = &ctx->hw_ctx;
         mbedtls_sha1_hw_init(&ctx->hw_ctx);
     } else {

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/sha/sha256_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/sha/sha256_alt.c
@@ -31,7 +31,7 @@
  */
 static void mbedtls_sha256_init_internal(mbedtls_sha256_context *ctx, int try_hw)
 {
-    if (try_hw && crypto_sha_acquire()) {
+    if (try_hw && crypto_sha_try_acquire()) {
         ctx->active_ctx = &ctx->hw_ctx;
         mbedtls_sha256_hw_init(&ctx->hw_ctx);
     } else {

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/sha/sha512_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_M480/sha/sha512_alt.c
@@ -31,7 +31,7 @@
  */
 static void mbedtls_sha512_init_internal(mbedtls_sha512_context *ctx, int try_hw)
 {
-    if (try_hw && crypto_sha_acquire()) {
+    if (try_hw && crypto_sha_try_acquire()) {
         ctx->active_ctx = &ctx->hw_ctx;
         mbedtls_sha512_hw_init(&ctx->hw_ctx);
     } else {

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/aes/aes_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/aes/aes_alt.c
@@ -144,10 +144,9 @@ static void __nvt_aes_crypt( mbedtls_aes_context *ctx,
         error("Buffer for AES alter. DMA requires to be word-aligned and located in 0x20000000-0x2FFFFFFF region.");
     }
 
-    /* TODO: Change busy-wait to other means to release CPU */
     /* Acquire ownership of AES H/W */
-    while (! crypto_aes_acquire());
-    
+    crypto_aes_acquire();
+
     /* Init crypto module */
     crypto_init();
     /* Enable AES interrupt */

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/des/des_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/des/des_alt.c
@@ -348,11 +348,10 @@ static int mbedtls_des_docrypt(uint16_t keyopt, uint8_t key[3][MBEDTLS_DES_KEY_S
         (! crypto_dma_buff_compat(dmabuf_out, MAXSIZE_DMABUF, 8))) {
         error("Buffer for DES alter. DMA requires to be word-aligned and located in 0x20000000-0x2FFFFFFF region.");
     }
-    
-    /* TODO: Change busy-wait to other means to release CPU */
+
     /* Acquire ownership of DES H/W */
-    while (! crypto_des_acquire());
-    
+    crypto_des_acquire();
+
     /* Init crypto module */
     crypto_init();
     /* Enable DES interrupt */

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/sha/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/sha/sha1_alt.c
@@ -31,7 +31,7 @@
  */
 static void mbedtls_sha1_init_internal(mbedtls_sha1_context *ctx, int try_hw)
 {
-    if (try_hw && crypto_sha_acquire()) {
+    if (try_hw && crypto_sha_try_acquire()) {
         ctx->active_ctx = &ctx->hw_ctx;
         mbedtls_sha1_hw_init(&ctx->hw_ctx);
     } else {

--- a/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/sha/sha256_alt.c
+++ b/features/mbedtls/targets/TARGET_NUVOTON/TARGET_NUC472/sha/sha256_alt.c
@@ -31,7 +31,7 @@
  */
 static void mbedtls_sha256_init_internal(mbedtls_sha256_context *ctx, int try_hw)
 {
-    if (try_hw && crypto_sha_acquire()) {
+    if (try_hw && crypto_sha_try_acquire()) {
         ctx->active_ctx = &ctx->hw_ctx;
         mbedtls_sha256_hw_init(&ctx->hw_ctx);
     } else {

--- a/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
@@ -19,25 +19,47 @@
 #include "mbed_assert.h"
 #include "mbed_critical.h"
 #include "mbed_error.h"
+#include "cmsis_os2.h"
+#include "mbed_rtos_storage.h"
+#include <string.h>
 #include <limits.h>
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include "crypto-misc.h"
+#include "SingletonPtr.h"
+#include "Mutex.h"
 
-/* Track if AES H/W is available */
-static uint16_t crypto_aes_avail = 1;
-/* Track if DES H/W is available */
-static uint16_t crypto_des_avail = 1;
-/* Track if SHA H/W is available */
-static uint16_t crypto_sha_avail = 1;
-/* Track if ECC H/W is available */
-static uint16_t crypto_ecc_avail = 1;
+/* Consideration for choosing proper synchronization mechanism
+ *
+ * 1. We choose mutex to synchronize access to crypto non-SHA AC. We can guarantee:
+ *    (1) No deadlock
+ *        We just lock mutex for a short sequence of operations rather than the whole lifetime
+ *        of crypto context.
+ *    (2) No priority inversion
+ *        Mutex supports priority inheritance and it is enabled.
+ * 2. We choose atomic flag to synchronize access to crypto SHA AC. We can guarantee:
+ *    (1) No deadlock
+ *        With SHA AC not supporting context save & restore, we provide SHA S/W fallback when
+ *        SHA AC is not available.
+ *    (2) No biting CPU
+ *        Same reason as above.
+ */
+
+/* Mutex for crypto AES AC management */
+static SingletonPtr<rtos::Mutex> crypto_aes_mutex;
+
+/* Mutex for crypto DES AC management */
+static SingletonPtr<rtos::Mutex> crypto_des_mutex;
+
+/* Mutex for crypto ECC AC management */
+static SingletonPtr<rtos::Mutex> crypto_ecc_mutex;
+
+/* Atomic flag for crypto SHA AC management */
+static core_util_atomic_flag crypto_sha_atomic_flag = CORE_UTIL_ATOMIC_FLAG_INIT;
+
 
 /* Crypto (AES, DES, SHA, etc.) init counter. Crypto's keeps active as it is non-zero. */
 static uint16_t crypto_init_counter = 0U;
-
-static bool crypto_submodule_acquire(uint16_t *submodule_avail);
-static void crypto_submodule_release(uint16_t *submodule_avail);
 
 /* Crypto done flags */
 #define CRYPTO_DONE_OK              BIT0    /* Done with OK */
@@ -119,44 +141,52 @@ void crypto_zeroize32(uint32_t *v, size_t n)
     }
 }
 
-bool crypto_aes_acquire(void)
+void crypto_aes_acquire(void)
 {
-    return crypto_submodule_acquire(&crypto_aes_avail);
+    /* Don't check return code of Mutex::lock(void)
+     *
+     * This function treats RTOS errors as fatal system errors, so it can only return osOK.
+     * Use of the return value is deprecated, as the return is expected to become void in
+     * the future.
+     */
+    crypto_aes_mutex->lock();
 }
 
 void crypto_aes_release(void)
 {
-    crypto_submodule_release(&crypto_aes_avail);
+    crypto_aes_mutex->unlock();
 }
 
-bool crypto_des_acquire(void)
+void crypto_des_acquire(void)
 {
-    return crypto_submodule_acquire(&crypto_des_avail);
+    /* Don't check return code of Mutex::lock(void) */
+    crypto_des_mutex->lock();
 }
 
 void crypto_des_release(void)
 {
-    crypto_submodule_release(&crypto_des_avail);
+    crypto_des_mutex->unlock();
 }
 
-bool crypto_sha_acquire(void)
+void crypto_ecc_acquire(void)
 {
-    return crypto_submodule_acquire(&crypto_sha_avail);
-}
-
-void crypto_sha_release(void)
-{
-    crypto_submodule_release(&crypto_sha_avail);
-}
-
-bool crypto_ecc_acquire(void)
-{
-    return crypto_submodule_acquire(&crypto_ecc_avail);
+    /* Don't check return code of Mutex::lock(void) */
+    crypto_ecc_mutex->lock();
 }
 
 void crypto_ecc_release(void)
 {
-    crypto_submodule_release(&crypto_ecc_avail);
+    crypto_ecc_mutex->unlock();
+}
+
+bool crypto_sha_try_acquire(void)
+{
+    return !core_util_atomic_flag_test_and_set(&crypto_sha_atomic_flag);
+}
+
+void crypto_sha_release(void)
+{
+    core_util_atomic_flag_clear(&crypto_sha_atomic_flag);
 }
 
 void crypto_prng_prestart(void)
@@ -240,18 +270,6 @@ bool crypto_dma_buffs_overlap(const void *in_buff, size_t in_buff_size, const vo
     return overlap;
 }
 
-static bool crypto_submodule_acquire(uint16_t *submodule_avail)
-{
-    uint16_t expectedCurrentValue = 1;
-    return core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 0);
-}
-
-static void crypto_submodule_release(uint16_t *submodule_avail)
-{
-    uint16_t expectedCurrentValue = 0;
-    while (! core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 1));
-}
-
 static void crypto_submodule_prestart(volatile uint16_t *submodule_done)
 {
     *submodule_done = 0;
@@ -285,7 +303,7 @@ static bool crypto_submodule_wait(volatile uint16_t *submodule_done)
 }
 
 /* Crypto interrupt handler */
-void CRYPTO_IRQHandler()
+extern "C" void CRYPTO_IRQHandler()
 {
     uint32_t intsts;
     

--- a/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.h
@@ -32,25 +32,32 @@ void crypto_uninit(void);
 void crypto_zeroize(void *v, size_t n);
 void crypto_zeroize32(uint32_t *v, size_t n);
 
-/* Acquire/release ownership of AES H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_aes_acquire(void);
+/* Acquire/release ownership of crypto sub-module
+ * 
+ * \note            "acquire" is blocking until ownership is acquired
+ *
+ * \note            "acquire"/"release" must be paired.
+ *
+ * \note            Recursive "acquire" is allowed because the underlying synchronization
+ *                  primitive mutex supports it.
+ */
+void crypto_aes_acquire(void);
 void crypto_aes_release(void);
-
-/* Acquire/release ownership of DES H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_des_acquire(void);
+void crypto_des_acquire(void);
 void crypto_des_release(void);
-
-/* Acquire/release ownership of SHA H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_sha_acquire(void);
-void crypto_sha_release(void);
-
-/* Acquire/release ownership of ECC H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_ecc_acquire(void);
+void crypto_ecc_acquire(void);
 void crypto_ecc_release(void);
+
+/* Acquire/release ownership of crypto sub-module
+ * 
+ * \return          false if crytpo sub-module is held by another thread or
+ *                  another mbedtls context.
+ *                  true if successful
+ *
+ * \note            Successful "try_acquire" and "release" must be paired.
+ */
+bool crypto_sha_try_acquire(void);
+void crypto_sha_release(void);
 
 /* Flow control between crypto/xxx start and crypto/xxx ISR 
  *

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
@@ -19,23 +19,44 @@
 #include "mbed_assert.h"
 #include "mbed_critical.h"
 #include "mbed_error.h"
+#include "cmsis_os2.h"
+#include "mbed_rtos_storage.h"
+#include <string.h>
 #include <limits.h>
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include "crypto-misc.h"
+#include "SingletonPtr.h"
+#include "Mutex.h"
 
-/* Track if AES H/W is available */
-static uint16_t crypto_aes_avail = 1;
-/* Track if DES H/W is available */
-static uint16_t crypto_des_avail = 1;
-/* Track if SHA H/W is available */
-static uint16_t crypto_sha_avail = 1;
+/* Consideration for choosing proper synchronization mechanism
+ *
+ * 1. We choose mutex to synchronize access to crypto non-SHA AC. We can guarantee:
+ *    (1) No deadlock
+ *        We just lock mutex for a short sequence of operations rather than the whole lifetime
+ *        of crypto context.
+ *    (2) No priority inversion
+ *        Mutex supports priority inheritance and it is enabled.
+ * 2. We choose atomic flag to synchronize access to crypto SHA AC. We can guarantee:
+ *    (1) No deadlock
+ *        With SHA AC not supporting context save & restore, we provide SHA S/W fallback when
+ *        SHA AC is not available.
+ *    (2) No biting CPU
+ *        Same reason as above.
+ */
+
+/* Mutex for crypto AES AC management */
+static SingletonPtr<rtos::Mutex> crypto_aes_mutex;
+
+/* Mutex for crypto DES AC management */
+static SingletonPtr<rtos::Mutex> crypto_des_mutex;
+
+/* Atomic flag for crypto SHA AC management */
+static core_util_atomic_flag crypto_sha_atomic_flag = CORE_UTIL_ATOMIC_FLAG_INIT;
+
 
 /* Crypto (AES, DES, SHA, etc.) init counter. Crypto's keeps active as it is non-zero. */
 static uint16_t crypto_init_counter = 0U;
-
-static bool crypto_submodule_acquire(uint16_t *submodule_avail);
-static void crypto_submodule_release(uint16_t *submodule_avail);
 
 /* Crypto done flags */
 #define CRYPTO_DONE_OK              BIT0    /* Done with OK */
@@ -106,34 +127,41 @@ void crypto_zeroize(void *v, size_t n)
     }
 }
 
-bool crypto_aes_acquire(void)
+void crypto_aes_acquire(void)
 {
-    return crypto_submodule_acquire(&crypto_aes_avail);
+    /* Don't check return code of Mutex::lock(void)
+     *
+     * This function treats RTOS errors as fatal system errors, so it can only return osOK.
+     * Use of the return value is deprecated, as the return is expected to become void in
+     * the future.
+     */
+    crypto_aes_mutex->lock();
 }
 
 void crypto_aes_release(void)
 {
-    crypto_submodule_release(&crypto_aes_avail);
+    crypto_aes_mutex->unlock();
 }
 
-bool crypto_des_acquire(void)
+void crypto_des_acquire(void)
 {
-    return crypto_submodule_acquire(&crypto_des_avail);
+    /* Don't check return code of Mutex::lock(void) */
+    crypto_des_mutex->lock();
 }
 
 void crypto_des_release(void)
 {
-    crypto_submodule_release(&crypto_des_avail);
+    crypto_des_mutex->unlock();
 }
 
-bool crypto_sha_acquire(void)
+bool crypto_sha_try_acquire(void)
 {
-    return crypto_submodule_acquire(&crypto_sha_avail);
+    return !core_util_atomic_flag_test_and_set(&crypto_sha_atomic_flag);
 }
 
 void crypto_sha_release(void)
 {
-    crypto_submodule_release(&crypto_sha_avail);
+    core_util_atomic_flag_clear(&crypto_sha_atomic_flag);
 }
 
 void crypto_prng_prestart(void)
@@ -207,18 +235,6 @@ bool crypto_dma_buffs_overlap(const void *in_buff, size_t in_buff_size, const vo
     return overlap;
 }
 
-static bool crypto_submodule_acquire(uint16_t *submodule_avail)
-{
-    uint16_t expectedCurrentValue = 1;
-    return core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 0);
-}
-
-static void crypto_submodule_release(uint16_t *submodule_avail)
-{
-    uint16_t expectedCurrentValue = 0;
-    while (! core_util_atomic_cas_u16(submodule_avail, &expectedCurrentValue, 1));
-}
-
 static void crypto_submodule_prestart(volatile uint16_t *submodule_done)
 {
     *submodule_done = 0;
@@ -252,7 +268,7 @@ static bool crypto_submodule_wait(volatile uint16_t *submodule_done)
 }
 
 /* Crypto interrupt handler */
-void CRYPTO_IRQHandler()
+extern "C" void CRYPTO_IRQHandler()
 {
     uint32_t intsts;
     

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.h
@@ -31,19 +31,29 @@ void crypto_uninit(void);
  * Implementation that should never be optimized out by the compiler */
 void crypto_zeroize(void *v, size_t n);
 
-/* Acquire/release ownership of AES H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_aes_acquire(void);
+/* Acquire/release ownership of crypto sub-module
+ * 
+ * \note            "acquire" is blocking until ownership is acquired
+ *
+ * \note            "acquire"/"release" must be paired.
+ *
+ * \note            Recursive "acquire" is allowed because the underlying synchronization
+ *                  primitive mutex supports it.
+ */
+void crypto_aes_acquire(void);
 void crypto_aes_release(void);
-
-/* Acquire/release ownership of DES H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_des_acquire(void);
+void crypto_des_acquire(void);
 void crypto_des_release(void);
 
-/* Acquire/release ownership of SHA H/W */
-/* NOTE: If "acquire" succeeds, "release" must be done to pair it. */
-bool crypto_sha_acquire(void);
+/* Acquire/release ownership of crypto sub-module
+ * 
+ * \return          false if crytpo sub-module is held by another thread or
+ *                  another mbedtls context.
+ *                  true if successful
+ *
+ * \note            Successful "try_acquire" and "release" must be paired.
+ */
+bool crypto_sha_try_acquire(void);
 void crypto_sha_release(void);
 
 /* Flow control between crypto/xxx start and crypto/xxx ISR 


### PR DESCRIPTION
### Description

This PR is continuation of #8985. Originally, it is to replace busy-wait loop with mutex in crypto AC management. But in PDMC Greentea test, `mbedtls_sha256_init()` (lock mutex) and `mbedtls_sha256_free()` (unlock mutex) are not necessarily called by the same thread, so managing crypto AC with mutex is suspended. This PR is reduced to include minor fixes with crypto AC.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

