### PR TITLE
Disable MPU support on NRF52x platforms

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6562,7 +6562,8 @@
             "TARGET_NRF52832",
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\"",
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "MBED_MPU_CUSTOM"
         ],
         "device_has": [
             "ANALOGIN",
@@ -6572,7 +6573,6 @@
             "INTERRUPTIN",
             "ITM",
             "LPTICKER",
-            "MPU",
             "PORTIN",
             "PORTINOUT",
             "PORTOUT",
@@ -6684,7 +6684,8 @@
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\"",
             "MBED_TICKLESS",
             "MBEDTLS_CONFIG_HW_SUPPORT",
-            "WSF_MAX_HANDLERS=10"
+            "WSF_MAX_HANDLERS=10",
+            "MBED_MPU_CUSTOM"
         ],
         "features": ["CRYPTOCELL310"],
         "device_has": [
@@ -6695,7 +6696,6 @@
             "INTERRUPTIN",
             "ITM",
             "LPTICKER",
-            "MPU",
             "PORTIN",
             "PORTINOUT",
             "PORTOUT",


### PR DESCRIPTION
### Description

This PR disables MPU support on NRF52x devices. Unfortunately, the Nordic Softdevice seems to attempt writes to addresses marked as "Write only" under certain conditions. For instance, this behaviour is triggered when attempting to discover GATT services on a remote peripheral, while in central mode.
Thanks to @pan- for the investigation.

MPU support can still be enabled if using Cordio, or if the Bluetooth feature is disabled.

This workaround creates an issue (MPU support disabled on NRF52x devices) - opening the following ticket to track it till the root cause is fixed and we can re-enable MPU on these platforms: https://github.com/ARMmbed/mbed-os/issues/9181

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-hal 