### PR TITLE
LoRaWAN: Retransmission back-off correction for re-join

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1229,6 +1229,7 @@ void LoRaMac::reset_mac_parameters(void)
 
     _params.sys_params.max_duty_cycle = 0;
     _params.sys_params.aggregated_duty_cycle = 1;
+    _params.timers.mac_init_time = get_current_time();
 
     _mac_commands.clear_command_buffer();
     _mac_commands.clear_repeat_buffer();
@@ -1448,6 +1449,8 @@ void LoRaMac::setup_link_check_request()
 
 lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_otaa)
 {
+    reset_mac_parameters();
+
     if (params) {
         if (is_otaa) {
             if ((params->connection_u.otaa.dev_eui == NULL)
@@ -1467,8 +1470,6 @@ lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_
             }
             // Reset variable JoinRequestTrials
             _params.join_request_trial_counter = 0;
-
-            reset_mac_parameters();
 
             _params.sys_params.channel_data_rate =
                 _lora_phy->get_alternate_DR(_params.join_request_trial_counter + 1);
@@ -1502,8 +1503,6 @@ lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_
 
         // Reset variable JoinRequestTrials
         _params.join_request_trial_counter = 0;
-
-        reset_mac_parameters();
 
         _params.sys_params.channel_data_rate =
             _lora_phy->get_alternate_DR(_params.join_request_trial_counter + 1);
@@ -1811,8 +1810,6 @@ lorawan_status_t LoRaMac::initialize(EventQueue *queue,
                     mbed::callback(this, &LoRaMac::open_rx2_window));
     _lora_time.init(_params.timers.ack_timeout_timer,
                     mbed::callback(this, &LoRaMac::on_ack_timeout_timer_event));
-
-    _params.timers.mac_init_time = _lora_time.get_current_time();
 
     _params.sys_params.adr_on = MBED_CONF_LORA_ADR_ON;
     _params.sys_params.channel_data_rate = _lora_phy->get_default_max_tx_datarate();


### PR DESCRIPTION

### Description

Previously, we had been initializing our time base in
LoRaMac::initialize() and if the device was not power-cycled, that
initial time was always being used in the calculation of the elapsed
time. This introduced a bug mentioned in issue #8921. The bug made the
re-join attempt of a device after a week or so to use wrong back-off
because in calculate_backoff() API we pass the elapsed time. If we do
not set the initial time while trying to connect, the elapsed time will
include previous session time as well and the device will think it has
spend tha much time and will apply harsher duty cycle back off.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@AnttiKauppila 
@kjbracey-arm 