### PR TITLE
WIFI test: improve debug messages

### DIFF
--- a/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
+++ b/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
@@ -31,13 +31,13 @@ void wifi_connect_disconnect_repeat(void)
     nsapi_error_t error;
 
     error = wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL);
-    TEST_ASSERT(error == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     for (int i = 0; i < 10; i++) {
         error = wifi->connect();
-        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
         error = wifi->disconnect();
-        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
     }
 }
 

--- a/TESTS/network/wifi/wifi_connect_nocredentials.cpp
+++ b/TESTS/network/wifi/wifi_connect_nocredentials.cpp
@@ -30,5 +30,5 @@ void wifi_connect_nocredentials(void)
     error_connect = wifi->connect();
     error_disconnect = wifi->disconnect();
     TEST_ASSERT(error_connect == NSAPI_ERROR_NO_SSID || error_connect == NSAPI_ERROR_PARAMETER);
-    TEST_ASSERT(error_disconnect == NSAPI_ERROR_NO_CONNECTION);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_CONNECTION, error_disconnect);
 }

--- a/TESTS/network/wifi/wifi_connect_params_null.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_null.cpp
@@ -29,8 +29,8 @@ void wifi_connect_params_null(void)
     WiFiInterface *wifi = get_interface();
     error = wifi->connect(NULL, NULL);
     wifi->disconnect();
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
     error =  wifi->connect("", "");
     wifi->disconnect();
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 }

--- a/TESTS/network/wifi/wifi_set_channel.cpp
+++ b/TESTS/network/wifi/wifi_set_channel.cpp
@@ -51,22 +51,22 @@ void wifi_set_channel(void)
 
     if (is_2Ghz) {
         error = wifi->set_channel(0);
-        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
         error = wifi->set_channel(1);
-        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
         error = wifi->set_channel(13);
         TEST_ASSERT(error == NSAPI_ERROR_OK || error == NSAPI_ERROR_PARAMETER);
         error = wifi->set_channel(15);
-        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
     }
 
     if (is_5Ghz) {
         error = wifi->set_channel(30);
-        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
         error = wifi->set_channel(36);
-        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
         error = wifi->set_channel(169);
-        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
     }
 
     wifi->set_channel(0);

--- a/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/TESTS/network/wifi/wifi_set_credential.cpp
@@ -29,31 +29,31 @@ void wifi_set_credential(void)
     nsapi_error_t error;
 
     error = iface->set_credentials(NULL, NULL, NSAPI_SECURITY_NONE);
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
     error = iface->set_credentials("", "", NSAPI_SECURITY_NONE);
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_NONE);
-    TEST_ASSERT(error == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     error = iface->set_credentials("OK", "", NSAPI_SECURITY_NONE);
-    TEST_ASSERT(error == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WEP);
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
     error = iface->set_credentials("OK", "", NSAPI_SECURITY_WEP);
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WPA_WPA2);
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
     error = iface->set_credentials("OK", "", NSAPI_SECURITY_WPA_WPA2);
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_NONE);
-    TEST_ASSERT(error == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WEP);
     TEST_ASSERT((error == NSAPI_ERROR_OK) || (error == NSAPI_ERROR_UNSUPPORTED));
@@ -65,11 +65,11 @@ void wifi_set_credential(void)
     TEST_ASSERT((error == NSAPI_ERROR_OK) || (error == NSAPI_ERROR_UNSUPPORTED));
 
     error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA_WPA2);
-    TEST_ASSERT(error == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni", get_security());
-    TEST_ASSERT(error == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni8", get_security());
-    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, error);
 }


### PR DESCRIPTION
### Description

Goal is only to update the console log in case of errors.
There is no test change.

Ex before:
mbedgt: :33::FAIL: Expression Evaluated To FALSE

Same error case with this patch:
mbedgt: :33::FAIL: Expected -3004 Was 0



### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

