### PR TITLE
DNS tests: improve debug messages

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns.cpp
@@ -34,8 +34,8 @@ void ASYNCHRONOUS_DNS()
 {
     do_asynchronous_gethostbyname(dns_test_hosts, 1, &result_ok, &result_no_mem, &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == 1);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(1, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
@@ -50,7 +50,7 @@ void ASYNCHRONOUS_DNS_CACHE()
 
         semaphore.wait();
 
-        TEST_ASSERT(data.result == NSAPI_ERROR_OK);
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
         TEST_ASSERT(strlen(data.addr.get_ip_address()) > 1);
 
         int delay_ms = (ticker_us - started_us) / 1000;

--- a/TESTS/netsocket/dns/asynchronous_dns_external_event_queue.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_external_event_queue.cpp
@@ -57,10 +57,10 @@ void ASYNCHRONOUS_DNS_EXTERNAL_EVENT_QUEUE()
     do_asynchronous_gethostbyname(dns_test_hosts, MBED_CONF_NSAPI_DNS_CACHE_SIZE, &result_ok, &result_no_mem,
                                   &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == MBED_CONF_NSAPI_DNS_CACHE_SIZE);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(MBED_CONF_NSAPI_DNS_CACHE_SIZE, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 
     // Dispatch event queue
     Thread eventThread(osPriorityNormal, EXTERNAL_THREAD_SIZE);
@@ -73,10 +73,10 @@ void ASYNCHRONOUS_DNS_EXTERNAL_EVENT_QUEUE()
     do_asynchronous_gethostbyname(dns_test_hosts_second, MBED_CONF_APP_DNS_SIMULT_QUERIES + 1, &result_ok, &result_no_mem,
                                   &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == MBED_CONF_APP_DNS_SIMULT_QUERIES);
-    TEST_ASSERT(result_no_mem == 1); // last query fails for no memory as expected
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(MBED_CONF_APP_DNS_SIMULT_QUERIES, result_ok);
+    TEST_ASSERT_EQUAL(1, result_no_mem); // last query fails for no memory as expected
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 
     // Give event queue time to finalise before destructors
     wait(2.0);

--- a/TESTS/netsocket/dns/asynchronous_dns_invalid_host.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_invalid_host.cpp
@@ -61,8 +61,8 @@ void ASYNCHRONOUS_DNS_INVALID_HOST()
     do_asynchronous_gethostbyname(dns_test_hosts_new, MBED_CONF_APP_DNS_SIMULT_QUERIES + 1, &result_ok, &result_no_mem,
                                   &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == exp_ok);
-    TEST_ASSERT(result_no_mem == 1); // last query fails for no memory as expected
+    TEST_ASSERT_EQUAL(exp_ok, result_ok);
+    TEST_ASSERT_EQUAL(1, result_no_mem); // last query fails for no memory as expected
     TEST_ASSERT(result_dns_failure == exp_dns_failure || result_dns_failure == exp_dns_failure + 1);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -47,7 +47,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
 
     semaphore.wait(100);
 
-    TEST_ASSERT(data.result == NSAPI_ERROR_OK);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
 
     printf("DNS: query \"%s\" => \"%s\"\n",
            dns_test_hosts_second[0], data.addr.get_ip_address());

--- a/TESTS/netsocket/dns/asynchronous_dns_simultaneous.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_simultaneous.cpp
@@ -35,8 +35,8 @@ void ASYNCHRONOUS_DNS_SIMULTANEOUS()
     do_asynchronous_gethostbyname(dns_test_hosts_second, MBED_CONF_APP_DNS_SIMULT_QUERIES + 1, &result_ok, &result_no_mem,
                                   &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == MBED_CONF_APP_DNS_SIMULT_QUERIES);
-    TEST_ASSERT(result_no_mem == 1); // last query fails for no memory as expected
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(MBED_CONF_APP_DNS_SIMULT_QUERIES, result_ok);
+    TEST_ASSERT_EQUAL(1, result_no_mem); // last query fails for no memory as expected
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_simultaneous_cache.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_simultaneous_cache.cpp
@@ -36,8 +36,8 @@ void ASYNCHRONOUS_DNS_SIMULTANEOUS_CACHE()
                                   &result_dns_failure, &result_exp_timeout);
 
     // Addresses were cached on last step, OK for all
-    TEST_ASSERT(result_ok == MBED_CONF_APP_DNS_SIMULT_QUERIES + 1);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(MBED_CONF_APP_DNS_SIMULT_QUERIES + 1, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_simultaneous_repeat.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_simultaneous_repeat.cpp
@@ -40,7 +40,7 @@ void ASYNCHRONOUS_DNS_SIMULTANEOUS_REPEAT()
         // For 1st round can fail to no memory, on other rounds some of the addresses are found from cache
         TEST_ASSERT(result_ok == MBED_CONF_APP_DNS_SIMULT_QUERIES || result_ok == MBED_CONF_APP_DNS_SIMULT_QUERIES + 1);
         TEST_ASSERT(result_no_mem == 1 || result_no_mem == 0); // last query fails for 1st round to no memory as expected
-        TEST_ASSERT(result_dns_failure == 0);
-        TEST_ASSERT(result_exp_timeout == 0);
+        TEST_ASSERT_EQUAL(0, result_dns_failure);
+        TEST_ASSERT_EQUAL(0, result_exp_timeout);
     }
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_timeouts.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_timeouts.cpp
@@ -53,10 +53,10 @@ void ASYNCHRONOUS_DNS_TIMEOUTS()
     do_asynchronous_gethostbyname(dns_test_hosts, MBED_CONF_NSAPI_DNS_CACHE_SIZE, &result_ok, &result_no_mem,
                                   &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == MBED_CONF_NSAPI_DNS_CACHE_SIZE);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(MBED_CONF_NSAPI_DNS_CACHE_SIZE, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 
     // Dispatch event queue
     Thread eventThread(osPriorityNormal, EXTERNAL_THREAD_SIZE);

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -122,7 +122,6 @@ void do_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_cou
         SocketAddress address;
         nsapi_error_t err = net->gethostbyname(hosts[i], &address);
 
-        TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_NO_MEMORY || err == NSAPI_ERROR_DNS_FAILURE || err == NSAPI_ERROR_TIMEOUT);
         if (err == NSAPI_ERROR_OK) {
             (*exp_ok)++;
             printf("DNS: query \"%s\" => \"%s\"\n",
@@ -136,6 +135,9 @@ void do_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_cou
         } else if (err == NSAPI_ERROR_NO_MEMORY) {
             (*exp_no_mem)++;
             printf("DNS: query \"%s\" => no memory\n", hosts[i]);
+        } else {
+            printf("DNS: query \"%s\" => %d, unexpected answer\n", hosts[i], err);
+            TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_NO_MEMORY || err == NSAPI_ERROR_DNS_FAILURE || err == NSAPI_ERROR_TIMEOUT);
         }
     }
 }

--- a/TESTS/netsocket/dns/synchronous_dns.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns.cpp
@@ -34,8 +34,8 @@ void SYNCHRONOUS_DNS()
 {
     do_gethostbyname(dns_test_hosts, 1, &result_ok, &result_no_mem, &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == 1);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(1, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }

--- a/TESTS/netsocket/dns/synchronous_dns_invalid.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_invalid.cpp
@@ -53,8 +53,8 @@ void SYNCHRONOUS_DNS_INVALID()
 
     do_gethostbyname(dns_test_hosts_new, MBED_CONF_APP_DNS_TEST_HOSTS_NUM, &result_ok, &result_no_mem, &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == expected_successes);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == expected_failures);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(expected_successes, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(expected_failures, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }

--- a/TESTS/netsocket/dns/synchronous_dns_multiple.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_multiple.cpp
@@ -34,8 +34,8 @@ void SYNCHRONOUS_DNS_MULTIPLE()
 {
     do_gethostbyname(dns_test_hosts, MBED_CONF_APP_DNS_TEST_HOSTS_NUM, &result_ok, &result_no_mem, &result_dns_failure, &result_exp_timeout);
 
-    TEST_ASSERT(result_ok == MBED_CONF_APP_DNS_TEST_HOSTS_NUM);
-    TEST_ASSERT(result_no_mem == 0);
-    TEST_ASSERT(result_dns_failure == 0);
-    TEST_ASSERT(result_exp_timeout == 0);
+    TEST_ASSERT_EQUAL(MBED_CONF_APP_DNS_TEST_HOSTS_NUM, result_ok);
+    TEST_ASSERT_EQUAL(0, result_no_mem);
+    TEST_ASSERT_EQUAL(0, result_dns_failure);
+    TEST_ASSERT_EQUAL(0, result_exp_timeout);
 }


### PR DESCRIPTION
### Description

Goal is only to update the console log in case of errors.
There is no test change.

Ex before:
mbedgt: :33::FAIL: Expression Evaluated To FALSE

Same error case with this patch:
mbedgt: :33::FAIL: Expected -3004 Was 0


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

