### PR TITLE
Renesas : Add USB Device feature

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4991,7 +4991,7 @@
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["RZA1H", "MBRZA1H", "RZ_A1_EMAC"],
         "components_add": ["SD"],
-        "device_has_add": ["EMAC", "FLASH", "LPTICKER"],
+        "device_has_add": ["USBDEVICE", "EMAC", "FLASH", "LPTICKER"],
         "release_versions": ["2", "5"],
         "device_name": "R7S72100",
         "bootloader_supported": true
@@ -5007,7 +5007,7 @@
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["RZA1UL", "MBRZA1LU"],
         "components_add": ["SD"],
-        "device_has_add": ["TRNG", "FLASH", "LPTICKER"],
+        "device_has_add": ["USBDEVICE", "TRNG", "FLASH", "LPTICKER"],
         "device_has_remove": ["ETHERNET"],
         "release_versions": ["2", "5"],
         "device_name": "R7S72103",

--- a/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBEndpoints_RZ_A1.h
+++ b/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBEndpoints_RZ_A1.h
@@ -1,0 +1,84 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited, All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define NUMBER_OF_LOGICAL_ENDPOINTS (16)
+#define NUMBER_OF_PHYSICAL_ENDPOINTS (NUMBER_OF_LOGICAL_ENDPOINTS * 2)
+
+/* Define physical endpoint numbers */
+
+/*      Endpoint    No.     Type(s)   MaxSiz  DoubleBuf  pipe */
+/*      ----------------    --------- ------  ---------  ---- */
+#define EP0OUT   (0x00)  /* Control    256    No           0  */
+#define EP0IN    (0x80)  /* Control    256    No           0  */
+#define EP1OUT   (0x01)  /* Int         64    No           6  */
+#define EP1IN    (0x81)  /* Int         64    No           7  */
+#define EP2OUT   (0x02)  /* Bulk      2048    Yes          3  */
+#define EP2IN    (0x82)  /* Bulk      2048    Yes          4  */
+#define EP3OUT   (0x03)  /* Bulk/Iso  2048    Yes          1  */
+#define EP3IN    (0x83)  /* Bulk/Iso  2048    Yes          2  */
+/*following EP is not configured in sample program*/
+#define EP6IN    (0x86)  /* Bulk      2048    Yes          5  */
+#define EP8IN    (0x88)  /* Int        64     No           8  */
+#define EP9IN    (0x89)  /* Bulk       512    Bulk         9  */
+#define EP10IN   (0x8A)  /* Int/Bulk  2048    Bulk        10  */
+#define EP11IN   (0x8B)  /* Bulk      2048    Yes         11  */
+#define EP12IN   (0x8C)  /* Bulk      2048    Yes         12  */
+#define EP13IN   (0x8D)  /* Bulk      2048    Yes         13  */
+#define EP14IN   (0x8E)  /* Bulk      2048    Yes         14  */
+#define EP15IN   (0x8F)  /* Bulk      2048    Yes         15  */
+
+/* Maximum Packet sizes */
+#define MAX_PACKET_SIZE_EP0   (64)      /*pipe0/pipe0: control      */
+#define MAX_PACKET_SIZE_EP1   (64)      /*pipe6/pipe7: interrupt    */
+#define MAX_PACKET_SIZE_EP2  (512)      /*pipe3/pipe4: bulk         */
+#define MAX_PACKET_SIZE_EP3  (512)      /*pipe1/pipe2: isochronous  */
+#define MAX_PACKET_SIZE_EP6   (64)      /*pipe5:    Note *1 */
+#define MAX_PACKET_SIZE_EP8   (64)      /*pipe7:    Note *1 */
+#define MAX_PACKET_SIZE_EP9  (512)      /*pipe8:    Note *1 */
+#define MAX_PACKET_SIZE_EP10 (512)      /*pipe9:    Note *1 */
+#define MAX_PACKET_SIZE_EP11 (512)      /*pipe10:   Note *1 */
+#define MAX_PACKET_SIZE_EP12 (512)      /*pipe11:   Note *1 */
+#define MAX_PACKET_SIZE_EP13 (512)      /*pipe12:   Note *1 */
+#define MAX_PACKET_SIZE_EP14 (512)      /*pipe13:   Note *1 */
+#define MAX_PACKET_SIZE_EP15 (512)      /*pipe14:   Note *1 */
+/* Note *1: This pipe is not configure in sample program */
+
+
+/* Generic endpoints - intended to be portable accross devices */
+/* and be suitable for simple USB devices. */
+
+/* Bulk endpoints */
+#define EPBULK_OUT  (EP2OUT)
+#define EPBULK_IN   (EP2IN)
+#define EPBULK_OUT_callback   EP2_OUT_callback
+#define EPBULK_IN_callback    EP2_IN_callback
+/* Interrupt endpoints */
+#define EPINT_OUT   (EP1OUT)
+#define EPINT_IN    (EP1IN)
+#define EPINT_OUT_callback    EP1_OUT_callback
+#define EPINT_IN_callback     EP1_IN_callback
+/* Isochronous endpoints */
+#define EPISO_OUT   (EP3OUT)
+#define EPISO_IN    (EP3IN)
+#define EPISO_OUT_callback    EP3_OUT_callback
+#define EPISO_IN_callback     EP3_IN_callback
+
+#define MAX_PACKET_SIZE_EPBULK  (MAX_PACKET_SIZE_EP2)
+#define MAX_PACKET_SIZE_EPINT   (MAX_PACKET_SIZE_EP1)
+#define MAX_PACKET_SIZE_EPISO   (MAX_PACKET_SIZE_EP3)
+
+/*EOF*/

--- a/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhyHw.h
+++ b/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhyHw.h
@@ -1,0 +1,106 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited, All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef USBPHYHW_H
+#define USBPHYHW_H
+
+#include "mbed.h"
+#include "USBPhy.h"
+
+
+class USBPhyHw : public USBPhy {
+public:
+    USBPhyHw();
+    virtual ~USBPhyHw();
+    virtual void init(USBPhyEvents *events);
+    virtual void deinit();
+    virtual bool powered();
+    virtual void connect();
+    virtual void disconnect();
+    virtual void configure();
+    virtual void unconfigure();
+    virtual void sof_enable();
+    virtual void sof_disable();
+    virtual void set_address(uint8_t address);
+    virtual void remote_wakeup();
+    virtual const usb_ep_table_t* endpoint_table();
+
+    virtual uint32_t ep0_set_max_packet(uint32_t max_packet);
+    virtual void ep0_setup_read_result(uint8_t *buffer, uint32_t size);
+    virtual void ep0_read(uint8_t *data, uint32_t size);
+    virtual uint32_t ep0_read_result();
+    virtual void ep0_write(uint8_t *buffer, uint32_t size);
+    virtual void ep0_stall();
+
+    virtual bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type);
+    virtual void endpoint_remove(usb_ep_t endpoint);
+    virtual void endpoint_stall(usb_ep_t endpoint);
+    virtual void endpoint_unstall(usb_ep_t endpoint);
+
+    virtual bool endpoint_read(usb_ep_t endpoint, uint8_t *data, uint32_t size);
+    virtual uint32_t endpoint_read_result(usb_ep_t endpoint);
+    virtual bool endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size);
+    virtual void endpoint_abort(usb_ep_t endpoint);
+
+    virtual void process();
+
+private:
+    #define PIPE_NUM      (16)
+
+    typedef struct {
+        bool        enable;
+        uint16_t    status;
+        uint32_t    req_size;
+        uint32_t    data_cnt;
+        uint8_t     *p_data;
+    } pipe_ctrl_t;
+
+    USBPhyEvents *events;
+    pipe_ctrl_t pipe_ctrl[PIPE_NUM];
+    uint16_t setup_buffer[32];
+
+    static void _usbisr(void);
+    void chg_curpipe(uint16_t pipe, uint16_t isel);
+    uint16_t is_set_frdy(uint16_t pipe, uint16_t isel);
+    uint8_t * read_fifo(uint16_t pipe, uint16_t count, uint8_t *read_p);
+    uint16_t read_data(uint16_t pipe);
+    void fifo_to_buf(uint16_t pipe);
+    uint8_t * write_fifo(uint16_t pipe, uint16_t count, uint8_t *write_p);
+    uint16_t write_data(uint16_t pipe);
+    void buf_to_fifo(uint16_t pipe);
+    uint16_t * get_pipectr_reg(uint16_t pipe);
+    uint16_t * get_pipetre_reg(uint16_t pipe);
+    uint16_t * get_pipetrn_reg(uint16_t pipe);
+    uint16_t * get_fifoctr_reg(uint16_t pipe);
+    uint16_t * get_fifosel_reg(uint16_t pipe);
+    uint32_t * get_fifo_reg(uint16_t pipe);
+    uint16_t get_pid(uint16_t pipe);
+    void set_mbw(uint16_t pipe, uint16_t data);
+    void set_pid(uint16_t pipe, uint16_t new_pid);
+    void cpu_delay_1us(uint16_t time);
+    uint16_t EP2PIPE(uint16_t endpoint);
+    uint16_t PIPE2EP(uint16_t pipe);
+    uint16_t PIPE2FIFO(uint16_t pipe);
+    void reset_usb(uint16_t clockmode);
+    bool chk_vbsts(void);
+    void ctrl_end(uint16_t status);
+    void data_end(uint16_t pipe, uint16_t status);
+    void forced_termination(uint16_t pipe, uint16_t status);
+
+};
+
+#endif

--- a/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhy_RZ_A1.cpp
+++ b/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhy_RZ_A1.cpp
@@ -1,0 +1,1507 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited, All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if defined(DEVICE_USBDEVICE) && DEVICE_USBDEVICE
+
+extern "C"
+{
+#include "r_typedefs.h"
+#include "iodefine.h"
+}
+#include "USBPhyHw.h"
+#include "rza_io_regrw.h"
+#include "USBDevice_Types.h"
+#include "USBEndpoints_RZ_A1.h"
+#include "USBPhy_RZ_A1_Def.h"
+
+
+/**** User Selection ****/
+#define USB_FUNCTION_CH        0
+#define USB_FUNCTION_HISPEED   0        // 1: High-Speed  0: Full-Speed
+
+#if (USB_FUNCTION_CH == 0)
+#define USB_MX       USB200
+#define USBIX_IRQn   USBI0_IRQn
+#else
+#define USB_MX       USB201
+#define USBIX_IRQn   USBI1_IRQn
+#endif
+
+/* There are maintenance routine of SHTNAK and BFRE bits in original sample program.
+* This sample is not programmed. Do maintenance the "def_pipecfg" array if you want it. */
+const struct PIPECFGREC {
+    uint16_t    endpoint;
+    uint16_t    pipesel;
+    uint16_t    pipecfg;
+    uint16_t    pipebuf;
+    uint16_t    pipemaxp;
+    uint16_t    pipeperi;
+} def_pipecfg[] = {
+    /* EP0OUT and EP0IN are configured by USB IP */
+    {
+        EP1OUT, /* EP1: Host -> Func, INT */
+        6 | USB_FUNCTION_D0FIFO_USE,
+        USB_TYPFIELD_INT  | USB_BFREOFF | USB_CFG_DBLBOFF | USB_CFG_CNTMDON  |                   USB_DIR_P_OUT | 1,
+        USB_BUF_SIZE(64) | 0x04u,
+        MAX_PACKET_SIZE_EP1,
+        3,
+    },
+    {
+        EP1IN,  /* EP1: Host <- Func, INT */
+        7 | USB_FUNCTION_D1FIFO_USE,
+        USB_TYPFIELD_INT  | USB_BFREOFF | USB_CFG_DBLBOFF | USB_CFG_CNTMDOFF |                   USB_DIR_P_IN  | 1,
+        USB_BUF_SIZE(64) | 0x05u,
+        MAX_PACKET_SIZE_EP1,
+        3,
+    },
+    {
+        EP2OUT, /* EP2: Host -> Func, BULK */
+        3 | USB_FUNCTION_D0FIFO_USE,
+        USB_TYPFIELD_BULK | USB_BFREOFF | USB_CFG_DBLBON  | USB_CFG_CNTMDON  | USB_SHTNAKFIELD | USB_DIR_P_OUT | 2,
+        USB_BUF_SIZE(2048) | 0x30u,
+        MAX_PACKET_SIZE_EP2,
+        0,
+    },
+    {
+        EP2IN,  /* EP2: Host <- Func, BULK */
+        4 | USB_FUNCTION_D1FIFO_USE,
+        USB_TYPFIELD_BULK | USB_BFREOFF | USB_CFG_DBLBOFF | USB_CFG_CNTMDON  |                   USB_DIR_P_IN  | 2,
+        USB_BUF_SIZE(2048) | 0x50u,
+        MAX_PACKET_SIZE_EP2,
+        0,
+    },
+    {
+        EP3OUT, /* EP3: Host -> Func, ISO */
+        1 | USB_FUNCTION_D0FIFO_USE,
+        USB_TYPFIELD_ISO  | USB_BFREOFF | USB_CFG_DBLBON  | USB_CFG_CNTMDOFF | USB_SHTNAKFIELD | USB_DIR_P_OUT | 3,
+        USB_BUF_SIZE(512) | 0x10u,
+        MAX_PACKET_SIZE_EP3,
+        0,
+    },
+    {
+        EP3IN,  /* EP3: Host <- Func, ISO */
+        2 | USB_FUNCTION_D1FIFO_USE,
+        USB_TYPFIELD_ISO  | USB_BFREOFF | USB_CFG_DBLBON  | USB_CFG_CNTMDOFF |                    USB_DIR_P_IN  | 3,
+        USB_BUF_SIZE(512) | 0x20u,
+        MAX_PACKET_SIZE_EP3,
+        0,
+    },
+    { /* terminator */
+        0, 0, 0, 0, 0, 0
+    },
+};
+
+static USBPhyHw *instance;
+static uint8_t _usb_speed = USB_FUNCTION_HISPEED;
+static bool run_later_ctrl_comp = false;
+
+USBPhy *get_usb_phy()
+{
+    static USBPhyHw usbphy;
+    return &usbphy;
+}
+
+USBPhyHw::USBPhyHw(): events(NULL)
+{
+}
+
+USBPhyHw::~USBPhyHw()
+{
+}
+
+void USBPhyHw::init(USBPhyEvents *events)
+{
+    volatile uint8_t dummy_read;
+
+    this->events = events;
+
+    /* registers me */
+    instance = this;
+
+    /* Disable IRQ */
+    GIC_DisableIRQ(USBIX_IRQn);
+
+#if (USB_FUNCTION_CH == 0)
+    CPG.STBCR7 &= ~(CPG_STBCR7_MSTP71);
+#else
+    CPG.STBCR7 &= ~(CPG_STBCR7_MSTP71 | CPG_STBCR7_MSTP70);
+#endif
+    dummy_read = CPG.STBCR7;
+    (void)dummy_read;
+
+    /* module reset and clock select */
+    reset_usb(USB_X1_48MHZ);                            /* USB_X1 48MHz */
+
+    /* Set to USB Function and select speed */
+    USB_MX.SYSCFG0 &= ~USB_DPRPU;
+    USB_MX.SYSCFG0 &= ~USB_DRPD;
+    USB_MX.SYSCFG0 &= ~USB_DCFM;                        /* USB Functoin */
+    USB_MX.SYSCFG0 |= USB_USBE;
+
+    if (_usb_speed == 0) {
+        USB_MX.SYSCFG0 &= ~USB_HSE;                     /* Full-Speed */
+    } else {
+        USB_MX.SYSCFG0 |= USB_HSE;                      /* High-Speed */
+    }
+    cpu_delay_1us(1500);
+}
+
+void USBPhyHw::deinit()
+{
+    volatile uint8_t dummy_read;
+
+    disconnect();
+
+#if (USB_FUNCTION_CH == 0)
+    CPG.STBCR7 |= CPG_STBCR7_MSTP71;
+#else
+    CPG.STBCR7 |= (CPG_STBCR7_MSTP71 | CPG_STBCR7_MSTP70);
+#endif
+    dummy_read = CPG.STBCR7;
+    (void)dummy_read;
+}
+
+bool USBPhyHw::powered()
+{
+    // return true if powered false otherwise. Devices which don't support
+    //    this should always return true
+    return true;
+}
+
+void USBPhyHw::connect()
+{
+    /* Enable pullup on D+ */
+    USB_MX.INTENB0 |= (USB_VBSE | USB_SOFE | USB_DVSE | USB_CTRE | USB_BEMPE | USB_NRDYE | USB_BRDYE);
+    USB_MX.SYSCFG0 |= USB_DPRPU;
+
+    /* Enable USB */
+    InterruptHandlerRegister(USBIX_IRQn, &_usbisr);
+    GIC_SetPriority(USBIX_IRQn, 16);
+    GIC_SetConfiguration(USBIX_IRQn, 1);
+    GIC_EnableIRQ(USBIX_IRQn);
+}
+
+void USBPhyHw::disconnect()
+{
+    /* Disable USB */
+    GIC_DisableIRQ(USBIX_IRQn);
+    InterruptHandlerRegister(USBIX_IRQn, NULL);
+
+    /* Disable pullup on D+ */
+    USB_MX.SYSCFG0 &= ~USB_DPRPU;
+    cpu_delay_1us(1);
+    USB_MX.SYSCFG0 |= USB_DCFM;
+    cpu_delay_1us(1);
+    USB_MX.SYSCFG0 &= ~USB_DCFM;
+}
+
+void USBPhyHw::configure()
+{
+}
+
+void USBPhyHw::unconfigure()
+{
+}
+
+void USBPhyHw::sof_enable()
+{
+    /* Enable SOF interrupt */
+    USB_MX.INTENB0 |= USB_SOFE;
+}
+
+void USBPhyHw::sof_disable()
+{
+    /* Disable SOF interrupt */
+    USB_MX.INTENB0 &= ~USB_SOFE;
+}
+
+void USBPhyHw::set_address(uint8_t address)
+{
+    if (address <= 127) {
+        set_pid(USB_PIPE0, USB_PID_BUF);        /* Set BUF */
+    } else {
+        set_pid(USB_PIPE0, USB_PID_STALL);      /* Not specification */
+    }
+}
+
+void USBPhyHw::remote_wakeup()
+{
+}
+
+const usb_ep_table_t *USBPhyHw::endpoint_table()
+{
+    static const usb_ep_table_t rza1_table = {
+        1, // No cost per endpoint - everything allocated up front
+        {
+            {USB_EP_ATTR_ALLOW_CTRL | USB_EP_ATTR_DIR_IN_AND_OUT, 0, 0},
+            {USB_EP_ATTR_ALLOW_INT  | USB_EP_ATTR_DIR_IN_AND_OUT, 0, 0},
+            {USB_EP_ATTR_ALLOW_BULK | USB_EP_ATTR_DIR_IN_AND_OUT, 0, 0},
+            {USB_EP_ATTR_ALLOW_ISO  | USB_EP_ATTR_DIR_IN_AND_OUT, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+            {0, 0, 0},
+        }
+    };
+    return &rza1_table;
+}
+
+uint32_t USBPhyHw::ep0_set_max_packet(uint32_t max_packet)
+{
+    return MAX_PACKET_SIZE_EP0;
+}
+
+void USBPhyHw::ep0_setup_read_result(uint8_t *buffer, uint32_t size)
+{
+    memcpy(buffer, setup_buffer, size);
+}
+
+void USBPhyHw::ep0_read(uint8_t *data, uint32_t size)
+{
+    pipe_ctrl[USB_PIPE0].req_size  = size;
+    pipe_ctrl[USB_PIPE0].data_cnt  = size;
+    pipe_ctrl[USB_PIPE0].p_data    = data;
+
+    chg_curpipe(USB_PIPE0, USB_ISEL_READ);      /* Switch FIFO and pipe number. */
+    USB_MX.CFIFOCTR = USB_BCLR;                 /* Buffer clear */
+    set_pid(USB_PIPE0, USB_PID_BUF);            /* Set BUF */
+    USB_MX.BRDYENB |= (1 << USB_PIPE0);         /* Enable ready interrupt */
+    USB_MX.NRDYENB |= (1 << USB_PIPE0);         /* Enable not ready interrupt */
+}
+
+uint32_t USBPhyHw::ep0_read_result()
+{
+    return pipe_ctrl[USB_PIPE0].req_size;
+}
+
+void USBPhyHw::ep0_write(uint8_t *buffer, uint32_t size)
+{
+    if ((buffer == NULL) || (size == 0)) {
+        set_pid(USB_PIPE0, USB_PID_BUF);            /* Set BUF */
+        return;
+    }
+
+    pipe_ctrl[USB_PIPE0].req_size  = size;
+    pipe_ctrl[USB_PIPE0].data_cnt  = size;
+    pipe_ctrl[USB_PIPE0].p_data    = buffer;
+
+    chg_curpipe(USB_PIPE0, USB_ISEL_WRITE);         /* Switch FIFO and pipe number. */
+    USB_MX.CFIFOCTR = USB_BCLR;                     /* Buffer clear */
+    /* Clear the PIPExBEMP status bit of the specified pipe to clear */
+    USB_MX.BEMPSTS = (uint16_t)((~(1 << USB_PIPE0)) & BEMPSTS_MASK);
+
+    /* Peripheral control sequence */
+    switch (write_data(USB_PIPE0)) {
+        case USB_WRITING :                          /* Continue of data write */
+            USB_MX.BRDYENB |= (1 << USB_PIPE0);     /* Enable Ready interrupt */
+            USB_MX.NRDYENB |= (1 << USB_PIPE0);     /* Enable Not Ready Interrupt */
+            set_pid(USB_PIPE0, USB_PID_BUF);
+            break;
+        case USB_WRITEEND :                         /* End of data write */
+        case USB_WRITESHRT :                        /* End of data write */
+            USB_MX.BEMPENB |= (1 << USB_PIPE0);     /* Enable Empty Interrupt */
+            USB_MX.NRDYENB |= (1 << USB_PIPE0);     /* Enable Not Ready Interrupt */
+            set_pid(USB_PIPE0, USB_PID_BUF);
+            break;
+        case USB_FIFOERROR :                        /* FIFO access error */
+            ctrl_end((uint16_t)USB_DATA_ERR);
+            break;
+        default :
+            break;
+    }
+}
+
+void USBPhyHw::ep0_stall()
+{
+    set_pid(USB_PIPE0, USB_PID_STALL);
+    run_later_ctrl_comp = false;
+}
+
+bool USBPhyHw::endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type)
+{
+    const struct PIPECFGREC *cfg;
+    uint16_t pipe;
+    volatile uint16_t *p_reg;
+
+    if ((endpoint == EP0OUT) || (endpoint == EP0IN)) {
+        return true;
+    }
+
+    for (cfg = &def_pipecfg[0]; cfg->pipesel != 0; cfg++) {
+        if (cfg->endpoint == endpoint) {
+            break;
+        }
+    }
+    if (cfg->pipesel == 0) {
+        return false;
+    }
+
+    pipe = (cfg->pipesel & USB_CURPIPE);
+
+    /* Interrupt Disable */
+    USB_MX.BRDYENB &= (~(1 << pipe));   /* Disable Ready Interrupt */
+    USB_MX.NRDYENB &= (~(1 << pipe));   /* Disable Not Ready Interrupt */
+    USB_MX.BEMPENB &= (~(1 << pipe));   /* Disable Empty Interrupt */
+
+    set_pid(pipe, USB_PID_NAK);
+
+    /* CurrentPIPE Clear */
+    if ((USB_MX.CFIFOSEL & USB_CURPIPE) == pipe) {
+        USB_MX.CFIFOSEL &= ~USB_CURPIPE;
+    }
+    if ((USB_MX.D0FIFOSEL & USB_CURPIPE) == pipe) {
+        USB_MX.D0FIFOSEL &= ~USB_CURPIPE;
+    }
+    if ((USB_MX.D1FIFOSEL & USB_CURPIPE) == pipe) {
+        USB_MX.D1FIFOSEL &= ~USB_CURPIPE;
+    }
+
+    /* PIPE Configuration */
+    USB_MX.PIPESEL  = pipe;             /* Pipe select */
+    USB_MX.PIPECFG  = cfg->pipecfg;
+    USB_MX.PIPEBUF  = cfg->pipebuf;
+    USB_MX.PIPEMAXP = cfg->pipemaxp;
+    USB_MX.PIPEPERI = cfg->pipeperi;
+
+    p_reg = get_pipectr_reg(pipe);
+    /* Set toggle bit to DATA0 */
+    *p_reg |= USB_SQCLR;
+    /* Buffer Clear */
+    *p_reg |= USB_ACLRM;
+    *p_reg &= ~USB_ACLRM;
+
+    return true;
+}
+
+void USBPhyHw::endpoint_remove(usb_ep_t endpoint)
+{
+    uint16_t pipe = EP2PIPE(endpoint);
+
+    /* Interrupt Disable */
+    USB_MX.BRDYENB &= (~(1 << pipe));   /* Disable Ready Interrupt */
+    USB_MX.NRDYENB &= (~(1 << pipe));   /* Disable Not Ready Interrupt */
+    USB_MX.BEMPENB &= (~(1 << pipe));   /* Disable Empty Interrupt */
+
+    set_pid(pipe, USB_PID_NAK);
+
+    /* CurrentPIPE Clear */
+    if ((USB_MX.CFIFOSEL & USB_CURPIPE) == pipe) {
+        USB_MX.CFIFOSEL &= ~USB_CURPIPE;
+    }
+    if ((USB_MX.D0FIFOSEL & USB_CURPIPE) == pipe) {
+        USB_MX.D0FIFOSEL &= ~USB_CURPIPE;
+    }
+    if ((USB_MX.D1FIFOSEL & USB_CURPIPE) == pipe) {
+        USB_MX.D1FIFOSEL &= ~USB_CURPIPE;
+    }
+
+    /* PIPE Configuration */
+    USB_MX.PIPESEL = pipe;              /* Pipe select */
+    USB_MX.PIPECFG = 0;
+
+    pipe_ctrl[pipe].enable = false;
+    pipe_ctrl[pipe].status = USB_DATA_NONE;
+}
+
+void USBPhyHw::endpoint_stall(usb_ep_t endpoint)
+{
+    uint16_t pipe = EP2PIPE(endpoint);
+
+    set_pid(pipe, USB_PID_STALL);
+
+    pipe_ctrl[pipe].enable = false;
+    pipe_ctrl[pipe].status = USB_DATA_STALL;
+}
+
+void USBPhyHw::endpoint_unstall(usb_ep_t endpoint)
+{
+    uint16_t pipe = EP2PIPE(endpoint);
+    volatile uint16_t *p_reg;
+
+    set_pid(pipe, USB_PID_NAK);
+
+    p_reg = get_pipectr_reg(pipe);
+    /* Set toggle bit to DATA0 */
+    *p_reg |= USB_SQCLR;
+    /* Buffer Clear */
+    *p_reg |= USB_ACLRM;
+    *p_reg &= ~USB_ACLRM;
+
+    pipe_ctrl[pipe].enable = false;
+    pipe_ctrl[pipe].status = USB_DATA_NONE;
+}
+
+bool USBPhyHw::endpoint_read(usb_ep_t endpoint, uint8_t *data, uint32_t size)
+{
+    uint16_t mxps;
+    uint16_t trncnt;
+    volatile uint16_t *p_reg;
+    uint16_t pipe = EP2PIPE(endpoint);
+
+    if (pipe_ctrl[pipe].status == USB_DATA_STALL) {
+        return false;
+    }
+
+    pipe_ctrl[pipe].status   = USB_DATA_READING;
+    pipe_ctrl[pipe].req_size = size;
+    pipe_ctrl[pipe].data_cnt = size;
+    pipe_ctrl[pipe].p_data   = data;
+    pipe_ctrl[pipe].enable   = true;
+
+    set_pid(pipe, USB_PID_NAK);                                     /* Set NAK */
+
+    USB_MX.BEMPSTS = (uint16_t)((~(1 << pipe)) & BEMPSTS_MASK);     /* BEMP Status Clear */
+    USB_MX.BRDYSTS = (uint16_t)((~(1 << pipe)) & BRDYSTS_MASK);     /* BRDY Status Clear */
+    USB_MX.NRDYSTS = (uint16_t)((~(1 << pipe)) & NRDYSTS_MASK);     /* NRDY Status Clear */
+
+    chg_curpipe(pipe, USB_ISEL_READ);                               /* Switch FIFO and pipe number. */
+    p_reg = get_fifoctr_reg(pipe);
+    *p_reg = USB_BCLR;                                              /* Clear BCLR */
+
+    if (size != 0) {
+        /* Max Packet Size */
+        USB_MX.PIPESEL = pipe;                                          /* Pipe select */
+        mxps = (uint16_t)(USB_MX.PIPEMAXP & USB_MXPS);
+        /* Data size check */
+        if ((size % mxps) == (uint32_t)0u) {
+            trncnt = (uint16_t)(size / mxps);
+        } else {
+            trncnt = (uint16_t)((size / mxps) + (uint32_t)1u);
+        }
+
+        /* Set Transaction counter */
+        p_reg = get_pipetre_reg(pipe);
+        if (p_reg != NULL) *p_reg |= USB_TRCLR;
+        p_reg = get_pipetrn_reg(pipe);
+        if (p_reg != NULL) *p_reg = trncnt;
+        p_reg = get_pipetre_reg(pipe);
+        if (p_reg != NULL) *p_reg |= USB_TRENB;
+
+        p_reg = get_pipectr_reg(pipe);
+        /* Buffer Clear */
+        *p_reg |= USB_ACLRM;
+        *p_reg &= ~USB_ACLRM;
+    }
+
+    set_pid(pipe, USB_PID_BUF);                                     /* Set BUF */
+    USB_MX.BRDYENB |= (1 << pipe);                                  /* Enable Ready Interrupt */
+    USB_MX.NRDYENB |= (1 << pipe);                                  /* Enable Not Ready Interrupt */
+
+    return true;
+}
+
+uint32_t USBPhyHw::endpoint_read_result(usb_ep_t endpoint)
+{
+    uint16_t pipe = EP2PIPE(endpoint);
+
+    return pipe_ctrl[pipe].req_size;
+}
+
+bool USBPhyHw::endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size)
+{
+    volatile uint16_t *p_reg;
+    uint16_t pipe = EP2PIPE(endpoint);
+
+    if (pipe_ctrl[pipe].status == USB_DATA_STALL) {
+        return false;
+    }
+
+    pipe_ctrl[pipe].status   = USB_DATA_WRITING;
+    pipe_ctrl[pipe].req_size = size;
+    pipe_ctrl[pipe].data_cnt = size;
+    pipe_ctrl[pipe].p_data   = data;
+    pipe_ctrl[pipe].enable   = true;
+
+    set_pid(pipe, USB_PID_NAK);                                     /* Set NAK */
+
+    USB_MX.BEMPSTS = (uint16_t)((~(1 << pipe)) & BEMPSTS_MASK);     /* BEMP Status Clear */
+    USB_MX.BRDYSTS = (uint16_t)((~(1 << pipe)) & BRDYSTS_MASK);     /* BRDY Status Clear */
+    USB_MX.NRDYSTS = (uint16_t)((~(1 << pipe)) & NRDYSTS_MASK);     /* NRDY Status Clear */
+
+    p_reg = get_pipectr_reg(pipe);
+    /* Buffer Clear */
+    *p_reg |= USB_ACLRM;
+    *p_reg &= ~USB_ACLRM;
+
+    buf_to_fifo(pipe);                                              /* Buffer to FIFO data write */
+    set_pid(pipe, USB_PID_BUF);                                     /* Set BUF */
+
+    return true;
+}
+
+void USBPhyHw::endpoint_abort(usb_ep_t endpoint)
+{
+    forced_termination(EP2PIPE(endpoint), (uint16_t)USB_DATA_NONE);
+}
+
+void USBPhyHw::process()
+{
+    /* Register Save */
+    uint16_t intsts0 = USB_MX.INTSTS0;
+    uint16_t brdysts = USB_MX.BRDYSTS;
+    uint16_t nrdysts = USB_MX.NRDYSTS;
+    uint16_t bempsts = USB_MX.BEMPSTS;
+    uint16_t intenb0 = USB_MX.INTENB0;
+    uint16_t brdyenb = USB_MX.BRDYENB;
+    uint16_t nrdyenb = USB_MX.NRDYENB;
+    uint16_t bempenb = USB_MX.BEMPENB;
+
+    /* Interrupt status get */
+    uint16_t ists0 = (uint16_t)(intsts0 & intenb0);
+    uint16_t bsts  = (uint16_t)(brdysts & brdyenb);
+    uint16_t nsts  = (uint16_t)(nrdysts & nrdyenb);
+    uint16_t ests  = (uint16_t)(bempsts & bempenb);
+
+    uint16_t i;
+
+    if ((intsts0 & (USB_VBINT | USB_RESM | USB_SOFR | USB_DVST |
+                    USB_CTRT | USB_BEMP | USB_NRDY | USB_BRDY)) == 0u) {
+        return;
+    }
+
+    /***** Processing USB bus signal *****/
+    /***** Resume signal *****/
+    if ((ists0 & USB_RESM) == USB_RESM) {
+        USB_MX.INTSTS0 = (uint16_t)~USB_RESM;
+        USB_MX.INTENB0 &= (~USB_RSME);        /* RESM interrupt disable */
+        events->suspend(true);
+    }
+
+    /***** Vbus change *****/
+    else if ((ists0 & USB_VBINT) == USB_VBINT) {
+        USB_MX.INTSTS0 = (uint16_t)~USB_VBINT;
+        if (chk_vbsts()) {
+            /* USB attach */
+            /* Non processing. */
+        } else {
+            /* USB detach */
+            for (i = USB_MIN_PIPE_NO; i < PIPE_NUM; i++) {
+                if (pipe_ctrl[i].enable) {
+                    forced_termination(i, (uint16_t)USB_DATA_NONE);
+                }
+            }
+            USB_MX.INTSTS0 = 0;
+            USB_MX.BRDYSTS = 0;
+            USB_MX.NRDYSTS = 0;
+            USB_MX.BEMPSTS = 0;
+            USB_MX.BRDYENB = 0;
+            USB_MX.NRDYENB = 0;
+            USB_MX.BEMPENB = 0;
+        }
+    }
+
+    /***** SOFR change *****/
+    else if ((ists0 & USB_SOFR) == USB_SOFR) {
+        USB_MX.INTSTS0 = (uint16_t)~USB_SOFR;
+        events->sof(USB_MX.FRMNUM & USB_FRNM);
+    }
+
+    /***** Processing device state *****/
+    /***** DVST change *****/
+    else if ((ists0 & USB_DVST) == USB_DVST) {
+        USB_MX.INTSTS0 = (uint16_t)~USB_DVST;
+
+        switch ((uint16_t)(intsts0 & USB_DVSQ)) {
+            case USB_DS_POWR :
+                break;
+            case USB_DS_DFLT :
+                USB_MX.DCPCFG = 0;                    /* DCP configuration register  (0x5C) */
+                USB_MX.DCPMAXP = MAX_PACKET_SIZE_EP0; /* DCP maxpacket size register (0x5E) */
+
+                events->reset();
+                break;
+            case USB_DS_ADDS :
+                break;
+            case USB_DS_CNFG :
+                break;
+            case USB_DS_SPD_POWR :
+            case USB_DS_SPD_DFLT :
+            case USB_DS_SPD_ADDR :
+            case USB_DS_SPD_CNFG :
+                events->suspend(false);
+                break;
+            default :
+                break;
+        }
+    }
+
+    /***** Processing PIPE0 data *****/
+    else if (((ists0 & USB_BRDY) == USB_BRDY) && ((bsts & USB_BRDY0) == USB_BRDY0)) {
+        /* ==== BRDY PIPE0 ==== */
+        USB_MX.BRDYSTS = (uint16_t)((~USB_BRDY0) & BRDYSTS_MASK);
+
+        /* When operating by the peripheral function, usb_brdy_pipe() is executed with PIPEx request because */
+        /* two BRDY messages are issued even when the demand of PIPE0 and PIPEx has been generated at the same time. */
+        if ((USB_MX.CFIFOSEL & USB_ISEL_WRITE) == USB_ISEL_WRITE) {
+            switch (write_data(USB_PIPE0)) {
+                case USB_WRITEEND :
+                case USB_WRITESHRT :
+                    USB_MX.BRDYENB &= (~(1 << USB_PIPE0));
+                    break;
+                case USB_WRITING :
+                    set_pid(USB_PIPE0, USB_PID_BUF);
+                    break;
+                case USB_FIFOERROR :
+                    ctrl_end((uint16_t)USB_DATA_ERR);
+                    break;
+                default :
+                    break;
+            }
+            events->ep0_in();
+        } else {
+            switch (read_data(USB_PIPE0)) {
+                case USB_READEND :
+                case USB_READSHRT :
+                    USB_MX.BRDYENB &= (~(1 << USB_PIPE0));
+                    pipe_ctrl[USB_PIPE0].req_size -= pipe_ctrl[USB_PIPE0].data_cnt;
+                    break;
+                case USB_READING :
+                    set_pid(USB_PIPE0, USB_PID_BUF);
+                    break;
+                case USB_READOVER :
+                    ctrl_end((uint16_t)USB_DATA_OVR);
+                    pipe_ctrl[USB_PIPE0].req_size -= pipe_ctrl[USB_PIPE0].data_cnt;
+                    break;
+                case USB_FIFOERROR :
+                    ctrl_end((uint16_t)USB_DATA_ERR);
+                    break;
+                default :
+                    break;
+            }
+            events->ep0_out();
+        }
+    }
+    else if (((ists0 & USB_BEMP) == USB_BEMP) && ((ests & USB_BEMP0) == USB_BEMP0)) {
+        /* ==== BEMP PIPE0 ==== */
+        USB_MX.BEMPSTS = (uint16_t)((~USB_BEMP0) & BEMPSTS_MASK);
+
+        events->ep0_in();
+    }
+    else if (((ists0 & USB_NRDY) == USB_NRDY) && ((nsts & USB_NRDY0) == USB_NRDY0)) {
+        /* ==== NRDY PIPE0 ==== */
+        USB_MX.NRDYSTS = (uint16_t)((~USB_NRDY0) & NRDYSTS_MASK);
+        /* Non processing. */
+    }
+
+    /***** Processing setup transaction *****/
+    else if ((ists0 & USB_CTRT) == USB_CTRT) {
+        USB_MX.INTSTS0 = (uint16_t)~USB_CTRT;
+
+        /* CTSQ bit changes later than CTRT bit for ASSP. */
+        /* CTSQ reloading */
+        uint16_t stginfo = (uint16_t)(intsts0 & USB_CTSQ);
+        if (stginfo != USB_CS_IDST) {
+            if (((USB_CS_RDDS == stginfo) || (USB_CS_WRDS == stginfo)) || (USB_CS_WRND == stginfo)) {
+                /* Save request register */
+                uint16_t *bufO = &setup_buffer[0];
+
+                USB_MX.INTSTS0 = (uint16_t)~USB_VALID;
+                *bufO++ = USB_MX.USBREQ;   /* data[0] <= bmRequest, data[1] <= bmRequestType */
+                *bufO++ = USB_MX.USBVAL;   /* data[2] data[3] <= wValue */
+                *bufO++ = USB_MX.USBINDX;  /* data[4] data[5] <= wIndex */
+                *bufO++ = USB_MX.USBLENG;  /* data[6] data[7] <= wLength */
+            }
+        }
+
+        /* Switch on the control transfer stage (CTSQ). */
+        switch (stginfo) {
+            case USB_CS_IDST :  /* Idle or setup stage */
+                break;
+            case USB_CS_RDDS :  /* Control read data stage */
+                events->ep0_setup();
+                break;
+            case USB_CS_WRDS :  /* Control write data stage */
+                events->ep0_setup();
+                break;
+            case USB_CS_WRND :  /* Status stage of a control write where there is no data stage. */
+                events->ep0_setup();
+                run_later_ctrl_comp = true;
+                break;
+            case USB_CS_RDSS :  /* Control read status stage */
+                USB_MX.DCPCTR |= USB_CCPL;
+                break;
+            case USB_CS_WRSS :  /* Control write status stage */
+                USB_MX.DCPCTR |= USB_CCPL;
+                break;
+            case USB_CS_SQER :  /* Control sequence error */
+            default :           /* Illegal */
+                ctrl_end((uint16_t)USB_DATA_ERR);
+                break;
+        }
+    }
+
+    /***** Processing PIPE1-MAX_PIPE_NO data *****/
+    else if ((ists0 & USB_BRDY) == USB_BRDY) {
+        /* ==== BRDY PIPEx ==== */
+        USB_MX.BRDYSTS = (uint16_t)((~bsts) & BRDYSTS_MASK);
+
+        for (i = USB_MIN_PIPE_NO; i < PIPE_NUM; i++) {
+            if ((bsts & USB_BITSET(i)) != 0u) {
+                /* Interrupt check */
+                if (pipe_ctrl[i].enable) {
+                    USB_MX.PIPESEL = i;
+                    if (USB_BUF2FIFO == (uint16_t)(USB_MX.PIPECFG & USB_DIRFIELD)) {
+                        /* write */
+                        buf_to_fifo(i);         /* Buffer to FIFO data write */
+                        events->in(PIPE2EP(i));
+                    } else {
+                        /* read */
+                        fifo_to_buf(i);         /* FIFO to Buffer data read */
+                        events->out(PIPE2EP(i));
+                    }
+                }
+            }
+        }
+    }
+    else if ((ists0 & USB_BEMP) == USB_BEMP) {
+        /* ==== BEMP PIPEx ==== */
+        USB_MX.BEMPSTS = (uint16_t)((~ests) & BEMPSTS_MASK);
+
+        for (i = USB_MIN_PIPE_NO; i < PIPE_NUM; i++) {
+            if ((ests & USB_BITSET(i)) != 0) {
+                /* Interrupt check */
+                if (pipe_ctrl[i].enable) {
+                    /* MAX packet size error ? */
+                    if (((get_pid(i) & USB_PID_STALL) == USB_PID_STALL) || ((get_pid(i) & USB_PID_STALL2) == USB_PID_STALL2)) {
+                        forced_termination(i, (uint16_t)USB_DATA_STALL);
+                    } else {
+                        if ((i >= USB_PIPE6) || ((*get_pipectr_reg(i) & USB_INBUFM) != USB_INBUFM)) {
+                            data_end(i, (uint16_t)USB_DATA_NONE);       /* End of data transfer */
+                        } else {
+                            USB_MX.BEMPENB |= (1 << i);
+                        }
+                    }
+                    events->in(PIPE2EP(i));
+                }
+            }
+        }
+    }
+    else if ((ists0 & USB_NRDY) == USB_NRDY) {
+        /* ==== NRDY PIPEx ==== */
+        USB_MX.NRDYSTS = (uint16_t)((~nsts) & NRDYSTS_MASK);
+
+        for (i = USB_MIN_PIPE_NO; i < PIPE_NUM; i++) {
+            if ((nsts & USB_BITSET(i)) != 0) {
+                /* Interrupt check */
+                if (pipe_ctrl[i].enable) {
+                    if (((get_pid(i) & USB_PID_STALL) != USB_PID_STALL) && ((get_pid(i) & USB_PID_STALL2) != USB_PID_STALL2)) {
+                        set_pid(i, USB_PID_BUF);
+                    }
+                }
+            }
+        }
+    }
+    else {
+        /* Non processing. */
+    }
+}
+
+void USBPhyHw::_usbisr(void)
+{
+    GIC_DisableIRQ(USBIX_IRQn);
+
+    run_later_ctrl_comp = false;
+
+    instance->events->start_process();
+
+    if (run_later_ctrl_comp) {
+        USB_MX.DCPCTR &= (~USB_PID);
+        USB_MX.DCPCTR |= USB_PID_BUF;
+
+        USB_MX.DCPCTR |= USB_CCPL;
+    }
+
+    /* Re-enable interrupt */
+    GIC_ClearPendingIRQ(USBIX_IRQn);
+    GIC_EnableIRQ(USBIX_IRQn);
+}
+
+void USBPhyHw::chg_curpipe(uint16_t pipe, uint16_t isel)
+{
+    volatile uint16_t *p_reg;
+    uint16_t fifo_use;
+    uint16_t isel_val;
+    uint16_t buf;
+
+    fifo_use = PIPE2FIFO(pipe);
+    if ((fifo_use == USB_FUNCTION_D0FIFO_USE) || (fifo_use == USB_FUNCTION_D1FIFO_USE)) {
+        isel_val = 0;
+    } else {
+        isel_val = isel;
+    }
+
+    p_reg = get_fifosel_reg(pipe);
+    buf  = *p_reg;
+    buf &= (uint16_t)(~(USB_RCNT | USB_ISEL | USB_CURPIPE | USB_MBW));
+    buf |= (uint16_t)((USB_RCNT | isel_val | pipe | USB_MBW_32) & (USB_RCNT | USB_ISEL | USB_CURPIPE | USB_MBW));
+    *p_reg = buf;
+
+    do {
+        cpu_delay_1us(1);
+        buf = *p_reg;
+    } while ((buf & (uint16_t)(USB_ISEL | USB_CURPIPE)) != (uint16_t)(isel_val | pipe));
+}
+
+uint16_t USBPhyHw::is_set_frdy(uint16_t pipe, uint16_t isel)
+{
+    volatile uint16_t *p_reg;
+    uint16_t buffer;
+    int retry_cnt = 0;
+
+    chg_curpipe(pipe, isel);                    /* Changes the FIFO port by the pipe. */
+    p_reg = get_fifoctr_reg(pipe);
+    for (retry_cnt = 0; retry_cnt < 10; retry_cnt++) {
+        buffer = *p_reg;
+        if ((uint16_t)(buffer & USB_FRDY) == USB_FRDY) {
+            return (buffer);
+        }
+        cpu_delay_1us(1);
+    }
+
+    return (USB_FIFOERROR);
+}
+
+uint8_t * USBPhyHw::read_fifo(uint16_t pipe, uint16_t count, uint8_t *read_p)
+{
+    iodefine_reg32_t *p_reg;
+    uint16_t even;
+    uint16_t odd;
+    uint32_t odd_byte_data_temp;
+
+    p_reg = (iodefine_reg32_t *)get_fifo_reg(pipe);
+    for (even = (uint16_t)(count >> 2); (even != 0); --even) {
+        /* 32bit FIFO access */
+        *((uint32_t *)read_p) = p_reg->UINT32;
+        read_p += sizeof(uint32_t);
+    }
+    odd = count % 4;
+    if (count < 4) {
+        odd = count;
+    }
+    if (odd != 0) {
+        /* 32bit FIFO access */
+        odd_byte_data_temp = p_reg->UINT32;
+        /* Condition compilation by the difference of the endian */
+        do {
+            *read_p = (uint8_t)(odd_byte_data_temp & 0x000000ff);
+            odd_byte_data_temp = odd_byte_data_temp >> 8;
+            /* Renewal read pointer */
+            read_p += sizeof(uint8_t);
+            odd--;
+        } while (odd != 0);
+    }
+
+    return read_p;
+}
+
+uint16_t USBPhyHw::read_data(uint16_t pipe)
+{
+    volatile uint16_t *p_reg;
+    uint16_t count;
+    uint16_t buffer;
+    uint16_t mxps;
+    uint16_t dtln;
+    uint16_t end_flag;
+
+    /* Changes FIFO port by the pipe. */
+    buffer = is_set_frdy(pipe, 0);
+    if (buffer == USB_FIFOERROR) {
+        return (USB_FIFOERROR);                 /* FIFO access error */
+    }
+    dtln = (uint16_t)(buffer & USB_DTLN);
+
+    /* Max Packet Size */
+    if (pipe == USB_PIPE0) {
+        mxps = (uint16_t)(USB_MX.DCPMAXP & USB_MAXP);
+    } else {
+        USB_MX.PIPESEL = pipe;                  /* Pipe select */
+        mxps = (uint16_t)(USB_MX.PIPEMAXP & USB_MXPS);
+    }
+
+    if (pipe_ctrl[pipe].data_cnt < dtln) {
+        /* Buffer Over ? */
+        end_flag = USB_READOVER;
+        set_pid(pipe, USB_PID_NAK);             /* Set NAK */
+        count = (uint16_t)pipe_ctrl[pipe].data_cnt;
+        pipe_ctrl[pipe].data_cnt = dtln;
+    } else if (pipe_ctrl[pipe].data_cnt == dtln) {
+        /* Just Receive Size */
+        count = dtln;
+        if ((count == 0) || ((dtln % mxps) != 0)) {
+            /* Just Receive Size */
+            /* Peripheral Function */
+            end_flag = USB_READSHRT;
+        } else {
+            end_flag = USB_READEND;
+            set_pid(pipe, USB_PID_NAK);         /* Set NAK */
+        }
+    } else {
+        /* Continuous Receive data */
+        count = dtln;
+        end_flag = USB_READING;
+        if (count == 0) {
+            /* Null Packet receive */
+            end_flag = USB_READSHRT;
+            set_pid(pipe, USB_PID_NAK);         /* Set NAK */
+        }
+        if ((count % mxps) != 0) {
+            /* Null Packet receive */
+            end_flag = USB_READSHRT;
+            set_pid(pipe, USB_PID_NAK);         /* Set NAK */
+        }
+    }
+
+    if (dtln == 0) { /* 0 length packet */
+        p_reg = get_fifoctr_reg(pipe);
+        *p_reg = USB_BCLR;                      /* Clear BCLR */
+    } else {
+        pipe_ctrl[pipe].p_data = read_fifo(pipe, count, pipe_ctrl[pipe].p_data);
+    }
+    pipe_ctrl[pipe].data_cnt -= count;
+
+    return end_flag;
+}
+
+void USBPhyHw::fifo_to_buf(uint16_t pipe)
+{
+    /* Check FIFO access sequence */
+    switch (read_data(pipe)) {
+        case USB_READING :                                      /* Continue of data read */
+            break;
+        case USB_READEND :                                      /* End of data read */
+            data_end(pipe, (uint16_t)USB_DATA_OK);
+            pipe_ctrl[pipe].req_size -= pipe_ctrl[pipe].data_cnt;
+            break;
+        case USB_READSHRT :                                     /* End of data read */
+            data_end(pipe, (uint16_t)USB_DATA_SHT);
+            pipe_ctrl[pipe].req_size -= pipe_ctrl[pipe].data_cnt;
+            break;
+        case USB_READOVER :                                     /* Buffer over */
+            forced_termination(pipe, (uint16_t)USB_DATA_OVR);
+            pipe_ctrl[pipe].req_size -= pipe_ctrl[pipe].data_cnt;
+            break;
+        case USB_FIFOERROR :                                    /* FIFO access error */
+        default:
+            forced_termination(pipe, (uint16_t)USB_DATA_ERR);
+            break;
+    }
+}
+
+uint8_t * USBPhyHw::write_fifo(uint16_t pipe, uint16_t count, uint8_t *write_p)
+{
+    iodefine_reg32_t *p_reg;
+    uint16_t even;
+    uint16_t odd;
+
+    p_reg = (iodefine_reg32_t *)get_fifo_reg(pipe);
+    set_mbw(pipe, USB_MBW_32);                                /* 32bit access */
+    for (even = (uint16_t)(count >> 2); (even != 0); --even) {
+        p_reg->UINT32 = *((uint32_t *)write_p);
+        write_p += sizeof(uint32_t);
+    }
+    odd = count % 4;
+    if (count < 4) {
+        odd = count;
+    }
+    if ((odd & (uint16_t)0x0002u) != 0u) {
+        set_mbw(pipe, USB_MBW_16);                            /* 16bit access */
+        p_reg->UINT16[H] = *((uint16_t *)write_p);
+        write_p += sizeof(uint16_t);
+    }
+    if ((odd & (uint16_t)0x0001u) != 0u) {
+        set_mbw(pipe, USB_MBW_8);                             /* 8bit access */
+        p_reg->UINT8[HH] = *write_p;
+        write_p++;
+    }
+
+    return write_p;
+}
+
+uint16_t USBPhyHw::write_data(uint16_t pipe)
+{
+    volatile uint16_t *p_reg;
+    uint16_t size;
+    uint16_t count;
+    uint16_t mxps;
+    uint16_t end_flag;
+    uint16_t buffer;
+
+    /* Changes FIFO port by the pipe. */
+    if (pipe == USB_PIPE0) {
+        buffer = is_set_frdy(pipe, USB_ISEL_WRITE);
+    } else {
+        buffer = is_set_frdy(pipe, 0);
+    }
+
+    if (buffer == USB_FIFOERROR) {
+        return (USB_FIFOERROR);
+    }
+
+    if (pipe == USB_PIPE0) {
+        /* Max Packet Size */
+        mxps = (uint16_t)(USB_MX.DCPMAXP & USB_MAXP);
+
+        /* Data buffer size */
+        if ((USB_MX.DCPCFG & USB_CNTMDFIELD) == USB_CFG_CNTMDON) {
+            size = USB_PIPE0BUF;
+        } else {
+            size = mxps;
+        }
+    } else {
+        /* Max Packet Size */
+        USB_MX.PIPESEL = pipe;                          /* Pipe select */
+        mxps = (uint16_t)(USB_MX.PIPEMAXP & USB_MXPS);
+
+        /* Data buffer size */
+        if ((USB_MX.PIPECFG & USB_CNTMDFIELD) == USB_CFG_CNTMDON) {
+            size = (uint16_t)((uint16_t)((USB_MX.PIPEBUF >> USB_BUFSIZE_BIT) + 1) * USB_PIPEXBUF);
+        } else {
+            size = mxps;
+        }
+    }
+
+    /* Data size check */
+    if (pipe_ctrl[pipe].data_cnt <= (uint32_t)size) {
+        count = (uint16_t)pipe_ctrl[pipe].data_cnt;
+        if (count == 0) {
+            end_flag = USB_WRITESHRT;                   /* Null Packet is end of write */
+        } else if ((count % mxps) != 0) {
+            end_flag = USB_WRITESHRT;                   /* Short Packet is end of write */
+        } else {
+            end_flag = USB_WRITEEND;                    /* Just Send Size */
+        }
+    } else {
+        /* Write continues */
+        end_flag = USB_WRITING;
+        count = size;
+    }
+
+    pipe_ctrl[pipe].p_data = write_fifo(pipe, count, pipe_ctrl[pipe].p_data);
+
+    /* Check data count to remain */
+    if (pipe_ctrl[pipe].data_cnt < (uint32_t)size) {
+        pipe_ctrl[pipe].data_cnt = 0u;                  /* Clear data count */
+
+        p_reg = get_fifoctr_reg(pipe);
+        if ((*p_reg & USB_BVAL) == 0u) {                /* Check BVAL */
+            *p_reg |= USB_BVAL;                         /* Short Packet */
+        }
+    } else {
+        pipe_ctrl[pipe].data_cnt -= count;              /* Total data count - count */
+    }
+
+    return end_flag;
+}
+
+void USBPhyHw::buf_to_fifo(uint16_t pipe)
+{
+    /* Disable Ready Interrupt */
+    USB_MX.BRDYENB &= (~(1 << pipe));
+
+    /* Peripheral control sequence */
+    switch (write_data(pipe)) {
+        case USB_WRITING :                          /* Continue of data write */
+            USB_MX.BRDYENB |= (1 << pipe);          /* Enable Ready Interrupt */
+            USB_MX.NRDYENB |= (1 << pipe);          /* Enable Not Ready Interrupt */
+            break;
+        case USB_WRITEEND :                         /* End of data write */
+        case USB_WRITESHRT :                        /* End of data write */
+            USB_MX.BEMPENB |= (1 << pipe);          /* Enable Empty Interrupt */
+            USB_MX.NRDYENB |= (1 << pipe);          /* Enable Not Ready Interrupt */
+            break;
+        case USB_FIFOERROR :                        /* FIFO access error */
+        default:
+            forced_termination(pipe, (uint16_t)USB_DATA_ERR);
+            break;
+    }
+}
+
+uint16_t * USBPhyHw::get_pipectr_reg(uint16_t pipe)
+{
+    if (pipe == USB_PIPE0) {
+        return (uint16_t *)&(USB_MX.DCPCTR);
+    } else {
+        return (uint16_t *)&(USB_MX.PIPE1CTR) + (pipe - USB_PIPE1);
+    }
+}
+
+uint16_t * USBPhyHw::get_pipetre_reg(uint16_t pipe)
+{
+    if ((pipe >= USB_PIPE1) && (pipe <= USB_PIPE5)) {
+        return (uint16_t *)&(USB_MX.PIPE1TRE) + ((pipe - USB_PIPE1) * 2);
+    } else if ((pipe >= USB_PIPE9) && (pipe <= USB_PIPE10)) {
+        return (uint16_t *)&(USB_MX.PIPE9TRE) + ((pipe - USB_PIPE9) * 2);
+    } else if ((pipe >= USB_PIPE11) && (pipe <= USB_PIPE15)) {
+        return (uint16_t *)&(USB_MX.PIPEBTRE) + ((pipe - USB_PIPE11) * 2);
+    } else {
+        return NULL;
+    }
+}
+
+uint16_t * USBPhyHw::get_pipetrn_reg(uint16_t pipe)
+{
+    if ((pipe >= USB_PIPE1) && (pipe <= USB_PIPE5)) {
+        return (uint16_t *)&(USB_MX.PIPE1TRN) + ((pipe - USB_PIPE1) * 2);
+    } else if ((pipe >= USB_PIPE9) && (pipe <= USB_PIPE10)) {
+        return (uint16_t *)&(USB_MX.PIPE9TRN) + ((pipe - USB_PIPE9) * 2);
+    } else if ((pipe >= USB_PIPE11) && (pipe <= USB_PIPE15)) {
+        return (uint16_t *)&(USB_MX.PIPEBTRN) + ((pipe - USB_PIPE11) * 2);
+    } else {
+        return NULL;
+    }
+}
+
+uint16_t * USBPhyHw::get_fifoctr_reg(uint16_t pipe)
+{
+    uint16_t fifo_use = PIPE2FIFO(pipe);
+
+    if ((fifo_use & USB_FUNCTION_D0FIFO_USE) == USB_FUNCTION_D0FIFO_USE) {
+        return (uint16_t *)&(USB_MX.D0FIFOCTR);
+    } else if ((fifo_use & USB_FUNCTION_D1FIFO_USE) == USB_FUNCTION_D1FIFO_USE) {
+        return (uint16_t *)&(USB_MX.D1FIFOCTR);
+    } else {
+        return (uint16_t *)&(USB_MX.CFIFOCTR);
+    }
+}
+
+uint16_t * USBPhyHw::get_fifosel_reg(uint16_t pipe)
+{
+    uint16_t fifo_use = PIPE2FIFO(pipe);
+
+    if ((fifo_use & USB_FUNCTION_D0FIFO_USE) == USB_FUNCTION_D0FIFO_USE) {
+        return (uint16_t *)&(USB_MX.D0FIFOSEL);
+    } else if ((fifo_use & USB_FUNCTION_D1FIFO_USE) == USB_FUNCTION_D1FIFO_USE) {
+        return (uint16_t *)&(USB_MX.D1FIFOSEL);
+    } else {
+        return (uint16_t *)&(USB_MX.CFIFOSEL);
+    }
+}
+
+uint32_t * USBPhyHw::get_fifo_reg(uint16_t pipe)
+{
+    uint16_t fifo_use = PIPE2FIFO(pipe);
+
+    if ((fifo_use & USB_FUNCTION_D0FIFO_USE) == USB_FUNCTION_D0FIFO_USE) {
+        return (uint32_t *)&(USB_MX.D0FIFO);
+    } else if ((fifo_use & USB_FUNCTION_D1FIFO_USE) == USB_FUNCTION_D1FIFO_USE) {
+        return (uint32_t *)&(USB_MX.D1FIFO);
+    } else {
+        return (uint32_t *)&(USB_MX.CFIFO);
+    }
+}
+
+uint16_t USBPhyHw::get_pid(uint16_t pipe)
+{
+    volatile uint16_t *p_reg;
+
+    p_reg = get_pipectr_reg(pipe);
+    return (uint16_t)(*p_reg & USB_PID);
+}
+
+void USBPhyHw::set_mbw(uint16_t pipe, uint16_t data)
+{
+    volatile uint16_t *p_reg;
+
+    p_reg = get_fifosel_reg(pipe);
+    *p_reg &= (~USB_MBW);
+    if (data != 0) {
+        *p_reg |= data;
+    }
+}
+
+void USBPhyHw::set_pid(uint16_t pipe, uint16_t new_pid)
+{
+    volatile uint16_t *p_reg;
+    uint16_t old_pid;
+
+    p_reg = get_pipectr_reg(pipe);
+    old_pid = get_pid(pipe);
+
+    switch (new_pid) {
+        case USB_PID_STALL:
+            if ((old_pid & USB_PID_BUF) == USB_PID_BUF) {
+                *p_reg &= (~USB_PID);
+                *p_reg |= USB_PID_STALL2;
+            } else {
+                *p_reg &= (~USB_PID);
+                *p_reg |= new_pid;
+            }
+            break;
+        case USB_PID_BUF:
+            if (((old_pid & USB_PID_STALL) == USB_PID_STALL) || 
+                ((old_pid & USB_PID_STALL2) == USB_PID_STALL2)) {
+                *p_reg &= (~USB_PID);
+                *p_reg |= USB_PID_NAK;
+            }
+            *p_reg &= (~USB_PID);
+            *p_reg |= new_pid;
+            break;
+        case USB_PID_NAK:
+            if ((old_pid & USB_PID_STALL2) == USB_PID_STALL2) {
+                *p_reg &= (~USB_PID);
+                *p_reg |= USB_PID_STALL;
+            }
+            *p_reg &= (~USB_PID);
+            *p_reg |= new_pid;
+
+            do {
+                cpu_delay_1us(1);
+                p_reg = get_pipectr_reg(pipe);
+            } while ((*p_reg & USB_PBUSY) == USB_PBUSY);
+            break;
+        default:
+            *p_reg &= (~USB_PID);
+            *p_reg |= new_pid;
+            break;
+    }
+}
+
+void USBPhyHw::cpu_delay_1us(uint16_t time)
+{
+    volatile uint32_t i = 38 * time;
+
+    while (i > 0) {
+        i--;
+    }
+}
+
+uint16_t USBPhyHw::EP2PIPE(uint16_t endpoint)
+{
+    const struct PIPECFGREC *cfg;
+
+    for (cfg = &def_pipecfg[0]; cfg->pipesel != 0; cfg++) {
+        if (cfg->endpoint == endpoint) {
+            break;
+        }
+    }
+    return (cfg->pipesel & USB_CURPIPE);
+}
+
+uint16_t USBPhyHw::PIPE2EP(uint16_t pipe)
+{
+    const struct PIPECFGREC *cfg;
+
+    if (pipe == USB_PIPE0) {
+        return 0;
+    }
+    for (cfg = &def_pipecfg[0]; cfg->pipesel != 0; cfg++) {
+        if ((cfg->pipesel & USB_CURPIPE) == pipe) {
+            break;
+        }
+    }
+    return cfg->endpoint;
+}
+
+uint16_t USBPhyHw::PIPE2FIFO(uint16_t pipe)
+{
+    const struct PIPECFGREC *cfg;
+    uint16_t fifo_use;
+
+    if (pipe == USB_PIPE0) {
+        fifo_use = USB_FUNCTION_CFIFO_USE;
+    } else {
+        for (cfg = &def_pipecfg[0]; cfg->pipesel != 0; cfg++) {
+            if ((cfg->pipesel & USB_CURPIPE) == pipe) {
+                break;
+            }
+        }
+        if ((cfg->pipesel & USB_FUNCTION_D0FIFO_USE) == USB_FUNCTION_D0FIFO_USE) {
+            fifo_use = USB_FUNCTION_D0FIFO_USE;
+        } else if ((cfg->pipesel & USB_FUNCTION_D1FIFO_USE) == USB_FUNCTION_D1FIFO_USE) {
+            fifo_use = USB_FUNCTION_D1FIFO_USE;
+        } else {
+            fifo_use = USB_FUNCTION_CFIFO_USE;
+        }
+    }
+
+    return fifo_use;
+}
+
+void USBPhyHw::reset_usb(uint16_t clockmode)
+{
+#if (USB_FUNCTION_CH == 0)
+    if ((USB200.SYSCFG0 & USB_UPLLE) == USB_UPLLE) {
+        if ((USB200.SYSCFG0 & USB_UCKSEL) != clockmode) {
+            USB200.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+            USB200.SYSCFG0 = 0;
+            USB200.SYSCFG0 = (clockmode | USB_UPLLE);
+            cpu_delay_1us(1000);
+            USB200.SUSPMODE |= USB_SUSPMODE_SUSPM;
+        } else {
+            USB200.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+            cpu_delay_1us(1000);
+            USB200.SUSPMODE |= USB_SUSPMODE_SUSPM;
+        }
+    } else {
+        USB200.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+        USB200.SYSCFG0 = 0;
+        USB200.SYSCFG0 = (clockmode | USB_UPLLE);
+        cpu_delay_1us(1000);
+        USB200.SUSPMODE |= USB_SUSPMODE_SUSPM;
+    }
+#else
+    /* UCKSEL and UPLLE bit is only USB0. If USB1, set to SYSCFG0 for USB0. */
+    if ((USB200.SYSCFG0 & USB_UPLLE) == USB_UPLLE) {
+        if ((USB200.SYSCFG0 & USB_UCKSEL) != clockmode) {
+            USB201.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+            USB200.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+            USB201.SYSCFG0 = 0;
+            USB200.SYSCFG0 = 0;
+            USB200.SYSCFG0 = (clockmode | USB_UPLLE);
+            cpu_delay_1us(1000);
+            USB200.SUSPMODE |= USB_SUSPMODE_SUSPM;
+            USB201.SUSPMODE |= USB_SUSPMODE_SUSPM;
+        } else {
+            USB201.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+            cpu_delay_1us(1000);
+            USB201.SUSPMODE |= USB_SUSPMODE_SUSPM;
+        }
+    } else {
+        USB201.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+        USB200.SUSPMODE &= ~(USB_SUSPMODE_SUSPM);
+        USB201.SYSCFG0 = 0;
+        USB200.SYSCFG0 = 0;
+        USB200.SYSCFG0 = (clockmode | USB_UPLLE);
+        cpu_delay_1us(1000);
+        USB200.SUSPMODE |= USB_SUSPMODE_SUSPM;
+        USB201.SUSPMODE |= USB_SUSPMODE_SUSPM;
+    }
+#endif
+    USB_MX.BUSWAIT = (uint16_t)(USB_BWAIT_3 & USB_BWAIT);   /* 3 : 5 access cycles  waits */
+    USB_MX.CFIFOSEL  = USB_MBW_32;
+    USB_MX.D0FIFOSEL = USB_MBW_32;
+    USB_MX.D1FIFOSEL = USB_MBW_32;
+}
+
+bool USBPhyHw::chk_vbsts(void)
+{
+    uint16_t buf1;
+    uint16_t buf2;
+    uint16_t buf3;
+    bool connect_flg = false;
+
+    /* VBUS chattering cut */
+    do {
+        buf1 = USB_MX.INTSTS0;
+        cpu_delay_1us(10);
+        buf2 = USB_MX.INTSTS0;
+        cpu_delay_1us(10);
+        buf3 = USB_MX.INTSTS0;
+    } while (((buf1 & USB_VBSTS) != (buf2 & USB_VBSTS)) || ((buf2 & USB_VBSTS) != (buf3 & USB_VBSTS)));
+
+    /* VBUS status judge */
+    if ((buf1 & USB_VBSTS) != (uint16_t)0) {
+        connect_flg = true;
+    }
+
+    return connect_flg;
+}
+
+void USBPhyHw::ctrl_end(uint16_t status)
+{
+    /* Interrupt disable */
+    USB_MX.BEMPENB &= (~(1 << USB_PIPE0));  /* Disable Empty Interrupt */
+    USB_MX.BRDYENB &= (~(1 << USB_PIPE0));  /* Disable Ready Interrupt */
+    USB_MX.NRDYENB &= (~(1 << USB_PIPE0));  /* Disable Not Ready Interrupt */
+
+    set_mbw(USB_PIPE0, USB_MBW_32);
+
+    if ((status == USB_DATA_ERR) || (status == USB_DATA_OVR)) {
+        set_pid(USB_PIPE0, USB_PID_STALL);  /* Request error */
+    } else if (status == USB_DATA_STOP) {
+        set_pid(USB_PIPE0, USB_PID_NAK);    /* Pipe stop */
+    } else {
+        USB_MX.DCPCTR |= USB_CCPL;          /* Set CCPL bit */
+    }
+}
+
+void USBPhyHw::data_end(uint16_t pipe, uint16_t status)
+{
+    volatile uint16_t *p_reg;
+
+    /* Disable Interrupt */
+    USB_MX.BRDYENB &= (~(1 << pipe));           /* Disable Ready Interrupt */
+    USB_MX.NRDYENB &= (~(1 << pipe));           /* Disable Not Ready Interrupt */
+    USB_MX.BEMPENB &= (~(1 << pipe));           /* Disable Empty Interrupt */
+
+    set_pid(pipe, USB_PID_NAK);                 /* Set NAK */
+
+    /* Disable Transaction count */
+    p_reg = get_pipetre_reg(pipe);
+    if (p_reg != NULL) {
+        *p_reg &= (~USB_TRENB);
+        *p_reg |= USB_TRCLR;
+    }
+
+    if (pipe_ctrl[pipe].enable) {
+        /* Check PIPE TYPE */
+        USB_MX.PIPESEL = pipe;                  /* Pipe select */
+        if ((USB_MX.PIPECFG & USB_TYPFIELD) != USB_TYPFIELD_ISO) {
+            /* Transfer information set */
+            pipe_ctrl[pipe].enable = false;
+            pipe_ctrl[pipe].status = status;
+        } else if ((uint16_t)(USB_MX.PIPECFG & USB_DIRFIELD) == USB_BUF2FIFO) {
+            /* ISO OUT Transfer (restart) */
+            pipe_ctrl[pipe].status = USB_DATA_WRITING;
+        } else {
+            /* ISO IN Transfer (restart) */
+            pipe_ctrl[pipe].status = USB_DATA_READING;
+        }
+    }
+}
+
+void USBPhyHw::forced_termination(uint16_t pipe, uint16_t status)
+{
+    volatile uint16_t *p_reg;
+
+    /* Disable Interrupt */
+    USB_MX.BRDYENB &= (~(1 << pipe));           /* Disable Ready Interrupt */
+    USB_MX.NRDYENB &= (~(1 << pipe));           /* Disable Not Ready Interrupt */
+    USB_MX.BEMPENB &= (~(1 << pipe));           /* Disable Empty Interrupt */
+
+    set_pid(pipe, USB_PID_NAK);                 /* Set NAK */
+
+    /* Disable Transaction count */
+    p_reg = get_pipetre_reg(pipe);
+    if (p_reg != NULL) {
+        *p_reg &= (~USB_TRENB);
+        *p_reg |= USB_TRCLR;
+    }
+
+    set_mbw(pipe, USB_MBW_32);
+
+    chg_curpipe(pipe, 0);                   /* Changes the FIFO port by the pipe. */
+
+    p_reg = get_pipectr_reg(pipe);
+    /* Buffer Clear */
+    *p_reg |= USB_ACLRM;
+    *p_reg &= ~USB_ACLRM;
+
+    pipe_ctrl[pipe].enable = false;
+    pipe_ctrl[pipe].status  = status;
+}
+
+#endif

--- a/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhy_RZ_A1_Def.h
+++ b/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhy_RZ_A1_Def.h
@@ -1,0 +1,697 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited, All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef USBPHY_RZ_A1_DEF
+#define USBPHY_RZ_A1_DEF
+
+/******************************************************************************
+ Macro definitions
+ ******************************************************************************/
+
+/* H/W function type */
+#define USB_BIT0                ((uint16_t)0x0001)
+#define USB_BIT1                ((uint16_t)0x0002)
+#define USB_BIT2                ((uint16_t)0x0004)
+#define USB_BIT3                ((uint16_t)0x0008)
+#define USB_BIT4                ((uint16_t)0x0010)
+#define USB_BIT5                ((uint16_t)0x0020)
+#define USB_BIT6                ((uint16_t)0x0040)
+#define USB_BIT7                ((uint16_t)0x0080)
+#define USB_BIT8                ((uint16_t)0x0100)
+#define USB_BIT9                ((uint16_t)0x0200)
+#define USB_BIT10               ((uint16_t)0x0400)
+#define USB_BIT11               ((uint16_t)0x0800)
+#define USB_BIT12               ((uint16_t)0x1000)
+#define USB_BIT13               ((uint16_t)0x2000)
+#define USB_BIT14               ((uint16_t)0x4000)
+#define USB_BIT15               ((uint16_t)0x8000)
+#define USB_BITSET(x)           ((uint16_t)((uint16_t)1 << (x)))
+
+/* Start Pipe No */
+#define USB_MIN_PIPE_NO         (1u)
+
+/* Pipe configuration table define */
+#define USB_EPL                 (6u)        /* Pipe configuration table length */
+#define USB_TYPFIELD            (0xC000u)   /* Transfer type */
+#define USB_PERIODIC            (0x8000u)   /* Periodic pipe */
+#define USB_TYPFIELD_ISO        (0xC000u)   /* Isochronous */
+#define USB_TYPFIELD_INT        (0x8000u)   /* Interrupt */
+#define USB_TYPFIELD_BULK       (0x4000u)   /* Bulk */
+#define USB_NOUSE               (0x0000u)   /* Not configuration */
+#define USB_BFREFIELD           (0x0400u)   /* Buffer ready interrupt mode select */
+#define USB_BFREON              (0x0400u)
+#define USB_BFREOFF             (0x0000u)
+#define USB_DBLBFIELD           (0x0200u)   /* Double buffer mode select */
+#define USB_CFG_DBLBON          (0x0200u)
+#define USB_CFG_DBLBOFF         (0x0000u)
+#define USB_CNTMDFIELD          (0x0100u)   /* Continuous transfer mode select */
+#define USB_CFG_CNTMDON         (0x0100u)
+#define USB_CFG_CNTMDOFF        (0x0000u)
+#define USB_SHTNAKFIELD         (0x0080u)   /* Transfer end NAK */
+#define USB_DIRFIELD            (0x0010u)   /* Transfer direction select */
+#define USB_DIR_H_OUT           (0x0010u)   /* HOST OUT */
+#define USB_DIR_P_IN            (0x0010u)   /* PERI IN */
+#define USB_DIR_H_IN            (0x0000u)   /* HOST IN */
+#define USB_DIR_P_OUT           (0x0000u)   /* PERI OUT */
+#define USB_BUF2FIFO            (0x0010u)   /* Buffer --> FIFO */
+#define USB_FIFO2BUF            (0x0000u)   /* FIFO --> buffer */
+#define USB_EPNUMFIELD          (0x000Fu)   /* Endpoint number select */
+#define USB_MAX_EP_NO           (15u)       /* EP0 EP1 ... EP15 */
+
+#define USB_BUF_SIZE(x)         ((uint16_t)(((x) / 64u) - 1u) << 10u)
+#define USB_BUF_NUMB(x)         (x)
+
+/* FIFO read / write result */
+#define USB_FIFOERROR           (0x00ffu)   /* FIFO not ready */
+#define USB_WRITEEND            (0x0000u)   /* End of write (but packet may not be outputting) */
+#define USB_WRITESHRT           (0x0001u)   /* End of write (send short packet) */
+#define USB_WRITING             (0x0002u)   /* Write continues */
+#define USB_READEND             (0x0000u)   /* End of read */
+#define USB_READSHRT            (0x0001u)   /* Insufficient (receive short packet) */
+#define USB_READING             (0x0002u)   /* Read continues */
+#define USB_READOVER            (0x0003u)   /* Buffer size over */
+
+/* Transfer status Type */
+#define USB_CTRL_END            (0u)
+#define USB_DATA_NONE           (1u)
+#define USB_DATA_WAIT           (2u)
+#define USB_DATA_OK             (3u)
+#define USB_DATA_SHT            (4u)
+#define USB_DATA_OVR            (5u)
+#define USB_DATA_STALL          (6u)
+#define USB_DATA_ERR            (7u)
+#define USB_DATA_STOP           (8u)
+#define USB_DATA_TMO            (9u)
+#define USB_CTRL_READING        (17u)
+#define USB_CTRL_WRITING        (18u)
+#define USB_DATA_READING        (19u)
+#define USB_DATA_WRITING        (20u)
+
+
+/* System Configuration Control Register */
+#define USB_HSE                 (0x0080u)   /* b7: Hi-speed enable */
+#define USB_DCFM                (0x0040u)   /* b6: Function select */
+#define USB_DRPD                (0x0020u)   /* b5: D+/D- pull down control */
+#define USB_DPRPU               (0x0010u)   /* b4: D+ pull up control */
+#define USB_DMRPU               (0x0008u)   /* b3: D- pull up control */ /* For low speed */
+#define USB_UCKSEL              (0x0004u)   /* b2: USB clock select */
+#define USB_EXTAL_12MHZ         (0x0004u)   /* EXTAL 12MHz */
+#define USB_X1_48MHZ            (0x0000u)   /* USB_X1 48MHz */
+#define USB_UPLLE               (0x0002u)   /* b1: USB internal PLL enable */
+#define USB_USBE                (0x0001u)   /* b0: USB module enable */
+
+/* CPU Bus Wait Register */
+#define USB_BWAIT               (0x003Fu)   /* b5-0: Bus wait bit */
+#define USB_BWAIT_15            (0x000Fu)   /* 15 wait (access cycle 17) */
+#define USB_BWAIT_14            (0x000Eu)   /* 14 wait (access cycle 16) */
+#define USB_BWAIT_13            (0x000Du)   /* 13 wait (access cycle 15) */
+#define USB_BWAIT_12            (0x000Cu)   /* 12 wait (access cycle 14) */
+#define USB_BWAIT_11            (0x000Bu)   /* 11 wait (access cycle 13) */
+#define USB_BWAIT_10            (0x000Au)   /* 10 wait (access cycle 12) */
+#define USB_BWAIT_9             (0x0009u)   /*  9 wait (access cycle 11) */
+#define USB_BWAIT_8             (0x0008u)   /*  8 wait (access cycle 10) */
+#define USB_BWAIT_7             (0x0007u)   /*  7 wait (access cycle  9) */
+#define USB_BWAIT_6             (0x0006u)   /*  6 wait (access cycle  8) */
+#define USB_BWAIT_5             (0x0005u)   /*  5 wait (access cycle  7) */
+#define USB_BWAIT_4             (0x0004u)   /*  4 wait (access cycle  6) */
+#define USB_BWAIT_3             (0x0003u)   /*  3 wait (access cycle  5) */
+#define USB_BWAIT_2             (0x0002u)   /*  2 wait (access cycle  4) */
+#define USB_BWAIT_1             (0x0001u)   /*  1 wait (access cycle  3) */
+#define USB_BWAIT_0             (0x0000u)   /*  0 wait (access cycle  2) */
+
+/* System Configuration Status Register */
+#define USB_OVCMON              (0xC000u)   /* b15-14: Over-current monitor */
+#define USB_OVCBIT              (0x8000u)   /* b15-14: Over-current bit */
+#define USB_HTACT               (0x0040u)   /* b6: USB Host Sequencer Status Monitor */
+#define USB_SOFEA               (0x0020u)   /* b5: SOF monitor */
+#define USB_IDMON               (0x0004u)   /* b2: ID-pin monitor */
+#define USB_LNST                (0x0003u)   /* b1-0: D+, D- line status */
+#define USB_SE1                 (0x0003u)   /* SE1 */
+#define USB_FS_KSTS             (0x0002u)   /* Full-Speed K State */
+#define USB_FS_JSTS             (0x0001u)   /* Full-Speed J State */
+#define USB_LS_JSTS             (0x0002u)   /* Low-Speed J State */
+#define USB_LS_KSTS             (0x0001u)   /* Low-Speed K State */
+#define USB_SE0                 (0x0000u)   /* SE0 */
+
+/* PLL Status Register */
+#define USB_PLLLOCK             (0x0001u)
+
+/* Device State Control Register */
+#define USB_HNPBTOA             (0x0800u)   /* b11: Host negotiation protocol (BtoA) */
+#define USB_EXICEN              (0x0400u)   /* b10: EXICEN output terminal control */
+#define USB_VBUSEN              (0x0200u)   /* b9: VBUS output terminal control */
+#define USB_WKUP                (0x0100u)   /* b8: Remote wakeup */
+#define USB_RWUPE               (0x0080u)   /* b7: Remote wakeup sense */
+#define USB_USBRST              (0x0040u)   /* b6: USB reset enable */
+#define USB_RESUME              (0x0020u)   /* b5: Resume enable */
+#define USB_UACT                (0x0010u)   /* b4: USB bus enable */
+#define USB_RHST                (0x0007u)   /* b2-0: Reset handshake status */
+#define USB_HSPROC              (0x0004u)   /* HS handshake processing */
+#define USB_HSMODE              (0x0003u)   /* Hi-Speed mode */
+#define USB_FSMODE              (0x0002u)   /* Full-Speed mode */
+#define USB_LSMODE              (0x0001u)   /* Low-Speed mode */
+#define USB_UNDECID             (0x0000u)   /* Undecided */
+
+/* Test Mode Register */
+#define USB_UTST                (0x000Fu)   /* b3-0: Test mode */
+#define USB_H_TST_F_EN          (0x000Du)   /* HOST TEST FORCE ENABLE */
+#define USB_H_TST_PACKET        (0x000Cu)   /* HOST TEST Packet */
+#define USB_H_TST_SE0_NAK       (0x000Bu)   /* HOST TEST SE0 NAK */
+#define USB_H_TST_K             (0x000Au)   /* HOST TEST K */
+#define USB_H_TST_J             (0x0009u)   /* HOST TEST J */
+#define USB_H_TST_NORMAL        (0x0000u)   /* HOST Normal Mode */
+#define USB_P_TST_PACKET        (0x0004u)   /* PERI TEST Packet */
+#define USB_P_TST_SE0_NAK       (0x0003u)   /* PERI TEST SE0 NAK */
+#define USB_P_TST_K             (0x0002u)   /* PERI TEST K */
+#define USB_P_TST_J             (0x0001u)   /* PERI TEST J */
+#define USB_P_TST_NORMAL        (0x0000u)   /* PERI Normal Mode */
+
+/* CFIFO/DxFIFO Port Select Register */
+#define USB_RCNT                (0x8000u)   /* b15: Read count mode */
+#define USB_REW                 (0x4000u)   /* b14: Buffer rewind */
+#define USB_DCLRM               (0x2000u)   /* b13: Automatic buffer clear mode */
+#define USB_DREQE               (0x1000u)   /* b12: DREQ output enable */
+#define USB_MBW                 (0x0C00u)   /* b10: Maximum bit width for FIFO access */
+#define USB_MBW_32              (0x0800u)   /* FIFO access : 32bit */
+#define USB_MBW_16              (0x0400u)   /* FIFO access : 16bit */
+#define USB_MBW_8               (0x0000u)   /* FIFO access : 8bit */
+#define USB_BIGEND              (0x0100u)   /* b8: Big endian mode */
+#define USB_FIFO_BIG            (0x0100u)   /* Big endian */
+#define USB_FIFO_LITTLE         (0x0000u)   /* Little endian */
+#define USB_ISEL                (0x0020u)   /* b5: DCP FIFO port direction select */
+#define USB_ISEL_WRITE          (0x0020u)   /* write */
+#define USB_ISEL_READ           (0x0000u)   /* read */
+#define USB_CURPIPE             (0x000Fu)   /* b2-0: PIPE select */
+
+/* CFIFO/DxFIFO Port Control Register */
+#define USB_BVAL                (0x8000u)   /* b15: Buffer valid flag */
+#define USB_BCLR                (0x4000u)   /* b14: Buffer clear */
+#define USB_FRDY                (0x2000u)   /* b13: FIFO ready */
+#define USB_DTLN                (0x0FFFu)   /* b11-0: FIFO data length */
+
+/* Interrupt Enable Register 0 */
+#define USB_VBSE                (0x8000u)   /* b15: VBUS interrupt */
+#define USB_RSME                (0x4000u)   /* b14: Resume interrupt */
+#define USB_SOFE                (0x2000u)   /* b13: Frame update interrupt */
+#define USB_DVSE                (0x1000u)   /* b12: Device state transition interrupt */
+#define USB_CTRE                (0x0800u)   /* b11: Control transfer stage transition interrupt */
+#define USB_BEMPE               (0x0400u)   /* b10: Buffer empty interrupt */
+#define USB_NRDYE               (0x0200u)   /* b9: Buffer notready interrupt */
+#define USB_BRDYE               (0x0100u)   /* b8: Buffer ready interrupt */
+
+/* Interrupt Enable Register 1 */
+#define USB_OVRCRE              (0x8000u)   /* b15: Over-current interrupt */
+#define USB_BCHGE               (0x4000u)   /* b14: USB bus change interrupt */
+#define USB_DTCHE               (0x1000u)   /* b12: Detach sense interrupt */
+#define USB_ATTCHE              (0x0800u)   /* b11: Attach sense interrupt */
+#define USB_L1RSMENDE           (0x0200u)   /* b9: L1 resume completion interrupt */
+#define USB_LPMENDE             (0x0100u)   /* b8: LPM transaction completion interrupt */
+#define USB_EOFERRE             (0x0040u)   /* b6: EOF error interrupt */
+#define USB_SIGNE               (0x0020u)   /* b5: SETUP IGNORE interrupt */
+#define USB_SACKE               (0x0010u)   /* b4: SETUP ACK interrupt */
+#define USB_PDDETINTE           (0x0001u)   /* b0: PDDET detection interrupt */
+
+/* BRDY Interrupt Enable/Status Register */
+#define USB_BRDY9               (0x0200u)   /* b9: PIPE9 */
+#define USB_BRDY8               (0x0100u)   /* b8: PIPE8 */
+#define USB_BRDY7               (0x0080u)   /* b7: PIPE7 */
+#define USB_BRDY6               (0x0040u)   /* b6: PIPE6 */
+#define USB_BRDY5               (0x0020u)   /* b5: PIPE5 */
+#define USB_BRDY4               (0x0010u)   /* b4: PIPE4 */
+#define USB_BRDY3               (0x0008u)   /* b3: PIPE3 */
+#define USB_BRDY2               (0x0004u)   /* b2: PIPE2 */
+#define USB_BRDY1               (0x0002u)   /* b1: PIPE1 */
+#define USB_BRDY0               (0x0001u)   /* b1: PIPE0 */
+
+/* NRDY Interrupt Enable/Status Register */
+#define USB_NRDY9               (0x0200u)   /* b9: PIPE9 */
+#define USB_NRDY8               (0x0100u)   /* b8: PIPE8 */
+#define USB_NRDY7               (0x0080u)   /* b7: PIPE7 */
+#define USB_NRDY6               (0x0040u)   /* b6: PIPE6 */
+#define USB_NRDY5               (0x0020u)   /* b5: PIPE5 */
+#define USB_NRDY4               (0x0010u)   /* b4: PIPE4 */
+#define USB_NRDY3               (0x0008u)   /* b3: PIPE3 */
+#define USB_NRDY2               (0x0004u)   /* b2: PIPE2 */
+#define USB_NRDY1               (0x0002u)   /* b1: PIPE1 */
+#define USB_NRDY0               (0x0001u)   /* b1: PIPE0 */
+
+/* BEMP Interrupt Enable/Status Register */
+#define USB_BEMP9               (0x0200u)   /* b9: PIPE9 */
+#define USB_BEMP8               (0x0100u)   /* b8: PIPE8 */
+#define USB_BEMP7               (0x0080u)   /* b7: PIPE7 */
+#define USB_BEMP6               (0x0040u)   /* b6: PIPE6 */
+#define USB_BEMP5               (0x0020u)   /* b5: PIPE5 */
+#define USB_BEMP4               (0x0010u)   /* b4: PIPE4 */
+#define USB_BEMP3               (0x0008u)   /* b3: PIPE3 */
+#define USB_BEMP2               (0x0004u)   /* b2: PIPE2 */
+#define USB_BEMP1               (0x0002u)   /* b1: PIPE1 */
+#define USB_BEMP0               (0x0001u)   /* b0: PIPE0 */
+
+/* SOF Pin Configuration Register */
+#define USB_TRNENSEL            (0x0100u)   /* b8: Select transaction enable period */
+#define USB_BRDYM               (0x0040u)   /* b6: BRDY clear timing */
+#define USB_INTL                (0x0020u)   /* b5: Interrupt sense select */
+#define USB_EDGESTS             (0x0010u)   /* b4:  */
+#define USB_SOFMODE             (0x000Cu)   /* b3-2: SOF pin select */
+#define USB_SOF_125US           (0x0008u)   /* SOF 125us Frame Signal */
+#define USB_SOF_1MS             (0x0004u)   /* SOF 1ms Frame Signal */
+#define USB_SOF_DISABLE         (0x0000u)   /* SOF Disable */
+
+#define USB_HSEB                (0x8000u)   /* b15: CL only mode bit */
+
+#define USB_REPSTART            (0x0800u)   /* b11: Terminator adjustment forcible starting bit */
+#define USB_REPSEL              (0x0300u)   /* b9-8: Terminator adjustment cycle setting */
+#define USB_REPSEL_128          (0x0300u)   /* 128 sec */
+#define USB_REPSEL_64           (0x0200u)   /* 64 sec */
+#define USB_REPSEL_16           (0x0100u)   /* 16 sec */
+#define USB_REPSEL_NONE         (0x0000u)   /* - */
+#define USB_CLKSEL              (0x0030u)   /* b5-4: System clock setting */
+#define USB_CLKSEL_24           (0x0030u)   /* 24MHz */
+#define USB_CLKSEL_20           (0x0020u)   /* 20MHz */
+#define USB_CLKSEL_48           (0x0010u)   /* 48MHz */
+#define USB_CLKSEL_30           (0x0000u)   /* 30MHz */
+#define USB_CDPEN               (0x0008u)   /* b3: Charging downstream port enable */
+#define USB_PLLRESET            (0x0002u)   /* b1: PLL reset control */
+#define USB_DIRPD               (0x0001u)   /* b0: Power down control */
+
+/* Interrupt Status Register 0 */
+#define USB_VBINT               (0x8000u)   /* b15: VBUS interrupt */
+#define USB_RESM                (0x4000u)   /* b14: Resume interrupt */
+#define USB_SOFR                (0x2000u)   /* b13: SOF update interrupt */
+#define USB_DVST                (0x1000u)   /* b12: Device state transition interrupt */
+#define USB_CTRT                (0x0800u)   /* b11: Control transfer stage transition interrupt */
+#define USB_BEMP                (0x0400u)   /* b10: Buffer empty interrupt */
+#define USB_NRDY                (0x0200u)   /* b9: Buffer notready interrupt */
+#define USB_BRDY                (0x0100u)   /* b8: Buffer ready interrupt */
+#define USB_VBSTS               (0x0080u)   /* b7: VBUS input port */
+#define USB_DVSQ                (0x0070u)   /* b6-4: Device state */
+#define USB_DS_SPD_CNFG         (0x0070u)   /* Suspend Configured */
+#define USB_DS_SPD_ADDR         (0x0060u)   /* Suspend Address */
+#define USB_DS_SPD_DFLT         (0x0050u)   /* Suspend Default */
+#define USB_DS_SPD_POWR         (0x0040u)   /* Suspend Powered */
+#define USB_DS_SUSP             (0x0040u)   /* Suspend */
+#define USB_DS_CNFG             (0x0030u)   /* Configured */
+#define USB_DS_ADDS             (0x0020u)   /* Address */
+#define USB_DS_DFLT             (0x0010u)   /* Default */
+#define USB_DS_POWR             (0x0000u)   /* Powered */
+#define USB_DVSQS               (0x0030u)   /* b5-4: Device state */
+#define USB_VALID               (0x0008u)   /* b3: Setup packet detect flag */
+#define USB_CTSQ                (0x0007u)   /* b2-0: Control transfer stage */
+#define USB_CS_SQER             (0x0006u)   /* Sequence error */
+#define USB_CS_WRND             (0x0005u)   /* Ctrl write nodata status stage */
+#define USB_CS_WRSS             (0x0004u)   /* Ctrl write status stage */
+#define USB_CS_WRDS             (0x0003u)   /* Ctrl write data stage */
+#define USB_CS_RDSS             (0x0002u)   /* Ctrl read status stage */
+#define USB_CS_RDDS             (0x0001u)   /* Ctrl read data stage */
+#define USB_CS_IDST             (0x0000u)   /* Idle or setup stage */
+
+/* Interrupt Status Register 1 */
+#define USB_OVRCR               (0x8000u)   /* b15: Over-current interrupt */
+#define USB_BCHG                (0x4000u)   /* b14: USB bus change interrupt */
+#define USB_DTCH                (0x1000u)   /* b12: Detach sense interrupt */
+#define USB_ATTCH               (0x0800u)   /* b11: Attach sense interrupt */
+#define USB_L1RSMEND            (0x0200u)   /* b9: L1 resume completion interrupt */
+#define USB_LPMEND              (0x0100u)   /* b8: LPM transaction completion interrupt */
+#define USB_EOFERR              (0x0040u)   /* b6: EOF-error interrupt */
+#define USB_SIGN                (0x0020u)   /* b5: Setup ignore interrupt */
+#define USB_SACK                (0x0010u)   /* b4: Setup ack interrupt */
+#define USB_PDDETINT            (0x0001u)   /* b0: PDDET detection interrupt */
+
+/* Frame Number Register */
+#define USB_OVRN                (0x8000u)   /* b15: Overrun error */
+#define USB_CRCE                (0x4000u)   /* b14: Received data error */
+#define USB_FRNM                (0x07FFu)   /* b10-0: Frame number */
+
+/* Device State Change Register */ /* For USB0 */
+#define USB_DVCHG               (0x8000u)   /* b15: Device state change */
+
+/* Micro Frame Number Register */ /* For USBHS */
+#define USB_UFRNM               (0x0007u)   /* b2-0: Micro frame number */
+
+/* USB Address / Low Power Status Recovery Register */
+#define USB_STSRECOV            (0x0F00u)   /* b11-8: Status Recovery */
+#define USB_USBADDR_MASK        (0x007Fu)   /* b6-0: USB address */
+
+/* USB Request Type Register */
+#define USB_BMREQUESTTYPE       (0x00FFu)   /* b7-0: USB_BMREQUESTTYPE */
+#define USB_BMREQUESTTYPEDIR    (0x0080u)   /* b7  : Data transfer direction */
+#define USB_BMREQUESTTYPETYPE   (0x0060u)   /* b6-5: Type */
+#define USB_BMREQUESTTYPERECIP  (0x001Fu)   /* b4-0: Recipient */
+
+/* USB Request Value Register */
+#define USB_WVALUE              (0xFFFFu)   /* b15-0: wValue */
+#define USB_DT_TYPE             (0xFF00u)
+#define USB_GET_DT_TYPE(v)      (((v) & USB_DT_TYPE) >> 8)
+#define USB_DT_INDEX            (0x00FFu)
+#define USB_CONF_NUM            (0x00FFu)
+#define USB_ALT_SET             (0x00FFu)
+
+/* USB Request Index Register */
+#define USB_WINDEX              (0xFFFFu)   /* b15-0: wIndex */
+#define USB_TEST_SELECT         (0xFF00u)   /* b15-b8: Test Mode Selectors */
+#define USB_TEST_J              (0x0100u)   /* Test_J */
+#define USB_TEST_K              (0x0200u)   /* Test_K */
+#define USB_TEST_SE0_NAK        (0x0300u)   /* Test_SE0_NAK */
+#define USB_TEST_PACKET         (0x0400u)   /* Test_Packet */
+#define USB_TEST_FORCE_ENABLE   (0x0500u)   /* Test_Force_Enable */
+#define USB_TEST_STSelectors    (0x0600u)   /* Standard test selectors */
+#define USB_TEST_RESERVED       (0x4000u)   /* Reserved */
+#define USB_TEST_VSTMODES       (0xC000u)   /* VendorSpecific test modes */
+#define USB_EP_DIR              (0x0080u)   /* b7: Endpoint Direction */
+#define USB_EP_DIR_IN           (0x0080u)
+#define USB_EP_DIR_OUT          (0x0000u)
+
+/* USB Request Length Register */
+#define USB_WLENGTH             (0xFFFFu)   /* b15-0: wLength */
+
+#define USB_TYPE                (0xC000u)   /* b15-14: Transfer type */
+#define USB_BFRE                (0x0400u)   /* b10: Buffer ready interrupt mode select */
+
+#define USB_DEVSEL              (0xF000u)   /* b15-14: Device address select */
+#define USB_MAXP                (0x007Fu)   /* b6-0: Maxpacket size of default control pipe */
+#define USB_MXPS                (0x07FFu)   /* b10-0: Maxpacket size */
+
+#define USB_BSTS                (0x8000u)   /* b15: Buffer status */
+#define USB_SUREQ               (0x4000u)   /* b14: Send USB request  */
+#define USB_INBUFM              (0x4000u)   /* b14: IN buffer monitor (Only for PIPE1 to 5) */
+#define USB_CSCLR               (0x2000u)   /* b13: c-split status clear */
+#define USB_CSSTS               (0x1000u)   /* b12: c-split status */
+#define USB_SUREQCLR            (0x0800u)   /* b11: stop setup request */
+#define USB_ATREPM              (0x0400u)   /* b10: Auto repeat mode */
+#define USB_ACLRM               (0x0200u)   /* b9: buffer auto clear mode */
+#define USB_SQCLR               (0x0100u)   /* b8: Sequence bit clear */
+#define USB_SQSET               (0x0080u)   /* b7: Sequence bit set */
+#define USB_SQMON               (0x0040u)   /* b6: Sequence bit monitor */
+#define USB_PBUSY               (0x0020u)   /* b5: pipe busy */
+#define USB_PINGE               (0x0010u)   /* b4: ping enable */
+#define USB_CCPL                (0x0004u)   /* b2: Enable control transfer complete */
+#define USB_PID                 (0x0003u)   /* b1-0: Response PID */
+#define USB_PID_STALL2          (0x0003u)   /* STALL2 */
+#define USB_PID_STALL           (0x0002u)   /* STALL */
+#define USB_PID_BUF             (0x0001u)   /* BUF */
+#define USB_PID_NAK             (0x0000u)   /* NAK */
+
+#define USB_PIPENM              (0x0007u)   /* b2-0: Pipe select */
+
+#define USB_BUFSIZE             (0x7C00u)   /* b14-10: Pipe buffer size */
+#define USB_BUFNMB              (0x007Fu)   /* b6-0: Pipe buffer number */
+#define USB_PIPE0BUF            (256u)
+#define USB_PIPEXBUF            (64u)
+
+#define USB_TRENB               (0x0200u)   /* b9: Transaction count enable */
+#define USB_TRCLR               (0x0100u)   /* b8: Transaction count clear */
+#define USB_TRNCNT              (0xFFFFu)   /* b15-0: Transaction counter */
+
+#define USB_UPPHUB              (0x7800u)   /* b14-11: HUB register */
+#define USB_HUBPORT             (0x0700u)   /* b10-8: HUB port */
+#define USB_USBSPD              (0x00C0u)   /* b7-6: Device speed */
+
+/********* USB0 Only ******************************************************************************/
+
+/* PHY Crosspoint Adjustment Register */
+/* PHYSLEW */
+#define USB_SLEWF01             (0x0008u)   /* b3: Cross point adjustment bit 01 */
+#define USB_SLEWF00             (0x0004u)   /* b2: Cross point adjustment bit 00 */
+#define USB_SLEWR01             (0x0002u)   /* b1: Cross point adjustment bit 01 */
+#define USB_SLEWR00             (0x0001u)   /* b0: Cross point adjustment bit 00 */
+
+/* Deep Standby USB Transceiver Control/Terminal Monitor Register */
+/* DPUSR0R */
+#define USB_DVBSTS0             (0x00800000u)   /* b23: USB0 VBUS input */
+#define USB_DOVCB0              (0x00200000u)   /* b21: USB0 OVRCURB input */
+#define USB_DOVCA0              (0x00100000u)   /* b20: USB0 OVRCURA input */
+#define USB_DM0                 (0x00200000u)   /* b17: USB0 D- input */
+#define USB_DP0                 (0x00100000u)   /* b16: USB0 D+ input */
+#define USB_FIXPHY0             (0x00000010u)   /* b4: USB0 transceiver output fixed bit  */
+#define USB_DRPD0               (0x00000008u)   /* b3: D+/D- pull down resistor control bit */
+#define USB_RPUE0               (0x00000002u)   /* b1: DP pull up resistor control bit */
+#define USB_SRPC0               (0x00000001u)   /* b0: USB0 single end receiver control bit */
+
+/* Deep Standby USB Suspend/Resume Interrupt Register */
+/* DPUSR1R */
+#define USB_DVBINT0             (0x00800000u)   /* b23: USB0 VBUS monitor bit */
+#define USB_DOVRCRB0            (0x00200000u)   /* b21: USB0 OVRCURB DM monitor bit */
+#define USB_DOVRCRA0            (0x00100000u)   /* b20: USB0 OVRCURA DM monitor bit */
+#define USB_DMINT0              (0x00020000u)   /* b17: USB0 DM monitor bit */
+#define USB_DPINT0              (0x00010000u)   /* b16: USB0 DP monitor bit */
+#define USB_DVBSE0              (0x00000080u)   /* b7: USB0 VBUS interrupt enable */
+#define USB_DOVRCRBE0           (0x00000020u)   /* b5: USB0 OVRCURB interrupt enable */
+#define USB_DOVRCRAE0           (0x00000010u)   /* b4: USB0 OVRCURA interrupt enable */
+#define USB_DMINTE0             (0x00000002u)   /* b1: USB0 DM interrupt enable */
+#define USB_DPINTE0             (0x00000001u)   /* b0: USB0 DP interrupt enable */
+
+/**************************************************************************************************/
+
+/********* USBHS Only *****************************************************************************/
+
+/* Low Power Control Register */
+/* LPCTRL */
+#define USB_HWUPM               (0x0080u)   /* b7:  */
+
+/* Low Power Status Register */
+/* LPSTS */
+#define USB_SUSPENDM            (0x4000u)   /* b14: UTMI SuspendM control */
+
+/* PHY Single Access Read Data Register */
+/* SPRDAT */
+#define USB_PHYRDAT             (0x00FFu)   /* PHY read data bit */
+
+/* Battery Charging Control Register */
+/* BCCTRL */
+#define USB_PDDETSTS            (0x0200u)   /* b9: PDDET status */
+#define USB_CHGDETSTS           (0x0100u)   /* b8: CHGDET status */
+#define USB_DCPMODE             (0x0020u)   /* b5: DCP mode  control */
+#define USB_VDMSRCE             (0x0010u)   /* b4: VDMSRC control */
+#define USB_IDPSINKE            (0x0008u)   /* b3: IDPSINK control */
+#define USB_VDPSRCE             (0x0004u)   /* b2: VDPSRC control */
+#define USB_IDMSINKE            (0x0002u)   /* b1: IDMSINK control */
+#define USB_IDPSRCE             (0x0001u)   /* b0: IDPSRC control */
+
+/* Function L1 Control Register 1 */
+/* PL1CTRL1 */
+#define USB_L1EXTMD             (0x4000u)   /* b14: PHY control mode */
+#define USB_DVSQEX              (0x0080u)   /* b7: DVSQ extension bit */
+#define USB_DVSQ                (0x0070u)   /* b6-4: Mirror of DVSQ */
+#define USB_L1NEGOMD            (0x0008u)   /* b3: L1 response negotiation control */
+#define USB_L1RESPMD            (0x0006u)   /* b2-1: L1 response mode */
+#define USB_L1RESPEN            (0x0001u)   /* b0: L1 response enable */
+
+/* Function L1 Control Register 2 */
+/* PL1CTRL2 */
+#define USB_HSRDMON             (0x0F00u)   /* b12: RWE monitor bit */
+#define USB_RWEMON              (0x1000u)   /* b11-8: HIRD monitor bit */
+
+/* Host L1 Control Register 1 */
+/* HL1CTRL1 */
+#define USB_L1STATUS            (0x0006u)   /* b2-1: L1 request completion state */
+#define USB_L1REQ               (0x0001u)   /* b0: L1 changes request bit 
+ */
+
+/* Host L1 Control Register 2 */
+/* HL1CTRL2 */
+#define USB_BESL                (0x8000u)   /* b15: BESL & Alternate HIRD bit */
+#define USB_L1RWE               (0x1000u)   /* b12: L1 RemoteWake enable for LPM tokens */
+#define USB_HSRD                (0x0F00u)   /* b11-8: HIRD bit for LPM tokens */
+#define USB_L1ADDR              (0x000Fu)   /* b3-0: DeviceAddress for LPM tokens */
+
+/* PHY Timing Register 1 */
+/* PHYTRIM1 */
+#define USB_IMPOFFSET           (0x7000u)   /* b14-12: Terminator adjustment */
+#define USB_HSIUP               (0x0F00u)   /* b11-8: Output level setup of HS  */
+#define USB_PCOMPENB            (0x0080u)   /* b7: PVDD starting detection setup */
+#define USB_DFALL               (0x000Cu)   /* b3-2: FS/LS falling output waveform compensation function setting */
+#define USB_DRISE               (0x0003u)   /* b1-0: FS/LS standup output waveform compensation function setting */
+
+/* PHY Timing Register 2 */
+/* PHYTRIM2 */
+#define USB_DIS                 (0x7000u)   /* b14-12: Disconnect disregard level setup */
+#define USB_PDR                 (0x0300u)   /* b9-8: HS output compensation function setting */
+#define USB_HSRXENMODE          (0x0080u)   /* b7: HS reception permission control mode setup */
+#define USB_SQU                 (0x000Fu)   /* b3-0: Squelch disregard level setup */
+
+/* Deep Standby USB Register */
+/* DPUSR0R */
+#define USB_DVBSTSHM            (0x00800000u)   /* b23: VBUS input */
+#define USB_DOVCBHM             (0x00200000u)   /* b21: OVRCURB input */
+#define USB_DOVCAHM             (0x00100000u)   /* b20: OVRCURA input */
+
+/* DPUSR1R */
+#define USB_DVBSTSH             (0x00800000u)   /* b23: Interruption factor return display of VBUS */
+#define USB_DOVCBH              (0x00200000u)   /* b21: Interruption factor return display of OVRCURB  */
+#define USB_DOVCAH              (0x00100000u)   /* b20: Interruption factor return display of OVRCURA  */
+#define USB_DVBSTSHE            (0x00000080u)   /* b7 : VBUS interrupt enable */
+#define USB_DOVCBHE             (0x00000020u)   /* b5 : OVRCURB interrupt enable */
+#define USB_DOVCAHE             (0x00000010u)   /* b4 : OVRCURA interrupt enable */
+
+/**************************************************************************************************/
+
+/* DMAx Pin Configuration Register */
+#define USB_DREQA               (0x4000u)   /* b14: Dreq active select */
+#define USB_BURST               (0x2000u)   /* b13: Burst mode */
+#define USB_DACKA               (0x0400u)   /* b10: Dack active select */
+#define USB_DFORM               (0x0380u)   /* b9-7: DMA mode select */
+#define USB_CPU_ADR_RD_WR       (0x0000u)   /* Address + RD/WR mode (CPU bus) */
+#define USB_CPU_DACK_RD_WR      (0x0100u)   /* DACK + RD/WR (CPU bus) */
+#define USB_CPU_DACK_ONLY       (0x0180u)   /* DACK only (CPU bus) */
+#define USB_SPLIT_DACK_ONLY     (0x0200u)   /* DACK only (SPLIT bus) */
+#define USB_DENDA               (0x0040u)   /* b6: Dend active select */
+#define USB_PKTM                (0x0020u)   /* b5: Packet mode */
+#define USB_DENDE               (0x0010u)   /* b4: Dend enable */
+#define USB_OBUS                (0x0004u)   /* b2: OUTbus mode */
+
+/* USB IO Register Reserved bit mask */
+#define INTSTS1_MASK            (0x5870u)   /* INTSTS1 Reserved bit mask */
+#define BRDYSTS_MASK            (0xFFFFu)   /* BRDYSTS Reserved bit mask */
+#define NRDYSTS_MASK            (0xFFFFu)   /* NRDYSTS Reserved bit mask */
+#define BEMPSTS_MASK            (0xFFFFu)   /* BEMPSTS Reserved bit mask */
+
+
+
+/* USB Request Type Register */
+#define USB_BREQUEST            (0xFF00u)   /* b15-8 */
+
+/* USB Standard request */
+#define USB_GET_STATUS          (0x0000u)
+#define USB_CLEAR_FEATURE       (0x0100u)
+#define USB_REQRESERVED         (0x0200u)
+#define USB_SET_FEATURE         (0x0300u)
+#define USB_REQRESERVED1        (0x0400u)
+#define USB_SET_ADDRESS         (0x0500u)
+#define USB_GET_DESCRIPTOR      (0x0600u)
+#define USB_SET_DESCRIPTOR      (0x0700u)
+#define USB_GET_CONFIGURATION   (0x0800u)
+#define USB_SET_CONFIGURATION   (0x0900u)
+#define USB_GET_INTERFACE       (0x0A00u)
+#define USB_SET_INTERFACE       (0x0B00u)
+#define USB_SYNCH_FRAME         (0x0C00u)
+
+/* USB_BMREQUESTTYPEDIR 0x0080u(b7) */
+#define USB_HOST_TO_DEV         (0x0000u)
+#define USB_DEV_TO_HOST         (0x0080u)
+
+/* USB_BMREQUESTTYPETYPE    0x0060u(b6-5) */
+#define USB_STANDARD            (0x0000u)
+#define USB_CLASS               (0x0020u)
+#define USB_VENDOR              (0x0040u)
+
+/* USB_BMREQUESTTYPERECIP   0x001Fu(b4-0) */
+#define USB_DEVICE              (0x0000u)
+#define USB_INTERFACE           (0x0001u)
+#define USB_ENDPOINT            (0x0002u)
+#define USB_OTHER               (0x0003u)
+
+#define USB_NULL                (0x0u)
+
+#define USB_IP0                 (0)         /* USB0 module */
+#define USB_IP1                 (1)         /* USB1 module */
+
+/* USB pipe number */
+#define USB_PIPE0               (0x0u)
+#define USB_PIPE1               (0x1u)
+#define USB_PIPE2               (0x2u)
+#define USB_PIPE3               (0x3u)
+#define USB_PIPE4               (0x4u)
+#define USB_PIPE5               (0x5u)
+#define USB_PIPE6               (0x6u)
+#define USB_PIPE7               (0x7u)
+#define USB_PIPE8               (0x8u)
+#define USB_PIPE9               (0x9u)
+#define USB_PIPE10              (0xAu)
+#define USB_PIPE11              (0xBu)
+#define USB_PIPE12              (0xCu)
+#define USB_PIPE13              (0xDu)
+#define USB_PIPE14              (0xEu)
+#define USB_PIPE15              (0xFu)
+
+#define USB_EP0                 (0x0u)
+#define USB_EP1                 (0x1u)
+#define USB_EP2                 (0x2u)
+#define USB_EP3                 (0x3u)
+#define USB_EP4                 (0x4u)
+#define USB_EP5                 (0x5u)
+#define USB_EP6                 (0x6u)
+#define USB_EP7                 (0x7u)
+#define USB_EP8                 (0x8u)
+#define USB_EP9                 (0x9u)
+#define USB_EP10                (0xAu)
+#define USB_EP11                (0xBu)
+#define USB_EP12                (0xCu)
+#define USB_EP13                (0xDu)
+#define USB_EP14                (0xEu)
+#define USB_EP15                (0xFu)
+
+/* Descriptor type  Define */
+#define USB_DT_DEVICE           (0x01u)     /* Configuration Descriptor */
+#define USB_DT_CONFIGURATION    (0x02u)     /* Configuration Descriptor */
+#define USB_DT_STRING           (0x03u)     /* Configuration Descriptor */
+#define USB_DT_INTERFACE        (0x04u)     /* Interface Descriptor */
+#define USB_DT_ENDPOINT         (0x05u)     /* Endpoint Descriptor */
+#define USB_DT_DEVICE_QUALIFIER (0x06u)     /* Device Qualifier Descriptor */
+#define USB_DT_OTHER_SPEED_CONF (0x07u)     /* Other Speed Configuration Descriptor */
+#define USB_DT_INTERFACE_POWER  (0x08u)     /* Interface Power Descriptor */
+#define USB_DT_OTGDESCRIPTOR    (0x09u)     /* OTG Descriptor */
+#define USB_DT_HUBDESCRIPTOR    (0x29u)     /* HUB descriptor */
+
+/* Interface class Define */
+#define USB_IFCLS_NOT           (0x00u)     /* Un corresponding Class */
+#define USB_IFCLS_AUD           (0x01u)     /* Audio Class */
+#define USB_IFCLS_CDC           (0x02u)     /* CDC Class */
+#define USB_IFCLS_CDCC          (0x02u)     /* CDC-Control Class */
+#define USB_IFCLS_HID           (0x03u)     /* HID Class */
+#define USB_IFCLS_PHY           (0x05u)     /* Physical Class */
+#define USB_IFCLS_IMG           (0x06u)     /* Image Class */
+#define USB_IFCLS_PRN           (0x07u)     /* Printer Class */
+#define USB_IFCLS_MAS           (0x08u)     /* Mass Storage Class */
+#define USB_IFCLS_HUB           (0x09u)     /* HUB Class */
+#define USB_IFCLS_CDCD          (0x0Au)     /* CDC-Data Class */
+#define USB_IFCLS_CHIP          (0x0Bu)     /* Chip/Smart Card Class */
+#define USB_IFCLS_CNT           (0x0Cu)     /* Content-Security Class */
+#define USB_IFCLS_VID           (0x0Du)     /* Video Class */
+#define USB_IFCLS_DIAG          (0xDCu)     /* Diagnostic Device */
+#define USB_IFCLS_WIRE          (0xE0u)     /* Wireless Controller */
+#define USB_IFCLS_APL           (0xFEu)     /* Application-Specific */
+#define USB_IFCLS_VEN           (0xFFu)     /* Vendor-Specific Class */
+
+/* Endpoint Descriptor  Define */
+#define USB_EP_IN               (0x80u)     /* In Endpoint */
+#define USB_EP_OUT              (0x00u)     /* Out Endpoint */
+#define USB_EP_ISO              (0x01u)     /* Isochronous Transfer */
+#define USB_EP_BULK             (0x02u)     /* Bulk Transfer */
+#define USB_EP_INT              (0x03u)     /* Interrupt Transfer */
+
+/* Configuration descriptor bit define */
+#define USB_CF_RESERVED         (0x80u)     /* Reserved(set to 1) */
+#define USB_CF_SELFP            (0x40u)     /* Self Powered */
+#define USB_CF_BUSP             (0x00u)     /* Bus Powered */
+#define USB_CF_RWUPON           (0x20u)     /* Remote Wake up ON */
+#define USB_CF_RWUPOFF          (0x00u)     /* Remote Wake up OFF */
+
+ /* Descriptor length Define */
+#define USB_DD_BLENGTH          (18u)       /* Device Descriptor Length */
+#define USB_CD_BLENGTH          (9u)        /* Configuration Descriptor Length */
+#define USB_ID_BLENGTH          (9u)        /* Interface Descriptor Length */
+#define USB_ED_BLENGTH          (7u)        /* Endpoint Descriptor Length */
+
+#define USB_BUFSIZE_BIT         (10u)
+
+/* other */
+#define USB_FUNCTION_CFIFO_USE  (0x0000u)
+#define USB_FUNCTION_D0FIFO_USE (0x1000u)
+#define USB_FUNCTION_D1FIFO_USE (0x2000u)
+
+
+#endif


### PR DESCRIPTION
### Description
I implemented USB Device feature for Renesas mbed boards(GR-PEACH and GR-LYCHEE).
The Greentea test of USB Device(Basic / Serial) results are here.
[Test_PEACH_GCC.txt](https://github.com/ARMmbed/mbed-os/files/2697445/Test_PEACH_GCC.txt)
[Test_LYCHEE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/2697446/Test_LYCHEE_GCC.txt)



<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

