### PR TITLE
Realtek-RTL8195AM-Hide_Debugging_Messages

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -85,11 +85,13 @@ static rtw_result_t scan_result_handler( rtw_scan_handler_result_t* malloced_sca
     return RTW_SUCCESS;
 }
 
-RTWInterface::RTWInterface(RTW_EMAC &get_rtw_emac, OnboardNetworkStack &get_rtw_obn_stack) :
+RTWInterface::RTWInterface(RTW_EMAC &get_rtw_emac, OnboardNetworkStack &get_rtw_obn_stack, bool debug) :
         EMACInterface(get_rtw_emac, get_rtw_obn_stack),
         rtw_emac(get_rtw_emac),
         rtw_obn_stack(get_rtw_obn_stack)
 {
+    extern __u32 GlobalDebugEnable;
+    GlobalDebugEnable = debug?1:0; //Conditional statement: display debugging message
     rtw_emac.power_up();
 }
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.h
@@ -40,7 +40,7 @@ public:
      */
     RTWInterface(
         RTW_EMAC &rtw_emac = RTW_EMAC::get_instance(),
-        OnboardNetworkStack &rtw_lwip_stack = OnboardNetworkStack::get_default_instance());
+        OnboardNetworkStack &rtw_lwip_stack = OnboardNetworkStack::get_default_instance(), bool debug=false);
 
     ~RTWInterface();
 


### PR DESCRIPTION
This PR addresses the issue of #8903.
A new boolean variable 'debug' is added to turn off the display of debugging message (by default). It can be turned on when needed.

### Description

1.	Add new boolean parameter ‘debug’ in function ‘RTWInterface’ in file "RTWInterface.h".
2.	Add conditional statement to enable/disable variable ‘GlobalDebugEnable’ in file "RTWInterface.h" to control whether debugging message should be displayed.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

