### PR TITLE
Nuvoton: Fix crypto compile error with Mbed OS 2

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
@@ -19,7 +19,7 @@
 #include "mbed_assert.h"
 #include "mbed_critical.h"
 #include "mbed_error.h"
-#if defined(MBED_CONF_RTOS_PRESENT) && MBED_CONF_RTOS_PRESENT
+#if MBED_CONF_RTOS_PRESENT
 #include "cmsis_os2.h"
 #endif
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
@@ -19,14 +19,16 @@
 #include "mbed_assert.h"
 #include "mbed_critical.h"
 #include "mbed_error.h"
+#if defined(MBED_CONF_RTOS_PRESENT) && MBED_CONF_RTOS_PRESENT
 #include "cmsis_os2.h"
+#endif
 #include <string.h>
 #include <limits.h>
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include "crypto-misc.h"
-#include "SingletonPtr.h"
-#include "Mutex.h"
+#include "platform/SingletonPtr.h"
+#include "platform/PlatformMutex.h"
 
 /* Consideration for choosing proper synchronization mechanism
  *
@@ -45,13 +47,13 @@
  */
 
 /* Mutex for crypto AES AC management */
-static SingletonPtr<rtos::Mutex> crypto_aes_mutex;
+static SingletonPtr<PlatformMutex> crypto_aes_mutex;
 
 /* Mutex for crypto DES AC management */
-static SingletonPtr<rtos::Mutex> crypto_des_mutex;
+static SingletonPtr<PlatformMutex> crypto_des_mutex;
 
 /* Mutex for crypto ECC AC management */
-static SingletonPtr<rtos::Mutex> crypto_ecc_mutex;
+static SingletonPtr<PlatformMutex> crypto_ecc_mutex;
 
 /* Atomic flag for crypto SHA AC management */
 static core_util_atomic_flag crypto_sha_atomic_flag = CORE_UTIL_ATOMIC_FLAG_INIT;

--- a/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M480/crypto/crypto-misc.cpp
@@ -20,7 +20,6 @@
 #include "mbed_critical.h"
 #include "mbed_error.h"
 #include "cmsis_os2.h"
-#include "mbed_rtos_storage.h"
 #include <string.h>
 #include <limits.h>
 #include "nu_modutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
@@ -19,7 +19,7 @@
 #include "mbed_assert.h"
 #include "mbed_critical.h"
 #include "mbed_error.h"
-#if defined(MBED_CONF_RTOS_PRESENT) && MBED_CONF_RTOS_PRESENT
+#if MBED_CONF_RTOS_PRESENT
 #include "cmsis_os2.h"
 #endif
 #include <string.h>

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
@@ -20,7 +20,6 @@
 #include "mbed_critical.h"
 #include "mbed_error.h"
 #include "cmsis_os2.h"
-#include "mbed_rtos_storage.h"
 #include <string.h>
 #include <limits.h>
 #include "nu_modutil.h"

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/crypto/crypto-misc.cpp
@@ -19,14 +19,16 @@
 #include "mbed_assert.h"
 #include "mbed_critical.h"
 #include "mbed_error.h"
+#if defined(MBED_CONF_RTOS_PRESENT) && MBED_CONF_RTOS_PRESENT
 #include "cmsis_os2.h"
+#endif
 #include <string.h>
 #include <limits.h>
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
 #include "crypto-misc.h"
-#include "SingletonPtr.h"
-#include "Mutex.h"
+#include "platform/SingletonPtr.h"
+#include "platform/PlatformMutex.h"
 
 /* Consideration for choosing proper synchronization mechanism
  *
@@ -43,12 +45,12 @@
  *    (2) No biting CPU
  *        Same reason as above.
  */
-
+ 
 /* Mutex for crypto AES AC management */
-static SingletonPtr<rtos::Mutex> crypto_aes_mutex;
+static SingletonPtr<PlatformMutex> crypto_aes_mutex;
 
 /* Mutex for crypto DES AC management */
-static SingletonPtr<rtos::Mutex> crypto_des_mutex;
+static SingletonPtr<PlatformMutex> crypto_des_mutex;
 
 /* Atomic flag for crypto SHA AC management */
 static core_util_atomic_flag crypto_sha_atomic_flag = CORE_UTIL_ATOMIC_FLAG_INIT;


### PR DESCRIPTION
### Description

This PR tries to fix #9081 which causes crypto compile error with Mbed OS 2 for Nuvoton targets.

#### Related PR or issue

#9081 
#9190 

#### Related targets

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M487/NUMAKER_IOT_M487

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

