### PR TITLE
TDBStore and NVStore should create an error if co exist.

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -527,7 +527,7 @@ bd_size_t DataFlashBlockDevice::size() const
     return device_size;
 }
 
-const char * DataFlashBlockDevice::get_type()
+const char *DataFlashBlockDevice::get_type()
 {
     return "DATAFLASH";
 }

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -527,7 +527,7 @@ bd_size_t DataFlashBlockDevice::size() const
     return device_size;
 }
 
-const char *DataFlashBlockDevice::get_type()
+const char *DataFlashBlockDevice::get_type() const
 {
     return "DATAFLASH";
 }

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -527,6 +527,11 @@ bd_size_t DataFlashBlockDevice::size() const
     return device_size;
 }
 
+const char * DataFlashBlockDevice::get_type()
+{
+    return "DATAFLASH";
+}
+
 /**
  * @brief Function for reading a specific register.
  * @details Used for reading either the Status Register or Manufacture and ID Register.

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -153,6 +153,12 @@ public:
      */
     virtual mbed::bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     // Master side hardware
     mbed::SPI _spi;

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -157,7 +157,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     // Master side hardware

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -157,7 +157,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     // Master side hardware

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -248,7 +248,7 @@ bd_size_t FlashIAPBlockDevice::size() const
     return _size;
 }
 
-const char *FlashIAPBlockDevice::get_type()
+const char *FlashIAPBlockDevice::get_type() const
 {
     return "FLASHIAP";
 }

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -248,4 +248,9 @@ bd_size_t FlashIAPBlockDevice::size() const
     return _size;
 }
 
+const char * FlashIAPBlockDevice::get_type()
+{
+    return "FLASHIAP";
+}
+
 #endif /* DEVICE_FLASH */

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -248,7 +248,7 @@ bd_size_t FlashIAPBlockDevice::size() const
     return _size;
 }
 
-const char * FlashIAPBlockDevice::get_type()
+const char *FlashIAPBlockDevice::get_type()
 {
     return "FLASHIAP";
 }

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -125,7 +125,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     // Device configuration

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -121,6 +121,12 @@ public:
      */
     virtual mbed::bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     // Device configuration
     mbed::FlashIAP _flash;

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -125,7 +125,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     // Device configuration

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -477,7 +477,7 @@ bd_size_t QSPIFBlockDevice::get_erase_size() const
     return _min_common_erase_size;
 }
 
-const char *QSPIFBlockDevice::get_type()
+const char *QSPIFBlockDevice::get_type() const
 {
     return "QSPIF";
 }

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -477,6 +477,11 @@ bd_size_t QSPIFBlockDevice::get_erase_size() const
     return _min_common_erase_size;
 }
 
+const char * QSPIFBlockDevice::get_type()
+{
+    return "QSPIF";
+}
+
 // Find minimal erase size supported by the region to which the address belongs to
 bd_size_t QSPIFBlockDevice::get_erase_size(bd_addr_t addr)
 {

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -477,7 +477,7 @@ bd_size_t QSPIFBlockDevice::get_erase_size() const
     return _min_common_erase_size;
 }
 
-const char * QSPIFBlockDevice::get_type()
+const char *QSPIFBlockDevice::get_type()
 {
     return "QSPIF";
 }

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -215,7 +215,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     // Internal functions

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -215,7 +215,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     // Internal functions

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -211,6 +211,12 @@ public:
      */
     virtual mbed::bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     // Internal functions
 
@@ -307,8 +313,6 @@ private:
     int _utils_iterate_next_largest_erase_type(uint8_t &bitfield, int size, int offset, int boundry);
 
 private:
-    // Internal Members
-
     // QSPI Driver Object
     mbed::QSPI _qspi;
 

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -344,7 +344,7 @@ bd_size_t SPIFReducedBlockDevice::size() const
     return _size;
 }
 
-const char *SPIFReducedBlockDevice::get_type()
+const char *SPIFReducedBlockDevice::get_type() const
 {
     return "SPIFR";
 }

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -48,7 +48,6 @@ enum ops {
 #define SPIF_WEL 0x2
 #define SPIF_WIP 0x1
 
-
 SPIFReducedBlockDevice::SPIFReducedBlockDevice(
     PinName mosi, PinName miso, PinName sclk, PinName cs, int freq)
     : _spi(mosi, miso, sclk), _cs(cs), _size(0)
@@ -344,3 +343,9 @@ bd_size_t SPIFReducedBlockDevice::size() const
 {
     return _size;
 }
+
+const char * SPIFReducedBlockDevice::get_type()
+{
+    return "SPIFR";
+}
+

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -344,7 +344,7 @@ bd_size_t SPIFReducedBlockDevice::size() const
     return _size;
 }
 
-const char * SPIFReducedBlockDevice::get_type()
+const char *SPIFReducedBlockDevice::get_type()
 {
     return "SPIFR";
 }

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
@@ -159,7 +159,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     // Master side hardware

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
@@ -155,6 +155,12 @@ public:
      */
     virtual mbed::bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     // Master side hardware
     mbed::SPI _spi;

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
@@ -159,7 +159,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     // Master side hardware

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -632,7 +632,7 @@ bd_size_t SDBlockDevice::size() const
     return _block_size * _sectors;
 }
 
-const char *SDBlockDevice::get_type()
+const char *SDBlockDevice::get_type() const
 {
     return "SD";
 }

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -632,7 +632,7 @@ bd_size_t SDBlockDevice::size() const
     return _block_size * _sectors;
 }
 
-const char * SDBlockDevice::get_type()
+const char *SDBlockDevice::get_type()
 {
     return "SD";
 }

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -632,6 +632,11 @@ bd_size_t SDBlockDevice::size() const
     return _block_size * _sectors;
 }
 
+const char * SDBlockDevice::get_type()
+{
+    return "SD";
+}
+
 void SDBlockDevice::debug(bool dbg)
 {
     _dbg = dbg;

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -120,7 +120,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     /* Commands : Listed below are commands supported

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -116,6 +116,11 @@ public:
      */
     virtual int frequency(uint64_t freq);
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
 
 private:
     /* Commands : Listed below are commands supported

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -120,7 +120,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     /* Commands : Listed below are commands supported

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -472,6 +472,11 @@ int SPIFBlockDevice::get_erase_value() const
     return 0xFF;
 }
 
+const char * SPIFBlockDevice::get_type()
+{
+    return "SPIF";
+}
+
 /***************************************************/
 /*********** SPI Driver API Functions **************/
 /***************************************************/

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -472,7 +472,7 @@ int SPIFBlockDevice::get_erase_value() const
     return 0xFF;
 }
 
-const char * SPIFBlockDevice::get_type()
+const char *SPIFBlockDevice::get_type()
 {
     return "SPIF";
 }

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -472,7 +472,7 @@ int SPIFBlockDevice::get_erase_value() const
     return 0xFF;
 }
 
-const char *SPIFBlockDevice::get_type()
+const char *SPIFBlockDevice::get_type() const
 {
     return "SPIF";
 }

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -193,7 +193,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
 

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -193,7 +193,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
 

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -189,6 +189,12 @@ public:
      */
     virtual mbed::bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
 
     // Internal functions

--- a/docs/design-documents/features/storage/BlockDevices/get_type_method.md
+++ b/docs/design-documents/features/storage/BlockDevices/get_type_method.md
@@ -1,0 +1,74 @@
+# Get type method addon to block devices class
+ 
+### Revision history
+| Revision  | Date            | Authors                                                     | Mbed OS version        | Comments         |
+|---------- |-----------------|-------------------------------------------------------------|------------------------|------------------|
+| 1.0       | 04/12/2018      | Yossi Levy ([@yossi2le](https://github.com/yossi2le/))      | 5.11+                  | Initial revision |
+ 
+## Introduction
+ 
+Most storage solutions use block devices, whether it is Filesystems, KVStore or any other solution 
+most of them will have some BlockDevice class underneath. However, sometimes a storage type or an application needs to know the physical 
+BlockDevice type in order to work smoothly or the BlockDevice type in order to decide what is
+the best storage configuration to use.
+To address this an add-on method of getting type is proposed for BlockDevice interface class.
+ 
+## The Motivation 
+ 
+Below there is a list of some examples to explain the motivation and the need for the adding of get_type to BlockDevice interface.
+ 
+examples:
+- TDBStore needs to know if there are flash characteristics for the block device and if there aren�t it should use
+  FlashSimBlockDevice to simulate a flash BlockDevice.
+- TDBStore should not co-exists with NVStore, but this is true only if TDBStore is running on internal memory. Therefore if TDBStore running on 
+  internal memory and NVStore is also there an error should be raised. 
+- When creating a file system you would prefer working with FAT on top of SD while LITTLEFS on top of any flash block device. 
+  Those preference in favor of better performance.
+
+To summarize the above, it may be very useful when using block device to know the type of the instance and especially, but not only, 
+when using get_default_instace. Sometimes applications and tests would like to behave differently depending on the instance that has been created
+or provided to them.
+ 
+In fact it might be worth to consider adding the get_type to any interface with get_default_instance at mbed-os.   
+  
+## Dive into details
+we should add the following method to BlockDevice interface class.
+ 
+```virtual const char * get_type() = 0;```
+ 
+then every physical BlockDevice class which implements the interface should also implement this method and return a string 
+representing its type. Furthermore, a nonphysical BlockDevice like SlicingBlockDevice should return the underlying physical 
+BlockDevice type.
+ 
+### Physical BlockDevice:
+```
+const char * HeapBlockDevice::get_type()
+{
+    return "HEAP";
+}
+```
+ 
+### Logical BlockDevice:
+```
+const char * SlicingBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+     return _bd->get_type();
+    }
+ 
+    return NULL;
+}
+```
+
+The below table describes physical BlockDevice and its tyep names
+
+
+| BlockDevice class           | String description | 
+|-----------------------------|--------------------|
+| HeapBlockDevice             | "HEAP"             |
+| SPIFBlockDevice             | "SPIF"             |
+| SPIFReducedBlockDevice      | "SPIFR"            |
+| QSPIFBlockDevice            | "QSPIF"            |
+| SDBlockDevice               | "SD"               |
+| FlashIAPBlockDevice         | "FLASHIAP"         |
+| DataFlashBlockDevice        | "DATAFLASH"        |

--- a/docs/design-documents/features/storage/BlockDevices/get_type_method.md
+++ b/docs/design-documents/features/storage/BlockDevices/get_type_method.md
@@ -34,7 +34,7 @@ In fact it might be worth to consider adding the get_type to any interface with 
 ## Dive into details
 we should add the following method to BlockDevice interface class.
  
-```virtual const char * get_type() = 0;```
+```virtual const char * get_type() const = 0;```
  
 then every physical BlockDevice class which implements the interface should also implement this method and return a string 
 representing its type. Furthermore, a nonphysical BlockDevice like SlicingBlockDevice should return the underlying physical 
@@ -42,7 +42,7 @@ BlockDevice type.
  
 ### Physical BlockDevice:
 ```
-const char * HeapBlockDevice::get_type()
+const char * HeapBlockDevice::get_type() const
 {
     return "HEAP";
 }
@@ -50,7 +50,7 @@ const char * HeapBlockDevice::get_type()
  
 ### Logical BlockDevice:
 ```
-const char * SlicingBlockDevice::get_type()
+const char * SlicingBlockDevice::get_type() const
 {
     if (_bd != NULL) {
      return _bd->get_type();
@@ -59,6 +59,12 @@ const char * SlicingBlockDevice::get_type()
     return NULL;
 }
 ```
+
+### Open issue
+The ChainingBlockDevice which chains different type of physical block devices into one block device is unable
+to return the underneath physical as it contains two or more types. Therefore it will return CHAINING as its 
+identity and its left for the user to decide how the application will treat this information.
+
 
 The below table describes physical BlockDevice and its tyep names
 
@@ -72,3 +78,4 @@ The below table describes physical BlockDevice and its tyep names
 | SDBlockDevice               | "SD"               |
 | FlashIAPBlockDevice         | "FLASHIAP"         |
 | DataFlashBlockDevice        | "DATAFLASH"        |
+| ChainingBlockDevice         | "CHAINING"         |

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -466,6 +466,30 @@ void test_program_read_small_data_sizes()
     delete block_device;
 }
 
+void test_get_type_functionality()
+{
+    BlockDevice *block_device = BlockDevice::get_default_instance();
+    if (block_device == NULL) {
+        TEST_SKIP_MESSAGE("No block device component is defined for this target");
+        return;
+    }
+    const char * bd_type = block_device->get_type();
+    TEST_ASSERT_NOT_EQUAL(0, bd_type);
+
+#if COMPONENT_QSPIF
+    TEST_ASSERT_EQUAL(0, strcmp(bd_type, "QSPIF"));
+#elif COMPONENT_SPIF
+    TEST_ASSERT_EQUAL(0, strcmp(bd_type, "SPIF"));
+#elif COMPONENT_DATAFLASH
+    TEST_ASSERT_EQUAL(0, strcmp(bd_type, "DATAFLASH"));
+#elif COMPONENT_SD
+    TEST_ASSERT_EQUAL(0, strcmp(bd_type, "SD"));
+#elif COMPONET_FLASHIAP
+    TEST_ASSERT_EQUAL(0, strcmp(bd_type, "FLASHIAP"));
+#endif
+
+}
+
 utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason)
 {
     greentea_case_failure_abort_handler(source, reason);
@@ -484,7 +508,8 @@ Case cases[] = {
     Case("Testing multi threads erase program read", test_multi_threads, greentea_failure_handler),
     Case("Testing contiguous erase, write and read", test_contiguous_erase_write_read, greentea_failure_handler),
     Case("Testing BlockDevice::get_erase_value()", test_get_erase_value, greentea_failure_handler),
-    Case("Testing program read small data sizes", test_program_read_small_data_sizes, greentea_failure_handler)
+    Case("Testing program read small data sizes", test_program_read_small_data_sizes, greentea_failure_handler),
+    Case("Testing get type functionality", test_get_type_functionality, greentea_failure_handler)
 };
 
 Specification specification(test_setup, cases);

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -473,7 +473,7 @@ void test_get_type_functionality()
         TEST_SKIP_MESSAGE("No block device component is defined for this target");
         return;
     }
-    const char * bd_type = block_device->get_type();
+    const char *bd_type = block_device->get_type();
     TEST_ASSERT_NOT_EQUAL(0, bd_type);
 
 #if COMPONENT_QSPIF

--- a/features/storage/TESTS/blockdevice/heap_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/heap_block_device/main.cpp
@@ -154,6 +154,19 @@ end:
 
 }
 
+void test_get_type_functionality()
+{
+    uint8_t *dummy = new (std::nothrow) uint8_t[TEST_BLOCK_DEVICE_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
+    HeapBlockDevice bd(TEST_BLOCK_DEVICE_SIZE, TEST_BLOCK_SIZE);
+
+    const char * bd_type = bd.get_type();
+    TEST_ASSERT_NOT_EQUAL(0, bd_type);
+    TEST_ASSERT_EQUAL(0, strcmp(bd_type, "HEAP"));
+}
+
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases)
@@ -164,6 +177,7 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 
 Case cases[] = {
     Case("Testing read write random blocks", test_read_write),
+    Case("Testing get type functionality", test_get_type_functionality)
 };
 
 Specification specification(test_setup, cases);

--- a/features/storage/TESTS/blockdevice/heap_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/heap_block_device/main.cpp
@@ -162,7 +162,7 @@ void test_get_type_functionality()
 
     HeapBlockDevice bd(TEST_BLOCK_DEVICE_SIZE, TEST_BLOCK_SIZE);
 
-    const char * bd_type = bd.get_type();
+    const char *bd_type = bd.get_type();
     TEST_ASSERT_NOT_EQUAL(0, bd_type);
     TEST_ASSERT_EQUAL(0, strcmp(bd_type, "HEAP"));
 }

--- a/features/storage/blockdevice/BlockDevice.h
+++ b/features/storage/blockdevice/BlockDevice.h
@@ -233,6 +233,12 @@ public:
                    (addr + size) % get_erase_size(addr + size - 1) == 0 &&
                    addr + size <= this->size());
     }
+
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type() = 0;
 };
 
 } // namespace mbed

--- a/features/storage/blockdevice/BlockDevice.h
+++ b/features/storage/blockdevice/BlockDevice.h
@@ -238,7 +238,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type() = 0;
+    virtual const char *get_type() = 0;
 };
 
 } // namespace mbed

--- a/features/storage/blockdevice/BlockDevice.h
+++ b/features/storage/blockdevice/BlockDevice.h
@@ -238,7 +238,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type() = 0;
+    virtual const char *get_type() const = 0;
 };
 
 } // namespace mbed

--- a/features/storage/blockdevice/BufferedBlockDevice.cpp
+++ b/features/storage/blockdevice/BufferedBlockDevice.cpp
@@ -330,4 +330,13 @@ bd_size_t BufferedBlockDevice::size() const
     return _bd_size;
 }
 
+const char * BufferedBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed

--- a/features/storage/blockdevice/BufferedBlockDevice.cpp
+++ b/features/storage/blockdevice/BufferedBlockDevice.cpp
@@ -330,7 +330,7 @@ bd_size_t BufferedBlockDevice::size() const
     return _bd_size;
 }
 
-const char * BufferedBlockDevice::get_type()
+const char *BufferedBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/BufferedBlockDevice.cpp
+++ b/features/storage/blockdevice/BufferedBlockDevice.cpp
@@ -330,7 +330,7 @@ bd_size_t BufferedBlockDevice::size() const
     return _bd_size;
 }
 
-const char *BufferedBlockDevice::get_type()
+const char *BufferedBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/BufferedBlockDevice.h
+++ b/features/storage/blockdevice/BufferedBlockDevice.h
@@ -152,6 +152,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 protected:
     BlockDevice *_bd;
     bd_size_t _bd_program_size;

--- a/features/storage/blockdevice/BufferedBlockDevice.h
+++ b/features/storage/blockdevice/BufferedBlockDevice.h
@@ -156,7 +156,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 protected:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/BufferedBlockDevice.h
+++ b/features/storage/blockdevice/BufferedBlockDevice.h
@@ -156,7 +156,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 protected:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ChainingBlockDevice.cpp
+++ b/features/storage/blockdevice/ChainingBlockDevice.cpp
@@ -283,4 +283,9 @@ bd_size_t ChainingBlockDevice::size() const
     return _size;
 }
 
+const char * ChainingBlockDevice::get_type()
+{
+    return "CHAINING";
+}
+
 } // namespace mbed

--- a/features/storage/blockdevice/ChainingBlockDevice.cpp
+++ b/features/storage/blockdevice/ChainingBlockDevice.cpp
@@ -283,7 +283,7 @@ bd_size_t ChainingBlockDevice::size() const
     return _size;
 }
 
-const char *ChainingBlockDevice::get_type()
+const char *ChainingBlockDevice::get_type() const
 {
     return "CHAINING";
 }

--- a/features/storage/blockdevice/ChainingBlockDevice.cpp
+++ b/features/storage/blockdevice/ChainingBlockDevice.cpp
@@ -283,7 +283,7 @@ bd_size_t ChainingBlockDevice::size() const
     return _size;
 }
 
-const char * ChainingBlockDevice::get_type()
+const char *ChainingBlockDevice::get_type()
 {
     return "CHAINING";
 }

--- a/features/storage/blockdevice/ChainingBlockDevice.h
+++ b/features/storage/blockdevice/ChainingBlockDevice.h
@@ -176,7 +176,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 protected:
     BlockDevice **_bds;

--- a/features/storage/blockdevice/ChainingBlockDevice.h
+++ b/features/storage/blockdevice/ChainingBlockDevice.h
@@ -176,7 +176,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 protected:
     BlockDevice **_bds;

--- a/features/storage/blockdevice/ChainingBlockDevice.h
+++ b/features/storage/blockdevice/ChainingBlockDevice.h
@@ -172,6 +172,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 protected:
     BlockDevice **_bds;
     size_t _bd_count;

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
@@ -194,4 +194,14 @@ bd_size_t ExhaustibleBlockDevice::size() const
     return _bd->size();
 }
 
+const char * ExhaustibleBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
@@ -194,7 +194,7 @@ bd_size_t ExhaustibleBlockDevice::size() const
     return _bd->size();
 }
 
-const char *ExhaustibleBlockDevice::get_type()
+const char *ExhaustibleBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
@@ -194,7 +194,7 @@ bd_size_t ExhaustibleBlockDevice::size() const
     return _bd->size();
 }
 
-const char * ExhaustibleBlockDevice::get_type()
+const char *ExhaustibleBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.h
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.h
@@ -154,6 +154,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     BlockDevice *_bd;
     uint32_t *_erase_array;

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.h
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.h
@@ -158,7 +158,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.h
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.h
@@ -158,7 +158,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/FlashSimBlockDevice.cpp
+++ b/features/storage/blockdevice/FlashSimBlockDevice.cpp
@@ -212,4 +212,14 @@ int FlashSimBlockDevice::get_erase_value() const
     return _erase_value;
 }
 
+const char * FlashSimBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/FlashSimBlockDevice.cpp
+++ b/features/storage/blockdevice/FlashSimBlockDevice.cpp
@@ -212,7 +212,7 @@ int FlashSimBlockDevice::get_erase_value() const
     return _erase_value;
 }
 
-const char *FlashSimBlockDevice::get_type()
+const char *FlashSimBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/FlashSimBlockDevice.cpp
+++ b/features/storage/blockdevice/FlashSimBlockDevice.cpp
@@ -212,7 +212,7 @@ int FlashSimBlockDevice::get_erase_value() const
     return _erase_value;
 }
 
-const char * FlashSimBlockDevice::get_type()
+const char *FlashSimBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/FlashSimBlockDevice.h
+++ b/features/storage/blockdevice/FlashSimBlockDevice.h
@@ -136,6 +136,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     uint8_t _erase_value;
     bd_size_t _blank_buf_size;

--- a/features/storage/blockdevice/FlashSimBlockDevice.h
+++ b/features/storage/blockdevice/FlashSimBlockDevice.h
@@ -140,7 +140,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     uint8_t _erase_value;

--- a/features/storage/blockdevice/FlashSimBlockDevice.h
+++ b/features/storage/blockdevice/FlashSimBlockDevice.h
@@ -140,7 +140,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     uint8_t _erase_value;

--- a/features/storage/blockdevice/HeapBlockDevice.cpp
+++ b/features/storage/blockdevice/HeapBlockDevice.cpp
@@ -183,7 +183,7 @@ int HeapBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     return 0;
 }
 
-const char *HeapBlockDevice::get_type()
+const char *HeapBlockDevice::get_type() const
 {
     return "HEAP";
 }

--- a/features/storage/blockdevice/HeapBlockDevice.cpp
+++ b/features/storage/blockdevice/HeapBlockDevice.cpp
@@ -183,7 +183,7 @@ int HeapBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     return 0;
 }
 
-const char * HeapBlockDevice::get_type()
+const char *HeapBlockDevice::get_type()
 {
     return "HEAP";
 }

--- a/features/storage/blockdevice/HeapBlockDevice.cpp
+++ b/features/storage/blockdevice/HeapBlockDevice.cpp
@@ -183,4 +183,10 @@ int HeapBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     return 0;
 }
 
+const char * HeapBlockDevice::get_type()
+{
+    return "HEAP";
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/HeapBlockDevice.h
+++ b/features/storage/blockdevice/HeapBlockDevice.h
@@ -154,7 +154,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     bd_size_t _read_size;

--- a/features/storage/blockdevice/HeapBlockDevice.h
+++ b/features/storage/blockdevice/HeapBlockDevice.h
@@ -150,6 +150,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     bd_size_t _read_size;
     bd_size_t _program_size;

--- a/features/storage/blockdevice/HeapBlockDevice.h
+++ b/features/storage/blockdevice/HeapBlockDevice.h
@@ -154,7 +154,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     bd_size_t _read_size;

--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -423,4 +423,14 @@ int MBRBlockDevice::get_partition_number() const
     return _part;
 }
 
+const char * MBRBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -423,7 +423,7 @@ int MBRBlockDevice::get_partition_number() const
     return _part;
 }
 
-const char * MBRBlockDevice::get_type()
+const char *MBRBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -423,7 +423,7 @@ int MBRBlockDevice::get_partition_number() const
     return _part;
 }
 
-const char *MBRBlockDevice::get_type()
+const char *MBRBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/MBRBlockDevice.h
+++ b/features/storage/blockdevice/MBRBlockDevice.h
@@ -249,6 +249,12 @@ public:
      */
     virtual int get_partition_number() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 protected:
     BlockDevice *_bd;
     bd_size_t _offset;

--- a/features/storage/blockdevice/MBRBlockDevice.h
+++ b/features/storage/blockdevice/MBRBlockDevice.h
@@ -253,7 +253,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 protected:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/MBRBlockDevice.h
+++ b/features/storage/blockdevice/MBRBlockDevice.h
@@ -253,7 +253,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 protected:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ObservingBlockDevice.cpp
+++ b/features/storage/blockdevice/ObservingBlockDevice.cpp
@@ -111,4 +111,14 @@ bd_size_t ObservingBlockDevice::size() const
     return _bd->size();
 }
 
+const char * ObservingBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/ObservingBlockDevice.cpp
+++ b/features/storage/blockdevice/ObservingBlockDevice.cpp
@@ -111,7 +111,7 @@ bd_size_t ObservingBlockDevice::size() const
     return _bd->size();
 }
 
-const char *ObservingBlockDevice::get_type()
+const char *ObservingBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ObservingBlockDevice.cpp
+++ b/features/storage/blockdevice/ObservingBlockDevice.cpp
@@ -111,7 +111,7 @@ bd_size_t ObservingBlockDevice::size() const
     return _bd->size();
 }
 
-const char * ObservingBlockDevice::get_type()
+const char *ObservingBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ObservingBlockDevice.h
+++ b/features/storage/blockdevice/ObservingBlockDevice.h
@@ -140,6 +140,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     BlockDevice *_bd;
     mbed::Callback<void(BlockDevice *)> _change;

--- a/features/storage/blockdevice/ObservingBlockDevice.h
+++ b/features/storage/blockdevice/ObservingBlockDevice.h
@@ -144,7 +144,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ObservingBlockDevice.h
+++ b/features/storage/blockdevice/ObservingBlockDevice.h
@@ -144,7 +144,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ProfilingBlockDevice.cpp
+++ b/features/storage/blockdevice/ProfilingBlockDevice.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "ProfilingBlockDevice.h"
+#include "stddef.h"
 
 namespace mbed {
 
@@ -120,4 +121,14 @@ bd_size_t ProfilingBlockDevice::get_erase_count() const
     return _erase_count;
 }
 
+const char * ProfilingBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/ProfilingBlockDevice.cpp
+++ b/features/storage/blockdevice/ProfilingBlockDevice.cpp
@@ -121,7 +121,7 @@ bd_size_t ProfilingBlockDevice::get_erase_count() const
     return _erase_count;
 }
 
-const char * ProfilingBlockDevice::get_type()
+const char *ProfilingBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ProfilingBlockDevice.cpp
+++ b/features/storage/blockdevice/ProfilingBlockDevice.cpp
@@ -121,7 +121,7 @@ bd_size_t ProfilingBlockDevice::get_erase_count() const
     return _erase_count;
 }
 
-const char *ProfilingBlockDevice::get_type()
+const char *ProfilingBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ProfilingBlockDevice.h
+++ b/features/storage/blockdevice/ProfilingBlockDevice.h
@@ -179,6 +179,12 @@ public:
      */
     bd_size_t get_erase_count() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     BlockDevice *_bd;
     bd_size_t _read_count;

--- a/features/storage/blockdevice/ProfilingBlockDevice.h
+++ b/features/storage/blockdevice/ProfilingBlockDevice.h
@@ -183,7 +183,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ProfilingBlockDevice.h
+++ b/features/storage/blockdevice/ProfilingBlockDevice.h
@@ -183,7 +183,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
@@ -101,6 +101,17 @@ bd_size_t ReadOnlyBlockDevice::size() const
     return _bd->size();
 }
 
+const char * ReadOnlyBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
 
 /** @}*/
+
+

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
@@ -101,7 +101,7 @@ bd_size_t ReadOnlyBlockDevice::size() const
     return _bd->size();
 }
 
-const char * ReadOnlyBlockDevice::get_type()
+const char *ReadOnlyBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
@@ -101,7 +101,7 @@ bd_size_t ReadOnlyBlockDevice::size() const
     return _bd->size();
 }
 
-const char *ReadOnlyBlockDevice::get_type()
+const char *ReadOnlyBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.h
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.h
@@ -133,6 +133,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 private:
     BlockDevice *_bd;
 };

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.h
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.h
@@ -137,7 +137,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.h
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.h
@@ -137,7 +137,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 private:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/SlicingBlockDevice.cpp
+++ b/features/storage/blockdevice/SlicingBlockDevice.cpp
@@ -16,8 +16,10 @@
 
 #include "SlicingBlockDevice.h"
 #include "platform/mbed_assert.h"
+#include "stddef.h"
 
 namespace mbed {
+
 
 SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t stop)
     : _bd(bd)
@@ -119,4 +121,14 @@ bd_size_t SlicingBlockDevice::size() const
     return _stop - _start;
 }
 
+const char * SlicingBlockDevice::get_type()
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
 } // namespace mbed
+

--- a/features/storage/blockdevice/SlicingBlockDevice.cpp
+++ b/features/storage/blockdevice/SlicingBlockDevice.cpp
@@ -121,7 +121,7 @@ bd_size_t SlicingBlockDevice::size() const
     return _stop - _start;
 }
 
-const char *SlicingBlockDevice::get_type()
+const char *SlicingBlockDevice::get_type() const
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/SlicingBlockDevice.cpp
+++ b/features/storage/blockdevice/SlicingBlockDevice.cpp
@@ -121,7 +121,7 @@ bd_size_t SlicingBlockDevice::size() const
     return _stop - _start;
 }
 
-const char * SlicingBlockDevice::get_type()
+const char *SlicingBlockDevice::get_type()
 {
     if (_bd != NULL) {
         return _bd->get_type();

--- a/features/storage/blockdevice/SlicingBlockDevice.h
+++ b/features/storage/blockdevice/SlicingBlockDevice.h
@@ -163,6 +163,12 @@ public:
      */
     virtual bd_size_t size() const;
 
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char * get_type();
+
 protected:
     BlockDevice *_bd;
     bool _start_from_end;

--- a/features/storage/blockdevice/SlicingBlockDevice.h
+++ b/features/storage/blockdevice/SlicingBlockDevice.h
@@ -167,7 +167,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char * get_type();
+    virtual const char *get_type();
 
 protected:
     BlockDevice *_bd;

--- a/features/storage/blockdevice/SlicingBlockDevice.h
+++ b/features/storage/blockdevice/SlicingBlockDevice.h
@@ -167,7 +167,7 @@ public:
      *
      *  @return         A string represent the BlockDevice class type.
      */
-    virtual const char *get_type();
+    virtual const char *get_type() const;
 
 protected:
     BlockDevice *_bd;

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -24,6 +24,7 @@
 #include "mbed_error.h"
 #include "mbed_wait_api.h"
 #include "MbedCRC.h"
+#include "SystemStorage.h"
 
 using namespace mbed;
 
@@ -952,11 +953,19 @@ int TDBStore::init()
     uint32_t actual_data_size;
     int os_ret, ret = MBED_SUCCESS, reserved_ret;
     uint16_t versions[_num_areas];
+    internal_mem_resident_type_e out_in_mem_res;
 
     _mutex.lock();
 
     if (_is_initialized) {
         goto end;
+    }
+
+    //Check if we are on internal memory && try to set the internal memory for TDBStore use.
+    if (strcmp(_bd->get_type(), "FLASHIAP")==0 &&
+            set_internal_storage_ownership(TDBSTORE, &out_in_mem_res) == MBED_ERROR_ALREADY_INITIALIZED) {
+
+        MBED_ERROR(MBED_ERROR_ALREADY_INITIALIZED, "TDBStore in internal memory can not be initialize when NVStore is in use");
     }
 
     _max_keys = initial_max_keys;

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -953,7 +953,6 @@ int TDBStore::init()
     uint32_t actual_data_size;
     int os_ret, ret = MBED_SUCCESS, reserved_ret;
     uint16_t versions[_num_areas];
-    internal_mem_resident_type_e out_in_mem_res;
 
     _mutex.lock();
 
@@ -962,8 +961,8 @@ int TDBStore::init()
     }
 
     //Check if we are on internal memory && try to set the internal memory for TDBStore use.
-    if (strcmp(_bd->get_type(), "FLASHIAP")==0 &&
-            set_internal_storage_ownership(TDBSTORE, &out_in_mem_res) == MBED_ERROR_ALREADY_INITIALIZED) {
+    if (strcmp(_bd->get_type(), "FLASHIAP") == 0 &&
+            avoid_conflict_nvstore_tdbstore(TDBSTORE) == MBED_ERROR_ALREADY_INITIALIZED) {
 
         MBED_ERROR(MBED_ERROR_ALREADY_INITIALIZED, "TDBStore in internal memory can not be initialize when NVStore is in use");
     }

--- a/features/storage/nvstore/source/nvstore.cpp
+++ b/features/storage/nvstore/source/nvstore.cpp
@@ -21,8 +21,10 @@
 #if NVSTORE_ENABLED
 
 #include "FlashIAP.h"
+#include "SystemStorage.h"
 #include "mbed_critical.h"
 #include "mbed_assert.h"
+#include "mbed_error.h"
 #include "mbed_wait_api.h"
 #include <algorithm>
 #include <string.h>
@@ -849,10 +851,17 @@ int NVStore::init()
     uint16_t keys[NVSTORE_NUM_AREAS];
     uint16_t actual_size;
     uint8_t owner;
+    internal_mem_resident_type_e out_in_mem_res;
 
     if (_init_done) {
         return NVSTORE_SUCCESS;
     }
+
+    //Check if we are on internal memory && try to set the internal memory for TDBStore use.
+    ret = set_internal_storage_ownership(NVSTORE, &out_in_mem_res);
+    //NVstore in internal memory can not be initialize when TDBStore is in use
+    MBED_ASSERT(ret != MBED_ERROR_ALREADY_INITIALIZED);
+
 
     // This handles the case that init function is called by more than one thread concurrently.
     // Only the one who gets the value of 1 in _init_attempts_val will proceed, while others will

--- a/features/storage/nvstore/source/nvstore.cpp
+++ b/features/storage/nvstore/source/nvstore.cpp
@@ -851,14 +851,13 @@ int NVStore::init()
     uint16_t keys[NVSTORE_NUM_AREAS];
     uint16_t actual_size;
     uint8_t owner;
-    internal_mem_resident_type_e out_in_mem_res;
 
     if (_init_done) {
         return NVSTORE_SUCCESS;
     }
 
     //Check if we are on internal memory && try to set the internal memory for TDBStore use.
-    ret = set_internal_storage_ownership(NVSTORE, &out_in_mem_res);
+    ret = avoid_conflict_nvstore_tdbstore(NVSTORE);
     //NVstore in internal memory can not be initialize when TDBStore is in use
     MBED_ASSERT(ret != MBED_ERROR_ALREADY_INITIALIZED);
 

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -43,27 +43,27 @@
 
 using namespace mbed;
 
-static internal_mem_resident_type_e internal_memory_residency = NONE;
-static SingletonPtr<PlatformMutex> system_storage_mutex;
 
-MBED_WEAK int set_internal_storage_ownership(internal_mem_resident_type_e in_mem_res, internal_mem_resident_type_e *out_mem_res)
+
+MBED_WEAK int avoid_conflict_nvstore_tdbstore(owner_type_e in_mem_owner)
 {
     int status = MBED_SUCCESS;
+    static PlatformMutex _mutex;
+    static owner_type_e internal_memory_owner = NONE;
 
-    system_storage_mutex->lock();
+    _mutex.lock();
 
-    if (internal_memory_residency != NONE &&
-            internal_memory_residency != in_mem_res) {
+    if (internal_memory_owner != NONE &&
+            internal_memory_owner != in_mem_owner) {
 
         status = MBED_ERROR_ALREADY_INITIALIZED;
 
     } else {
 
-        internal_memory_residency = in_mem_res;
+        internal_memory_owner = in_mem_owner;
     }
 
-    *out_mem_res = internal_memory_residency;
-    system_storage_mutex->unlock();
+    _mutex.unlock();
 
     return status;
 }

--- a/features/storage/system_storage/SystemStorage.h
+++ b/features/storage/system_storage/SystemStorage.h
@@ -22,16 +22,15 @@ typedef enum {
     NONE        = 0,
     NVSTORE,
     TDBSTORE
-} internal_mem_resident_type_e;
+} owner_type_e;
 
 /**
  * @brief Try to get an ownership for the internal flash memory storage type.
  *        KVSTORE or NVSTORE is the current option and once the ownership is taken by one
  *        second one can not be initialize.
- * @param[in] in_mem_res       Enum parameter to specify NVSTORE or KVSTORE as the storage owner
- * @param[in] out_mem_res      Enum parameter which specify who is the current owner of the storage.
+ * @param[in] in_mem_owner     Enum parameter to specify NVSTORE or KVSTORE as the storage owner
  * @returns                    MBED_SUCCESS if succeeded or MBED_ERROR_ALREADY_INITIALIZED if fails.
  */
-int set_internal_storage_ownership(internal_mem_resident_type_e in_mem_res, internal_mem_resident_type_e *out_mem_res);
+int avoid_conflict_nvstore_tdbstore(owner_type_e in_mem_owner);
 
 #endif

--- a/features/storage/system_storage/SystemStorage.h
+++ b/features/storage/system_storage/SystemStorage.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_SYSTEM_STORAGE_H
+#define MBED_SYSTEM_STORAGE_H
+
+#include "mbed_error.h"
+
+typedef enum {
+    NONE        = 0,
+    NVSTORE,
+    TDBSTORE
+} internal_mem_resident_type_e;
+
+/**
+ * @brief Try to get an ownership for the internal flash memory storage type.
+ *        KVSTORE or NVSTORE is the current option and once the ownership is taken by one
+ *        second one can not be initialize.
+ * @param[in] in_mem_res       Enum parameter to specify NVSTORE or KVSTORE as the storage owner
+ * @param[in] out_mem_res      Enum parameter which specify who is the current owner of the storage.
+ * @returns                    MBED_SUCCESS if succeeded or MBED_ERROR_ALREADY_INITIALIZED if fails.
+ */
+int set_internal_storage_ownership(internal_mem_resident_type_e in_mem_res, internal_mem_resident_type_e *out_mem_res);
+
+#endif


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
TDBStore and NVStore usually use the same flash address for storage and therefore should not be instantiated simultaneously in the same process.
This PR adds a checkup for NVStore and TDBStore to create a runtime error in case that both of them co-exist in the same application.

This PR is dependent on #9135 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

