### PR TITLE
Corrected-mbed_trace library always enabled irrespective of config

### DIFF
--- a/features/frameworks/mbed-trace/mbed-trace/mbed_trace.h
+++ b/features/frameworks/mbed-trace/mbed-trace/mbed_trace.h
@@ -59,22 +59,24 @@ extern "C" {
 #include <stdarg.h>
 
 #ifndef YOTTA_CFG_MBED_TRACE
-#define YOTTA_CFG_MBED_TRACE 0
+#define YOTTA_CFG_MBED_TRACE            0
 #endif
 
 #ifndef YOTTA_CFG_MBED_TRACE_FEA_IPV6
-#define YOTTA_CFG_MBED_TRACE_FEA_IPV6 1
+#define YOTTA_CFG_MBED_TRACE_FEA_IPV6   1
 #else
 #warning YOTTA_CFG_MBED_TRACE_FEA_IPV6 is deprecated and will be removed in the future! Use MBED_CONF_MBED_TRACE_FEA_IPV6 instead.
 #define MBED_CONF_MBED_TRACE_FEA_IPV6 YOTTA_CFG_MBED_TRACE_FEA_IPV6
 #endif
 
 #ifndef MBED_CONF_MBED_TRACE_ENABLE
-#define MBED_CONF_MBED_TRACE_ENABLE 0
+#define MBED_CONF_MBED_TRACE_ENABLE     0
 #endif
 
+#if MBED_CONF_MBED_TRACE_ENABLE == 1
 #ifndef MBED_CONF_MBED_TRACE_FEA_IPV6
-#define MBED_CONF_MBED_TRACE_FEA_IPV6 1
+#define MBED_CONF_MBED_TRACE_FEA_IPV6   1
+#endif
 #endif
 
 /** 3 upper bits are trace modes related,

--- a/features/frameworks/mbed-trace/source/mbed_trace.c
+++ b/features/frameworks/mbed-trace/source/mbed_trace.c
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if MBED_CONF_MBED_TRACE_ENABLE == 1
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-
-#ifdef MBED_CONF_MBED_TRACE_ENABLE
-#undef MBED_CONF_MBED_TRACE_ENABLE
-#endif
-#define MBED_CONF_MBED_TRACE_ENABLE 1
-#ifndef MBED_CONF_MBED_TRACE_FEA_IPV6
-#define MBED_CONF_MBED_TRACE_FEA_IPV6 1
-#endif
 
 #include "mbed-trace/mbed_trace.h"
 #if MBED_CONF_MBED_TRACE_FEA_IPV6 == 1
@@ -593,3 +588,5 @@ char *mbed_trace_array(const uint8_t *buf, uint16_t len)
     m_trace.tmp_data_ptr = wptr;
     return str;
 }
+
+#endif


### PR DESCRIPTION
### Description
Mbed_trace library didn't consider predefine config operation, and was always enabled as default.
Updated the behavior to enable/disable based on the config set.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Found here: https://github.com/ARMmbed/mbed-bootloader-internal/pull/148#issuecomment-447264445

CC @JanneKiiskila @kjbracey-arm 