### PR TITLE
Add versioning limits to `intervaltree` module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ junit-xml==1.8
 pyYAML==3.13
 urllib3[secure]==1.23
 requests>=2.20,<2.21
+intervaltree>=2,<3
 mbed-ls>=1.5.1,<1.7
 mbed-host-tests>=1.1.2,<=1.5
 mbed-greentea>=0.2.24,<=1.5


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

PyOCD (required by mbed-host-test) does not do version capping in it's setup.py module requirements, which is pulling a breaking change/latest major release of `intervaltree`, (3.0.0 was released today). As a result, Travis CI builds are breaking. 

This PR caps the module version before checking PyOCD.

Proof that issue is fixed: https://travis-ci.org/cmonr/mbed-os/builds/469097405

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

