### PR TITLE
STM32: enable TICKLESS

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2379,7 +2379,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0744"],
         "device_has_add": [
             "ANALOGOUT",
@@ -2551,7 +2551,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
@@ -2589,7 +2589,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
@@ -2828,7 +2828,7 @@
         "device_name": "STM32F746ZG",
         "bootloader_supported": true,
         "overrides": {
-            "lpticker_delay_ticks": 3,
+            "lpticker_delay_ticks": 4,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -2878,7 +2878,7 @@
         "release_versions": ["2", "5"],
         "device_name": "STM32F756ZG",
         "overrides": {
-            "lpticker_delay_ticks": 3,
+            "lpticker_delay_ticks": 4,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -2929,7 +2929,7 @@
         "device_name": "STM32F767ZI",
         "bootloader_supported": true,
         "overrides": {
-            "lpticker_delay_ticks": 3,
+            "lpticker_delay_ticks": 4,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -3081,7 +3081,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0770"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3113,7 +3113,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0779"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3174,7 +3174,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0765"],
         "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": [
@@ -3234,7 +3234,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0827"],
         "macros_add": [
             "USBHOST_OTHER",
@@ -3699,7 +3699,7 @@
         "device_name": "STM32F746NG",
         "bootloader_supported": true,
         "overrides": {
-            "lpticker_delay_ticks": 3,
+            "lpticker_delay_ticks": 4,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -3746,7 +3746,7 @@
         "release_versions": ["2", "5"],
         "device_name": "STM32F769NI",
         "overrides": {
-            "lpticker_delay_ticks": 3,
+            "lpticker_delay_ticks": 4,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -3766,7 +3766,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
         "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
@@ -3799,7 +3799,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0820"],
         "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": [
@@ -7172,7 +7172,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0822"],
         "device_has_add": [
             "ANALOGOUT",
@@ -7205,7 +7205,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0823"],
         "device_has_add": [
             "ANALOGOUT",
@@ -7241,7 +7241,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0776"],
         "device_has_add": [
             "ANALOGOUT",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2379,6 +2379,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0744"],
         "device_has_add": [
@@ -2553,7 +2556,11 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0743"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USB_STM_HAL",
+            "USBHOST_OTHER"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -2591,7 +2598,11 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0743"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USB_STM_HAL",
+            "USBHOST_OTHER"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -2811,7 +2822,10 @@
                 "value": 1
             }
         },
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USBHOST_OTHER"
+        ],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0816"],
         "device_has_add": [
@@ -2859,7 +2873,7 @@
             }
         },
         "macros_add": [
-            "TRANSACTION_QUEUE_SIZE_SPI=2",
+            "MBED_TICKLESS",
             "USBHOST_OTHER",
             "MBEDTLS_CONFIG_HW_SUPPORT"
         ],
@@ -2913,7 +2927,10 @@
             }
         },
         "supported_form_factors": ["ARDUINO"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USBHOST_OTHER"
+        ],
         "detect_code": ["0818"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3028,6 +3045,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0760"],
         "device_has_add": [
@@ -3081,6 +3101,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0770"],
         "device_has_add": [
@@ -3113,6 +3136,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0779"],
         "device_has_add": [
@@ -3176,7 +3202,11 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0765"],
-        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USBHOST_OTHER",
+            "TWO_RAM_REGIONS"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -3237,6 +3267,7 @@
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0827"],
         "macros_add": [
+            "MBED_TICKLESS",
             "USBHOST_OTHER",
             "MBEDTLS_CONFIG_HW_SUPPORT",
             "TWO_RAM_REGIONS"
@@ -3621,6 +3652,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0833"],
         "device_has_add": [
@@ -3684,7 +3718,11 @@
             }
         },
         "detect_code": ["0815"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USB_STM_HAL",
+            "USBHOST_OTHER"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -3731,7 +3769,11 @@
             }
         },
         "detect_code": ["0817"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USB_STM_HAL",
+            "USBHOST_OTHER"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -3769,7 +3811,11 @@
         "overrides": { "lpticker_delay_ticks": 4 },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
-        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USBHOST_OTHER",
+            "TWO_RAM_REGIONS"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -3801,7 +3847,11 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0820"],
-        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USBHOST_OTHER",
+            "TWO_RAM_REGIONS"
+        ],
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
@@ -7172,6 +7222,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0822"],
         "device_has_add": [
@@ -7205,6 +7258,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0823"],
         "device_has_add": [
@@ -7241,6 +7297,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0776"],
         "device_has_add": [


### PR DESCRIPTION
### Description

I propose to enable TICKLESS for STM32 targets which are using LPTIM feature for LPTICKER.

This PR also update the LPTICKER_DELAY_TICKS to 4 according to #8783

NB: note that it is still possible to remove this tickless feature in you mbed_app.json file if needed/wanted:
ex:
    "target_overrides": {
        "NUCLEO_L476RG": {
            "target.macros_remove": ["MBED_TICKLESS"]
        },


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

