### PR TITLE
BLE: Enforce advertising data payload limits

### DIFF
--- a/features/FEATURE_BLE/ble/gap/AdvertisingParameters.h
+++ b/features/FEATURE_BLE/ble/gap/AdvertisingParameters.h
@@ -174,6 +174,11 @@ public:
      */
     AdvertisingParameters &setType(advertising_type_t newAdvType)
     {
+        if (newAdvType == advertising_type_t::CONNECTABLE_UNDIRECTED ||
+            newAdvType == advertising_type_t::CONNECTABLE_DIRECTED) {
+            /* these types can only be used with legacy PDUs */
+            MBED_ASSERT(_legacyPDU);
+        }
         _advType = newAdvType;
         return *this;
     }
@@ -461,6 +466,12 @@ public:
      */
     AdvertisingParameters &setUseLegacyPDU(bool enable = true)
     {
+        if (!enable) {
+            /* these types can only be used with legacy PDUs */
+            MBED_ASSERT((_advType != advertising_type_t::CONNECTABLE_UNDIRECTED) &&
+                        (_advType != advertising_type_t::CONNECTABLE_DIRECTED));
+        }
+
         _legacyPDU = enable;
         return *this;
     }

--- a/features/FEATURE_BLE/ble/gap/AdvertisingParameters.h
+++ b/features/FEATURE_BLE/ble/gap/AdvertisingParameters.h
@@ -124,6 +124,9 @@ public:
      * A range is provided to the LE subsystem, so it can adjust the advertising
      * interval with other transmission happening on the BLE radio.
      *
+     * @note If CONNECTABLE_UNDIRECTED or CONNECTABLE_DIRECTED advertising is used
+     * you must use legacy PDU.
+     *
      * @note If values in input are out of range, they will be normalized.
      */
     AdvertisingParameters(
@@ -161,6 +164,9 @@ public:
 
     /**
      * Update the advertising type.
+     *
+     * @note If legacy PDU is not used then you cannot use
+     * CONNECTABLE_UNDIRECTED nor CONNECTABLE_DIRECTED.
      *
      * @param[in] newAdvType The new advertising type.
      *
@@ -448,6 +454,9 @@ public:
      *
      * @param enable If true, legacy PDU will be used.
      *
+     * @note If CONNECTABLE_UNDIRECTED or CONNECTABLE_DIRECTED advertising is used
+     * you must use legacy PDU.
+     *
      * @return A reference to this object.
      */
     AdvertisingParameters &setUseLegacyPDU(bool enable = true)
@@ -489,6 +498,8 @@ public:
     /** Advertise without your own address.
      *
      * @param enable Advertising anonymous if true.
+     *
+     * @note You may not use anonymous advertising with periodic advertising on the same set.
      *
      * @return reference to this object.
      */

--- a/features/FEATURE_BLE/ble/gap/AdvertisingParameters.h
+++ b/features/FEATURE_BLE/ble/gap/AdvertisingParameters.h
@@ -161,6 +161,29 @@ public:
     }
 
 public:
+    /**
+     * Update the advertising type and whether to use legacy PDU.
+     *
+     * @note If legacy PDU is not used then you cannot use
+     * CONNECTABLE_UNDIRECTED nor CONNECTABLE_DIRECTED.
+     *
+     * @param[in] newAdvType The new advertising type.
+     *
+     * @param[in] legacy If true, legacy PDU will be used.
+     *
+     * @return reference to this object.
+     */
+    AdvertisingParameters &setType(advertising_type_t newAdvType, bool legacy)
+    {
+        if (newAdvType == advertising_type_t::CONNECTABLE_UNDIRECTED ||
+            newAdvType == advertising_type_t::CONNECTABLE_DIRECTED) {
+            /* these types can only be used with legacy PDUs */
+            MBED_ASSERT(legacy);
+        }
+        _advType = newAdvType;
+        _legacyPDU = legacy;
+        return *this;
+    }
 
     /**
      * Update the advertising type.

--- a/features/FEATURE_BLE/ble/gap/Gap.h
+++ b/features/FEATURE_BLE/ble/gap/Gap.h
@@ -544,6 +544,12 @@ public:
      */
     virtual uint16_t getMaxConnectableAdvertisingDataLength();
 
+    /** Return maximum advertising data length you may set if advertising set is active.
+     *
+     * @return Maximum advertising data length you may set if advertising set is active.
+     */
+    virtual uint8_t getMaxActiveSetAdvertisingDataLength();
+
     /** Create an advertising set and apply the passed in parameters. The handle returned
      *  by this function must be used for all other calls that accept an advertising handle.
      *  When done with advertising, remove from the system using destroyAdvertisingSet().
@@ -589,6 +595,10 @@ public:
      * @param handle Advertising set handle.
      * @param payload Advertising payload.
      *
+     * @note If advertising set is active you may only set payload of length equal or less
+     * than getMaxActiveSetAdvertisingDataLength(). If you require a longer payload you must
+     * stop the advertising set, set the payload and restart the set.
+     *
      * @return BLE_ERROR_NONE on success.
      *
      * @see ble::AdvertisingDataBuilder to build a payload.
@@ -603,6 +613,10 @@ public:
      *
      * @param handle Advertising set handle.
      * @param response Advertising scan response.
+     *
+     * @note If advertising set is active you may only set payload of length equal or less
+     * than getMaxActiveSetAdvertisingDataLength(). If you require a longer payload you must
+     * stop the advertising set, set the payload and restart the set.
      *
      * @return BLE_ERROR_NONE on success.
      *
@@ -668,6 +682,11 @@ public:
      * @param handle Advertising set handle.
      * @param payload Advertising payload.
      * @return BLE_ERROR_NONE on success.
+     *
+     * @note If advertising set is active you may only set payload of length equal or less
+     * than getMaxActiveSetAdvertisingDataLength(). If you require a longer payload you must
+     * stop the advertising set, set the payload and restart the set. Stopping the set will
+     * cause peers to lose sync on the periodic set.
      *
      * @see ble::AdvertisingDataBuilder to build a payload.
      *

--- a/features/FEATURE_BLE/ble/gap/Gap.h
+++ b/features/FEATURE_BLE/ble/gap/Gap.h
@@ -548,7 +548,7 @@ public:
      *
      * @return Maximum advertising data length you may set if advertising set is active.
      */
-    virtual uint8_t getMaxActiveSetAdvertisingDataLength();
+    virtual uint16_t getMaxActiveSetAdvertisingDataLength();
 
     /** Create an advertising set and apply the passed in parameters. The handle returned
      *  by this function must be used for all other calls that accept an advertising handle.

--- a/features/FEATURE_BLE/ble/gap/Gap.h
+++ b/features/FEATURE_BLE/ble/gap/Gap.h
@@ -538,6 +538,12 @@ public:
      */
     virtual uint16_t getMaxAdvertisingDataLength();
 
+    /** Return maximum advertising data length supported for connectable advertising.
+     *
+     * @return Maximum advertising data length supported for connectable advertising.
+     */
+    virtual uint16_t getMaxConnectableAdvertisingDataLength();
+
     /** Create an advertising set and apply the passed in parameters. The handle returned
      *  by this function must be used for all other calls that accept an advertising handle.
      *  When done with advertising, remove from the system using destroyAdvertisingSet().

--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -97,7 +97,7 @@ public:
 
     /** @copydoc Gap::getMaxActiveSetAdvertisingDataLength
      */
-    virtual uint8_t getMaxActiveSetAdvertisingDataLength();
+    virtual uint16_t getMaxActiveSetAdvertisingDataLength();
 
     /** @copydoc Gap::createAdvertisingSet
      */

--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -50,7 +50,6 @@ class GenericGap :
 public:
     /* TODO: move to config */
     static const uint8_t MAX_ADVERTISING_SETS = 15;
-    static const size_t MAX_HCI_DATA_LENGTH = 251;
 
     /**
      * Construct a GenericGap.
@@ -91,6 +90,10 @@ public:
     /** @copydoc Gap::getMaxAdvertisingDataLength
      */
     virtual uint16_t getMaxAdvertisingDataLength();
+
+    /** @copydoc Gap::getMaxConnectableAdvertisingDataLength
+     */
+    virtual uint16_t getMaxConnectableAdvertisingDataLength();
 
     /** @copydoc Gap::createAdvertisingSet
      */

--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -787,6 +787,8 @@ private:
     BitArray<MAX_ADVERTISING_SETS> _existing_sets;
     BitArray<MAX_ADVERTISING_SETS> _active_sets;
     BitArray<MAX_ADVERTISING_SETS> _active_periodic_sets;
+    BitArray<MAX_ADVERTISING_SETS> _connectable_payload_size_exceeded;
+    BitArray<MAX_ADVERTISING_SETS> _set_is_connectable;
 
     // deprecation flags
     mutable bool _deprecated_scan_api_used : 1;

--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -95,6 +95,10 @@ public:
      */
     virtual uint16_t getMaxConnectableAdvertisingDataLength();
 
+    /** @copydoc Gap::getMaxActiveSetAdvertisingDataLength
+     */
+    virtual uint8_t getMaxActiveSetAdvertisingDataLength();
+
     /** @copydoc Gap::createAdvertisingSet
      */
     virtual ble_error_t createAdvertisingSet(

--- a/features/FEATURE_BLE/ble/pal/PalGap.h
+++ b/features/FEATURE_BLE/ble/pal/PalGap.h
@@ -779,7 +779,7 @@ struct Gap {
      *
      * @return Max size of the HCI packet transporting the data.
      */
-    virtual uint8_t get_max_hci_advertising_data_length() = 0;
+    virtual uint8_t get_maximum_hci_advertising_data_length() = 0;
 
     /**
      * Query the maximum number of concurrent advertising sets that is supported

--- a/features/FEATURE_BLE/ble/pal/PalGap.h
+++ b/features/FEATURE_BLE/ble/pal/PalGap.h
@@ -765,6 +765,23 @@ struct Gap {
     virtual uint16_t get_maximum_advertising_data_length() = 0;
 
     /**
+     * Query the maximum data length the controller supports in an advertising set
+     * using connectable advertising.
+     *
+     * @return The length in byte the controller can support in an advertising set
+     * for connectable advertising.
+     */
+    virtual uint16_t get_maximum_connectable_advertising_data_length() = 0;
+
+    /**
+     * Query the maximum payload length for a single HCI packet carrying partial
+     * (or complete if it fits) data for advertising set.
+     *
+     * @return Max size of the HCI packet transporting the data.
+     */
+    virtual uint8_t get_max_hci_advertising_data_length() = 0;
+
+    /**
      * Query the maximum number of concurrent advertising sets that is supported
      * by the controller.
      *

--- a/features/FEATURE_BLE/source/gap/Gap.cpp
+++ b/features/FEATURE_BLE/source/gap/Gap.cpp
@@ -42,6 +42,12 @@ uint16_t Gap::getMaxConnectableAdvertisingDataLength()
     return LEGACY_ADVERTISING_MAX_SIZE;
 }
 
+uint8_t Gap::getMaxActiveSetAdvertisingDataLength()
+{
+    /* Requesting action from porter(s): override this API if this capability is supported. */
+    return LEGACY_ADVERTISING_MAX_SIZE;
+}
+
 ble_error_t Gap::createAdvertisingSet(
     advertising_handle_t *handle,
     const AdvertisingParameters &parameters

--- a/features/FEATURE_BLE/source/gap/Gap.cpp
+++ b/features/FEATURE_BLE/source/gap/Gap.cpp
@@ -36,6 +36,12 @@ uint16_t Gap::getMaxAdvertisingDataLength()
     return LEGACY_ADVERTISING_MAX_SIZE;
 }
 
+uint16_t Gap::getMaxConnectableAdvertisingDataLength()
+{
+    /* Requesting action from porter(s): override this API if this capability is supported. */
+    return LEGACY_ADVERTISING_MAX_SIZE;
+}
+
 ble_error_t Gap::createAdvertisingSet(
     advertising_handle_t *handle,
     const AdvertisingParameters &parameters

--- a/features/FEATURE_BLE/source/gap/Gap.cpp
+++ b/features/FEATURE_BLE/source/gap/Gap.cpp
@@ -42,7 +42,7 @@ uint16_t Gap::getMaxConnectableAdvertisingDataLength()
     return LEGACY_ADVERTISING_MAX_SIZE;
 }
 
-uint8_t Gap::getMaxActiveSetAdvertisingDataLength()
+uint16_t Gap::getMaxActiveSetAdvertisingDataLength()
 {
     /* Requesting action from porter(s): override this API if this capability is supported. */
     return LEGACY_ADVERTISING_MAX_SIZE;

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -2013,6 +2013,12 @@ uint16_t GenericGap::getMaxConnectableAdvertisingDataLength()
     return _pal_gap.get_maximum_connectable_advertising_data_length();
 }
 
+uint8_t GenericGap::getMaxActiveSetAdvertisingDataLength()
+{
+    useVersionTwoAPI();
+    return _pal_gap.get_max_hci_advertising_data_length();
+}
+
 ble_error_t GenericGap::createAdvertisingSet(
     advertising_handle_t *handle,
     const AdvertisingParameters &parameters

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -2150,6 +2150,14 @@ ble_error_t GenericGap::setExtendedAdvertisingParameters(
         return BLE_ERROR_OPERATION_NOT_PERMITTED;
     }
 
+    /* check for illegal parameter combination */
+    if ((params.getType() == advertising_type_t::CONNECTABLE_UNDIRECTED ||
+        params.getType() == advertising_type_t::CONNECTABLE_DIRECTED) &&
+        params.getUseLegacyPDU() == false) {
+        /* these types can only be used with legacy PDUs */
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
     pal::advertising_event_properties_t event_properties(params.getType());
     event_properties.include_tx_power = params.getTxPowerInHeader();
     event_properties.omit_advertiser_address = params.getAnonymousAdvertising();

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -2018,7 +2018,7 @@ uint16_t GenericGap::getMaxConnectableAdvertisingDataLength()
 uint8_t GenericGap::getMaxActiveSetAdvertisingDataLength()
 {
     useVersionTwoAPI();
-    return _pal_gap.get_max_hci_advertising_data_length();
+    return _pal_gap.get_maximum_hci_advertising_data_length();
 }
 
 ble_error_t GenericGap::createAdvertisingSet(
@@ -2314,7 +2314,7 @@ ble_error_t GenericGap::setAdvertisingData(
         &pal::Gap::set_extended_scan_response_data :
         &pal::Gap::set_extended_advertising_data;
 
-    const size_t hci_length = _pal_gap.get_max_hci_advertising_data_length();
+    const size_t hci_length = _pal_gap.get_maximum_hci_advertising_data_length();
 
     for (size_t i = 0, end = payload.size(); (i < end) || (i == 0 && end == 0); i += hci_length) {
         // select the operation based on the index
@@ -2526,7 +2526,7 @@ ble_error_t GenericGap::setPeriodicAdvertisingPayload(
 
     typedef pal::advertising_fragment_description_t op_t;
 
-    const size_t hci_length = _pal_gap.get_max_hci_advertising_data_length();
+    const size_t hci_length = _pal_gap.get_maximum_hci_advertising_data_length();
 
     for (size_t i = 0, end = payload.size(); (i < end) || (i == 0 && end == 0); i += hci_length) {
         // select the operation based on the index

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -1380,6 +1380,8 @@ ble_error_t GenericGap::reset(void)
         _existing_sets.clear();
         _active_sets.clear();
         _active_periodic_sets.clear();
+        _connectable_payload_size_exceeded.clear();
+        _set_is_connectable.clear();
 
         /* clear advertising set data on the controller */
         _pal_gap.clear_advertising_sets();
@@ -2033,6 +2035,8 @@ ble_error_t GenericGap::createAdvertisingSet(
     uint8_t new_handle = LEGACY_ADVERTISING_HANDLE + 1;
     uint8_t end = getMaxAdvertisingSetNumber();
 
+    *handle = INVALID_ADVERTISING_HANDLE;
+
     for (; new_handle < end; ++new_handle) {
         if (!_existing_sets.get(new_handle)) {
             ble_error_t err = setExtendedAdvertisingParameters(
@@ -2045,11 +2049,11 @@ ble_error_t GenericGap::createAdvertisingSet(
 
             _existing_sets.set(new_handle);
             *handle = new_handle;
+
             return BLE_ERROR_NONE;
         }
     }
 
-    *handle = INVALID_ADVERTISING_HANDLE;
     return BLE_ERROR_NO_MEM;
 }
 
@@ -2086,6 +2090,8 @@ ble_error_t GenericGap::destroyAdvertisingSet(advertising_handle_t handle)
         return err;
     }
 
+    _connectable_payload_size_exceeded.clear(handle);
+    _set_is_connectable.clear(handle);
     _existing_sets.clear(handle);
     return BLE_ERROR_NONE;
 }
@@ -2140,6 +2146,10 @@ ble_error_t GenericGap::setExtendedAdvertisingParameters(
         return BLE_ERROR_INVALID_PARAM;
     }
 
+    if (_active_sets.get(handle)) {
+        return BLE_ERROR_OPERATION_NOT_PERMITTED;
+    }
+
     pal::advertising_event_properties_t event_properties(params.getType());
     event_properties.include_tx_power = params.getTxPowerInHeader();
     event_properties.omit_advertiser_address = params.getAnonymousAdvertising();
@@ -2171,6 +2181,12 @@ ble_error_t GenericGap::setExtendedAdvertisingParameters(
 
     if (err) {
         return err;
+    }
+
+    if (event_properties.connectable) {
+        _set_is_connectable.set(handle);
+    } else {
+        _set_is_connectable.clear(handle);
     }
 
     return _pal_gap.set_advertising_set_random_address(
@@ -2261,7 +2277,28 @@ ble_error_t GenericGap::setAdvertisingData(
     }
 
     if (payload.size() > getMaxAdvertisingDataLength()) {
+        MBED_WARNING(MBED_ERROR_INVALID_SIZE, "Payload size exceeds getMaxAdvertisingDataLength().");
         return BLE_ERROR_INVALID_PARAM;
+    }
+
+    if (!_active_sets.get(handle) && payload.size() > getMaxActiveSetAdvertisingDataLength()) {
+        MBED_WARNING(MBED_ERROR_INVALID_SIZE, "Payload size for active sets needs to fit in a single operation"
+                     " - not greater than getMaxActiveSetAdvertisingDataLength().");
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
+    if (!scan_response) {
+        if (payload.size() > getMaxConnectableAdvertisingDataLength()) {
+            if (_active_sets.get(handle) && _set_is_connectable.get(handle)) {
+                MBED_WARNING(MBED_ERROR_INVALID_SIZE, "Payload size for connectable advertising"
+                             " exceeds getMaxAdvertisingDataLength().");
+                return BLE_ERROR_INVALID_PARAM;
+            } else {
+                _connectable_payload_size_exceeded.set(handle);
+            }
+        } else {
+            _connectable_payload_size_exceeded.clear(handle);
+        }
     }
 
     // select the pal function
@@ -2320,6 +2357,11 @@ ble_error_t GenericGap::startAdvertising(
 
     if (!_existing_sets.get(handle)) {
         return BLE_ERROR_INVALID_PARAM;
+    }
+
+    if (_connectable_payload_size_exceeded.get(handle) && _set_is_connectable.get(handle)) {
+        MBED_WARNING(MBED_ERROR_INVALID_SIZE, "Payload size exceeds size allowed for connectable advertising.");
+        return BLE_ERROR_INVALID_STATE;
     }
 
     if (is_extended_advertising_available()) {

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -2527,8 +2527,11 @@ ble_error_t GenericGap::setPeriodicAdvertisingPayload(
     typedef pal::advertising_fragment_description_t op_t;
 
     const size_t hci_length = _pal_gap.get_maximum_hci_advertising_data_length();
+    size_t i = 0;
+    size_t end = payload.size();
 
-    for (size_t i = 0, end = payload.size(); (i < end) || (i == 0 && end == 0); i += hci_length) {
+    /* always do at least one iteration for empty payload */
+    do {
         // select the operation based on the index
         op_t op(op_t::INTERMEDIATE_FRAGMENT);
         if (end < hci_length) {
@@ -2555,7 +2558,9 @@ ble_error_t GenericGap::setPeriodicAdvertisingPayload(
         if (err) {
             return err;
         }
-    }
+
+        i += hci_length;
+    } while (i < end);
 
     return BLE_ERROR_NONE;
 }

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -2015,7 +2015,7 @@ uint16_t GenericGap::getMaxConnectableAdvertisingDataLength()
     return _pal_gap.get_maximum_connectable_advertising_data_length();
 }
 
-uint8_t GenericGap::getMaxActiveSetAdvertisingDataLength()
+uint16_t GenericGap::getMaxActiveSetAdvertisingDataLength()
 {
     useVersionTwoAPI();
     return _pal_gap.get_maximum_hci_advertising_data_length();

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioPalGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioPalGap.h
@@ -223,7 +223,7 @@ public:
 
     virtual uint16_t get_maximum_connectable_advertising_data_length();
 
-    virtual uint8_t get_max_hci_advertising_data_length();
+    virtual uint8_t get_maximum_hci_advertising_data_length();
 
     virtual uint8_t get_max_number_of_advertising_sets();
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioPalGap.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioPalGap.h
@@ -221,6 +221,10 @@ public:
 
     virtual uint16_t get_maximum_advertising_data_length();
 
+    virtual uint16_t get_maximum_connectable_advertising_data_length();
+
+    virtual uint8_t get_max_hci_advertising_data_length();
+
     virtual uint8_t get_max_number_of_advertising_sets();
 
     virtual ble_error_t remove_advertising_set(

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalGap.cpp
@@ -926,7 +926,7 @@ uint16_t Gap::get_maximum_connectable_advertising_data_length()
     return HCI_EXT_ADV_CONN_DATA_LEN;
 }
 
-uint8_t Gap::get_max_hci_advertising_data_length()
+uint8_t Gap::get_maximum_hci_advertising_data_length()
 {
     return HCI_EXT_ADV_DATA_LEN;
 }

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalGap.cpp
@@ -921,6 +921,16 @@ uint16_t Gap::get_maximum_advertising_data_length()
     return HciGetMaxAdvDataLen();
 }
 
+uint16_t Gap::get_maximum_connectable_advertising_data_length()
+{
+    return HCI_EXT_ADV_CONN_DATA_LEN;
+}
+
+uint8_t Gap::get_max_hci_advertising_data_length()
+{
+    return HCI_EXT_ADV_DATA_LEN;
+}
+
 uint8_t Gap::get_max_number_of_advertising_sets()
 {
     return std::min(HciGetNumSupAdvSets(), (uint8_t) DM_NUM_ADV_SETS);


### PR DESCRIPTION
### Description

The complete advertising data length may be different based on whether it's connectable advertising. A new call has been added to the API.
Data set when advertising is active is also limited. New function added to advise of the limit.
There is an illegal adv parameters combinations that is now checked.

On Pal side:
The HCI length of packets may be variable and dependent on the controller. This fix queries the PAL to use the correct fragmentation of set data.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

