### PR TITLE
Remove redundant code in stm32l1xx_hal_adc.c

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc.c
@@ -1338,21 +1338,12 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
     
     /* Disable the DMA channel (in case of DMA in circular mode or stop while */
     /* DMA transfer is on going)                                              */
-    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+    HAL_DMA_Abort(hadc->DMA_Handle);
     
-    /* Check if DMA channel effectively disabled */
-    if (tmp_hal_status == HAL_OK)
-    {
-      /* Set ADC state */
-      ADC_STATE_CLR_SET(hadc->State,
-                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
-                        HAL_ADC_STATE_READY);
-    }
-    else
-    {
-      /* Update ADC state machine to error */
-      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
-    }
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_READY);
     
     /* Disable ADC overrun interrupt */
     __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);


### PR DESCRIPTION
### Description
The function call to HAL_DMA_Abort (stm32l1xx_hal_dma.c) will always return HAL_OK, therefore there is no point in checking if tmp_hal_status is still HAL_OK. Additionally, the else block will never be called and can be removed as redundant. If this change is to be made the declaration of the status variable should also be removed as it serves no purpose and no other calls within the driver check the returned value.

### Pull request type
    [ ] Fix
    [x ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


