### PR TITLE
Fix to unit test losing process output due to timing issue

### DIFF
--- a/UNITTESTS/unit_test/utils.py
+++ b/UNITTESTS/unit_test/utils.py
@@ -51,8 +51,13 @@ def execute_program(args, error_msg="An error occurred!", success_msg=None):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT)
 
+        # Output is stripped to remove newline character. logging adds its own
+        # so we avoid double newlines.
+        # Because the process can terminate before the loop has read all lines,
+        # we read the output remnant just in case. Otherwise we lose it.
         while process.poll() is None:
-            logging.info(process.stdout.readline().decode("utf8"))
+            logging.info(process.stdout.readline().decode('utf8').rstrip('\n'))
+        logging.info(process.stdout.read().decode('utf8').rstrip('\n'))
 
         retcode = process.wait()
 


### PR DESCRIPTION
### Description

The loop would read lines until the child process terminated, but if the process terminated before every line was read we would lose output and the testing person might have concluded that no tests were run after that point. This fixes that by reading the remnant after the child process terminates.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

