### PR TITLE
Disable printf in crash reporting for release builds

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -211,7 +211,9 @@ mbed_error_status_t mbed_error_initialize(void)
         if ((report_error_ctx->crc_error_ctx == crc_val) && (report_error_ctx->is_error_processed == 0)) {
             is_reboot_error_valid = true;
             //Report the error info
+#ifndef NDEBUG
             printf("\n== The system has been rebooted due to a fatal error. ==\n");
+#endif
 
             //Call the mbed_error_reboot_callback, this enables applications to do some handling before we do the handling
             mbed_error_reboot_callback(report_error_ctx);
@@ -223,7 +225,9 @@ mbed_error_status_t mbed_error_initialize(void)
 #if MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED
                 if (report_error_ctx->error_reboot_count >= MBED_CONF_PLATFORM_ERROR_REBOOT_MAX) {
                     //We have rebooted more than enough, hold the system here.
+#ifndef NDEBUG
                     printf("\n== Reboot count(=%ld) exceeded maximum, system halting ==\n", report_error_ctx->error_reboot_count);
+#endif
                     mbed_halt_system();
                 }
 #endif


### PR DESCRIPTION
### Description
The current implementation of crash reporting uses printf() to print some debug messages to terminal during boot up. This is pulling in printf() dependencies which is potentially causing ~7k increase in ROM size for GCC ARM. This change wraps it for debug builds only so release builds doesn't increase in size for applications not using printf() otherwise. Interestingly other toolchains(IAR, ARMC) is not impacted by this. 

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

