### PR TITLE
Cellular: Fix to use PPP stack in PPP mode

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularContext.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularContext.cpp
@@ -28,6 +28,7 @@ QUECTEL_BC95_CellularContext::~QUECTEL_BC95_CellularContext()
 {
 }
 
+#if !NSAPI_PPP_AVAILABLE
 NetworkStack *QUECTEL_BC95_CellularContext::get_stack()
 {
     if (!_stack) {
@@ -35,6 +36,7 @@ NetworkStack *QUECTEL_BC95_CellularContext::get_stack()
     }
     return _stack;
 }
+#endif // #if !NSAPI_PPP_AVAILABLE
 
 bool QUECTEL_BC95_CellularContext::stack_type_supported(nsapi_ip_stack_t stack_type)
 {

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularContext.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularContext.h
@@ -27,7 +27,9 @@ public:
     virtual ~QUECTEL_BC95_CellularContext();
 
 protected:
+#if !NSAPI_PPP_AVAILABLE
     virtual NetworkStack *get_stack();
+#endif // #if !NSAPI_PPP_AVAILABLE
     virtual bool stack_type_supported(nsapi_ip_stack_t stack_type);
 };
 

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -34,6 +34,7 @@ using namespace events;
 
 static const AT_CellularBase::SupportedFeature unsupported_features[] =  {
     AT_CellularBase::AT_CGSN_WITH_TYPE,
+    AT_CellularBase::AT_CGDATA,
     AT_CellularBase::SUPPORTED_FEATURE_END_MARK
 };
 

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.cpp
@@ -36,6 +36,7 @@ bool QUECTEL_BG96_CellularContext::stack_type_supported(nsapi_ip_stack_t stack_t
     return false;
 }
 
+#if !NSAPI_PPP_AVAILABLE
 NetworkStack *QUECTEL_BG96_CellularContext::get_stack()
 {
     if (!_stack) {
@@ -43,6 +44,7 @@ NetworkStack *QUECTEL_BG96_CellularContext::get_stack()
     }
     return _stack;
 }
+#endif // #if !NSAPI_PPP_AVAILABLE
 
 nsapi_error_t QUECTEL_BG96_CellularContext::do_user_authentication()
 {

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.h
@@ -28,7 +28,9 @@ public:
 
 protected:
     virtual bool stack_type_supported(nsapi_ip_stack_t stack_type);
+#if !NSAPI_PPP_AVAILABLE
     virtual NetworkStack *get_stack();
+#endif // #if !NSAPI_PPP_AVAILABLE
     virtual nsapi_error_t do_user_authentication();
 };
 


### PR DESCRIPTION
### Description

In QUECTEL_BG96 and QUECTEL_BC95 there was missing #ifdefs for
PPP mode and our stack was used instead of PPP stack.

@AriParkkila please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

