### PR TITLE
Add some rounding to determine the pulse value for PWM for the STM target

### DIFF
--- a/targets/TARGET_STM/pwmout_api.c
+++ b/targets/TARGET_STM/pwmout_api.c
@@ -182,7 +182,7 @@ void pwmout_write(pwmout_t *obj, float value)
         value = 1.0;
     }
 
-    obj->pulse = (uint32_t)((float)obj->period * value);
+    obj->pulse = (uint32_t)((float)obj->period * value + 0.5);
 
     // Configure channels
     sConfig.OCMode       = TIM_OCMODE_PWM1;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

The changes are pretty obvious : when computing the pulse value for PWM in the function pwmout_write, no rounding was performed, so for very small periods (think <10µs), it could cause quite a large offset for changes in pulse values. This pull request solves that by adding one of the most common way to round a value after float to int casting.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Fix for a particular set of targets, haven't checked if this omission is also present on other targets.