### PR TITLE
Revert "STM32 RTC : skip rtc_write if possible"

### DIFF
--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -217,11 +217,6 @@ void rtc_write(time_t t)
     RTC_DateTypeDef dateStruct = {0};
     RTC_TimeTypeDef timeStruct = {0};
 
-    /* if the requested time is the current time, no need to continue */
-    if (t == rtc_read()) {
-        return;
-    }
-
     core_util_critical_section_enter();
     RtcHandle.Instance = RTC;
 


### PR DESCRIPTION
### Description

`rtc_write` must start the RTC. `time()` uses `rtc_write(0)` to start the RTC if it is not already enabled, but this check made that not work.

There's no point trying to optimise this case in a HAL - if we wanted `set_time()` to protect against users making pointless adjustments, the implementation should be there. But even then, you might want different levels of hysteresis depending on application, so it's probably best left to applications.

This reverts commit 9da5e489418aba9d99c666edd9c55aad1d2ac2bc.

Fixes #9176, which is caused by PR #8777 which is currently labelled for 5.11.1.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant