### PR TITLE
RTC time init value 1

### DIFF
--- a/TESTS/mbed_drivers/rtc/main.cpp
+++ b/TESTS/mbed_drivers/rtc/main.cpp
@@ -223,7 +223,7 @@ void test_time_RTC_func_defined_RTC_is_enabled()
  *
  * Given environment has RTC functions defined and RTC is disabled.
  * When time() functions is called.
- * Then function result is 0.
+ * Then function result is 1.
  */
 void test_time_RTC_func_defined_RTC_is_disabled()
 {
@@ -242,7 +242,7 @@ void test_time_RTC_func_defined_RTC_is_disabled()
     seconds = time(NULL);
 
     /* Check if expected value has been returned. */
-    TEST_ASSERT_EQUAL(0, seconds);
+    TEST_ASSERT_EQUAL(1, seconds);
 }
 
 /* This test verifies if time() function can be successfully

--- a/platform/mbed_rtc_time.cpp
+++ b/platform/mbed_rtc_time.cpp
@@ -88,7 +88,7 @@ time_t time(time_t *timer)
     _mutex->lock();
     if (_rtc_isenabled != NULL) {
         if (!(_rtc_isenabled())) {
-            set_time(0);
+            set_time(1);
         }
     }
 


### PR DESCRIPTION
### Description

Hi

This proposition follows discussion in #9176 

time in mbed_rtc_time.cpp does this:

time_t time(time_t *timer)
{
    _mutex->lock();
    if (_rtc_isenabled != NULL) {
        if (!(_rtc_isenabled())) {
            set_time(0);
    ...

We think that the 0 value could be the default init value in the system.
Setting 1 make the RTC really "enabled".

Regards,

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mattbrown015 
