### PR TITLE
Cellular: Removed unnecessary checks after new

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/at_cellulardevicetest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/at_cellulardevicetest.cpp
@@ -397,6 +397,6 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_set_ready_cb)
     FileHandle_stub fh1;
     AT_CellularDevice *dev = new AT_CellularDevice(&fh1);
 
-    EXPECT_TRUE(NSAPI_ERROR_UNSUPPORTED == dev->set_ready_cb(&device_ready_cb));
-    EXPECT_TRUE(NSAPI_ERROR_UNSUPPORTED == dev->set_ready_cb(0));
+    dev->set_ready_cb(&device_ready_cb);
+    dev->set_ready_cb(0);
 }

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsms/at_cellularsmstest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsms/at_cellularsmstest.cpp
@@ -71,14 +71,14 @@ TEST_F(TestAT_CellularSMS, test_AT_CellularSMS_initialize)
 
     AT_CellularSMS sms(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
-    EXPECT_TRUE(NSAPI_ERROR_NO_MEMORY == sms.initialize(CellularSMS::CellularSMSMmodeText));
+    EXPECT_EQ(NSAPI_ERROR_AUTH_FAILURE, sms.initialize(CellularSMS::CellularSMSMmodeText));
 
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    EXPECT_TRUE(NSAPI_ERROR_OK == sms.initialize(CellularSMS::CellularSMSMmodeText));
+    EXPECT_EQ(NSAPI_ERROR_OK, sms.initialize(CellularSMS::CellularSMSMmodeText));
 
     sms.set_sms_callback(&my_callback);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    EXPECT_TRUE(NSAPI_ERROR_OK == sms.initialize(CellularSMS::CellularSMSMmodeText));
+    EXPECT_EQ(NSAPI_ERROR_OK, sms.initialize(CellularSMS::CellularSMSMmodeText));
 
     ATHandler_stub::call_immediately = false;
 }

--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -128,7 +128,7 @@ TEST_F(TestATHandler, test_ATHandler_set_urc_handler)
     at.set_urc_handler(ch, cb);
 
     //THIS IS NOT same callback in find_urc_handler???
-    EXPECT_TRUE(NSAPI_ERROR_OK == at.set_urc_handler(ch, cb));
+    at.set_urc_handler(ch, cb);
 }
 
 TEST_F(TestATHandler, test_ATHandler_remove_urc_handler)

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -117,7 +117,7 @@ void ATHandler::set_file_handle(FileHandle *fh)
 {
 }
 
-nsapi_error_t ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()> cb)
+void ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()> cb)
 {
     if (ATHandler_stub::urc_amount < kATHandler_urc_table_max_size) {
         ATHandler_stub::callback[ATHandler_stub::urc_amount] = cb;
@@ -134,7 +134,6 @@ nsapi_error_t ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()>
     if (ATHandler_stub::call_immediately) {
         cb();
     }
-    return ATHandler_stub::nsapi_error_value;
 }
 
 void ATHandler::remove_urc_handler(const char *prefix)

--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -149,9 +149,8 @@ nsapi_error_t AT_CellularDevice::is_ready()
     return NSAPI_ERROR_OK;
 }
 
-nsapi_error_t AT_CellularDevice::set_ready_cb(mbed::Callback<void()> callback)
+void AT_CellularDevice::set_ready_cb(mbed::Callback<void()> callback)
 {
-    return NSAPI_ERROR_UNSUPPORTED;
 }
 
 nsapi_error_t AT_CellularDevice::set_power_save_mode(int periodic_time, int active_time)

--- a/UNITTESTS/target_h/myCellularDevice.h
+++ b/UNITTESTS/target_h/myCellularDevice.h
@@ -129,9 +129,8 @@ public:
         return NSAPI_ERROR_OK;
     }
 
-    virtual nsapi_error_t set_ready_cb(Callback<void()> callback)
+    virtual void set_ready_cb(Callback<void()> callback)
     {
-        return NSAPI_ERROR_UNSUPPORTED;
     }
 
     nsapi_error_t set_power_save_mode(int periodic_time, int active_time)

--- a/features/cellular/TESTS/api/cellular_power/main.cpp
+++ b/features/cellular/TESTS/api/cellular_power/main.cpp
@@ -52,11 +52,10 @@ static void urc_callback()
 
 static void wait_for_power(CellularPower *pwr)
 {
-    nsapi_error_t err = cellular_device->set_ready_cb(&urc_callback);
-    TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_UNSUPPORTED);
+    cellular_device->set_ready_cb(&urc_callback);
 
     int sanity_count = 0;
-    err = cellular_device->init();
+    nsapi_error_t err = cellular_device->init();
     while (err != NSAPI_ERROR_OK) {
         sanity_count++;
         wait(1);
@@ -65,8 +64,7 @@ static void wait_for_power(CellularPower *pwr)
     }
 
     TEST_ASSERT(cellular_device->is_ready() == NSAPI_ERROR_OK);
-
-    TEST_ASSERT(cellular_device->set_ready_cb(0) == NSAPI_ERROR_OK);
+    cellular_device->set_ready_cb(0);
 }
 
 static void test_power_interface()

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -285,12 +285,8 @@ public:
     /** Set callback function to listen when device is ready.
      *
      *  @param callback function to call on device ready, or NULL to remove callback.
-     *
-     *  @return         NSAPI_ERROR_OK on success
-     *                  NSAPI_ERROR_NO_MEMORY on memory failure
-     *                  NSAPI_ERROR_UNSUPPORTED if not overridden by the target modem
      */
-    virtual nsapi_error_t set_ready_cb(Callback<void()> callback) = 0;
+    virtual void set_ready_cb(Callback<void()> callback) = 0;
 
     /** Set power save mode
      *

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -90,11 +90,7 @@ ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, int timeout, const char 
 
     if (output_delimiter) {
         _output_delimiter = new char[strlen(output_delimiter) + 1];
-        if (!_output_delimiter) {
-            MBED_ASSERT(0);
-        } else {
-            memcpy(_output_delimiter, output_delimiter, strlen(output_delimiter) + 1);
-        }
+        memcpy(_output_delimiter, output_delimiter, strlen(output_delimiter) + 1);
     } else {
         _output_delimiter = NULL;
     }
@@ -160,38 +156,32 @@ void ATHandler::set_is_filehandle_usable(bool usable)
     _is_fh_usable = usable;
 }
 
-nsapi_error_t ATHandler::set_urc_handler(const char *prefix, Callback<void()> callback)
+void ATHandler::set_urc_handler(const char *prefix, Callback<void()> callback)
 {
     if (!callback) {
         remove_urc_handler(prefix);
-        return NSAPI_ERROR_OK;
+        return;
     }
 
     if (find_urc_handler(prefix)) {
         tr_warn("URC already added with prefix: %s", prefix);
-        return NSAPI_ERROR_OK;
+        return;
     }
 
     struct oob_t *oob = new struct oob_t;
-    if (!oob) {
-        return NSAPI_ERROR_NO_MEMORY;
-    } else {
-        size_t prefix_len = strlen(prefix);
-        if (prefix_len > _oob_string_max_length) {
-            _oob_string_max_length = prefix_len;
-            if (_oob_string_max_length > _max_resp_length) {
-                _max_resp_length = _oob_string_max_length;
-            }
+    size_t prefix_len = strlen(prefix);
+    if (prefix_len > _oob_string_max_length) {
+        _oob_string_max_length = prefix_len;
+        if (_oob_string_max_length > _max_resp_length) {
+            _max_resp_length = _oob_string_max_length;
         }
-
-        oob->prefix = prefix;
-        oob->prefix_len = prefix_len;
-        oob->cb = callback;
-        oob->next = _oobs;
-        _oobs = oob;
     }
 
-    return NSAPI_ERROR_OK;
+    oob->prefix = prefix;
+    oob->prefix_len = prefix_len;
+    oob->cb = callback;
+    oob->next = _oobs;
+    _oobs = oob;
 }
 
 void ATHandler::remove_urc_handler(const char *prefix)

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -101,9 +101,8 @@ public:
      *
      *  @param prefix   URC text to look for, e.g. "+CMTI:"
      *  @param callback function to call on prefix, or 0 to remove callback
-     *  @return NSAPI_ERROR_OK or NSAPI_ERROR_NO_MEMORY if no memory
      */
-    nsapi_error_t set_urc_handler(const char *prefix, Callback<void()> callback);
+    void set_urc_handler(const char *prefix, Callback<void()> callback);
 
     ATHandler *_nextATHandler; // linked list
 

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -201,26 +201,22 @@ CellularContext *AT_CellularDevice::get_context_list() const
 
 CellularContext *AT_CellularDevice::create_context(FileHandle *fh, const char *apn)
 {
-    ATHandler *atHandler = get_at_handler(fh);
-    if (atHandler) {
-        AT_CellularContext *ctx = create_context_impl(*atHandler, apn);
-        AT_CellularContext *curr = _context_list;
+    AT_CellularContext *ctx = create_context_impl(*get_at_handler(fh), apn);
+    AT_CellularContext *curr = _context_list;
 
-        if (_context_list == NULL) {
-            _context_list = ctx;
-            return ctx;
-        }
-
-        AT_CellularContext *prev;
-        while (curr) {
-            prev = curr;
-            curr = (AT_CellularContext *)curr->_next;
-        }
-
-        prev->_next = ctx;
+    if (_context_list == NULL) {
+        _context_list = ctx;
         return ctx;
     }
-    return NULL;
+
+    AT_CellularContext *prev;
+    while (curr) {
+        prev = curr;
+        curr = (AT_CellularContext *)curr->_next;
+    }
+
+    prev->_next = ctx;
+    return ctx;
 }
 
 AT_CellularContext *AT_CellularDevice::create_context_impl(ATHandler &at, const char *apn)
@@ -249,56 +245,36 @@ void AT_CellularDevice::delete_context(CellularContext *context)
 CellularNetwork *AT_CellularDevice::open_network(FileHandle *fh)
 {
     if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = open_network_impl(*atHandler);
-        }
+        _network = open_network_impl(*get_at_handler(fh));
     }
-    if (_network) {
-        _network_ref_count++;
-    }
+    _network_ref_count++;
     return _network;
 }
 
 CellularSMS *AT_CellularDevice::open_sms(FileHandle *fh)
 {
     if (!_sms) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _sms = open_sms_impl(*atHandler);
-        }
+        _sms = open_sms_impl(*get_at_handler(fh));
     }
-    if (_sms) {
-        _sms_ref_count++;
-    }
+    _sms_ref_count++;
     return _sms;
 }
 
 CellularPower *AT_CellularDevice::open_power(FileHandle *fh)
 {
     if (!_power) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _power = open_power_impl(*atHandler);
-        }
+        _power = open_power_impl(*get_at_handler(fh));
     }
-    if (_power) {
-        _power_ref_count++;
-    }
+    _power_ref_count++;
     return _power;
 }
 
 CellularInformation *AT_CellularDevice::open_information(FileHandle *fh)
 {
     if (!_information) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _information = open_information_impl(*atHandler);
-        }
+        _information = open_information_impl(*get_at_handler(fh));
     }
-    if (_information) {
-        _info_ref_count++;
-    }
+    _info_ref_count++;
     return _information;
 }
 
@@ -453,9 +429,8 @@ nsapi_error_t AT_CellularDevice::is_ready()
     return _at->unlock_return_error();
 }
 
-nsapi_error_t AT_CellularDevice::set_ready_cb(Callback<void()> callback)
+void AT_CellularDevice::set_ready_cb(Callback<void()> callback)
 {
-    return NSAPI_ERROR_UNSUPPORTED;
 }
 
 nsapi_error_t AT_CellularDevice::set_power_save_mode(int periodic_time, int active_time)

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -78,7 +78,7 @@ public:
 
     virtual nsapi_error_t is_ready();
 
-    virtual nsapi_error_t set_ready_cb(Callback<void()> callback);
+    virtual void set_ready_cb(Callback<void()> callback);
 
     virtual nsapi_error_t set_power_save_mode(int periodic_time, int active_time = 0);
 

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -248,10 +248,8 @@ nsapi_error_t AT_CellularSMS::set_csdh(int show_header)
 
 nsapi_error_t AT_CellularSMS::initialize(CellularSMSMmode mode)
 {
-    if (NSAPI_ERROR_OK != _at.set_urc_handler("+CMTI:", callback(this, &AT_CellularSMS::cmti_urc)) ||
-            NSAPI_ERROR_OK != _at.set_urc_handler("+CMT:", callback(this, &AT_CellularSMS::cmt_urc))) {
-        return NSAPI_ERROR_NO_MEMORY;
-    }
+    _at.set_urc_handler("+CMTI:", callback(this, &AT_CellularSMS::cmti_urc));
+    _at.set_urc_handler("+CMT:", callback(this, &AT_CellularSMS::cmt_urc));
 
     _at.lock();
     set_cnmi();     //set new SMS indication
@@ -1047,11 +1045,6 @@ nsapi_error_t AT_CellularSMS::list_messages()
     _at.resp_start("+CMGL:");
     while (_at.info_resp()) {
         info = new sms_info_t();
-        if (!info) {
-            _at.resp_stop();
-            return NSAPI_ERROR_NO_MEMORY;
-        }
-
         if (_mode == CellularSMSMmodePDU) {
             //+CMGL: <index>,<stat>,[<alpha>],<length><CR><LF><pdu>[<CR><LF>
             // +CMGL:<index>,<stat>,[<alpha>],<length><CR><LF><pdu>
@@ -1062,11 +1055,6 @@ nsapi_error_t AT_CellularSMS::list_messages()
             length = length * 2 + 20; // *2 as it's hex encoded and +20 as service center number is not included in size given by CMGL
             pdu = new char[length];
             memset(pdu, 0, length);
-            if (!pdu) {
-                delete info;
-                _at.resp_stop();
-                return NSAPI_ERROR_NO_MEMORY;
-            }
             _at.read_string(pdu, length, true);
             if (_at.get_last_error() == NSAPI_ERROR_OK) {
                 info->msg_size = get_data_from_pdu(pdu, info, &part_number);
@@ -1194,9 +1182,6 @@ uint16_t AT_CellularSMS::pack_7_bit_gsm_and_hex(const char *str, uint16_t len, c
     }
     // convert to 7bit gsm first
     char *gsm_str = new char[len];
-    if (!gsm_str) {
-        return 0;
-    }
     for (uint16_t y = 0; y < len; y++) {
         for (int x = 0; x < GSM_TO_ASCII_TABLE_SIZE; x++) {
             if (gsm_to_ascii[x] == str[y]) {

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -116,11 +116,6 @@ nsapi_error_t AT_CellularStack::socket_open(nsapi_socket_t *handle, nsapi_protoc
         }
 
         _socket = new CellularSocket*[max_socket_count];
-        if (!_socket) {
-            tr_error("No memory to open socket!");
-            _socket_mutex.unlock();
-            return NSAPI_ERROR_NO_SOCKET;
-        }
         _socket_count = max_socket_count;
         for (int i = 0; i < max_socket_count; i++) {
             _socket[i] = 0;

--- a/features/cellular/framework/common/CellularList.h
+++ b/features/cellular/framework/common/CellularList.h
@@ -50,9 +50,6 @@ public:
     T *add_new()
     {
         T *temp = new T;
-        if (!temp) {
-            return NULL;
-        }
         temp->next = NULL;
         if (_head == NULL) {
             _head = temp;

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -66,7 +66,7 @@ AT_CellularInformation *QUECTEL_BG96::open_information_impl(ATHandler &at)
     return new QUECTEL_BG96_CellularInformation(at);
 }
 
-nsapi_error_t QUECTEL_BG96::set_ready_cb(Callback<void()> callback)
+void QUECTEL_BG96::set_ready_cb(Callback<void()> callback)
 {
-    return _at->set_urc_handler(DEVICE_READY_URC, callback);
+    _at->set_urc_handler(DEVICE_READY_URC, callback);
 }

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
@@ -32,7 +32,7 @@ protected: // AT_CellularDevice
     virtual AT_CellularPower *open_power_impl(ATHandler &at);
     virtual AT_CellularContext *create_context_impl(ATHandler &at, const char *apn);
     virtual AT_CellularInformation *open_information_impl(ATHandler &at);
-    virtual nsapi_error_t set_ready_cb(Callback<void()> callback);
+    virtual void set_ready_cb(Callback<void()> callback);
 
 public:
     void handle_urc(FileHandle *fh);


### PR DESCRIPTION
### Description

After this change we were able to change methods
ATHandler::set_urc_handler and CellularDevice::set_ready_cb to void
and simplify error handling.

@AriParkkila please review

Not set as Breaking change as this CellularDevice API was already changed in this branch.

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

