### PR TITLE
UBLOX_EVK_ODIN_W2 bridge implementation

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -319,7 +319,7 @@ char *LWIP::Interface::get_gateway(char *buf, nsapi_size_t buflen)
 LWIP::Interface::Interface() :
     hw(NULL), has_addr_state(0),
     connected(NSAPI_STATUS_DISCONNECTED),
-    dhcp_started(false), dhcp_has_to_be_set(false), blocking(true), ppp(false)
+    dhcp_started(false), dhcp_has_to_be_set(false), blocking(true), ppp(false), _broadcast_to_self(false)
 {
     memset(&netif, 0, sizeof netif);
 
@@ -647,4 +647,13 @@ nsapi_error_t LWIP::Interface::bringdown()
         client_callback(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, connected);
     }
     return 0;
+}
+void LWIP::Interface::set_broadcast_to_self(bool enabled)
+{
+    _broadcast_to_self = enabled;
+}
+
+bool LWIP::Interface::get_broadcast_to_self(void)
+{
+    return _broadcast_to_self;
 }

--- a/features/lwipstack/LWIPInterfaceEMAC.cpp
+++ b/features/lwipstack/LWIPInterfaceEMAC.cpp
@@ -37,7 +37,7 @@ err_t LWIP::Interface::emac_low_level_output(struct netif *netif, struct pbuf *p
     pbuf_ref(p);
 
 #if MBED_EMAC_LWIP_L2_BRIDGE
-    return emac_lwip_l2b_output(netif, (emac_mem_buf_t*) p);
+    return emac_lwip_l2b_output(netif, (emac_mem_buf_t *) p);
 #else
 
     LWIP::Interface *mbed_if = static_cast<LWIP::Interface *>(netif->state);
@@ -192,7 +192,7 @@ err_t LWIP::Interface::emac_if_init(struct netif *netif)
     netif->linkoutput = &LWIP::Interface::emac_low_level_output;
 
 #if MBED_EMAC_LWIP_L2_BRIDGE
-    if(err == ERR_OK) {
+    if (err == ERR_OK) {
         emac_lwip_l2b_register_interface(netif);
     }
 #endif

--- a/features/lwipstack/LWIPInterfaceEMAC.cpp
+++ b/features/lwipstack/LWIPInterfaceEMAC.cpp
@@ -24,6 +24,10 @@
 
 #include "LWIPStack.h"
 
+#if MBED_EMAC_LWIP_L2_BRIDGE
+#include "lwip_l2_bridge.h"
+#endif
+
 #if LWIP_ETHERNET
 
 err_t LWIP::Interface::emac_low_level_output(struct netif *netif, struct pbuf *p)
@@ -32,13 +36,21 @@ err_t LWIP::Interface::emac_low_level_output(struct netif *netif, struct pbuf *p
        it after output */
     pbuf_ref(p);
 
+#if MBED_EMAC_LWIP_L2_BRIDGE
+    return emac_lwip_l2b_output(netif, (emac_mem_buf_t*) p);
+#else
+
     LWIP::Interface *mbed_if = static_cast<LWIP::Interface *>(netif->state);
     bool ret = mbed_if->emac->link_out(p);
     return ret ? ERR_OK : ERR_IF;
+#endif
 }
 
 void LWIP::Interface::emac_input(emac_mem_buf_t *buf)
 {
+#if MBED_EMAC_LWIP_L2_BRIDGE
+    emac_lwip_l2b_input(&netif, buf);
+#else
     struct pbuf *p = static_cast<struct pbuf *>(buf);
 
     /* pass all packets to ethernet_input, which decides what packets it supports */
@@ -47,6 +59,7 @@ void LWIP::Interface::emac_input(emac_mem_buf_t *buf)
 
         pbuf_free(p);
     }
+#endif
 }
 
 void LWIP::Interface::emac_state_change(bool up)
@@ -177,6 +190,12 @@ err_t LWIP::Interface::emac_if_init(struct netif *netif)
 #endif
 
     netif->linkoutput = &LWIP::Interface::emac_low_level_output;
+
+#if MBED_EMAC_LWIP_L2_BRIDGE
+    if(err == ERR_OK) {
+        emac_lwip_l2b_register_interface(netif);
+    }
+#endif
 
     return err;
 }

--- a/features/lwipstack/LWIPMemoryManager.cpp
+++ b/features/lwipstack/LWIPMemoryManager.cpp
@@ -161,3 +161,8 @@ void LWIPMemoryManager::set_total_len(struct pbuf *pbuf)
         pbuf = pbuf->next;
     }
 }
+
+void LWIPMemoryManager::ref(emac_mem_buf_t *buf)
+{
+    pbuf_ref(static_cast<struct pbuf *>(buf));
+}

--- a/features/lwipstack/LWIPMemoryManager.h
+++ b/features/lwipstack/LWIPMemoryManager.h
@@ -160,6 +160,13 @@ public:
      */
     virtual void set_len(emac_mem_buf_t *buf, uint32_t len);
 
+    /**
+     * Increases the reference count on the provided buffer
+     *
+     * @param buf      Memory buffer
+     */
+	virtual void ref(emac_mem_buf_t *buf);
+
 private:
 
     /**

--- a/features/lwipstack/LWIPMemoryManager.h
+++ b/features/lwipstack/LWIPMemoryManager.h
@@ -165,7 +165,7 @@ public:
      *
      * @param buf      Memory buffer
      */
-	virtual void ref(emac_mem_buf_t *buf);
+    virtual void ref(emac_mem_buf_t *buf);
 
 private:
 

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -110,8 +110,15 @@ public:
          */
         virtual char *get_gateway(char *buf, nsapi_size_t buflen);
 
+        virtual void set_broadcast_to_self(bool enabled);
+        virtual bool get_broadcast_to_self(void);
+
     private:
         friend LWIP;
+        friend err_t output_from_netif_to_netifs(struct netif *net, emac_mem_buf_t *buf);
+        friend err_t output_from_local_to_netifs(emac_mem_buf_t *buf);
+        friend err_t emac_lwip_l2b_output(struct netif *netif, emac_mem_buf_t *buf);
+        friend err_t emac_lwip_l2b_input(struct netif *net, emac_mem_buf_t *buf);
 
         Interface();
 
@@ -119,6 +126,7 @@ public:
         static void netif_link_irq(struct netif *netif);
         static void netif_status_irq(struct netif *netif);
         static Interface *our_if_from_netif(struct netif *netif);
+        bool _broadcast_to_self;
 
 #if LWIP_ETHERNET
         static err_t emac_low_level_output(struct netif *netif, struct pbuf *p);

--- a/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
@@ -426,6 +426,7 @@ void sys_init(void) {
     lwip_sys_mutex_attr.name = "lwip_sys_mutex";
     lwip_sys_mutex_attr.cb_mem = &lwip_sys_mutex_data;
     lwip_sys_mutex_attr.cb_size = sizeof(lwip_sys_mutex_data);
+    lwip_sys_mutex_attr.attr_bits = osMutexRecursive;
     lwip_sys_mutex = osMutexNew(&lwip_sys_mutex_attr);
     if (lwip_sys_mutex == NULL)
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_NETWORK_STACK, MBED_ERROR_CODE_INITIALIZATION_FAILED), "sys_init error, mutex initialization failed\n");

--- a/features/lwipstack/lwip_l2_bridge.cpp
+++ b/features/lwipstack/lwip_l2_bridge.cpp
@@ -1,0 +1,411 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "lwip_l2_bridge.h"
+#include "string.h"
+#include "mbed.h"
+#include "mbed_assert.h"
+#include "LWIPMemoryManager.h"
+#include "LWIPStack.h"
+
+extern "C" {
+#include "sys.h"
+}
+
+/* This is a simple bridge. The master branch of lwIP contains another bridge 
+   that should probably be used instead once it's available in an official release.
+   TODO Make those functions object oriented */
+
+static LWIPMemoryManager _mem; // TODO, is it possible to use some singleton of this instead?
+
+#define EMAC_LWIP_L2B_MAC_ADDR_SIZE         (6)
+#define EMAC_LWIP_L2B_THREAD_STACKSIZE      (512) // TODO optimize
+#define EMAC_LWIP_L2B_THREAD_PRIO           (osPriorityAboveNormal)
+
+#define EMAC_LWIP_L2B_MAC_SRC(buf)  (&(((u8_t*)_mem.get_ptr(buf))[EMAC_LWIP_L2B_MAC_ADDR_SIZE]))
+#define EMAC_LWIP_L2B_MAC_DEST(buf) ((u8_t*)_mem.get_ptr(buf))
+
+#define EMAC_LWIP_L2B_IS_MULTICAST(mac_address)  ((mac_address[0] & 0x01) == 0x01)
+
+#define EMAC_LWIP_L2B_IS_BROADCAST(mac_address)  ((mac_address[0] == 0xFF) &&\
+                                                  (mac_address[1] == 0xFF) &&\
+                                                  (mac_address[2] == 0xFF) &&\
+                                                  (mac_address[3] == 0xFF) &&\
+                                                  (mac_address[4] == 0xFF) &&\
+                                                  (mac_address[5] == 0xFF))
+
+
+typedef struct emac_lwip_l2b_entry_s {
+    struct emac_lwip_l2b_entry_s    *next;
+    struct emac_lwip_l2b_entry_s    *previous;
+
+    struct netif                    *net;
+    u8_t                            mac_address[EMAC_LWIP_L2B_MAC_ADDR_SIZE];
+    int                             ticks;
+} emac_lwip_l2b_entry_t;
+
+typedef struct {
+    bool    active;
+
+    struct netif *net;
+} emac_lwip_l2b_netif_t;
+
+static bool                     _initialised = false;
+static int                      _bridge_count = 0;
+static emac_lwip_l2b_entry_t    *_bridge = 0;
+static emac_lwip_l2b_netif_t    _netifs[EMAC_LWIP_L2B_MAX_NETIFS];
+static sys_mutex_t              _mutex;
+static sys_thread_t             _thread;
+
+static void timer(void *data)
+{
+    emac_lwip_l2b_entry_t   *next;
+    emac_lwip_l2b_entry_t   *entry;
+
+    while(true) {
+
+        wait_ms(EMAC_LWIP_L2B_TIMER_INTERVAL);
+
+        sys_mutex_lock(&_mutex);
+        entry = _bridge;
+
+        while(entry != 0) {
+            next = entry->next;
+
+            entry->ticks++;
+
+            if(entry->ticks > EMAC_LWIP_L2B_ENTRY_TIMEOUT) {
+                if(entry->previous != 0) {
+                    entry->previous->next = entry->next;
+                }
+                if(entry->next != 0) {
+                    entry->next->previous = entry->previous;
+                }
+                if(entry == _bridge) {
+                    _bridge = entry->next;
+                }
+
+                free(entry);
+                _bridge_count--;
+            }
+
+            entry = next;
+        }
+        sys_mutex_unlock(&_mutex);
+    }
+}
+
+static emac_lwip_l2b_entry_t* get_bridge_entry(uint8_t *mac_address)
+{
+    emac_lwip_l2b_entry_t   *found = 0;
+
+    MBED_ASSERT(mac_address != 0);
+
+    if(_bridge_count > 0) {
+        emac_lwip_l2b_entry_t *entry;
+
+        for(entry = _bridge; (entry != 0) && (found == 0); entry = entry->next) {
+            if(memcmp(mac_address, entry->mac_address, EMAC_LWIP_L2B_MAC_ADDR_SIZE) == 0) {
+                found = entry;
+            }
+        }
+    }
+
+    return found;
+}
+
+static emac_lwip_l2b_entry_t* alloc_bridge_entry(struct netif *net, uint8_t *mac_address)
+{
+    emac_lwip_l2b_entry_t *entry = 0;
+
+    MBED_ASSERT(net != 0);
+    MBED_ASSERT(mac_address != 0);
+
+    //Room in list
+    if(_bridge_count < EMAC_LWIP_L2B_MAX_BRIDGE_ENTRIES) {
+        entry = (emac_lwip_l2b_entry_t*)malloc(sizeof(emac_lwip_l2b_entry_t));
+        MBED_ASSERT(entry != 0);
+
+        // Place first
+        entry->next = _bridge;
+        entry->previous = 0;
+        if(_bridge != 0) {
+            _bridge->previous = entry;
+        }
+        _bridge = entry;
+        _bridge_count++;
+    }
+    // Re-use oldest one in list
+    else {
+        MBED_ASSERT(_bridge != 0);
+
+        emac_lwip_l2b_entry_t *oldest_entry = _bridge;
+
+        entry = _bridge->next;
+        while(entry != 0) {
+            if(entry->ticks >= oldest_entry->ticks) {
+                oldest_entry = entry;
+            }
+
+            entry = entry->next;
+        }
+
+        entry = oldest_entry;
+    }
+    MBED_ASSERT(entry != 0);
+
+    // Initialize
+    entry->ticks = 0;
+    entry->net = net;
+    memcpy(entry->mac_address, mac_address, EMAC_LWIP_L2B_MAC_ADDR_SIZE);
+
+    //printf("alloc_bridge_entry(%c%c,%02x:%02x:%02x:%02x:%02x:%02x)\n",net->name[0],net->name[1],mac_address[0],mac_address[1],mac_address[2],mac_address[3],mac_address[4],mac_address[5]); // TODO remove
+
+    return entry;
+}
+
+err_t output_from_netif_to_netifs(struct netif *net, emac_mem_buf_t *buf)
+{
+    err_t              res = ERR_IF;
+    bool               ok;
+
+    MBED_ASSERT(net != 0);
+    MBED_ASSERT(buf != 0);
+
+    for(int i = 0; i < EMAC_LWIP_L2B_MAX_NETIFS; i++) {
+        if(_netifs[i].active) {
+            LWIP::Interface *mbed_if = static_cast<LWIP::Interface *>(_netifs[i].net->state);
+            MBED_ASSERT(mbed_if != 0);
+
+            if((_netifs[i].net != net) ||
+               (mbed_if->get_broadcast_to_self() != 0)) {
+
+                ok = mbed_if->emac->link_out(buf);
+
+                if(ok) {
+                    res = ERR_OK; //At least one successful transmission
+                }
+            }
+        }
+    }
+
+    return res;
+}
+
+err_t output_from_local_to_netifs(emac_mem_buf_t *buf)
+{
+    MBED_ASSERT(buf != 0);
+
+    err_t               res = ERR_IF;
+    bool                ok;
+    u8_t                *mac_src = EMAC_LWIP_L2B_MAC_SRC(buf);
+
+    for(int i = 0; i < EMAC_LWIP_L2B_MAX_NETIFS; i++) {
+        if(_netifs[i].active) {
+            LWIP::Interface *mbed_if = static_cast<LWIP::Interface *>(_netifs[i].net->state);
+            MBED_ASSERT(mbed_if != 0);
+
+            //TODO: Works if each interface copies data or is done with buf when link_out is returned
+            memcpy(mac_src, _netifs[i].net->hwaddr, EMAC_LWIP_L2B_MAC_ADDR_SIZE);
+
+            ok = mbed_if->emac->link_out(buf);
+
+            if(ok) {
+                res = ERR_OK; //At least one successful transmission
+            }
+        }
+    }
+
+    return res;
+}
+
+static bool is_addr_local(u8_t *mac_addr)
+{
+    bool found = false;
+
+    MBED_ASSERT(mac_addr != 0);
+
+    for(int i = 0; (i < EMAC_LWIP_L2B_MAX_NETIFS) && (!found); i++) {
+        if(_netifs[i].active) {
+            if(memcmp(mac_addr, _netifs[i].net->hwaddr, EMAC_LWIP_L2B_MAC_ADDR_SIZE) == 0) {
+                found = true;
+            }
+        }
+    }
+
+    return found;
+}
+
+static void touch_bridge_entry(struct netif *net, u8_t *mac_address)
+{
+    MBED_ASSERT(net != 0);
+    MBED_ASSERT(mac_address != 0);
+
+    emac_lwip_l2b_entry_t *entry = get_bridge_entry(mac_address);
+
+    if(entry != 0) {
+
+        entry->net = net;
+        entry->ticks = 0;
+    }
+    else {
+        entry = alloc_bridge_entry(net, mac_address);
+        MBED_ASSERT(entry != 0);
+    }
+}
+
+err_t emac_lwip_l2b_register_interface(struct netif *net)
+{
+    err_t res = ERR_MEM;
+
+    MBED_ASSERT(net != 0);
+
+    if(!_initialised) {
+        sys_mutex_new(&_mutex);
+
+        for(int i = 0; i < EMAC_LWIP_L2B_MAX_NETIFS; i++) {
+            _netifs[i].active = false;
+        }
+
+        _thread = sys_thread_new("emac_lwip_l2b:_thread", timer, 0, EMAC_LWIP_L2B_THREAD_STACKSIZE, EMAC_LWIP_L2B_THREAD_PRIO);
+
+        _initialised = true;
+    }
+
+    for(int i = 0; (i < EMAC_LWIP_L2B_MAX_NETIFS) && (res != ERR_OK); i++) {
+        if(_netifs[i].active == false) {
+            _netifs[i].active = true;
+            _netifs[i].net = net;
+            res = ERR_OK;
+        }
+    }
+
+    return res;
+}
+
+err_t emac_lwip_l2b_output(struct netif *netif, emac_mem_buf_t *buf)
+{
+    MBED_ASSERT(netif != 0);
+    MBED_ASSERT(buf != 0);
+
+    bool    ok = false;
+    err_t   res = ERR_IF;
+
+    u8_t    *mac_src = EMAC_LWIP_L2B_MAC_SRC(buf);
+    u8_t    *mac_dest = EMAC_LWIP_L2B_MAC_DEST(buf);
+
+    //All
+    if(EMAC_LWIP_L2B_IS_MULTICAST(mac_dest)) {// || EMAC_LWIP_L2B_IS_BROADCAST(mac_dest)) {
+        res = output_from_local_to_netifs(buf);
+    }
+    //Other
+    else {
+        sys_mutex_lock(&_mutex);
+        emac_lwip_l2b_entry_t *entry = get_bridge_entry(mac_dest);
+
+        //Forward
+        if(entry != 0) {
+            LWIP::Interface *mbed_if = static_cast<LWIP::Interface *>(entry->net->state);
+
+            if(netif != entry->net) {
+                memcpy(mac_src, entry->net->hwaddr, EMAC_LWIP_L2B_MAC_ADDR_SIZE);
+            }
+            sys_mutex_unlock(&_mutex);
+
+            ok = mbed_if->emac->link_out(buf);
+
+            if(ok) {
+                res = ERR_OK;
+            }
+        }
+        //Flood
+        else {
+            sys_mutex_unlock(&_mutex);
+            res = output_from_local_to_netifs(buf);
+        }
+    }
+
+    return res;
+}
+
+err_t emac_lwip_l2b_input(struct netif *net, emac_mem_buf_t *buf)
+{
+    MBED_ASSERT(net != 0);
+    MBED_ASSERT(buf != 0);
+
+    err_t   res;
+    bool    free_msg = true;
+    
+    _mem.ref(buf);
+
+    u8_t    *mac_src = EMAC_LWIP_L2B_MAC_SRC(buf);
+    u8_t    *mac_dest = EMAC_LWIP_L2B_MAC_DEST(buf);
+
+    //All
+    if(EMAC_LWIP_L2B_IS_MULTICAST(mac_dest)) {// || EMAC_LWIP_L2B_IS_BROADCAST(mac_dest)) {
+
+        // Netifs
+        res = output_from_netif_to_netifs(net, buf);
+
+        //Local
+        res = net->input((struct pbuf *)buf, net);
+        if(res == ERR_OK) {
+            free_msg = false;
+        }
+    }
+    //Local only
+    else if(is_addr_local(mac_dest)) {
+        res = net->input((struct pbuf *)buf, net);
+        if(res == ERR_OK) {
+            free_msg = false;
+        }
+    }
+    //Other
+    else {
+        sys_mutex_lock(&_mutex);
+        emac_lwip_l2b_entry_t *entry = get_bridge_entry(mac_dest);
+
+        //Forward
+        if(entry != 0) {
+            LWIP::Interface *mbed_if = static_cast<LWIP::Interface *>(entry->net->state);
+            sys_mutex_unlock(&_mutex);
+            MBED_ASSERT(mbed_if != 0);
+
+            res = mbed_if->emac->link_out(buf);
+        }
+        //Flood
+        else {
+            sys_mutex_unlock(&_mutex);
+            res = output_from_netif_to_netifs(net, buf);
+        }
+
+    }
+
+    //Touch entry for source mac address
+    sys_mutex_lock(&_mutex);
+    touch_bridge_entry(net, mac_src);
+    sys_mutex_unlock(&_mutex);
+
+    _mem.free(buf); // To match mem_ref above
+
+    //Release buffer unless IP stack received message
+    if(free_msg) {
+        _mem.free(buf);
+    }
+
+    return res;
+}
+

--- a/features/lwipstack/lwip_l2_bridge.h
+++ b/features/lwipstack/lwip_l2_bridge.h
@@ -36,10 +36,34 @@
 #define EMAC_LWIP_L2B_ENTRY_TIMEOUT         (120)  //timer ticks before removing inactive L2B entry
 #endif
 
+
+    /**
+     * Registers the network interface
+     *
+     *
+     * @param *netif   Pointer to network interface to be registered.
+     * @return         Error code.
+     */
 err_t emac_lwip_l2b_register_interface(struct netif *netif);
 
+    /**
+     * Sends out data buffer through bridge
+     *
+     *
+     * @param *netif   Pointer to a registered network interface.
+     * @param *buf     Pointer to a data buffer.
+     * @return         Error code.
+     */
 err_t emac_lwip_l2b_output(struct netif *netif, emac_mem_buf_t *buf);
 
+    /**
+     * Receives data buffer through bridge
+     *
+     *
+     * @param *netif   Pointer to a registered network interface.
+     * @param *buf     Pointer to a data buffer.
+     * @return         Error code.
+     */
 err_t emac_lwip_l2b_input(struct netif *netif, emac_mem_buf_t *buf);
 
 

--- a/features/lwipstack/lwip_l2_bridge.h
+++ b/features/lwipstack/lwip_l2_bridge.h
@@ -1,0 +1,47 @@
+/* emac_lwip_l2_bridge.h */
+/* Copyright (C) 2012 mbed.org, MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef EMAC_LWIP_L2_BRIDGE_H_
+#define EMAC_LWIP_L2_BRIDGE_H_
+
+#include "lwip/netif.h"
+#include "EMACMemoryManager.h"
+
+#ifndef EMAC_LWIP_L2B_MAX_BRIDGE_ENTRIES
+#define EMAC_LWIP_L2B_MAX_BRIDGE_ENTRIES    (10)
+#endif
+#ifndef EMAC_LWIP_L2B_MAX_NETIFS
+#define EMAC_LWIP_L2B_MAX_NETIFS            (2)
+#endif
+#ifndef EMAC_LWIP_L2B_TIMER_INTERVAL
+#define EMAC_LWIP_L2B_TIMER_INTERVAL        (1000) //~timer interval in ms
+#endif
+#ifndef EMAC_LWIP_L2B_ENTRY_TIMEOUT
+#define EMAC_LWIP_L2B_ENTRY_TIMEOUT         (120)  //timer ticks before removing inactive L2B entry
+#endif
+
+err_t emac_lwip_l2b_register_interface(struct netif *netif);
+
+err_t emac_lwip_l2b_output(struct netif *netif, emac_mem_buf_t *buf);
+
+err_t emac_lwip_l2b_input(struct netif *netif, emac_mem_buf_t *buf);
+
+
+#endif // #ifndef EMAC_LWIP_L2_BRIDGE_H_
+

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -121,7 +121,8 @@ public:
         virtual char *get_gateway(char *buf, nsapi_size_t buflen) = 0;
 
         virtual void set_broadcast_to_self(bool enabled) { }
-        virtual bool get_broadcast_to_self(void) {
+        virtual bool get_broadcast_to_self(void)
+        {
             return false;
         }
     };

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -119,6 +119,11 @@ public:
          * @return              Pointer to a buffer, or NULL if the buffer is too small
          */
         virtual char *get_gateway(char *buf, nsapi_size_t buflen) = 0;
+
+        virtual void set_broadcast_to_self(bool enabled) { }
+        virtual bool get_broadcast_to_self(void) {
+            return false;
+        }
     };
 
     /** Register a network interface with the IP stack

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/stm32f4_eth_conf.c
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/stm32f4_eth_conf.c
@@ -36,7 +36,11 @@ void _eth_config_mac(ETH_HandleTypeDef *heth)
         .PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL,
         .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
         .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
+#if MBED_EMAC_LWIP_L2_BRIDGE
+        .PromiscuousMode = ETH_PROMISCUOUS_MODE_ENABLE,
+#else
         .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
+#endif
         .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
         .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
         .HashTableHigh = 0x0U,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -1344,6 +1344,8 @@ void OdinWiFiInterface::handle_wlan_status_ap_up()
 				_ap.gateway[0] ? _ap.gateway : 0,
 				DEFAULT_STACK);
 
+			_interface->set_broadcast_to_self(true);
+
 			if(error_code == NSAPI_ERROR_OK) {
 				_state_ap = S_AP_STARTED;
 

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_eth.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_eth.c
@@ -1606,7 +1606,11 @@ static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err)
   macinit.PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL;
   macinit.BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE;
   macinit.DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL;
-  macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE;
+#if MBED_EMAC_LWIP_L2_BRIDGE
+        macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_ENABLE,
+#else
+        macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
+#endif
   macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
   macinit.UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT;
   macinit.HashTableHigh = 0x0U;

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_eth.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_eth.c
@@ -1607,9 +1607,9 @@ static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err)
   macinit.BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE;
   macinit.DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL;
 #if MBED_EMAC_LWIP_L2_BRIDGE
-        macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_ENABLE,
+  macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_ENABLE,
 #else
-        macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
+  macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
 #endif
   macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
   macinit.UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

- Bridge functionality added

- To enable the bridge add the below macro and increase the lwIP pbuf pool size in mbed_app.json, for example:
"macros": ["MBED_EMAC_LWIP_L2_BRIDGE=1"],
"lwip-pbuf-pool-size":
{ "help": "Number of pbuf pool buffers", "value": "80" }

- Tests performed 
[mbed_os_tests_arm.txt](https://github.com/ARMmbed/mbed-os/files/2712306/mbed_os_tests_arm.txt)
[mbed_os_tests_gcc.txt](https://github.com/ARMmbed/mbed-os/files/2712307/mbed_os_tests_gcc.txt)
[mbed_os_tests_iar.txt](https://github.com/ARMmbed/mbed-os/files/2712308/mbed_os_tests_iar.txt)




### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

