### PR TITLE
[SDT64B] changed UART0 to UART2, added UART_5 on SDT64B

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/PeripheralNames.h
@@ -32,6 +32,7 @@ typedef enum {
     UART_2 = 2,
     UART_3 = 3,
     UART_4 = 4,
+    UART_5 = 5,
 } UARTName;
 
 #define STDIO_UART_TX     USBTX

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/PeripheralPins.c
@@ -94,6 +94,8 @@ const PinMap PinMap_UART_TX[] = {
     {PTE24, UART_4, 3},
     {PTE4 , UART_3, 3},
     {PTE0,  UART_1, 3},
+    {PTE0,  UART_1, 3},
+    {PTD9,  UART_5, 3},
     {NC  ,  NC    , 0}
 };
 
@@ -109,6 +111,7 @@ const PinMap PinMap_UART_RX[] = {
     {PTC14, UART_4, 3},
     {PTD2 , UART_2, 3},
     {PTD6 , UART_0, 3},
+    {PTD8,  UART_5, 3},
     {NC  ,  NC    , 0}
 };
 
@@ -126,6 +129,7 @@ const PinMap PinMap_UART_CTS[] = {
     {PTC19, UART_3, 3},
     {PTD1 , UART_2, 3},
     {PTD5 , UART_0, 3},
+    {PTD11, UART_5, 3},
     {NC   , NC    , 0}
 };
 
@@ -143,6 +147,7 @@ const PinMap PinMap_UART_RTS[] = {
     {PTD4 , UART_0, 3},
     {PTA3 , UART_0, 2},
     {PTB2 , UART_0, 3},
+    {PTD10, UART_5, 3},
     {NC   , NC    , 0}
 };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/PinNames.h
@@ -228,20 +228,20 @@ typedef enum {
     USBRX = PTC14,
 
     // UART pins
-    UART0_RX  = PTD8,
-    UART0_TX  = PTD9,
-    UART0_CTS = PTD11,
-    UART0_RTS = PTD10,
+    UART0_RX  = PTC16,
+    UART0_TX  = PTC17,
+    UART0_CTS = PTC19,
+    UART0_RTS = PTC18,
 
     UART1_RX  = USBRX,
     UART1_TX  = USBTX,
     UART1_CTS = PTC13,
     UART1_RTS = PTC12,
 
-    UART2_RX  = PTC16,
-    UART2_TX  = PTC17,
-    UART2_CTS = PTC19,
-    UART2_RTS = PTC18,
+    UART2_RX  = PTD8,
+    UART2_TX  = PTD9,
+    UART2_CTS = PTD11,
+    UART2_RTS = PTD10,
 
     // I2C pins
     I2C0_SCL = PTC10,


### PR DESCRIPTION
### Description

Hi, I'm heejung Park, engineer at Sigma Delta Technologies.
We made a new hardware of SDT64B.
So, we want to change some pin name.
please check below.
thanks.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

