### PR TITLE
Prevent ESP8266 stopping HW control on init

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -339,9 +339,6 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_esp.at_available()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
-        if (!_esp.stop_uart_hw_flow_ctrl()) {
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
         if (!_esp.reset()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }


### PR DESCRIPTION
### Description

When trying to connect ESP8266 to WiFi, after it was previously disconnect, AT commands time out. This does not occur if CTS/RTS is disabled (for example, by not configuring the pins in mbed_app.json or hardcoding them to NC in ESP8266 class constructor). This also does not occur if we do not stop the HW control inside _init() when reconnecting. The stop function was anyway immediately overwritten by the call to start_uart_hw_flow_ctrl(), right after the reset, so the change should be otherwise neutral.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo, @VeijoPesonen , please review.

