### PR TITLE
Realtek-rtl8195am-Network_Socket_Updates

### DIFF
--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -115,7 +115,8 @@
     },
     "target_overrides": {
         "REALTEK_RTL8195AM": {
-            "tcpip-thread-stacksize": 1600
+            "tcpip-thread-stacksize": 1600,
+            "mem-size": 12800
         },
         "UBLOX_EVK_ODIN_W2": {
             "pbuf-pool-size" :  10

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -104,29 +104,38 @@ RTWInterface::~RTWInterface()
  */
 nsapi_error_t RTWInterface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
 {
-    if (!ssid) {
+    _security = security;
+    // Check if ssid is empty
+    if (!ssid) { 
         return NSAPI_ERROR_PARAMETER;
     }
 
-    switch (security) {
-        case NSAPI_SECURITY_WPA:
-        case NSAPI_SECURITY_WPA2:
-        case NSAPI_SECURITY_WPA_WPA2:
-        case NSAPI_SECURITY_WEP:
-            if ((strlen(pass) < 8) || (strlen(pass) > 63)) { // 802.11 password 8-63 characters
-                return NSAPI_ERROR_PARAMETER;
-            }
-            break;
-        case NSAPI_SECURITY_NONE:
-            break;
-        default:
-            return NSAPI_ERROR_PARAMETER;
+    // Check if ssid is too long
+    int ssid_length = strlen(ssid);
+
+    if (ssid_length > 0 && ssid_length <= SSID_MAX_LENGTH) {
+        memset(_ssid, 0, sizeof(_ssid));
+        strncpy(_ssid, ssid, sizeof(_ssid));
+    } else {
+        return NSAPI_ERROR_PARAMETER;
     }
 
-    strncpy(_ssid, ssid, 255);
-    strncpy(_pass, pass, 255);
-    _security = security;
-
+    // Check if it is an open access point 
+    if (_security != NSAPI_SECURITY_NONE) {
+    // Check if passphase is empty
+        if (!pass) {
+            return NSAPI_ERROR_PARAMETER;
+        }
+        // Check if passphase too long
+        if (strlen(pass) >= PASSPHRASE_MIN_LENGTH && strlen(pass) <= PASSPHRASE_MAX_LENGTH ) {
+            memset(_pass, 0, sizeof(_pass));
+            strncpy(_pass, pass, sizeof(_pass));
+        } else {
+            return NSAPI_ERROR_PARAMETER;
+        }
+    } else { // It is an open access point
+        memset(_pass, 0, sizeof(_pass));
+    }
     return NSAPI_ERROR_OK;
 }
 
@@ -135,11 +144,15 @@ nsapi_error_t RTWInterface::connect()
     int ret;
     rtw_security_t sec;
 
-    if (!_ssid || (!_pass && _security != NSAPI_SECURITY_NONE)) {
-        printf("Invalid credentials\r\n");
-        return NSAPI_ERROR_PARAMETER;
+    // Check if the ssid is empty 
+    if (strlen(_ssid) == 0) {
+        return NSAPI_ERROR_NO_SSID;
     }
-
+    // Check the security is empty and the passphase is valid 
+    if ((_security != NSAPI_SECURITY_NONE) && (strlen(_pass) < PASSPHRASE_MIN_LENGTH)) {
+            return NSAPI_ERROR_PARAMETER;
+    }
+    // Based on security type set, adapt to Ameba SDK format
     switch (_security) {
         case NSAPI_SECURITY_WPA:
         case NSAPI_SECURITY_WPA2:
@@ -155,22 +168,24 @@ nsapi_error_t RTWInterface::connect()
         default:
             return NSAPI_ERROR_PARAMETER;
     }
-
+    // Check if channel number is valid
     if (_channel > 0 && _channel < 14) {
         uint8_t pscan_config = PSCAN_ENABLE;
-        wifi_set_pscan_chan(&_channel, &pscan_config, 1);
+        wifi_set_pscan_chan(&_channel, &pscan_config, 1); // Indicate which channel will be scanned
     }
-
-    ret = wifi_connect(_ssid, sec, _pass, strlen(_ssid), strlen(_pass), 0, (void *)NULL);
+    ret = wifi_connect(_ssid, sec, _pass, strlen(_ssid), strlen(_pass), 0, (void *)NULL); // Join a WiFi network
+    // Check if the WiFi is connected. Return RTW_SUCCESS for succeful; Return RTW_ERROR for error
     if (ret != RTW_SUCCESS) {
-        printf("failed: %d\r\n", ret);
-        return NSAPI_ERROR_NO_CONNECTION;
+        if(_ssid == "NULL"){
+            return NSAPI_ERROR_PARAMETER;
+        }
+        else{
+            printf("failed: %d\r\n", ret);
+            return NSAPI_ERROR_NO_CONNECTION;
+        }
     }
-
     rtw_emac.wlan_emac_link_change(true);
-
     ret = EMACInterface::connect();
-
     return ret;
 }
 
@@ -200,7 +215,7 @@ nsapi_error_t RTWInterface::scan(WiFiAccessPoint *res, unsigned count)
 nsapi_error_t RTWInterface::set_channel(uint8_t channel)
 {
     _channel = channel;
-    return NSAPI_ERROR_OK;
+    return NSAPI_ERROR_UNSUPPORTED;
 }
 
 int8_t RTWInterface::get_rssi()
@@ -215,8 +230,11 @@ int8_t RTWInterface::get_rssi()
 nsapi_error_t RTWInterface::connect(const char *ssid, const char *pass,
                             nsapi_security_t security, uint8_t channel)
 {
-    set_credentials(ssid, pass, security);
     set_channel(channel);
+    int err = set_credentials(ssid, pass, security);
+    if(err) {
+        return err;
+    }
     return connect();
 }
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.h
@@ -112,5 +112,8 @@ protected:
     char _pass[256];
     nsapi_security_t _security;
     uint8_t _channel;
+    static const int SSID_MAX_LENGTH = 32; //The longest ssid
+    static const int PASSPHRASE_MAX_LENGTH = 63; //The longest passphrase
+    static const int PASSPHRASE_MIN_LENGTH = 8; // The shortest passphrase
 };
 #endif


### PR DESCRIPTION
This PR addresses the issue of [#8124](https://github.com/ARMmbed/mbed-os/issues/8124).
It updates and enriches the wifi connection error type to adapt the [Network Socket test plan](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md) requirement.
In the meantime, it increases the heap size that allows the transmission of larger packet size.

### Description

1) Increase heap size in lwipstack\mbed_lib.json to fulfill bursty TCP and UDP transmission [requirement](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md#udpsocket_echotest_burst). 
2) Modify and enrich wifi connection error types in TARGET_AMEBA\RTWInterface.cpp to adapt the decision logic of the [wifi test cases](https://github.com/ARMmbed/mbed-os/tree/master/TESTS/network/wifi).  
3) Add new static constants in TARGET_AMEBA\RTWInterface.h, including 'SSID_MAX_LENGTH', 'PASSPHRASE_MAX_LENGTH' and 'PASSPHRASE_MIN_LENGTH' to help verifying the validity of ssid and passphrase.



### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

