### PR TITLE
Fix FLASHIAP_ROM_END macro for GCC_ARM & IAR toolchains

### DIFF
--- a/TESTS/mbed_drivers/flashiap/main.cpp
+++ b/TESTS/mbed_drivers/flashiap/main.cpp
@@ -59,8 +59,8 @@ void flashiap_program_test()
     // the one before the last sector in the system
     uint32_t address = (flash_device.get_flash_start() + flash_device.get_flash_size()) - (sector_size);
     TEST_ASSERT_TRUE(address != 0UL);
-    utest_printf("ROM ends at 0x%lx, test starts at 0x%lx\n", FLASHIAP_ROM_END, address);
-    TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_ROM_END, "Test skipped. Test region overlaps code.");
+    utest_printf("ROM ends at 0x%lx, test starts at 0x%lx\n", FLASHIAP_APP_ROM_END_ADDR, address);
+    TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_APP_ROM_END_ADDR, "Test skipped. Test region overlaps code.");
 
     ret = flash_device.erase(address, sector_size);
     TEST_ASSERT_EQUAL_INT32(0, ret);
@@ -128,7 +128,7 @@ void flashiap_cross_sector_program_test()
         agg_size += sector_size;
         address -= sector_size;
     }
-    TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_ROM_END, "Test skipped. Test region overlaps code.");
+    TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_APP_ROM_END_ADDR, "Test skipped. Test region overlaps code.");
     ret = flash_device.erase(address, agg_size);
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
@@ -184,7 +184,7 @@ void flashiap_program_error_test()
     TEST_ASSERT_TRUE(address != 0UL);
 
     // unaligned address
-    TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_ROM_END, "Test skipped. Test region overlaps code.");
+    TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_APP_ROM_END_ADDR, "Test skipped. Test region overlaps code.");
     ret = flash_device.erase(address + 1, sector_size);
     TEST_ASSERT_EQUAL_INT32(-1, ret);
     if (flash_device.get_page_size() > 1) {

--- a/drivers/FlashIAP.h
+++ b/drivers/FlashIAP.h
@@ -33,14 +33,18 @@
 // Export ROM end address
 #if defined(TOOLCHAIN_GCC_ARM)
 extern uint32_t __etext;
-#define FLASHIAP_ROM_END ((uint32_t) &__etext)
+extern uint32_t __data_start__;
+extern uint32_t __data_end__;
+#define FLASHIAP_APP_ROM_END_ADDR (((uint32_t) &__etext) + ((uint32_t) &__data_end__) - ((uint32_t) &__data_start__))
 #elif defined(TOOLCHAIN_ARM)
 extern uint32_t Load$$LR$$LR_IROM1$$Limit[];
-#define FLASHIAP_ROM_END ((uint32_t)Load$$LR$$LR_IROM1$$Limit)
+#define FLASHIAP_APP_ROM_END_ADDR ((uint32_t)Load$$LR$$LR_IROM1$$Limit)
 #elif defined(TOOLCHAIN_IAR)
 #pragma section=".rodata"
 #pragma section=".text"
-#define FLASHIAP_ROM_END (std::max((uint32_t) __section_end(".rodata"), (uint32_t) __section_end(".text")))
+#pragma section=".init_array"
+#define FLASHIAP_APP_ROM_END_ADDR std::max(std::max((uint32_t) __section_end(".rodata"), (uint32_t) __section_end(".text")), \
+                                  (uint32_t) __section_end(".init_array"))
 #endif
 
 namespace mbed {

--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -264,7 +264,7 @@ BlockDevice *_get_blockdevice_FLASHIAP(bd_addr_t start_address, bd_size_t size)
     }
 
     //Get flash parameters before starting
-    flash_first_writable_sector_address = align_up(FLASHIAP_ROM_END, flash.get_sector_size(FLASHIAP_ROM_END));
+    flash_first_writable_sector_address = align_up(FLASHIAP_APP_ROM_END_ADDR, flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR));
     flash_start_address = flash.get_flash_start();
     flash_end_address = flash_start_address + flash.get_flash_size();;
 
@@ -551,7 +551,7 @@ int _storage_config_TDB_INTERNAL()
         if (flash.init() != 0) {
             return MBED_ERROR_FAILED_OPERATION;
         }
-        internal_start_address = align_up(FLASHIAP_ROM_END, flash.get_sector_size(FLASHIAP_ROM_END));
+        internal_start_address = align_up(FLASHIAP_APP_ROM_END_ADDR, flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR));
         flash.deinit();
     }
 

--- a/features/storage/nvstore/TESTS/nvstore/functionality/main.cpp
+++ b/features/storage/nvstore/TESTS/nvstore/functionality/main.cpp
@@ -88,7 +88,7 @@ static void nvstore_basic_functionality_test()
         size_t area_size;
         nvstore.get_area_params(area, area_address, area_size);
         printf("Area %d: address 0x%08lx, size %d (0x%x)\n", area, area_address, area_size, area_size);
-        if (area_address < FLASHIAP_ROM_END) {
+        if (area_address < FLASHIAP_APP_ROM_END_ADDR) {
             nvstore_overlaps_code = true;
         }
         TEST_SKIP_UNLESS_MESSAGE(!nvstore_overlaps_code, "Test skipped. NVStore region overlaps code.");

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -116,7 +116,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
     }
 
     //Find the start of first sector after text area
-    bottom_address = align_up(FLASHIAP_ROM_END, flash.get_sector_size(FLASHIAP_ROM_END));
+    bottom_address = align_up(FLASHIAP_APP_ROM_END_ADDR, flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR));
     start_address = flash.get_flash_start();
     flash_size = flash.get_flash_size();
 


### PR DESCRIPTION
### Description
- Consider `data` section in GCC_ARM toolchain
- Consider `init_array` section in IAR toolchain
- Rename macro to `FLASHIAP_APP_ROM_END_ADDR` for clarity sake

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

