### PR TITLE
Corrected SCB->ICSR mask value

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_MCU_NRF51822/hal_patch/sleep.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_MCU_NRF51822/hal_patch/sleep.c
@@ -21,7 +21,7 @@
 
 // Mask of reserved bits of the register ICSR in the System Control Block peripheral
 // In this case, bits which are equal to 0 are the bits reserved in this register
-#define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
+#define SCB_ICSR_RESERVED_BITS_MASK     0x9443F03F
 
 void hal_sleep(void)
 {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/sleep.c
@@ -23,7 +23,7 @@
 
 // Mask of reserved bits of the register ICSR in the System Control Block peripheral
 // In this case, bits which are equal to 0 are the bits reserved in this register
-#define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
+#define SCB_ICSR_RESERVED_BITS_MASK     0x9443F03F
 
 #define FPU_EXCEPTION_MASK 0x0000009F
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/sleep.c
@@ -29,7 +29,7 @@
 
 // Mask of reserved bits of the register ICSR in the System Control Block peripheral
 // In this case, bits which are equal to 0 are the bits reserved in this register
-#define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
+#define SCB_ICSR_RESERVED_BITS_MASK     0x9443F03F
 
 #define FPU_EXCEPTION_MASK 0x0000009F
 


### PR DESCRIPTION
### Description

SCB_ICSR_RESERVED_BITS_MASK was 0x9E43F03F which maps to
31: NMIPENDSET - 1 - Correct
28: PENDSVSET - 1 - Correct
27: PENDSVCLR - 1 Set and Clear both cannot be true
26: PENDSTSET - 1 - Correct
25: PENDSTCLR - 1 Set and Clear both cannot be true.

Pending Set and CLR bit both cannot be true, hence set PENDSVCLR and PENDSTCLR
as zero. New mask value - 0x9443F03F

Resolves : https://github.com/ARMmbed/mbed-os/issues/5647

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

