### PR TITLE
CAN: Fix signness mismatch in `CANMessage` constructors

### DIFF
--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -41,10 +41,10 @@ public:
      */
     CANMessage() : CAN_Message()
     {
-        len    = 8;
+        len    = 8U;
         type   = CANData;
         format = CANStandard;
-        id     = 0;
+        id     = 0U;
         memset(data, 0, 8);
     }
 
@@ -56,7 +56,7 @@ public:
      *  @param _type    Type of Data: Use enum CANType for valid parameter values
      *  @param _format  Data Format: Use enum CANFormat for valid parameter values
      */
-    CANMessage(unsigned _id, const char *_data, char _len = 8, CANType _type = CANData, CANFormat _format = CANStandard)
+    CANMessage(unsigned int _id, const unsigned char *_data, unsigned char _len = 8, CANType _type = CANData, CANFormat _format = CANStandard)
     {
         len    = _len & 0xF;
         type   = _type;
@@ -70,7 +70,7 @@ public:
      *  @param _id      Message ID
      *  @param _format  Data Format: Use enum CANType for valid parameter values
      */
-    CANMessage(unsigned _id, CANFormat _format = CANStandard)
+    CANMessage(unsigned int _id, CANFormat _format = CANStandard)
     {
         len    = 0;
         type   = CANRemote;
@@ -104,10 +104,10 @@ public:
      * CAN can1(MBED_CONF_APP_CAN1_RD, MBED_CONF_APP_CAN1_TD);
      * CAN can2(MBED_CONF_APP_CAN2_RD, MBED_CONF_APP_CAN2_TD);
      *
-     * char counter = 0;
+     * unsigned char counter = 0;
      *
      * void send() {
-     *     if(can1.write(CANMessage(1337, &counter, 1))) {
+     *     if(can1.write(CANMessage(1337U, &counter, 1))) {
      *         printf("Message sent: %d\n", counter);
      *         counter++;
      *     }
@@ -116,7 +116,7 @@ public:
      *
      * int main() {
      *     ticker.attach(&send, 1);
-     *    CANMessage msg;
+     *     CANMessage msg;
      *     while(1) {
      *         if(can2.read(msg)) {
      *             printf("Message received: %d\n\n", msg.data[0]);

--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -65,6 +65,24 @@ public:
         memcpy(data, _data, _len);
     }
 
+
+    /** Creates CAN message with specific content.
+     *
+     *  @param _id      Message ID
+     *  @param _data    Mesaage Data
+     *  @param _len     Message Data length
+     *  @param _type    Type of Data: Use enum CANType for valid parameter values
+     *  @param _format  Data Format: Use enum CANFormat for valid parameter values
+     */
+    CANMessage(unsigned int _id, const char *_data, unsigned char _len = 8, CANType _type = CANData, CANFormat _format = CANStandard)
+    {
+        len    = _len & 0xF;
+        type   = _type;
+        format = _format;
+        id     = _id;
+        memcpy(data, _data, _len);
+    }
+
     /** Creates CAN remote message.
      *
      *  @param _id      Message ID


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Fixed another signness mismatch in `CAN` driver reported in https://github.com/ARMmbed/mbed-os/issues/7444 and partially fixed in https://github.com/ARMmbed/mbed-os/pull/7848

There is another mismatch (fields should be unsigned) in the `data` and `length` members as well (in accord with the definition of `CAN_Message` in the HAL file: `hal\can_helper.h`).

The example in the docs is also effected to reflect this change (and not cause a warning in certain builds).


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

