### PR TITLE
Fix LTO build failures due to duplicate local types

### DIFF
--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -50,6 +50,8 @@
 #define RFF_TX 0x04
 #define RFF_CCA 0x08
 
+namespace {
+
 typedef enum {
     RF_MODE_NORMAL = 0,
     RF_MODE_SNIFFER = 1,
@@ -81,6 +83,8 @@ typedef enum {
     TX_ARET_ON = 0x19,
     STATE_TRANSITION_IN_PROGRESS = 0x1F
 } rf_trx_states_t;
+
+} // anonymous namespace
 
 static const uint8_t *rf_tx_data; // Points to Nanostack's buffer
 static uint8_t rf_tx_length;

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
@@ -65,6 +65,8 @@ extern "C" {
 #define gXcvrLowPowerState_d  gXcvrPwrAutodoze_c
 #endif
 
+namespace {
+
 /* MCR20A XCVR states */
 typedef enum xcvrState_tag {
     gIdle_c,
@@ -105,6 +107,8 @@ typedef enum {
     RX_AACK_ON = 0x16,
     TX_ARET_ON = 0x19
 } rf_trx_states_t;
+
+} // anonymous namespace
 
 /*RF receive buffer*/
 static uint8_t rf_buffer[RF_BUFFER_SIZE];

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -39,6 +39,8 @@ static const uint32_t supported_flags = mbed::KVStore::WRITE_ONCE_FLAG;
 
 using namespace mbed;
 
+namespace {
+
 // incremental set handle
 typedef struct {
     char *key;
@@ -52,6 +54,8 @@ typedef struct {
     void *dir_handle;
     char *prefix;
 } key_iterator_handle_t;
+
+} // anonymous namespace
 
 // Local Functions
 static char *string_ndup(const char *src, size_t size);

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -48,6 +48,8 @@ static const char *const auth_prefix = "AUTH";
 
 static const uint32_t security_flags = KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG;
 
+namespace {
+
 typedef struct {
     uint16_t metadata_size;
     uint16_t revision;
@@ -71,6 +73,8 @@ typedef struct {
 typedef struct {
     KVStore::iterator_t underlying_it;
 } key_iterator_handle_t;
+
+} // anonymous namespace
 
 
 // -------------------------------------------------- Local Functions Declaration ----------------------------------------------------

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -33,6 +33,8 @@ static const uint32_t delete_flag = (1UL << 31);
 static const uint32_t internal_flags = delete_flag;
 static const uint32_t supported_flags = KVStore::WRITE_ONCE_FLAG;
 
+namespace {
+
 typedef struct {
     uint32_t magic;
     uint16_t header_size;
@@ -92,6 +94,8 @@ typedef struct {
     uint32_t ram_table_ind;
     char *prefix;
 } key_iterator_handle_t;
+
+} // anonymous namespace
 
 
 // -------------------------------------------------- Local Functions Declaration ----------------------------------------------------

--- a/features/storage/nvstore/source/nvstore.cpp
+++ b/features/storage/nvstore/source/nvstore.cpp
@@ -30,6 +30,8 @@
 
 // --------------------------------------------------------- Definitions ----------------------------------------------------------
 
+namespace {
+
 static const uint16_t delete_item_flag = 0x8000;
 static const uint16_t set_once_flag    = 0x4000;
 static const uint16_t header_flag_mask = 0xF000;
@@ -72,6 +74,17 @@ static const int num_write_retries = 16;
 
 static const uint8_t blank_flash_val = 0xFF;
 
+typedef enum {
+    NVSTORE_AREA_STATE_NONE = 0,
+    NVSTORE_AREA_STATE_EMPTY,
+    NVSTORE_AREA_STATE_VALID,
+} area_state_e;
+
+static const uint32_t initial_crc = 0xFFFFFFFF;
+
+} // anonymous namespace
+
+
 // See whether any of these defines are given (by config files)
 // If so, this means that that area configuration is given by the user
 #if defined(NVSTORE_AREA_1_ADDRESS) || defined(NVSTORE_AREA_1_SIZE) ||\
@@ -94,15 +107,6 @@ NVStore::nvstore_area_data_t NVStore::initial_area_params[] = {{0, 0},
     {0, 0}
 };
 #endif
-
-typedef enum {
-    NVSTORE_AREA_STATE_NONE = 0,
-    NVSTORE_AREA_STATE_EMPTY,
-    NVSTORE_AREA_STATE_VALID,
-} area_state_e;
-
-static const uint32_t initial_crc = 0xFFFFFFFF;
-
 
 // -------------------------------------------------- Local Functions Declaration ----------------------------------------------------
 


### PR DESCRIPTION
### Description

This PR fixes failures in build when using LTO (Link Time Optimizations) in the GCC_ARM toolchain. Failures are caused by local types having similar names and different content (like structures with similar names and different fields). Solution is achieved by wrapping these types with the anonymous namespace.

Resolves [#9099](https://github.com/ARMmbed/mbed-os/issues/9099).

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

