### PR TITLE
Cellular: fix state machine to check network attach

### DIFF
--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -185,7 +185,7 @@ private:
     bool _is_retry;
     cell_callback_data_t _cb_data;
     nsapi_event_t _current_event;
-    bool _active_context; // Is there any active context?
+    int _network_status; // Is there any active context or is modem attached to a network?
     PlatformMutex _mutex;
 };
 


### PR DESCRIPTION
### Description

Added check to state machine that if modem is attached to a network it is considered to be registered to a network and state machine can continue to next states. This fixes issues seen in IoT network
that network does not allow registering if already attached.

@AriParkkila @mirelachirica  please review.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

