### PR TITLE
Greentea tests ignore bind returning UNSUPPORTED

### DIFF
--- a/TESTS/netsocket/tcp/tcpsocket_bind_address.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address.cpp
@@ -39,7 +39,12 @@ void TCPSOCKET_BIND_ADDRESS()
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
     SocketAddress sockAddr = SocketAddress(get_interface()->get_ip_address(), 80);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(sockAddr));
+    nsapi_error_t bind_result = sock->bind(sockAddr);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
@@ -38,7 +38,12 @@ void TCPSOCKET_BIND_ADDRESS_INVALID()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->bind("190.2.3.4", 1024));
+    nsapi_error_t bind_result = sock->bind("190.2.3.4", 1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_null.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_null.cpp
@@ -38,7 +38,12 @@ void TCPSOCKET_BIND_ADDRESS_NULL()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(NULL, 1024));
+    nsapi_error_t bind_result = sock->bind(NULL, 1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_port.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_port.cpp
@@ -38,7 +38,12 @@ void TCPSOCKET_BIND_ADDRESS_PORT()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(get_interface()->get_ip_address(), 80));
+    nsapi_error_t bind_result = sock->bind(get_interface()->get_ip_address(), 80);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/tcp/tcpsocket_bind_port.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_port.cpp
@@ -38,7 +38,12 @@ void TCPSOCKET_BIND_PORT()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(1024));
+    nsapi_error_t bind_result = sock->bind(1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/tcp/tcpsocket_bind_port_fail.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_port_fail.cpp
@@ -38,7 +38,14 @@ void TCPSOCKET_BIND_PORT_FAIL()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(1024));
+    nsapi_error_t bind_result = sock->bind(1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+        delete sock;
+        return;
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     TCPSocket *sock2 = new TCPSocket;
     if (!sock2) {

--- a/TESTS/netsocket/tcp/tcpsocket_bind_unopened.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_unopened.cpp
@@ -37,7 +37,12 @@ void TCPSOCKET_BIND_UNOPENED()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_SOCKET, sock->bind(1024));
+    nsapi_error_t bind_result = sock->bind(1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_SOCKET, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
@@ -40,7 +40,12 @@ void TCPSOCKET_BIND_WRONG_TYPE()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
     char addr_bytes[16] = {0xfe, 0x80, 0xff, 0x1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     SocketAddress sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->bind(sockAddr));
+    nsapi_error_t bind_result = sock->bind(sockAddr);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_address.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address.cpp
@@ -39,7 +39,12 @@ void UDPSOCKET_BIND_ADDRESS()
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
     SocketAddress sockAddr = SocketAddress(get_interface()->get_ip_address(), 80);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(sockAddr));
+    nsapi_error_t bind_result = sock->bind(sockAddr);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_invalid.cpp
@@ -38,7 +38,12 @@ void UDPSOCKET_BIND_ADDRESS_INVALID()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->bind("190.2.3.4", 1024));
+    nsapi_error_t bind_result = sock->bind("190.2.3.4", 1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_address_null.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_null.cpp
@@ -38,7 +38,12 @@ void UDPSOCKET_BIND_ADDRESS_NULL()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(NULL, 1024));
+    nsapi_error_t bind_result = sock->bind(NULL, 1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_address_port.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_port.cpp
@@ -38,7 +38,12 @@ void UDPSOCKET_BIND_ADDRESS_PORT()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(get_interface()->get_ip_address(), 80));
+    nsapi_error_t bind_result = sock->bind(get_interface()->get_ip_address(), 80);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_port.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_port.cpp
@@ -38,7 +38,12 @@ void UDPSOCKET_BIND_PORT()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(1024));
+    nsapi_error_t bind_result = sock->bind(1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_port_fail.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_port_fail.cpp
@@ -38,7 +38,14 @@ void UDPSOCKET_BIND_PORT_FAIL()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->bind(1024));
+    nsapi_error_t bind_result = sock->bind(1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+        delete sock;
+        return;
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, bind_result);
+    }
 
     UDPSocket *sock2 = new UDPSocket;
     if (!sock2) {

--- a/TESTS/netsocket/udp/udpsocket_bind_unopened.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_unopened.cpp
@@ -37,7 +37,12 @@ void UDPSOCKET_BIND_UNOPENED()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_SOCKET, sock->bind(1024));
+    nsapi_error_t bind_result = sock->bind(1024);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_SOCKET, bind_result);
+    }
 
     delete sock;
 

--- a/TESTS/netsocket/udp/udpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_wrong_type.cpp
@@ -40,7 +40,12 @@ void UDPSOCKET_BIND_WRONG_TYPE()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
     char addr_bytes[16] = {0xfe, 0x80, 0xff, 0x1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     SocketAddress sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->bind(sockAddr));
+    nsapi_error_t bind_result = sock->bind(sockAddr);
+    if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("bind() not supported");
+    } else {
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, bind_result);
+    }
 
     delete sock;
 


### PR DESCRIPTION
### Description

Greentea tests should not fail if the stack doesn't support bind(). Instead some tests should be ignored.
I tested this by running the whole udp and tcp suites (including extended tests) with LWIP stack and then again with LWIP stack hacked to always return NSAPI_ERROR_UNSUPPORTED from socket_bind.
I also checked tests-netsocket-dns with this "hacked" LWIP but it never failed, so no adjustments are needed.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@KariHaapalehto 

