### PR TITLE
TDBStore: Perform garbage collection on failed writes

### DIFF
--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -258,9 +258,7 @@ static void set_several_keys_multithreaded()
     for (i = 0; i < num_of_threads; i++) {
         res = kvstore->get(keys[i], buffer, buffer_size, &actual_size, 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
-
         TEST_ASSERT_EQUAL_STRING_LEN(buffer, data, data_size);
-
     }
 
     for (i = 0; i < num_of_threads; i++) {
@@ -329,6 +327,7 @@ static void set_key_value_two_byte_size()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_two, 1);
     memset(buffer, 0, buffer_size);
 
@@ -346,6 +345,7 @@ static void set_key_value_five_byte_size()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_five, 4);
     memset(buffer, 0, buffer_size);
 
@@ -363,6 +363,7 @@ static void set_key_value_fifteen_byte_size()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_fif, 14);
     memset(buffer, 0, buffer_size);
 
@@ -380,6 +381,7 @@ static void set_key_value_seventeen_byte_size()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     TEST_ASSERT_EQUAL_STRING_LEN(buffer, data_fif, 16);
     memset(buffer, 0, buffer_size);
 
@@ -451,7 +453,8 @@ static void set_key_init_deinit()
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
     res = kvstore->get(key, buffer, buffer_size, &actual_size, 0);
-    TEST_ASSERT_EQUAL_STRING(buffer, data);
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
+    TEST_ASSERT_EQUAL_STRING(data, buffer);
     memset(buffer, 0, buffer_size);
 
     res = kvstore->remove(key);


### PR DESCRIPTION
### Description

In TDBStore, partial writes may turn the storage unusable, as records are written sequentially. This change adds garbage collection following each write failure, in order to prevent such a scenario.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

