### PR TITLE
Add more information to error url to enhance error analytics

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -108,11 +108,6 @@
             "value": null
         },
 
-        "error-decode-http-url-str": {
-            "help": "HTTP URL string for ARM Mbed-OS Error Decode microsite",
-            "value": "\"\\nFor more info, visit: https://armmbed.github.io/mbedos-error/?error=0x%08X\""
-        },
-
         "cthunk_count_max": {
             "help": "The maximum CThunk objects used at the same time. This must be greater than 0 and less 256",
             "value": 8

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -191,7 +191,7 @@ class mbedToolchain:
                 labels = self.get_labels()
                 self.cxx_symbols = ["TARGET_%s" % t for t in labels['TARGET']]
                 self.cxx_symbols.extend(["TOOLCHAIN_%s" % t for t in labels['TOOLCHAIN']])
-                
+
                 # Cortex CPU symbols
                 if self.target.core in mbedToolchain.CORTEX_SYMBOLS:
                     self.cxx_symbols.extend(mbedToolchain.CORTEX_SYMBOLS[self.target.core])

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -191,7 +191,7 @@ class mbedToolchain:
                 labels = self.get_labels()
                 self.cxx_symbols = ["TARGET_%s" % t for t in labels['TARGET']]
                 self.cxx_symbols.extend(["TOOLCHAIN_%s" % t for t in labels['TOOLCHAIN']])
-
+                
                 # Cortex CPU symbols
                 if self.target.core in mbedToolchain.CORTEX_SYMBOLS:
                     self.cxx_symbols.extend(mbedToolchain.CORTEX_SYMBOLS[self.target.core])
@@ -201,6 +201,8 @@ class mbedToolchain:
                 if MBED_ORG_USER:
                     self.cxx_symbols.append('MBED_USERNAME=' + MBED_ORG_USER)
 
+                # Add target's name
+                self.cxx_symbols += ["TARGET_NAME=" + self.target.name]
                 # Add target's symbols
                 self.cxx_symbols += self.target.macros
                 # Add target's hardware


### PR DESCRIPTION
### Description
This change adds more info to the error URL in error-report to enable additional analytics in  https://mbed.com/s/error. It adds following info to the error URL:
CPU id (if stats enabled)
Compiler used (if stats enabled)
Compiler version (if stats enabled)
MbedOS version (if stats enabled)
Target name


### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

