### PR TITLE
EventQueue: Old pointers of sibling were not cleared

### DIFF
--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -239,8 +239,8 @@ static int equeue_enqueue(equeue_t *q, struct equeue_event *e, unsigned tick)
         if (e->next) {
             e->next->ref = &e->next;
         }
-
         e->sibling = *p;
+        e->sibling->next = 0;
         e->sibling->ref = &e->sibling;
     } else {
         e->next = *p;

--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -114,7 +114,7 @@ void equeue_destroy(equeue_t *q)
             }
         }
         if (es->dtor) {
-                es->dtor(es + 1);
+            es->dtor(es + 1);
         }
     }
     // notify background timer

--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -108,13 +108,15 @@ void equeue_destroy(equeue_t *q)
 {
     // call destructors on pending events
     for (struct equeue_event *es = q->queue; es; es = es->next) {
-        for (struct equeue_event *e = q->queue; e; e = e->sibling) {
+        for (struct equeue_event *e = es->sibling; e; e = e->sibling) {
             if (e->dtor) {
                 e->dtor(e + 1);
             }
         }
+        if (es->dtor) {
+                es->dtor(es + 1);
+        }
     }
-
     // notify background timer
     if (q->background.update) {
         q->background.update(q->background.timer, -1);


### PR DESCRIPTION
### Description

When adding sibling at the head of linked list, the head if pointing to something in linked list was not updated, hence a loop was formed in linked list

Element0 - First addition to linked list
Element1 - Has higher delay hence added to back
0 ->(next) 1
Element2 - Delay is same as Element0, hence should be sibling of 0, shall be added at head

Expected:
2    ------------->(next) 1
|(sibling)
0

Bug: (Resolved with this)
2    ------------->(next) 1
|(sibling)
0    ------------->(next) 1

If we add more elements and next pointer of sibling is updated, old references will cause issues
Element3 added

Expected:
2    ------------->(next) 3  ------------->(next) 1
|(sibling)
0

Bug: (Resolved with this)
2    ------------->(next) 3  ------------->(next) 1
|(sibling)
0    ------------->(next) 1
***Both siblings here point to different next***

Resolves: https://github.com/ARMmbed/mbed-os/issues/8664

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

