### PR TITLE
Fix SPM HAL test

### DIFF
--- a/TESTS/mbed_hal/spm/main.cpp
+++ b/TESTS/mbed_hal/spm/main.cpp
@@ -84,7 +84,7 @@ __attribute__((naked)) void call_mem(uint32_t addr)
     // since exception will be generated for invalid memory access.
     // Other instructions are for calling do_nothing function according to AAPCS.
     __ASM(
-        "LDR     r4, [r0]\n"
+        "LDR     r3, [r0]\n"
         "BX      lr\n"
     );
 }

--- a/TESTS/mbed_hal/spm/main.cpp
+++ b/TESTS/mbed_hal/spm/main.cpp
@@ -84,7 +84,7 @@ __attribute__((naked)) void call_mem(uint32_t addr)
     // since exception will be generated for invalid memory access.
     // Other instructions are for calling do_nothing function according to AAPCS.
     __ASM(
-        "LDR     r1, [r0]\n"
+        "LDR     r4, [r0]\n"
         "BX      lr\n"
     );
 }

--- a/TESTS/mbed_hal/spm/main.cpp
+++ b/TESTS/mbed_hal/spm/main.cpp
@@ -138,10 +138,10 @@ utest::v1::status_t fault_override_teardown(const Case *const source, const size
 }
 
 Case cases[] = {
-    Case("SPM - Access secure RAM",       fault_override_setup, secure_ram_fault_test, fault_override_teardown),
-    Case("SPM - Access secure Flash",     fault_override_setup, secure_flash_fault_test, fault_override_teardown),
     Case("SPM - Access non-secure RAM",   fault_override_setup, non_secure_ram_fault_test, fault_override_teardown),
     Case("SPM - Access non-secure Flash", fault_override_setup, non_secure_flash_fault_test, fault_override_teardown),
+    Case("SPM - Access secure RAM",       fault_override_setup, secure_ram_fault_test, fault_override_teardown),
+    Case("SPM - Access secure Flash",     fault_override_setup, secure_flash_fault_test, fault_override_teardown)
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)


### PR DESCRIPTION

### Description
When accessing non-secure ram and flash r1 was actually used by the calling function.
Change to a callee saved register.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

@alzix @mikisch81 please review