### PR TITLE
Add Dynamic heap support to IAR

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_IAR/MPS2.icf
@@ -63,7 +63,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_IAR/MPS2.icf
@@ -63,7 +63,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_IAR/MPS2.icf
@@ -63,7 +63,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_IAR/MPS2.icf
@@ -63,7 +63,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_IAR/MPS2.icf
@@ -63,7 +63,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TOOLCHAIN_IAR/ADuCM3029.icf
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TOOLCHAIN_IAR/ADuCM3029.icf
@@ -54,7 +54,8 @@ define region RAM_bank1_region            = mem:[from 0x20000200 size 0x00003E00
 define region RAM_bank2_region            = mem:[from 0x20004000 size 0x00004000]
                                           | mem:[from 0x20040000 size 0x00007000];
 define block CSTACK   with alignment = 16, size = MBED_BOOT_STACK_SIZE { };
-define block HEAP     with alignment = 16, size = 0x2000 { };
+define block HEAP     with expanding size, minimum size = 0x2000, alignment = 16 { };
+
 do not initialize                         { section .noinit };
 initialize by copy                        { rw };
 place at start of ROM_PAGE0_INTVEC        { ro section .vectors };

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TOOLCHAIN_IAR/ADuCM4050.icf
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TOOLCHAIN_IAR/ADuCM4050.icf
@@ -53,8 +53,10 @@ define region ROM_REGION                  = mem:[from MBED_APP_START+ADUCM_SECTO
 define region RAM_bank1_region            = mem:[from 0x20040000 size 0x00008000];
 define region RAM_bank2_region            = mem:[from 0x20000200 size 0x00006E00]
                                           | mem:[from 0x20048000 size 0x00010000];
+
 define block CSTACK   with alignment = 16, size = MBED_BOOT_STACK_SIZE { };
-define block HEAP     with alignment = 16, size = 0x6000 { };
+define block HEAP     with expanding size, minimum size = 0x6000, alignment = 16 { };
+
 do not initialize                         { section .noinit };
 initialize by copy                        { rw };
 place at start of ROM_PAGE0_INTVEC        { ro section .vectors  };

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C63XX/TARGET_MCU_PSOC6_M0/device/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C63XX/TARGET_MCU_PSOC6_M0/device/TOOLCHAIN_IAR/cy8c6xx7_cm0plus.icf
@@ -148,7 +148,7 @@ define region IRAM1_region = mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFED
 
 define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__     { };
 define block PROC_STACK with alignment = 8, size = __ICFEDIT_size_proc_stack__ { };
-define block HEAP       with alignment = 8, size = __ICFEDIT_size_heap__       { };
+define block HEAP       with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C63XX/TARGET_MCU_PSOC6_M4/device/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C63XX/TARGET_MCU_PSOC6_M4/device/TOOLCHAIN_IAR/cy8c6xx7_cm4_dual.icf
@@ -148,7 +148,7 @@ define region IRAM1_region = mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFED
 
 define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__     { };
 define block PROC_STACK with alignment = 8, size = __ICFEDIT_size_proc_stack__ { };
-define block HEAP       with alignment = 8, size = __ICFEDIT_size_heap__       { };
+define block HEAP       with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 define block HSTACK {block HEAP, block PROC_STACK, last block CSTACK};
 define block RO     {first section .intvec, readonly};
 

--- a/targets/TARGET_GigaDevice/TARGET_GD32F30X/TARGET_GD32F307VG/device/TOOLCHAIN_IAR/gd32f307vg.icf
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F30X/TARGET_GD32F307VG/device/TOOLCHAIN_IAR/gd32f307vg.icf
@@ -27,7 +27,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/device/TOOLCHAIN_IAR/MAX32620.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/device/TOOLCHAIN_IAR/MAX32620.icf
@@ -22,7 +22,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0xF000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32625/device/TOOLCHAIN_IAR/TARGET_MAX32625_BOOT/MAX32625.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/device/TOOLCHAIN_IAR/TARGET_MAX32625_BOOT/MAX32625.icf
@@ -29,7 +29,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0xA000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -56,7 +56,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .nvictable };

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
@@ -60,7 +60,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .nvictable };

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_IAR/M2351.icf
@@ -107,7 +107,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 102)          { };
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/TOOLCHAIN_IAR/LPC54628J512.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/TOOLCHAIN_IAR/LPC54628J512.icf
@@ -95,7 +95,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/device/TOOLCHAIN_IAR/MIMXRT1052xxxxx.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/device/TOOLCHAIN_IAR/MIMXRT1052xxxxx.icf
@@ -125,7 +125,7 @@ define region NCACHE_region = mem:[from m_ncache_start to m_ncache_end];
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block RW        { first readwrite, section m_usb_dma_init_data  };
 define block ZI        with alignment = 32  { first  zi, section m_usb_dma_noninit_data };
 define block NCACHE_VAR with size = 0x200000 , alignment = 0x100000  { section NonCacheable , section NonCacheable.init };

--- a/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_IAR/TARGET_UNO_91H/RDA5981C.icf
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_IAR/TARGET_UNO_91H/RDA5981C.icf
@@ -52,7 +52,7 @@ define region AES_REGION    = mem:[from AES_BASE to AES_END];
 define region WLAN_REGION   = mem:[from WLAN_BASE to WLAN_END];
 
 define block CSTACK with alignment = 8, size = CSTACK_SIZE { };
-define block HEAP   with alignment = 8, size = HEAP_SIZE   { };
+define block HEAP   with expanding size, minimum size = HEAP_SIZE, alignment = 8 { };
 define block RW     { readwrite };
 define block ZI     { zi };
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_IAR/MBRZA1LU.icf
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_IAR/MBRZA1LU.icf
@@ -55,7 +55,7 @@ define block IRQ_STACK with alignment = 8, size = __ICFEDIT_size_irqstack__ { };
 define block FIQ_STACK with alignment = 8, size = __ICFEDIT_size_fiqstack__ { };
 define block UND_STACK with alignment = 8, size = __ICFEDIT_size_undstack__ { };
 define block ABT_STACK with alignment = 8, size = __ICFEDIT_size_abtstack__ { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/TOOLCHAIN_IAR/stm32f303xc.icf
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/TOOLCHAIN_IAR/stm32f303xc.icf
@@ -26,7 +26,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x2000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/device/TOOLCHAIN_IAR/stm32f411xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/device/TOOLCHAIN_IAR/stm32f411xe.icf
@@ -21,7 +21,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/device/TOOLCHAIN_IAR/stm32f407xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/device/TOOLCHAIN_IAR/stm32f407xx.icf
@@ -23,7 +23,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/device/TOOLCHAIN_IAR/stm32l082xZ.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/device/TOOLCHAIN_IAR/stm32l082xZ.icf
@@ -22,7 +22,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_IAR/stm32l152xc.icf
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_IAR/stm32l152xc.icf
@@ -23,7 +23,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_IAR/stm32l152xba.icf
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_IAR/stm32l152xba.icf
@@ -23,7 +23,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_MTS_DRAGONFLY_L471QG/device/TOOLCHAIN_IAR/stm32l471xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_MTS_DRAGONFLY_L471QG/device/TOOLCHAIN_IAR/stm32l471xx.icf
@@ -28,7 +28,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x8000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/TOOLCHAIN_IAR/stm32l433xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/TOOLCHAIN_IAR/stm32l433xx.icf
@@ -25,7 +25,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
@@ -28,7 +28,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_IAR/stm32l496xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_IAR/stm32l496xx.icf
@@ -25,7 +25,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0xa000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_IAR/stm32l4r5xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_IAR/stm32l4r5xx.icf
@@ -26,7 +26,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x20000; /* 128KB */
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/device/TOOLCHAIN_IAR/efm32gg11b820f2048gl192.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/device/TOOLCHAIN_IAR/efm32gg11b820f2048gl192.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/device/TOOLCHAIN_IAR/tmpm3h6fwfg.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/device/TOOLCHAIN_IAR/tmpm3h6fwfg.icf
@@ -29,7 +29,7 @@ define region BRAM_region     = mem:[from __BRAM_start__     to __BRAM_end__  ];
 define region DFLASH_region   = mem:[from __DFLASH_start__   to __DFLASH_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3HQ/device/TOOLCHAIN_IAR/tmpm3hqfdfg.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3HQ/device/TOOLCHAIN_IAR/tmpm3hqfdfg.icf
@@ -32,7 +32,7 @@ define region BRAM_region     = mem:[from __BRAM_start__     to __BRAM_end__  ];
 define region DFLASH_region   = mem:[from __DFLASH_start__   to __DFLASH_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TOOLCHAIN_IAR/tmpm46bf10fg.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TOOLCHAIN_IAR/tmpm46bf10fg.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 define block FLASH_CODE_ROM  {section FLASH_ROM_init object flash_api.o};
 define block FLASH_CODE_RAM  {section FLASH_ROM object flash_api.o};

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/device/TOOLCHAIN_IAR/tmpm4g9f15.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/device/TOOLCHAIN_IAR/tmpm4g9f15.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8 { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };


### PR DESCRIPTION
### Description

`feature-iar8` is rebased on top of master. This PR is for IAR dynamic heap changes in new linker files.

PR should be tested with CI first - Please note new addition to linker script will result in failures with IAR 7.x
`feature-iar8` needs to be tested with IAR 8.32 version - Update needed in CI

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

