### PR TITLE
Nuvoton: Support boot stack size configuration option

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_MICRO/M2351.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_MICRO/M2351.sct
@@ -41,6 +41,10 @@
 #define MBED_RAM_APP_SIZE       (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+#define MBED_BOOT_STACK_SIZE    0x400
+#endif
+
 #else
 
 #ifndef MBED_APP_START
@@ -59,6 +63,10 @@
 #define MBED_RAM_APP_SIZE       MBED_RAM_SIZE_S
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+#define MBED_BOOT_STACK_SIZE    0x400
+#endif
+
 #endif
 
 /* Requirements for NSC location
@@ -69,15 +77,6 @@
  * 4. NSC region size defaults to 4KiB if not defined.
  */
 #define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
-
-/* Initial/ISR stack size */
-#if (! defined(NU_INITIAL_STACK_SIZE))
-#if defined(DOMAIN_NS) && DOMAIN_NS
-#define NU_INITIAL_STACK_SIZE   0x800
-#else
-#define NU_INITIAL_STACK_SIZE   0x800
-#endif
-#endif
 
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
@@ -91,7 +90,7 @@ LR_IROM1    MBED_APP_START
         .ANY (+RO)
     }
 
-    ARM_LIB_STACK   MBED_RAM_APP_START    EMPTY   NU_INITIAL_STACK_SIZE
+    ARM_LIB_STACK   MBED_RAM_APP_START    EMPTY   MBED_BOOT_STACK_SIZE
     {
     }
 
@@ -129,7 +128,7 @@ LR_IROM1 MBED_APP_START
         .ANY (+RO)
     }
 
-    ARM_LIB_STACK   0x20000000  EMPTY   NU_INITIAL_STACK_SIZE
+    ARM_LIB_STACK   0x20000000  EMPTY   MBED_BOOT_STACK_SIZE
     {
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_STD/M2351.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_ARM_STD/M2351.sct
@@ -41,6 +41,10 @@
 #define MBED_RAM_APP_SIZE       (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+#define MBED_BOOT_STACK_SIZE    0x400
+#endif
+
 #else
 
 #ifndef MBED_APP_START
@@ -59,6 +63,10 @@
 #define MBED_RAM_APP_SIZE       MBED_RAM_SIZE_S
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+#define MBED_BOOT_STACK_SIZE    0x400
+#endif
+
 #endif
 
 /* Requirements for NSC location
@@ -69,15 +77,6 @@
  * 4. NSC region size defaults to 4KiB if not defined.
  */
 #define NU_TZ_NSC_START         (MBED_APP_START + MBED_APP_SIZE  - 0x2000 - NU_TZ_NSC_SIZE)
-
-/* Initial/ISR stack size */
-#if (! defined(NU_INITIAL_STACK_SIZE))
-#if defined(DOMAIN_NS) && DOMAIN_NS
-#define NU_INITIAL_STACK_SIZE   0x800
-#else
-#define NU_INITIAL_STACK_SIZE   0x800
-#endif
-#endif
 
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
@@ -91,7 +90,7 @@ LR_IROM1    MBED_APP_START
         .ANY (+RO)
     }
 
-    ARM_LIB_STACK   MBED_RAM_APP_START    EMPTY   NU_INITIAL_STACK_SIZE
+    ARM_LIB_STACK   MBED_RAM_APP_START    EMPTY   MBED_BOOT_STACK_SIZE
     {
     }
 
@@ -129,7 +128,7 @@ LR_IROM1 MBED_APP_START
         .ANY (+RO)
     }
 
-    ARM_LIB_STACK   0x20000000  EMPTY   NU_INITIAL_STACK_SIZE
+    ARM_LIB_STACK   0x20000000  EMPTY   MBED_BOOT_STACK_SIZE
     {
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/M2351.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/M2351.ld
@@ -28,46 +28,50 @@
 #if defined(DOMAIN_NS) && DOMAIN_NS
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
+#define MBED_APP_START          (0x10000000 + MBED_ROM_START + MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
+#define MBED_APP_SIZE           (MBED_ROM_SIZE  - MBED_ROM_SIZE_S)
 #endif
 
 #ifndef MBED_RAM_APP_START
-#define MBED_RAM_APP_START  (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
+#define MBED_RAM_APP_START      (0x10000000 + MBED_RAM_START + MBED_RAM_SIZE_S)
 #endif
 
 #ifndef MBED_RAM_APP_SIZE
-#define MBED_RAM_APP_SIZE   (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
+#define MBED_RAM_APP_SIZE       (MBED_RAM_SIZE - MBED_RAM_SIZE_S)
+#endif
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+#define MBED_BOOT_STACK_SIZE    0x400
 #endif
 
 #else
 
 #ifndef MBED_APP_START
-#define MBED_APP_START      MBED_ROM_START
+#define MBED_APP_START          MBED_ROM_START
 #endif
 
 #ifndef MBED_APP_SIZE
-#define MBED_APP_SIZE       MBED_ROM_SIZE_S
+#define MBED_APP_SIZE           MBED_ROM_SIZE_S
 #endif
 
 #ifndef MBED_RAM_APP_START
-#define MBED_RAM_APP_START  MBED_RAM_START
+#define MBED_RAM_APP_START      MBED_RAM_START
 #endif
 
 #ifndef MBED_RAM_APP_SIZE
-#define MBED_RAM_APP_SIZE   MBED_RAM_SIZE_S
+#define MBED_RAM_APP_SIZE       MBED_RAM_SIZE_S
+#endif
+
+#ifndef MBED_BOOT_STACK_SIZE
+#define MBED_BOOT_STACK_SIZE    0x400
 #endif
 
 #endif
 
-#if defined(DOMAIN_NS) && DOMAIN_NS
-StackSize = 0x800;
-#else
-StackSize = 0x800;
-#endif
+StackSize = MBED_BOOT_STACK_SIZE;
 
 /* Requirements for NSC location
  *

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
@@ -33,6 +33,10 @@ if (isdefinedsymbol(DOMAIN_NS)) {
         define symbol MBED_RAM_APP_SIZE             = (MBED_RAM_SIZE - MBED_RAM_SIZE_S);
     }
 
+    if (! isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
+        define symbol MBED_BOOT_STACK_SIZE          = 0x400;
+    }
+    
     /*-Specials-*/
     define symbol __ICFEDIT_intvec_start__          = MBED_APP_START;
     /*-Memory Regions-*/
@@ -42,7 +46,7 @@ if (isdefinedsymbol(DOMAIN_NS)) {
     define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 1;
     
     /*-Sizes-*/
-    define symbol __ICFEDIT_size_cstack__           = 0x800;
+    define symbol __ICFEDIT_size_cstack__           = MBED_BOOT_STACK_SIZE;
     define symbol __ICFEDIT_size_heap__             = 0x8000;
 
 } else {
@@ -61,6 +65,10 @@ if (isdefinedsymbol(DOMAIN_NS)) {
 
     if (! isdefinedsymbol(MBED_RAM_APP_SIZE)) {
         define symbol MBED_RAM_APP_SIZE             = MBED_RAM_SIZE_S;
+    }
+
+    if (! isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
+        define symbol MBED_BOOT_STACK_SIZE          = 0x400;
     }
 
     /* Requirements for NSC location
@@ -87,7 +95,7 @@ if (isdefinedsymbol(DOMAIN_NS)) {
     define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_APP_START + MBED_RAM_APP_SIZE - 1;
 
     /*-Sizes-*/
-    define symbol __ICFEDIT_size_cstack__           = 0x800;
+    define symbol __ICFEDIT_size_cstack__           = MBED_BOOT_STACK_SIZE;
     define symbol __ICFEDIT_size_heap__             = 0x4000;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/M453.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/M453.sct
@@ -8,6 +8,10 @@
   #define MBED_APP_SIZE 0x00040000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -16,10 +20,15 @@ LR_IROM1 MBED_APP_START {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
   
-  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 512) EMPTY (4*(16 + 64)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/M453.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/M453.sct
@@ -8,6 +8,10 @@
   #define MBED_APP_SIZE 0x00040000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -16,10 +20,15 @@ LR_IROM1 MBED_APP_START {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
-  
-  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 512) EMPTY (4*(16 + 64)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_GCC_ARM/M453.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_GCC_ARM/M453.ld
@@ -10,7 +10,11 @@
   #define MBED_APP_SIZE 0x00040000
 #endif 
 
-StackSize = 0x800;
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+StackSize = MBED_BOOT_STACK_SIZE;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
@@ -3,6 +3,7 @@
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
 if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x00040000; }
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
@@ -11,7 +12,7 @@ define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20008000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_heap__   = 0x4000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/M487.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/M487.sct
@@ -8,17 +8,14 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+
 #define SPIM_CCM_START  0x20020000
 #define SPIM_CCM_END    0x20028000
 
-#define MBED_RAM_START              0x20000000
-#define MBED_RAM_SIZE               0x20000
-#define MBED_STACK_RAM_START        (MBED_RAM_START)
-#define MBED_STACK_RAM_SIZE         0x800
-#define MBED_VECTTABLE_RAM_START    (MBED_STACK_RAM_START + MBED_STACK_RAM_SIZE)
-#define MBED_VECTTABLE_RAM_SIZE     (4*(16 + 96))
-#define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
-#define MBED_CRASH_REPORT_RAM_SIZE  0x100
 
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
@@ -26,15 +23,19 @@ LR_IROM1 MBED_APP_START {
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  
-  
-  ARM_LIB_STACK MBED_STACK_RAM_START EMPTY MBED_STACK_RAM_SIZE {
+
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
+  }
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 512) EMPTY (4*(16 + 96)) {  ; Reserve for vectors
   }
   
-  ER_IRAMVEC MBED_VECTTABLE_RAM_START EMPTY MBED_VECTTABLE_RAM_SIZE {  ; Reserve for vectors
-  }
-  
-  RW_m_crash_data MBED_CRASH_REPORT_RAM_START EMPTY MBED_CRASH_REPORT_RAM_SIZE { ; Reserve for crash data storage
+  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 { ; Reserve for crash data storage
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/M487.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/M487.sct
@@ -8,17 +8,14 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+
 #define SPIM_CCM_START  0x20020000
 #define SPIM_CCM_END    0x20028000
 
-#define MBED_RAM_START              0x20000000
-#define MBED_RAM_SIZE               0x20000
-#define MBED_STACK_RAM_START        (MBED_RAM_START)
-#define MBED_STACK_RAM_SIZE         0x800
-#define MBED_VECTTABLE_RAM_START    (MBED_STACK_RAM_START + MBED_STACK_RAM_SIZE)
-#define MBED_VECTTABLE_RAM_SIZE     (4*(16 + 96))
-#define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
-#define MBED_CRASH_REPORT_RAM_SIZE  0x100
 
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
@@ -26,15 +23,19 @@ LR_IROM1 MBED_APP_START {
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  
-  
-  ARM_LIB_STACK MBED_STACK_RAM_START EMPTY MBED_STACK_RAM_SIZE {
+
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
+  }
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 512) EMPTY (4*(16 + 96)) {  ; Reserve for vectors
   }
   
-  ER_IRAMVEC MBED_VECTTABLE_RAM_START EMPTY MBED_VECTTABLE_RAM_SIZE {  ; Reserve for vectors
-  }
-  
-  RW_m_crash_data MBED_CRASH_REPORT_RAM_START EMPTY MBED_CRASH_REPORT_RAM_SIZE { ; Reserve for crash data storage
+  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 { ; Reserve for crash data storage
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_GCC_ARM/M487.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_GCC_ARM/M487.ld
@@ -10,8 +10,12 @@
   #define MBED_APP_SIZE 0x00080000
 #endif 
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 M_CRASH_DATA_RAM_SIZE = 0x100;
-StackSize = 0x800;
+StackSize = MBED_BOOT_STACK_SIZE;
 SPIM_CCM_START = 0x20020000;
 SPIM_CCM_END = 0x20028000;
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -3,6 +3,7 @@
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
 if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x00080000; }
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
@@ -11,7 +12,7 @@ define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20028000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_crash_data__ = 0x100;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 96));
 define symbol __ICFEDIT_size_heap__   = 0x10000;

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/NANO130.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/NANO130.sct
@@ -1,3 +1,8 @@
+#! armcc -E
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
 
 LR_IROM1 0x00000000 {
   ER_IROM1 0x00000000 {  ; load address = execution address
@@ -7,7 +12,7 @@ LR_IROM1 0x00000000 {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/NANO130.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/NANO130.sct
@@ -1,3 +1,8 @@
+#! armcc -E
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
 
 LR_IROM1 0x00000000 {
   ER_IROM1 0x00000000 {  ; load address = execution address
@@ -7,7 +12,7 @@ LR_IROM1 0x00000000 {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_GCC_ARM/NANO130.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_GCC_ARM/NANO130.ld
@@ -2,7 +2,11 @@
  * Nuvoton NANO130 GCC linker script file
  */
 
-StackSize = 0x600;
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+StackSize = MBED_BOOT_STACK_SIZE;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -1,6 +1,7 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = 0x00000000;
 /*-Memory Regions-*/
@@ -9,7 +10,7 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x00020000 - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20004000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x400;
+define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_heap__   = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -8,6 +8,10 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -16,10 +20,15 @@ LR_IROM1 MBED_APP_START {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
-  
-  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 1024) EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
@@ -8,6 +8,10 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -16,10 +20,15 @@ LR_IROM1 MBED_APP_START {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
-  
-  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 1024) EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -8,6 +8,10 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -16,10 +20,15 @@ LR_IROM1 MBED_APP_START {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
-  
-  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 1024) EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
@@ -8,6 +8,10 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -16,10 +20,15 @@ LR_IROM1 MBED_APP_START {
   }
   
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY MBED_BOOT_STACK_SIZE {
   }
-  
-  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+
+  /* VTOR[TBLOFF] alignment requires:
+   *
+   * 1. Minumum 32-word
+   * 2. Rounding up to the next power of two of table size
+   */
+  ER_IRAMVEC AlignExpr(+0, 1024) EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_SUPPORTED/NUC472.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_SUPPORTED/NUC472.ld
@@ -10,7 +10,11 @@
   #define MBED_APP_SIZE 0x00080000
 #endif 
 
-StackSize = 0x800;
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+StackSize = MBED_BOOT_STACK_SIZE;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_UNSUPPORTED/NUC472.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_UNSUPPORTED/NUC472.ld
@@ -9,8 +9,12 @@
 #if !defined(MBED_APP_SIZE)
   #define MBED_APP_SIZE 0x00080000
 #endif 
- 
-StackSize = 0x800;
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE      0x400
+#endif
+
+StackSize = MBED_BOOT_STACK_SIZE;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
@@ -3,6 +3,7 @@
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
 if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x00080000; }
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
@@ -13,7 +14,7 @@ define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000 - 1;
 define symbol __ICFEDIT_region_XRAM_start__ = 0x60000000;
 define symbol __ICFEDIT_region_XRAM_end__   = 0x60100000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_heap__   = 0xC0000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
@@ -3,6 +3,7 @@
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
 if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x00080000; }
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
@@ -11,7 +12,7 @@ define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_heap__   = 0x8000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -45,13 +45,6 @@
     #error "no toolchain defined"
 #endif
 
-#if defined(TARGET_NANO100)
-#ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
-#undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
-#endif
-#define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
-#endif
-
 #endif  // TARGET_NUVOTON
 
 #endif  // MBED_MBED_RTX_H


### PR DESCRIPTION
### Description

Based on #8039, this PR adds support for target configuration option `target.boot-stack-size` for configuring interrupt stack size in mbed-os 5 and main stack size in mbed-os 2.

#### Support targets
- NUMAKER_PFM_NANO130
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487/NUMAKER_IOT_M487
- NUMAKER_PFM_M2351

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

