### PR TITLE
Give the app space to grow in internal KVStore default configuration

### DIFF
--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -547,6 +547,27 @@ int _storage_config_TDB_INTERNAL()
             return MBED_ERROR_FAILED_OPERATION;
         }
         internal_start_address = align_up(FLASHIAP_APP_ROM_END_ADDR, flash.get_sector_size(FLASHIAP_APP_ROM_END_ADDR));
+
+        // Give the application a couple of spare sectors to grow (if there are such)
+        bd_size_t spare_size_for_app = 0;
+        bd_addr_t curr_addr = internal_start_address;
+        bd_addr_t flash_end_address = flash.get_flash_start() + flash.get_flash_size();
+
+        int spare_sectors_for_app = 2;
+        int min_sectors_for_storage = 2;
+        for (int i = 0; i < spare_sectors_for_app + min_sectors_for_storage - 1; i++) {
+            bd_size_t sector_size = flash.get_sector_size(curr_addr);
+            curr_addr += sector_size;
+            if (curr_addr >= flash_end_address) {
+                spare_size_for_app = 0;
+                break;
+            }
+            if (i < spare_sectors_for_app) {
+                spare_size_for_app += sector_size;
+            }
+        }
+        internal_start_address += spare_size_for_app;
+
         flash.deinit();
     }
 


### PR DESCRIPTION
### Description

Prior to this change, the space left for the internal TDBStore (when working in the default internal configuration) was allocated from the sector following the end of the application until the end of flash. While this worked, it was problematic if the application would have crossed the sector boundary after an update. This PR leaves the application a couple of sectors to grow at the expense of the allocated storage (if they are available, which is the likely case).

This PR is defined as a breaking change, even if not a typical one: Boards that use the default internal configuration will lose the storage content after the upgrade (as the internal storage start will move forwards). Two boards will be affected: K66F and FUTURE_SEQUANA_M0_PSA. Non default configurations won't be harmed.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [x] Breaking change

