### PR TITLE
Don't use define checks on DEVICE_FOO macros (partner code)

### DIFF
--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/flash_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/flash_api.c
@@ -38,7 +38,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#ifdef DEVICE_FLASH
+#if DEVICE_FLASH
 #include "flash_api.h"
 #include "flash_data.h"
 #include "mbed_critical.h"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_irq_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_irq_api.c
@@ -43,7 +43,7 @@
 #include "adi_gpio_def.h"
 #include "ADuCM302x_device.h"
 
-#ifdef DEVICE_INTERRUPTIN
+#if DEVICE_INTERRUPTIN
 
 #define MAX_GPIO_LINES    16
 #define MAX_GPIO_PORTS    ADI_GPIO_NUM_PORTS
@@ -327,4 +327,4 @@ void gpio_irq_disable(gpio_irq_t *obj)
     channel_ids[port][pin_num].int_enable = 0;
 }
 
-#endif 	// #ifdef DEVICE_INTERRUPTIN
+#endif 	// #if DEVICE_INTERRUPTIN

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/sleep.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/sleep.c
@@ -40,7 +40,7 @@
 
 #include "sleep_api.h"
 
-#ifdef DEVICE_SLEEP
+#if DEVICE_SLEEP
 
 #include "adi_pwr.h"
 #include "adi_pwr_def.h"
@@ -218,4 +218,4 @@ void hal_deepsleep(void)
     pADI_CLKG0_CLK->CTL5 = 0;
 }
 
-#endif  // #ifdef DEVICE_SLEEP
+#endif  // #if DEVICE_SLEEP

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/trng_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/trng_api.c
@@ -38,7 +38,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include <drivers/rng/adi_rng.h>

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/flash_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/flash_api.c
@@ -38,7 +38,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#ifdef DEVICE_FLASH
+#if DEVICE_FLASH
 #include "flash_api.h"
 #include "flash_data.h"
 #include "mbed_critical.h"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_irq_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_irq_api.c
@@ -42,7 +42,7 @@
 #include "adi_gpio.h"
 #include "adi_gpio_def.h"
 
-#ifdef DEVICE_INTERRUPTIN
+#if DEVICE_INTERRUPTIN
 
 #define MAX_GPIO_LINES    16
 #define MAX_GPIO_PORTS    ADI_GPIO_NUM_PORTS
@@ -326,4 +326,4 @@ void gpio_irq_disable(gpio_irq_t *obj)
     channel_ids[port][pin_num].int_enable = 0;
 }
 
-#endif	// #ifdef DEVICE_INTERRUPTIN
+#endif	// #if DEVICE_INTERRUPTIN

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/sleep.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/sleep.c
@@ -40,7 +40,7 @@
 
 #include "sleep_api.h"
 
-#ifdef DEVICE_SLEEP
+#if DEVICE_SLEEP
 
 #include "adi_pwr.h"
 #include "adi_pwr_def.h"
@@ -253,4 +253,4 @@ void hal_deepsleep(void)
     pADI_CLKG0_CLK->CTL5 = 0;
 }
 
-#endif  // #ifdef DEVICE_SLEEP
+#endif  // #if DEVICE_SLEEP

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/trng_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/trng_api.c
@@ -38,7 +38,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include <adi_rng.h>

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/serial_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/serial_api.c
@@ -503,7 +503,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     enable_usart(obj);
 }
 
-#ifdef DEVICE_SERIAL_FC
+#if DEVICE_SERIAL_FC
 
 void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, PinName txflow)
 {

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/serial_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/serial_api.c
@@ -283,7 +283,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     sysclk_enable_peripheral_clock(clockid);
 }
 
-#ifdef DEVICE_SERIAL_FC
+#if DEVICE_SERIAL_FC
 
 void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, PinName txflow)
 {

--- a/targets/TARGET_Cypress/TARGET_PSOC6/PeripheralPins.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/PeripheralPins.h
@@ -34,7 +34,7 @@ extern const PinMap PinMap_PWM_OUT[];
 #endif
 
 //*** SERIAL ***
-#ifdef DEVICE_SERIAL
+#if DEVICE_SERIAL
 extern const PinMap PinMap_UART_TX[];
 extern const PinMap PinMap_UART_RX[];
 extern const PinMap PinMap_UART_RTS[];
@@ -42,7 +42,7 @@ extern const PinMap PinMap_UART_CTS[];
 #endif
 
 //*** SPI ***
-#ifdef DEVICE_SPI
+#if DEVICE_SPI
 extern const PinMap PinMap_SPI_MOSI[];
 extern const PinMap PinMap_SPI_MISO[];
 extern const PinMap PinMap_SPI_SCLK[];
@@ -50,12 +50,12 @@ extern const PinMap PinMap_SPI_SSEL[];
 #endif
 
 //*** ADC ***
-#ifdef DEVICE_ANALOGIN
+#if DEVICE_ANALOGIN
 extern const PinMap PinMap_ADC[];
 #endif
 
 //*** DAC ***
-#ifdef DEVICE_ANALOGOUT
+#if DEVICE_ANALOGOUT
 extern const PinMap PinMap_DAC[];
 #endif
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/objects.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/objects.h
@@ -185,7 +185,7 @@ struct pwmout_s {
 };
 #endif // DEVICE_PWMOUT
 
-#ifdef DEVICE_ANALOGIN
+#if DEVICE_ANALOGIN
 #include "cy_sar.h"
 
 struct analogin_s {
@@ -196,7 +196,7 @@ struct analogin_s {
 };
 #endif // DEVICE_ANALOGIN
 
-#ifdef DEVICE_ANALOGOUT
+#if DEVICE_ANALOGOUT
 #include "cy_ctdac.h"
 
 struct dac_s {
@@ -206,7 +206,7 @@ struct dac_s {
 };
 #endif // DEVICE_ANALOGOUT
 
-#ifdef DEVICE_FLASH
+#if DEVICE_FLASH
 struct flash_s {
     /*  nothing to be stored for now */
     void *dummy;

--- a/targets/TARGET_Cypress/TARGET_PSOC6/sleep_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/sleep_api.c
@@ -19,7 +19,7 @@
 #include "device.h"
 #include "cy_syspm.h"
 
-#ifdef DEVICE_SLEEP
+#if DEVICE_SLEEP
 
 void hal_sleep(void)
 {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/trng_api.c
@@ -22,7 +22,7 @@
  * Reference: "K66 Sub-Family Reference Manual, Rev. 2", chapter 38
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include "cmsis.h"

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/trng_api.c
@@ -18,7 +18,7 @@
  *
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include "cmsis.h"

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/trng_api.c
@@ -22,7 +22,7 @@
  * Reference: "MKW41Z/31Z/21Z Reference Manual", chapter 43
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include "fsl_trng.h"
 #include "trng_api.h"

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/trng_api.c
@@ -18,7 +18,7 @@
  *
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include "cmsis.h"

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/trng_api.c
@@ -18,7 +18,7 @@
  *
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include "cmsis.h"

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/mbed_crc_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/mbed_crc_api.c
@@ -18,7 +18,7 @@
 #include "drivers/fsl_crc.h"
 #include "platform/mbed_assert.h"
 
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
 
 static crc_bits_t width;
 static uint32_t final_xor;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/trng_api.c
@@ -22,7 +22,7 @@
  * Reference: "K64 Sub-Family Reference Manual, Rev. 2", chapter 34
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include "cmsis.h"

--- a/targets/TARGET_GigaDevice/TARGET_GD32F30X/PeripheralPins.h
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F30X/PeripheralPins.h
@@ -27,12 +27,12 @@ extern const int GD_GPIO_MODE[];
 extern const int GD_GPIO_SPEED[];
 
 /* ADC */
-#ifdef DEVICE_ANALOGIN
+#if DEVICE_ANALOGIN
 extern const PinMap PinMap_ADC[];
 #endif
 
 /* DAC */
-#ifdef DEVICE_ANALOGOUT
+#if DEVICE_ANALOGOUT
 extern const PinMap PinMap_DAC[];
 #endif
 
@@ -48,17 +48,17 @@ extern const PinMap PinMap_PWM[];
 #endif
 
 /* SERIAL */
-#ifdef DEVICE_SERIAL
+#if DEVICE_SERIAL
 extern const PinMap PinMap_UART_TX[];
 extern const PinMap PinMap_UART_RX[];
-#ifdef DEVICE_SERIAL_FC
+#if DEVICE_SERIAL_FC
 extern const PinMap PinMap_UART_RTS[];
 extern const PinMap PinMap_UART_CTS[];
 #endif
 #endif
 
 /* SPI */
-#ifdef DEVICE_SPI
+#if DEVICE_SPI
 extern const PinMap PinMap_SPI_MOSI[];
 extern const PinMap PinMap_SPI_MISO[];
 extern const PinMap PinMap_SPI_SCLK[];
@@ -66,7 +66,7 @@ extern const PinMap PinMap_SPI_SSEL[];
 #endif
 
 /* CAN */
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 extern const PinMap PinMap_CAN_RD[];
 extern const PinMap PinMap_CAN_TD[];
 #endif

--- a/targets/TARGET_Maxim/TARGET_MAX32600/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/rtc_api.c
@@ -74,7 +74,7 @@ void rtc_init(void)
     MXC_PWRSEQ->reg0 |= MXC_F_PWRSEQ_REG0_PWR_RTCEN_RUN;
 
     // Prepare interrupt handlers
-#ifdef DEVICE_LPTICKER
+#if DEVICE_LPTICKER
     NVIC_SetVector(RTC0_IRQn, (uint32_t)lp_ticker_irq_handler);
     NVIC_EnableIRQ(RTC0_IRQn);
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/TARGET_MCU_NRF51822_UNIFIED/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/TARGET_MCU_NRF51822_UNIFIED/analogin_api.c
@@ -19,7 +19,7 @@
 #include "pinmap.h"
 #include "nrf_drv_adc.h"
 
-#ifdef DEVICE_ANALOGIN
+#if DEVICE_ANALOGIN
 
 
 #define ADC_10BIT_RANGE  0x3FF

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/flash_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/flash_api.c
@@ -36,7 +36,7 @@
  *
  */
 
-#if (defined(DEVICE_FLASH) && defined(DEVICE_LPTICKER))
+#if DEVICE_FLASH && DEVICE_LPTICKER
 
 #include "hal/flash_api.h"
 #include "hal/lp_ticker_api.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/i2c_api.c
@@ -39,7 +39,7 @@
 
 #include "i2c_api.h"
 
-#if (defined(DEVICE_I2C) && defined(DEVICE_LPTICKER))
+#if DEVICE_I2C && DEVICE_LPTICKER
 
 #include "mbed_assert.h"
 #include "mbed_error.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/trng_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/trng_api.c
@@ -36,7 +36,7 @@
  *
  */
 
-#if (defined(DEVICE_TRNG) && defined(DEVICE_LPTICKER))
+#if DEVICE_TRNG && DEVICE_LPTICKER
 
 #include "hal/trng_api.h"
 #include "hal/lp_ticker_api.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/system_nrf52.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/system_nrf52.c
@@ -222,7 +222,7 @@ void SystemInit(void)
      *
      * The ITM has to be initialized before the SoftDevice which weren't guaranteed using the normal API.
      */
-#if defined (DEVICE_ITM)
+#if DEVICE_ITM
         /* Enable SWO trace functionality */
         CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
         NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Serial << CLOCK_TRACECONFIG_TRACEMUX_Pos;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/system_nrf52840.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/system_nrf52840.c
@@ -198,7 +198,7 @@ void SystemInit(void)
      *
      * The ITM has to be initialized before the SoftDevice which weren't guaranteed using the normal API.
      */
-#if defined (DEVICE_ITM)
+#if DEVICE_ITM
         /* Enable SWO trace functionality */
         CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
         NRF_CLOCK->TRACECONFIG |= CLOCK_TRACECONFIG_TRACEMUX_Serial << CLOCK_TRACECONFIG_TRACEMUX_Pos;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/analogin_api.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
  
-#ifdef DEVICE_ANALOGIN
+#if DEVICE_ANALOGIN
 #include "hal/analogin_api.h"
 
 #include "pinmap.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/flash_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/flash_api.c
@@ -36,7 +36,7 @@
  *
  */
 
-#if (defined(DEVICE_FLASH) && defined(DEVICE_LPTICKER))
+#if DEVICE_FLASH && DEVICE_LPTICKER
 
 #include "hal/flash_api.h"
 #include "hal/lp_ticker_api.h"

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/i2c_api.c
@@ -36,7 +36,7 @@
  *
  */
 
-#if (defined(DEVICE_I2C) && defined(DEVICE_LPTICKER))
+#if DEVICE_I2C && DEVICE_LPTICKER
 /* I2C
  *
  * This HAL implementation uses the nrf_drv_twi.h API primarily but switches to TWI for the

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/itm_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/itm_api.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(DEVICE_ITM)
+#if DEVICE_ITM
 
 #include "hal/itm_api.h"
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/trng_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/trng_api.c
@@ -36,7 +36,7 @@
  *
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 #if !defined(FEATURE_CRYPTOCELL310)
 #include "hal/trng_api.h"
 #include "hal/critical_section_api.h"

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/objects.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/objects.h
@@ -59,13 +59,13 @@ struct spi_s {
     uint8_t bits;
 };
 
-#if defined(DEVICE_FLASH)
+#if DEVICE_FLASH
 struct flash_s {
     uint8_t dummy;
 };
 #endif
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 struct trng_s {
     uint8_t dummy;
 };

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/exceptions.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/exceptions.c
@@ -117,7 +117,7 @@ void fIrqUart2Handler(void)
     Uart2_Irq();
 }
 
-#ifdef DEVICE_RTC
+#if DEVICE_RTC
 /** Call the RTC IRQ handler */
 void fIrqRtcHandler(void)
 {

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/rtc.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/rtc.c
@@ -42,7 +42,7 @@
  *
  */
 
-#ifdef DEVICE_RTC
+#if DEVICE_RTC
 
 #include "rtc.h"
 #include "mbed_assert.h"

--- a/targets/TARGET_RDA/TARGET_UNO_91H/trng_api.c
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/trng_api.c
@@ -18,7 +18,7 @@
  *
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include "cmsis.h"
 #include "trng_api.h"

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/trng_api_esp32.cpp
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/trng_api_esp32.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 #include "drivers/I2C.h"
 #include "platform/mbed_wait_api.h"
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/trng_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/trng_api.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 #include "trng_api.h"
 
 #if defined(TARGET_GR_LYCHEE)

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/trng_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/trng_api.c
@@ -21,7 +21,7 @@
 #include "platform_stdlib.h"
 #endif
 
-#ifdef DEVICE_TRNG
+#if DEVICE_TRNG
 
 
 void trng_init(trng_t *obj)

--- a/targets/TARGET_STM/PeripheralPins.h
+++ b/targets/TARGET_STM/PeripheralPins.h
@@ -35,13 +35,13 @@
 #include "PeripheralNames.h"
 
 //*** ADC ***
-#ifdef DEVICE_ANALOGIN
+#if DEVICE_ANALOGIN
 extern const PinMap PinMap_ADC[];
 extern const PinMap PinMap_ADC_Internal[];
 #endif
 
 //*** DAC ***
-#ifdef DEVICE_ANALOGOUT
+#if DEVICE_ANALOGOUT
 extern const PinMap PinMap_DAC[];
 #endif
 
@@ -57,17 +57,17 @@ extern const PinMap PinMap_PWM[];
 #endif
 
 //*** SERIAL ***
-#ifdef DEVICE_SERIAL
+#if DEVICE_SERIAL
 extern const PinMap PinMap_UART_TX[];
 extern const PinMap PinMap_UART_RX[];
-#ifdef DEVICE_SERIAL_FC
+#if DEVICE_SERIAL_FC
 extern const PinMap PinMap_UART_RTS[];
 extern const PinMap PinMap_UART_CTS[];
 #endif
 #endif
 
 //*** SPI ***
-#ifdef DEVICE_SPI
+#if DEVICE_SPI
 extern const PinMap PinMap_SPI_MOSI[];
 extern const PinMap PinMap_SPI_MISO[];
 extern const PinMap PinMap_SPI_SCLK[];
@@ -75,12 +75,12 @@ extern const PinMap PinMap_SPI_SSEL[];
 #endif
 
 //*** CAN ***
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 extern const PinMap PinMap_CAN_RD[];
 extern const PinMap PinMap_CAN_TD[];
 #endif
 
-#ifdef DEVICE_QSPI
+#if DEVICE_QSPI
 extern const PinMap PinMap_QSPI_DATA[];
 extern const PinMap PinMap_QSPI_SCLK[];
 extern const PinMap PinMap_QSPI_SSEL[];

--- a/targets/TARGET_STM/TARGET_STM32F0/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -57,7 +57,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 #if defined I2C1_BASE
 #define I2C1_EV_IRQn I2C1_IRQn

--- a/targets/TARGET_STM/TARGET_STM32F0/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32F0/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/TARGET_STM32F1/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -76,7 +76,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 /*  Define IP version */
 #define I2C_IP_VERSION_V1

--- a/targets/TARGET_STM/TARGET_STM32F1/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM1_BASE)

--- a/targets/TARGET_STM/TARGET_STM32F1/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/TARGET_STM32F2/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F2/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 #define I2C_IP_VERSION_V1
 

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -94,7 +94,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif
@@ -137,7 +137,7 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F2/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32F2/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/TARGET_STM32F3/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -57,7 +57,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F3/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 #define I2C_IP_VERSION_V2
 

--- a/targets/TARGET_STM/TARGET_STM32F3/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32F3/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -411,7 +411,7 @@ int OdinWiFiInterface::scan(WiFiAccessPoint *res_list, unsigned count)
      return found_aps;
 }
 
-#ifdef DEVICE_WIFI_AP
+#if DEVICE_WIFI_AP
 
 nsapi_error_t OdinWiFiInterface::set_ap_network(const char *ip_address, const char *netmask, const char *gateway)
 {
@@ -1044,10 +1044,6 @@ void OdinWiFiInterface::handle_wlan_status_started(wlan_status_started_s *start)
 				start->info.macAddress[4],
 				start->info.macAddress[5]);
 
-			if(!_wlan_initialized) {
-				//Initialize network stack interface without activating it
-			}
-
 			if (!_interface) {
 				nsapi_error_t error_code = _stack.add_ethernet_interface(_emac, true, &_interface);
 				if (error_code != NSAPI_ERROR_OK) {
@@ -1058,16 +1054,9 @@ void OdinWiFiInterface::handle_wlan_status_started(wlan_status_started_s *start)
 				}
 			}
 
-
-	#ifdef DEVICE_WIFI_AP
-			if(!_wlan_initialized) {
-				_wlan_initialized = true;
-			}
-	#else
 			if (!_wlan_initialized) {
 				_wlan_initialized = true;
 			}
-	#endif
 
 			// The OdinWifiInterface object is now fully initialized
 			_state = S_STARTED;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
@@ -18,7 +18,7 @@
 #define ODIN_WIFI_INTERFACE_H
 
 #include "WiFiInterface.h"
-#ifdef DEVICE_WIFI_AP
+#if DEVICE_WIFI_AP
 #include "UbloxWiFiSoftAPInterface.h"
 #endif
 
@@ -46,7 +46,7 @@ struct wlan_scan_indication_s;
 /** OdinWiFiInterface class
  *  Implementation of the WiFiInterface for the ODIN-W2 module
  */
-#ifdef DEVICE_WIFI_AP
+#if DEVICE_WIFI_AP
 class OdinWiFiInterface : public WiFiInterface, public UbloxWiFiSoftAPInterface, public EMACInterface
 #else
 class OdinWiFiInterface : public WiFiInterface, public EMACInterface
@@ -141,7 +141,7 @@ public:
      */
     virtual nsapi_error_t set_timeout(int ms);
 
-#ifdef DEVICE_WIFI_AP
+#if DEVICE_WIFI_AP
 
     /** Set IP config for access point
          *

--- a/targets/TARGET_STM/TARGET_STM32F4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #if defined(CAN3_BASE)
 

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -76,7 +76,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 /*  Define IP version */
 #define I2C_IP_VERSION_V1

--- a/targets/TARGET_STM/TARGET_STM32F4/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32F4/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/TARGET_STM32F7/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #if defined(CAN3_BASE)
 

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -57,7 +57,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 #define I2C_IP_VERSION_V2
 

--- a/targets/TARGET_STM/TARGET_STM32F7/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32F7/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/TARGET_STM32L0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 #define I2C_IP_VERSION_V2
 

--- a/targets/TARGET_STM/TARGET_STM32L0/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32L0/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 #define PWMOUT_INVERTED_NOT_SUPPORTED
 

--- a/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
@@ -76,7 +76,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 /*  Define IP version */
 #define I2C_IP_VERSION_V1

--- a/targets/TARGET_STM/TARGET_STM32L1/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32L1/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 /*  L1 HAL do not offer Output Compare idle nor inverted mode*/
 #define PWMOUT_INVERTED_NOT_SUPPORTED

--- a/targets/TARGET_STM/TARGET_STM32L4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/can_device.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_CAN
+#if DEVICE_CAN
 
 #define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -57,7 +57,7 @@ struct spi_s {
     PinName pin_mosi;
     PinName pin_sclk;
     PinName pin_ssel;
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
     uint32_t event;
     uint8_t transfer_type;
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L4/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/i2c_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_I2C
+#if DEVICE_I2C
 
 #define I2C_IP_VERSION_V2
 

--- a/targets/TARGET_STM/TARGET_STM32L4/pwmout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/pwmout_device.c
@@ -31,7 +31,7 @@
 #include "pwmout_api.h"
 #include "pwmout_device.h"
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 const pwm_apb_map_t pwm_apb_map_table[] = {
 #if defined(TIM2_BASE)

--- a/targets/TARGET_STM/TARGET_STM32L4/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/pwmout_device.h
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_PWMOUT
+#if DEVICE_PWMOUT
 
 typedef enum {
     PWMOUT_ON_APB1 = 0,

--- a/targets/TARGET_STM/mbed_crc_api.c
+++ b/targets/TARGET_STM/mbed_crc_api.c
@@ -3,7 +3,7 @@
 
 #include "platform/mbed_assert.h"
 
-#ifdef DEVICE_CRC
+#if DEVICE_CRC
 
 static CRC_HandleTypeDef current_state;
 static uint32_t final_xor;

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -497,7 +497,7 @@ int spi_busy(spi_t *obj)
     return ssp_busy(obj);
 }
 
-#ifdef DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
 typedef enum {
     SPI_TRANSFER_TYPE_NONE = 0,
     SPI_TRANSFER_TYPE_TX = 1,

--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -18,7 +18,7 @@
  *
  */
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 
 #include <stdlib.h>
 #include "cmsis.h"

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
@@ -441,7 +441,7 @@ void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 
 #endif //DEVICE_I2CSLAVE
 
-#ifdef DEVICE_I2C_ASYNCH
+#if DEVICE_I2C_ASYNCH
 
 #include "em_dma.h"
 #include "dma_api_HAL.h"

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/itm_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/itm_api.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(DEVICE_ITM)
+#if DEVICE_ITM
 
 #include "hal/itm_api.h"
 #include "cmsis.h"

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/trng/trng_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/trng/trng_api.c
@@ -24,7 +24,7 @@
 #include "trng_api.h"
 #include "sl_trng.h"
 
-#if defined(DEVICE_TRNG)
+#if DEVICE_TRNG
 static bool is_trng_enabled = false;
 
 void trng_init(trng_t *obj)

--- a/tools/targets/STM32_gen_PeripheralPins.py
+++ b/tools/targets/STM32_gen_PeripheralPins.py
@@ -28,7 +28,7 @@ from argparse import RawTextHelpFormatter
 
 GENPINMAP_VERSION = "1.3"
 
-ADD_DEVICE_IFDEF = 0
+ADD_DEVICE_IF = 0
 ADD_QSPI_FEATURE = 1
 
 mcu_file=""
@@ -485,8 +485,8 @@ def print_list_header(comment, name, l, switch):
                 s += "// You have to comment all PWM using TIM_MST defined in hal_tick.h file\n"
                 s += "//  or update python script (check TIM_MST_LIST) and re-run it\n"
 
-        if ADD_DEVICE_IFDEF:
-            s += "#ifdef DEVICE_%s\n" % switch
+        if ADD_DEVICE_IF:
+            s += "#if DEVICE_%s\n" % switch
 
         s += "MBED_WEAK const PinMap PinMap_%s[] = {\n" % name
 
@@ -541,7 +541,7 @@ MBED_WEAK const PinMap PinMap_ADC_Internal[] = {
     {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_dac():
@@ -568,7 +568,7 @@ def print_dac():
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_i2c(l):
@@ -610,7 +610,7 @@ def print_i2c(l):
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_pwm():
@@ -662,7 +662,7 @@ def print_pwm():
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_uart(l):
@@ -703,7 +703,7 @@ def print_uart(l):
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_spi(l):
@@ -741,7 +741,7 @@ def print_spi(l):
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_can(l):
@@ -775,7 +775,7 @@ def print_can(l):
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_qspi(l):
@@ -801,7 +801,7 @@ def print_qspi(l):
     out_c_file.write( """    {NC, NC, 0}
 };
 """)
-    if ADD_DEVICE_IFDEF:
+    if ADD_DEVICE_IF:
         out_c_file.write( "#endif\n" )
 
 def print_h_file(l, comment):


### PR DESCRIPTION
### Description

Continuation of #8957  (partner components).

The DEVICE_FOO macros are predefined to be 0 or 1. There are a number of instances which incorrectly check if they are defined, rather than checking the value.

This PR addresses most (if not all) of these incorrect checks.

Fixes #8913

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

