### PR TITLE
Check correct ARMC6 predefine for FP codegen

### DIFF
--- a/cmsis/TARGET_CORTEX_A/core_ca.h
+++ b/cmsis/TARGET_CORTEX_A/core_ca.h
@@ -59,7 +59,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else

--- a/cmsis/TARGET_CORTEX_M/core_armv8mbl.h
+++ b/cmsis/TARGET_CORTEX_M/core_armv8mbl.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_armv8mml.h
+++ b/cmsis/TARGET_CORTEX_M/core_armv8mml.h
@@ -97,7 +97,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else

--- a/cmsis/TARGET_CORTEX_M/core_cm0.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm0.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_cm0plus.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm0plus.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_cm1.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm1.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_cm23.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm23.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_cm3.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm3.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_cm33.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm33.h
@@ -97,7 +97,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined (__ARM_PCS_VFP)
+  #if defined (__ARM_FP)
     #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else

--- a/cmsis/TARGET_CORTEX_M/core_cm4.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm4.h
@@ -86,7 +86,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else

--- a/cmsis/TARGET_CORTEX_M/core_cm7.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm7.h
@@ -86,7 +86,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
       #define __FPU_USED       1U
     #else

--- a/cmsis/TARGET_CORTEX_M/core_sc000.h
+++ b/cmsis/TARGET_CORTEX_M/core_sc000.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 

--- a/cmsis/TARGET_CORTEX_M/core_sc300.h
+++ b/cmsis/TARGET_CORTEX_M/core_sc300.h
@@ -81,7 +81,7 @@
   #endif
 
 #elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_PCS_VFP
+  #if defined __ARM_FP
     #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
   #endif
 


### PR DESCRIPTION

### Description

For ARMC6, CMSIS headers were checking the `__ARM_PCS_VFP`, which indicates hardfp ABI in use, when they need to check whether FP code generation is enabled. Change this to `__ARM_FP`, so it works for platforms using softfp ABI.

Change already present in CMSIS_5 repo, via commit https://github.com/ARM-software/CMSIS_5/commit/969822ae162539d50617d1e5a3634ee2fd3b60f6, but redone with local search-and-replace.

Resolves #9142

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

