### PR TITLE
Nuvoton: Fix NUC472 hard fault in SMCC tests

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_clk.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/StdDriver/nuc472_clk.c
@@ -75,6 +75,8 @@ void CLK_PowerDown(void)
     SCB->SCR = SCB_SCR_SLEEPDEEP_Msk;
     CLK->PWRCTL |= (CLK_PWRCTL_PDEN_Msk | CLK_PWRCTL_PDWKDLY_Msk );
     __WFI();
+    __DSB();
+    __ISB();
 }
 
 /**
@@ -92,6 +94,8 @@ void CLK_Idle(void)
 
     /* Chip enter idle mode after CPU run WFI instruction */
     __WFI();
+    __DSB();
+    __ISB();
 }
 
 


### PR DESCRIPTION
### Description
This PR is to fix NUC472 hard fault what Mihail Stoyanov found in SMCC connect or update tests.
Test by pelion-enablement repo with `mbed test -t ARM -m NUMAKER_PFM_NUC472 -n simple-mbed-cloud-client-tests-dev_mgmt-* --run -v`

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Test log:
```mbedgt: test suite results: 2 OK
mbedgt: test case report:
+------------------------+--------------------+-------------------------------------------------+----------------------------+--------+--------+--------+--------------------+
| target                 | platform_name      | test suite                                      | test case                  | passed | failed | result | elapsed_time (sec) |
+------------------------+--------------------+-------------------------------------------------+----------------------------+--------+--------+--------+--------------------+
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Connect to Ethernet        | 1      | 0      | OK     | 4.7                |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Format FAT                 | 1      | 0      | OK     | 0.23               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Initialize NUSD+FAT        | 1      | 0      | OK     | 0.12               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Initialize Simple PDMC     | 1      | 0      | OK     | 8.85               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Pelion DM Bootstrap & Reg. | 1      | 0      | OK     | 62.16              |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Pelion DM Directory        | 1      | 0      | OK     | 6.71               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Pelion DM Re-register      | 1      | 0      | OK     | 20.43              |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Post-reset Identity        | 1      | 0      | OK     | 2.37               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Resource LwM2M GET         | 1      | 0      | OK     | 1.72               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Resource LwM2M POST        | 1      | 0      | OK     | 1.78               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Resource LwM2M PUT         | 1      | 0      | OK     | 1.54               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-connect | Resource LwM2M SET         | 1      | 0      | OK     | 0.77               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Connect to Ethernet        | 1      | 0      | OK     | 4.55               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Firmware Download          | 1      | 0      | OK     | 142.29             |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Firmware Prepare           | 1      | 0      | OK     | 0.58               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Firmware Update            | 1      | 0      | OK     | 16.98              |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Format FAT                 | 1      | 0      | OK     | 0.08               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Initialize NUSD+FAT        | 1      | 0      | OK     | 0.04               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Initialize Simple PDMC     | 1      | 0      | OK     | 8.78               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Pelion DM Bootstrap & Reg. | 1      | 0      | OK     | 63.07              |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Pelion DM Directory        | 1      | 0      | OK     | 6.42               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Pelion DM Re-register      | 1      | 0      | OK     | 20.41              |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Post-update Erase          | 1      | 0      | OK     | 0.01               |
| NUMAKER_PFM_NUC472-ARM | NUMAKER_PFM_NUC472 | simple-mbed-cloud-client-tests-dev_mgmt-update  | Post-update Identity       | 1      | 0      | OK     | 2.1                |
+------------------------+--------------------+-------------------------------------------------+----------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 24 OK
mbedgt: completed in 464.09 sec
```
### Reviewers
@MarceloSalazar
@samchuarm 
<!-- 
    Optional
    Request additional reviewers with @username
-->

