### PR TITLE
 Allow LwIP TCP retransmissions to be configured and tune those smaller.

### DIFF
--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -159,6 +159,14 @@
 #define TCP_WND                     MBED_CONF_LWIP_TCP_WND
 #endif
 
+#ifdef MBED_CONF_LWIP_TCP_MAXRTX
+#define TCP_MAXRTX                  MBED_CONF_LWIP_TCP_MAXRTX
+#endif
+
+#ifdef MBED_CONF_LWIP_TCP_SYNMAXRTX
+#define TCP_SYNMAXRTX               MBED_CONF_LWIP_TCP_SYNMAXRTX
+#endif
+
 // Number of pool pbufs.
 // Each requires 684 bytes of RAM (if MSS=536 and PBUF_POOL_BUFSIZE defaulting to be based on MSS)
 #ifdef MBED_CONF_LWIP_PBUF_POOL_SIZE

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -88,6 +88,14 @@
             "help": "TCP sender buffer space (bytes). Current default (used if null here) is set to (4 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.",
             "value": null
         },
+        "tcp-maxrtx": {
+            "help": "Maximum number of retransmissions of data segments.",
+            "value": 6
+        },
+        "tcp-synmaxrtx": {
+            "help": "Maximum number of retransmissions of SYN segments. Current default (used if null here) is set to 6 in opt.h",
+            "value": null
+        },
         "pbuf-pool-size": {
             "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.",
             "value": null
@@ -125,7 +133,7 @@
             "mem-size": 25600
         },
         "Freescale": {
-            "mem-size": 36560
+            "mem-size": 16384
         },
         "LPC1768": {
             "mem-size": 16362

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/mbed_lib.json
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/mbed_lib.json
@@ -1,7 +1,7 @@
 {
     "name": "kinetis-emac",
     "config": {
-        "rx-ring-len": 16,
-        "tx-ring-len": 8
+        "rx-ring-len": 2,
+        "tx-ring-len": 1
     }
 }


### PR DESCRIPTION
### Description

Allow LwIP TCP retransmissions to be configured and tune those smaller.
    
Currently, LwIP segment retransmission time is 12, which is very long
time as each timeout doubles the retransmission timeout.
Make that to 6 as that is same what we use in Nanostack.

LwIP TCP engine uses 500 ms slow timer and each retransmit will double the previous timeout.
```
          /* Double retransmission time-out unless we are trying to
           * connect to somebody (i.e., we are in SYN_SENT). */
          if (pcb->state != SYN_SENT) {
            u8_t backoff_idx = LWIP_MIN(pcb->nrtx, sizeof(tcp_backoff)-1);
            pcb->rto = ((pcb->sa >> 3) + pcb->sv) << tcp_backoff[backoff_idx];
          }
```

TCP timeouts come from table:
```
static const u8_t tcp_backoff[13] =
    { 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7};
```

And to my best understanding, this `pcb->sv` is 6. so `6 << tcp_backoff[7]` will already lead to 6 minutes. Going through all timeouts will eventually take something like 40 minutes, unless I'm mistaken by values of `pcb->sa` and `pcb->sv`

This will fix the issue where Client+HTTP update stops into DNS queries not going through because timeouted TCP sessions have already eaten the full heap.


Also change the number of Freescale EMAC driver ring buffers down to 3. Earlier it was using 16+8 buffers, each 1500 bytes. This was the biggest consumer of LwIP heap.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
@teetak01 
@yogpan01 


