### PR TITLE
Fix BLE long write execution failure

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF51/source/nRF5xGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF51/source/nRF5xGattServer.cpp
@@ -664,6 +664,7 @@ void nRF5xGattServer::hwCallback(const ble_evt_t *p_ble_evt)
                                                                            * set to AUTH_CALLBACK_REPLY_SUCCESS if the client
                                                                            * request is to proceed. */
                     };
+                    characteristicIndex = resolveValueHandleToCharIndex(req->attr_handle);
                     uint16_t write_authorization = p_characteristics[characteristicIndex]->authorizeWrite(&cbParams);
 
                     // the user code didn't provide the write authorization,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xGattServer.cpp
@@ -670,6 +670,7 @@ void nRF5xGattServer::hwCallback(const ble_evt_t *p_ble_evt)
                                                                            * set to AUTH_CALLBACK_REPLY_SUCCESS if the client
                                                                            * request is to proceed. */
                     };
+                    characteristicIndex = resolveValueHandleToCharIndex(req->attr_handle);
                     uint16_t write_authorization = p_characteristics[characteristicIndex]->authorizeWrite(&cbParams);
 
                     // the user code didn't provide the write authorization,


### PR DESCRIPTION
### Description

In function nRF5xGattServer::hwCallback(), case BLE_GATTS_OP_EXEC_WRITE_REQ_NOW, the value of variable characteristicIndex is -1 so that causes an exception. 
 
The reason is that the handle_value is retrieved from Execute Write Request, but in spec there is no attribute handle field for this command, I believe this attribute handle should be retrieved from previous Prepare Write Request, in our code, it’s req->attr_handle. 

There is one issue (#8548) regarding this fix.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

