### PR TITLE
Cellular: Add generic cellular modem

### DIFF
--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -49,9 +49,9 @@ public:
         PROPERTY_AT_CGSN_WITH_TYPE, // 0 = not supported, 1 = supported. AT+CGSN without type is likely always supported similar to AT+GSN.
         PROPERTY_AT_CGDATA,         // 0 = not supported, 1 = supported. Alternative is to support only ATD*99***<cid>#
         PROPERTY_AT_CGAUTH,         // 0 = not supported, 1 = supported. APN authentication AT commands supported
-        PROPERTY_IPV4_STACK,        // 0 = not supported, 1 = supported
-        PROPERTY_IPV6_STACK,        // 0 = not supported, 1 = supported
-        PROPERTY_IPV4V6_STACK,      // 0 = not supported, 1 = supported
+        PROPERTY_IPV4_STACK,        // 0 = not supported, 1 = supported. Does modem support IPV4?
+        PROPERTY_IPV6_STACK,        // 0 = not supported, 1 = supported. Does modem support IPV6?
+        PROPERTY_IPV4V6_STACK,      // 0 = not supported, 1 = supported. Does modem support dual stack IPV4V6?
         PROPERTY_MAX
     };
 

--- a/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
+++ b/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GENERIC_AT3GPP.h"
+#include "AT_CellularNetwork.h"
+
+using namespace mbed;
+
+// by default all properties are supported
+static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
+    AT_CellularNetwork::RegistrationModeLAC,    // C_EREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
+    1,  // AT_CGSN_WITH_TYPE
+    1,  // AT_CGDATA
+    1,  // AT_CGAUTH
+    1,  // PROPERTY_IPV4_STACK
+    1,  // PROPERTY_IPV6_STACK
+    1,  // PROPERTY_IPV4V6_STACK
+};
+
+GENERIC_AT3GPP::GENERIC_AT3GPP(FileHandle *fh) : AT_CellularDevice(fh)
+{
+    AT_CellularBase::set_cellular_properties(cellular_properties);
+}
+
+GENERIC_AT3GPP::~GENERIC_AT3GPP()
+{
+}

--- a/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.h
+++ b/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GENERIC_AT3GPP_H_
+#define GENERIC_AT3GPP_H_
+
+#include "AT_CellularDevice.h"
+
+namespace mbed {
+
+/**
+ * Generic Cellular module which can be used as a default module when porting new cellular module.
+ * GENERIC_AT3GPP uses standard 3GPP AT commands (3GPP TS 27.007 V14.5.0 (2017-09)) to communicate with the modem.
+ *
+ * GENERIC_AT3GPP can be used as a shield for example on top K64F.
+ * Cellular example can be used for testing: https://github.com/ARMmbed/mbed-os-example-cellular
+ * Add line to mbed_app.json where you define this class as CELLULAR_DEVICE and the correct pins. In cellular example
+ * line would be for example just above "target_overrides": {...
+ * For example:
+ * "macros": ["CELLULAR_DEVICE=GENERIC_AT3GPP", "MDMRXD=PTC16", "MDMTXD=PTC17","MDMRTS=NC", "MDMCTS=NC"],
+ * You can define CELLULAR_DEVICE and pins also in ../../../common/CellularTargets.h
+ *
+ * If new target don't work with GENERIC_AT3GPP then it needs some customizations.
+ * First thing to try can be checking/modifying cellular_properties array in GENERIC_AT3GPP.cpp, does the module support
+ * these commands or not? Modify array and if that's not enough then some AT_xxx classes might need to be created and
+ * methods overridden. Check help how other modules are done what methods they have overridden. Happy porting!
+ */
+class GENERIC_AT3GPP : public AT_CellularDevice {
+public:
+    GENERIC_AT3GPP(FileHandle *fh);
+    virtual ~GENERIC_AT3GPP();
+
+};
+} // namespace mbed
+#endif // GENERIC_AT3GPP_H_

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -35,7 +35,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_REG
     0,  // AT_CGSN_WITH_TYPE
-    1,  // AT_CGDATA
+    0,  // AT_CGDATA
     1,  // AT_CGAUTH
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK


### PR DESCRIPTION
### Description

Generic cellular module (GENERIC_AT3GPP) can by used as a default module when porting new cellular module. It's a good starting point and eases porting of new modules. GENERIC_AT3GPP uses only standard 3GPP AT commands when communicating with the modem.

@AriParkkila please review

btw, I used Functionality change as there is no new feature anymore. Pull request types don't match with these: https://os.mbed.com/docs/latest/reference/workflow.html#pull-request-types

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

