### PR TITLE
BLE: NRF52 returns used tx/rx phy on phy update callback

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xGap.cpp
@@ -115,6 +115,23 @@ peer_address_type_t convert_identity_address(advertising_peer_address_type_t add
     }
 }
 
+ble::phy_t convert_phy(uint8_t nordic_phy)
+{ 
+    switch(nordic_phy) {
+        case BLE_GAP_PHY_1MBPS:
+            return ble::phy_t::LE_1M;
+
+        case BLE_GAP_PHY_2MBPS:
+            return ble::phy_t::LE_2M;
+
+        case BLE_GAP_PHY_CODED:
+            return ble::phy_t::LE_CODED;
+
+        default:
+            return ble::phy_t::NONE;
+    }
+}
+
 // FIXME: update when SD 5 (not alpha!) or more is used for 52840.
 #ifndef BLE_GAP_PHY_AUTO
 #define BLE_GAP_PHY_AUTO 0
@@ -1630,8 +1647,8 @@ void nRF5xGap::on_phy_update(
     _eventHandler->onPhyUpdateComplete(
         status,
         connection,
-        Phy_t::LE_1M,
-        Phy_t::LE_1M
+        convert_phy(evt.tx_phy),
+        convert_phy(evt.rx_phy)
     );
 }
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

The on phy upate callback function of NRF52, which is nRF5xGap::on_phy_update(), doesn't respect to used tx/rx phy, the parameters are hard-coded to LE_1M.

Those parameters should be set according to event from btle_handler()

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

