### PR TITLE
Change to mbedtls_platform_zeroize()

### DIFF
--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ecdh_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ecdh_alt.c
@@ -27,14 +27,9 @@
 #include "crys_ecpki_domain.h"
 #include "crys_ec_mont_api.h"
 #include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
 #include "cc_internal.h"
 
-
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v;
-    while( n-- ) *p++ = 0;
-}
 
 #if defined (MBEDTLS_ECDH_GEN_PUBLIC_ALT)
 int mbedtls_ecdh_gen_public( mbedtls_ecp_group *grp, mbedtls_mpi *d, mbedtls_ecp_point *Q,
@@ -84,12 +79,12 @@ int mbedtls_ecdh_gen_public( mbedtls_ecp_group *grp, mbedtls_mpi *d, mbedtls_ecp
                                                             4*((((grp->nbits+7)/8)+3)/4) ) );
           if( ret != 0 )
           {
-              mbedtls_zeroize( temp_buf, sizeof( temp_buf ) );
+              mbedtls_platform_zeroize( temp_buf, sizeof( temp_buf ) );
               goto cleanup;
           }
 
           MBEDTLS_MPI_CHK(mbedtls_mpi_read_binary( d, temp_buf, (grp->nbits+7)/8 ) );
-          mbedtls_zeroize( temp_buf, sizeof( temp_buf ) );
+          mbedtls_platform_zeroize( temp_buf, sizeof( temp_buf ) );
       }
 
       /* if CRYS_ECPKI_GetEcDomain returns NULL, then the given curve is either Montgomery 25519
@@ -124,7 +119,7 @@ cleanup:
 
     if ( pHeap )
     {
-        mbedtls_zeroize( pHeap, heapSize );
+        mbedtls_platform_zeroize( pHeap, heapSize );
         mbedtls_free( pHeap );
     }
 
@@ -190,7 +185,7 @@ int mbedtls_ecdh_compute_shared( mbedtls_ecp_group *grp, mbedtls_mpi *z,
                                                                          temp_buf,
                                                                          mbedtls_mpi_size( d ),
                                                                          &ecdhParams->privKey ) );
-        mbedtls_zeroize( temp_buf, sizeof( temp_buf ) );
+        mbedtls_platform_zeroize( temp_buf, sizeof( temp_buf ) );
         if ( ret != 0 )
         {
             goto cleanup;
@@ -241,13 +236,13 @@ cleanup:
 
     if ( pHeap )
     {
-        mbedtls_zeroize( pHeap, heapSize );
+        mbedtls_platform_zeroize( pHeap, heapSize );
         mbedtls_free ( pHeap );
     }
 
     if ( secret )
     {
-        mbedtls_zeroize( secret, secret_size_in_heap );
+        mbedtls_platform_zeroize( secret, secret_size_in_heap );
         mbedtls_free ( secret );
     }
 

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ecdsa_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ecdsa_alt.c
@@ -27,13 +27,8 @@
 #include "crys_ecpki_domain.h"
 #include "crys_ec_edw_api.h"
 #include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
 #include "cc_internal.h"
-
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v;
-    while( n-- ) *p++ = 0;
-}
 
 static CRYS_ECPKI_HASH_OpMode_t message_size_to_hash_mode( size_t blen )
 {
@@ -110,7 +105,7 @@ int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
         if( CrysRet != CRYS_OK )
         {
             ret = convert_CrysError_to_mbedtls_err( CrysRet );
-            mbedtls_zeroize( temp_buf, sizeof(temp_buf) );
+            mbedtls_platform_zeroize( temp_buf, sizeof(temp_buf) );
             goto cleanup;
         }
 
@@ -123,7 +118,7 @@ int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
                                 blen,
                                 pSignature,
                                 &signature_size );
-        mbedtls_zeroize( temp_buf, sizeof(temp_buf) );
+        mbedtls_platform_zeroize( temp_buf, sizeof(temp_buf) );
         if( CrysRet != CRYS_OK )
         {
             ret = convert_CrysError_to_mbedtls_err( CrysRet );
@@ -145,13 +140,13 @@ cleanup:
 
     if ( pHeap )
     {
-        mbedtls_zeroize( pHeap, heapSize );
+        mbedtls_platform_zeroize( pHeap, heapSize );
         mbedtls_free( pHeap );
     }
 
     if( pSignature )
     {
-        mbedtls_zeroize( pSignature, signature_size_for_heap );
+        mbedtls_platform_zeroize( pSignature, signature_size_for_heap );
         mbedtls_free( pSignature );
 
     }
@@ -232,13 +227,13 @@ cleanup:
 
     if( pHeap )
     {
-        mbedtls_zeroize( pHeap, heapSize );
+        mbedtls_platform_zeroize( pHeap, heapSize );
         mbedtls_free( pHeap );
     }
 
     if( pSignature )
     {
-        mbedtls_zeroize( pSignature, signature_size );
+        mbedtls_platform_zeroize( pSignature, signature_size );
         mbedtls_free( pSignature );
 
     }
@@ -301,12 +296,12 @@ int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
         if ( CrysRet != CRYS_OK )
         {
             ret = convert_CrysError_to_mbedtls_err( CrysRet );
-            mbedtls_zeroize( temp_buf, sizeof(temp_buf) );
+            mbedtls_platform_zeroize( temp_buf, sizeof(temp_buf) );
             goto cleanup;
         }
 
         ret = mbedtls_mpi_read_binary( &ctx->d, temp_buf, (ctx->grp.nbits+7)/8 );
-        mbedtls_zeroize( temp_buf, sizeof(temp_buf) );
+        mbedtls_platform_zeroize( temp_buf, sizeof(temp_buf) );
         if ( ret != 0 )
         {
             goto cleanup;
@@ -319,7 +314,7 @@ int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
 cleanup:
     if ( pHeap )
     {
-        mbedtls_zeroize( pHeap, heapSize );
+        mbedtls_platform_zeroize( pHeap, heapSize );
         mbedtls_free ( pHeap );
     }
     return ( ret );


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Change the use of the local static function `mbedtls_zeroize()` to
the Mbed TLS platform function `mbedtls_platform_zeroize()`, since this platform function was introduced after the Cryptocell 310 adaptation driver was introduced.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

@ARMmbed/mbed-os-crypto 