### PR TITLE
Fix ESP8266 "Link Type" errors after reset

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -190,11 +190,6 @@ int ESP8266Interface::connect()
         return NSAPI_ERROR_IS_CONNECTED;
     }
 
-    status = _startup(ESP8266::WIFIMODE_STATION);
-    if (status != NSAPI_ERROR_OK) {
-        return status;
-    }
-
     if (!_esp.dhcp(true, 1)) {
         return NSAPI_ERROR_DHCP_FAILURE;
     }
@@ -315,11 +310,6 @@ int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count)
         return status;
     }
 
-    status = _startup(ESP8266::WIFIMODE_STATION);
-    if (status != NSAPI_ERROR_OK) {
-        return status;
-    }
-
     return _esp.scan(res, count);
 }
 
@@ -370,6 +360,9 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_esp.cond_enable_tcp_passive_mode()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
+        if (!_esp.startup(ESP8266::WIFIMODE_STATION)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
 
         _initialized = true;
     }
@@ -383,16 +376,6 @@ void ESP8266Interface::_hw_reset()
     // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
     wait_us(200);
     _rst_pin.rst_deassert();
-}
-
-nsapi_error_t ESP8266Interface::_startup(const int8_t wifi_mode)
-{
-    if (_conn_stat == NSAPI_STATUS_DISCONNECTED) {
-        if (!_esp.startup(wifi_mode)) {
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
-    }
-    return NSAPI_ERROR_OK;
 }
 
 struct esp8266_socket {

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -353,7 +353,6 @@ private:
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
     void _hw_reset();
-    nsapi_error_t _startup(const int8_t wifi_mode);
 
     //sigio
     struct {


### PR DESCRIPTION
### Description

As part of the ESP8266 connect sequence, ```ESP8266Interface::connect```, a software reset is performed. If the ESP8266 had been connected previously then the ESP8266 will sometimes send a "WIFI DISCONNECT" OOB message before performing the software reset. This causes the function ```ESP8266::_oob_connection_status``` to get called and change its state (_conn_status) from NSAPI_STATUS_DISCONNECTED to NSAPI_STATUS_CONNECTING. This causes ```ESP8266Interface::_startup```, called later in the boot seqeunce, to skip ```ESP8266::startup```. Without this call socket mux mode (CIPMUX=1) is never enabled and all send commands using this format fail with a "Link Type" error.

This patch fixes that problem by unconditionally calling ```ESP8266::startup``` as part of the ESP8266 connect sequence.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

