### PR TITLE
Added `poll` wakeup mechanism in the presence of rtos

### DIFF
--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -19,7 +19,7 @@
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos/Kernel.h"
 #include "rtos/ThisThread.h"
-#include "rtos/EventFlags"
+#include "rtos/EventFlags.h"
 using namespace rtos;
 #else
 #include "drivers/Timer.h"
@@ -42,7 +42,7 @@ void on_fd_change()
 // timeout -1 forever, or milliseconds
 int poll(pollfh fhs[], unsigned nfhs, int timeout)
 {
-    
+
 #if MBED_CONF_RTOS_PRESENT
     uint64_t start_time = 0;
     if (timeout > 0) {
@@ -63,8 +63,7 @@ int poll(pollfh fhs[], unsigned nfhs, int timeout)
 
 #if MBED_CONF_RTOS_PRESENT
     /* Register for sigio event */
-    for(unsigned n = 0; n < nfhs; n++)
-    {
+    for(unsigned n = 0; n < nfhs; n++) {
         fhs[n].fh->sigio(callback(on_fd_change));
     }
 #endif // MBED_CONF_RTOS_PRESENT
@@ -96,13 +95,12 @@ int poll(pollfh fhs[], unsigned nfhs, int timeout)
 #if MBED_CONF_RTOS_PRESENT
         /* Block until being notified of an event or until the specified timeout */
         poll_event_flags.wait_all(FILE_CHANGED_FLAG, 
-            (timeout >= 0) ? timeout - TIME_ELAPSED() : osWaitForever);
+                                (timeout >= 0) ? timeout - TIME_ELAPSED() : osWaitForever);
 #endif // MBED_CONF_RTOS_PRESENT
     }
 #if MBED_CONF_RTOS_PRESENT
     /* Unregister the sigio */
-    for(unsigned n = 0; n < nfhs; n++)
-    {
+    for(unsigned n = 0; n < nfhs; n++) {
         fhs[n].fh->sigio(NULL);
     }
 #endif // MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
### Description

Added a mechanism to NOT busy wait in `poll` but instead register an event flag to the sigios of all file handles we wait upon and the polling thread is properly waiting.
Resolves https://github.com/ARMmbed/mbed-os/issues/9112
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

