### PR TITLE
kvstore tests: reduce reset

### DIFF
--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -207,7 +207,7 @@ static void set_buffer_size_is_zero()
     int res = kvstore->set(key, data, 0, 0);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -225,7 +225,7 @@ static void set_same_key_several_time()
     res = kvstore->set(key, data, data_size, 0);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -239,7 +239,7 @@ static void test_thread_set(char *th_key)
 static void set_several_keys_multithreaded()
 {
     TEST_SKIP_UNLESS(kvstore != NULL);
-
+    int i = 0, res = 0;
     rtos::Thread kvstore_thread[num_of_threads];
     osStatus threadStatus;
 
@@ -248,23 +248,25 @@ static void set_several_keys_multithreaded()
     kvstore_thread[2].start(callback(test_thread_set, (char *)keys[2]));
 
 
-    for (int i = 0; i < num_of_threads; i++) {
+    for (i = 0; i < num_of_threads; i++) {
         threadStatus = kvstore_thread[i].join();
         if (threadStatus != 0) {
             utest_printf("\nthread %d join failed!", i + 1);
         }
     }
 
-    for (int i = 0; i < num_of_threads; i++) {
-        int res = kvstore->get(keys[i], buffer, buffer_size, &actual_size, 0);
+    for (i = 0; i < num_of_threads; i++) {
+        res = kvstore->get(keys[i], buffer, buffer_size, &actual_size, 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
         TEST_ASSERT_EQUAL_STRING_LEN(buffer, data, data_size);
 
     }
 
-    int res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    for (i = 0; i < num_of_threads; i++) {
+        res = kvstore->remove(keys[i]);
+        TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    }
 }
 
 //set key "write once" and try to set it again
@@ -313,7 +315,7 @@ static void set_key_value_one_byte_size()
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -330,7 +332,7 @@ static void set_key_value_two_byte_size()
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_two, 1);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -347,7 +349,7 @@ static void set_key_value_five_byte_size()
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_five, 4);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -364,7 +366,7 @@ static void set_key_value_fifteen_byte_size()
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_fif, 14);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -381,36 +383,78 @@ static void set_key_value_seventeen_byte_size()
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_fif, 16);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
-//set several different key value byte size
+//set several different keys and retrieve them
 static void set_several_key_value_sizes()
 {
     TEST_SKIP_UNLESS(kvstore != NULL);
 
     char name[7] = "name_";
-    char c[2] = {0};
+    char c = 0;
     int i = 0, res = 0;
 
-    for (i = 0; i < 30; i++) {
-        c[0] = i + '0';
-        name[6] = c[0];
+    name[6] = 0;
+
+    for (i = 0; i < 26; i++) {
+        c = i + 'a';
+        name[5] = c;
         res = kvstore->set(name, name, sizeof(name), 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     }
 
-    for (i = 0; i < 30; i++) {
-        c[0] = i + '0';
-        name[6] = c[0];
+    for (i = 0; i < 26; i++) {
+        c = i + 'a';
+        name[5] = c;
         res = kvstore->get(name, buffer, sizeof(buffer), &actual_size, 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
         TEST_ASSERT_EQUAL_STRING_LEN(name, buffer, sizeof(name));
         memset(buffer, 0, sizeof(buffer));
-    }
 
-    res = kvstore->reset();
+        res = kvstore->remove(name);
+        TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    }
+}
+
+//try to set several different unvalid key names
+static void set_several_unvalid_key_names()
+{
+    TEST_SKIP_UNLESS(kvstore != NULL);
+
+    char name[7] = "name_";
+    char unvalid[] = {'*', '?', ':', ';', '"', '|', ' ', '<', '>', '\\', '/'};
+    int i = 0, res = 0;
+
+    name[6] = 0;
+
+    for (i = 0; i < 11; i++) {
+        name[5] = unvalid[i];
+        res = kvstore->set(name, name, sizeof(name), 0);
+        TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_INVALID_ARGUMENT, res);
+    }
+}
+
+//set key initialize kvstore and retrieve it
+static void set_key_init_deinit()
+{
+    TEST_SKIP_UNLESS(kvstore != NULL);
+
+    int res = kvstore->set(key, data, data_size, 0);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+
+    res = kvstore->deinit();
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+
+    res = kvstore->init();
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+
+    res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
+    TEST_ASSERT_EQUAL_STRING(buffer, data);
+    memset(buffer, 0, buffer_size);
+
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -453,29 +497,13 @@ static void Sec_set_key_encrypt()
     res = kvstore->get(key, buffer, sizeof(buffer), &actual_size, 0);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     TEST_ASSERT_EQUAL_STRING_LEN(data, buffer, sizeof(data));
+
+    res = kvstore->get_info(key, &info);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    TEST_ASSERT_EQUAL_ERROR_CODE(KVStore::REQUIRE_CONFIDENTIALITY_FLAG, info.flags);
     memset(buffer, 0, sizeof(buffer));
 
-    res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-}
-
-//set key with AUTH flag and retrieve it
-static void Sec_set_key_auth()
-{
-    TEST_SKIP_UNLESS(kvstore != NULL);
-    if (kv_setup != SecStoreSet) {
-        return;
-    }
-
-    int res = kvstore->set(key, data, data_size, 0);
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-
-    res = kvstore->get(key, buffer, sizeof(buffer), &actual_size, 0);
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-    TEST_ASSERT_EQUAL_STRING_LEN(data, buffer, sizeof(data));
-    memset(buffer, 0, sizeof(buffer));
-
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -537,7 +565,7 @@ static void get_buffer_size_smaller_than_data_real_size()
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, big_data, &actual_size);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -555,7 +583,7 @@ static void get_buffer_size_bigger_than_data_real_size()
     TEST_ASSERT_EQUAL_STRING_LEN(big_buffer, data, &actual_size);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -570,7 +598,7 @@ static void get_offset_bigger_than_data_size()
     res = kvstore->get(key, buffer, buffer_size, &actual_size, data_size + 1);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_INVALID_SIZE, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -596,9 +624,6 @@ static void get_removed_key()
 
     res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, res);
-
-    res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
 //set the same key twice and get latest data
@@ -618,7 +643,7 @@ static void get_key_that_was_set_twice()
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, new_data, &actual_size);
     memset(buffer, 0, buffer_size);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -652,8 +677,10 @@ static void get_several_keys_multithreaded()
         }
     }
 
-    int res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    for (int i = 0; i < num_of_threads; i++) {
+        int res = kvstore->remove(keys[i]);
+        TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    }
 }
 
 
@@ -702,9 +729,6 @@ static void remove_removed_key()
 
     res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, res);
-
-    res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
 //key exist - valid flow
@@ -716,9 +740,6 @@ static void remove_existed_key()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->remove(key);
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-
-    res = kvstore->reset();
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -755,10 +776,11 @@ template_case_t template_cases[] = {
     {"set_key_value_fifteen_byte_size", set_key_value_fifteen_byte_size, greentea_failure_handler},
     {"set_key_value_seventeen_byte_size", set_key_value_seventeen_byte_size, greentea_failure_handler},
     {"set_several_key_value_sizes", set_several_key_value_sizes, greentea_failure_handler},
+    {"set_several_unvalid_key_names", set_several_unvalid_key_names, greentea_failure_handler},
+    {"set_key_init_deinit", set_key_init_deinit, greentea_failure_handler},
 
     {"Sec_set_key_rollback_set_again_no_rollback", Sec_set_key_rollback_set_again_no_rollback, greentea_failure_handler},
     {"Sec_set_key_encrypt", Sec_set_key_encrypt, greentea_failure_handler},
-    {"Sec_set_key_auth", Sec_set_key_auth, greentea_failure_handler},
 
     {"get_key_null", get_key_null, greentea_failure_handler},
     {"get_key_length_exceeds_max", get_key_length_exceeds_max, greentea_failure_handler},

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -204,9 +204,6 @@ static void get_info_removed_key()
 
     res = kvstore->get_info(key, &info);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, res);
-
-    res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
 //get_info of existing key - valid flow
@@ -236,8 +233,7 @@ static void get_info_overwritten_key()
 {
     TEST_SKIP_UNLESS(kvstore != NULL);
 
-    char new_key[] = "get_info_key";
-    int res = kvstore->set(new_key, data, data_size, 0);
+    int res = kvstore->set(key, data, data_size, 0);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     char new_data[] = "new_data";
@@ -248,7 +244,7 @@ static void get_info_overwritten_key()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     TEST_ASSERT_EQUAL_ERROR_CODE(info.size, sizeof(new_data));
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -310,15 +306,15 @@ static void iterator_next_one_key_list()
     res = kvstore->iterator_open(&kvstore_it, NULL);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    char key[KVStore::MAX_KEY_SIZE];
+    char key_buf[KVStore::MAX_KEY_SIZE];
 
-    res = kvstore->iterator_next(kvstore_it, key, sizeof(key));
+    res = kvstore->iterator_next(kvstore_it, key_buf, sizeof(key_buf));
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->iterator_close(kvstore_it);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -344,15 +340,12 @@ static void iterator_next_empty_list_keys_removed()
     res = kvstore->iterator_open(&kvstore_it, NULL);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    char key[KVStore::MAX_KEY_SIZE];
+    char key_buf[KVStore::MAX_KEY_SIZE];
 
-    res = kvstore->iterator_next(kvstore_it, key, sizeof(key));
+    res = kvstore->iterator_next(kvstore_it, key_buf, sizeof(key_buf));
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, res);
 
     res = kvstore->iterator_close(kvstore_it);
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-
-    res = kvstore->reset();
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -372,15 +365,18 @@ static void iterator_next_empty_list_non_matching_prefix()
     res = kvstore->iterator_open(&kvstore_it, "Key*");
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    char key[KVStore::MAX_KEY_SIZE];
+    char key_buf[KVStore::MAX_KEY_SIZE];
 
-    res = kvstore->iterator_next(kvstore_it, key, sizeof(key));
+    res = kvstore->iterator_next(kvstore_it, key_buf, sizeof(key_buf));
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, res);
 
     res = kvstore->iterator_close(kvstore_it);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(new_key_1);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+
+    res = kvstore->remove(new_key_2);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -408,7 +404,7 @@ static void iterator_next_several_overwritten_keys()
     res = kvstore->iterator_close(kvstore_it);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -449,8 +445,10 @@ static void iterator_next_full_list()
     res = kvstore->iterator_close(kvstore_it);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    for (i = 0; i < num_of_keys; i++) {
+        int res = kvstore->remove(keys[i]);
+        TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    }
 }
 
 //iteartor_next remove while iterating
@@ -483,7 +481,6 @@ static void iterator_next_remove_while_iterating()
         if (res != MBED_SUCCESS) {
             break;
         }
-
         res = kvstore->remove(key);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     }
@@ -496,14 +493,13 @@ static void iterator_next_remove_while_iterating()
         if (res != MBED_SUCCESS) {
             break;
         }
-
         TEST_ASSERT_EQUAL_STRING_LEN("new", key, 3);
+
+        res = kvstore->remove(key);
+        TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     }
 
     res = kvstore->iterator_close(kvstore_it);
-    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-
-    res = kvstore->reset();
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -628,7 +624,7 @@ static void set_add_data_data_size_is_zero()
     res = kvstore->set_finalize(handle);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -683,7 +679,7 @@ static void set_add_data_set_different_data_size_in_same_transaction()
 
     TEST_ASSERT_EQUAL_STRING(new_data, buffer);
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 
@@ -715,7 +711,7 @@ static void set_add_data_set_key_value_five_Kbytes()
 
     TEST_ASSERT_EQUAL_STRING_LEN(temp_buf, read_temp_buf, sizeof(temp_buf));
 
-    res = kvstore->reset();
+    res = kvstore->remove(key);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 }
 

--- a/features/storage/TESTS/kvstore/static_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/static_tests/main.cpp
@@ -327,7 +327,6 @@ static void set_several_unvalid_key_names()
     for (i = 0; i < 11; i++) {
         name[5] = unvalid[i];
         res = kv_set(name, name, sizeof(name), 0);
-        //if (i != 10) {
         if (unvalid[i] != '/') {
             TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_INVALID_ARGUMENT, res);
         } else {


### PR DESCRIPTION
Improve kvstore tests by reducing kvstore reset occurrences.
Following kvstore flags changes Sec_set_key_auth test is no more relevant and was removed.

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

