### PR TITLE
Fix ticker_read_us() race condition.

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -416,13 +416,16 @@ timestamp_t ticker_read(const ticker_data_t *const ticker)
 
 us_timestamp_t ticker_read_us(const ticker_data_t *const ticker)
 {
+    us_timestamp_t ret;
+
     initialize(ticker);
 
     core_util_critical_section_enter();
     update_present_time(ticker);
+    ret = ticker->queue->present_time;
     core_util_critical_section_exit();
 
-    return ticker->queue->present_time;
+    return ret;
 }
 
 int ticker_get_next_timestamp(const ticker_data_t *const data, timestamp_t *timestamp)


### PR DESCRIPTION
### Description

`ticker_event_queue_t::present_time` is an `us_timestamp_t`, which is 64-bit, and therefore _not_ atomic. It is therefore subject to race conditions if accessed outside a critical section, especially since it is also updated in `ticker_irq_handler`.

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

