### PR TITLE
Fixing bug - overwrite of default configuration values for RBP start address and size fails

### DIFF
--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -270,11 +270,6 @@ BlockDevice *_get_blockdevice_FLASHIAP(bd_addr_t start_address, bd_size_t size)
 
     if (start_address != 0) {
 
-        if (start_address < flash_first_writable_sector_address) {
-            tr_error("KV Config: Internal block device start address overlapped ROM address ");
-            flash.deinit();
-            return NULL;
-        }
         aligned_start_address = align_down(start_address, flash.get_sector_size(start_address));
         if (start_address != aligned_start_address) {
             tr_error("KV Config: Internal block device start address is not aligned. Better use %02llx", aligned_start_address);


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Removing the ROM overlap check when nondefault values are used for KVStore internal FLASHIAP blockdevice.

This PR fix bug IOTSTOR-723

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

