### PR TITLE
critical sections: remove unnecessary volatile

### DIFF
--- a/hal/mbed_critical_section_api.c
+++ b/hal/mbed_critical_section_api.c
@@ -21,8 +21,8 @@
 
 #include <stdbool.h>
 
-static volatile bool critical_interrupts_enabled = false;
-static volatile bool state_saved = false;
+static bool critical_interrupts_enabled = false;
+static bool state_saved = false;
 
 static bool are_interrupts_enabled(void)
 {

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -43,7 +43,7 @@
 #endif
 #endif
 
-static volatile uint32_t critical_section_reentrancy_counter = 0;
+static uint32_t critical_section_reentrancy_counter = 0;
 
 bool core_util_are_interrupts_enabled(void)
 {
@@ -77,10 +77,10 @@ bool core_util_in_critical_section(void)
 
 void core_util_critical_section_enter(void)
 {
+    hal_critical_section_enter();
+
     // If the reentrancy counter overflows something has gone badly wrong.
     MBED_ASSERT(critical_section_reentrancy_counter < UINT32_MAX);
-
-    hal_critical_section_enter();
 
     ++critical_section_reentrancy_counter;
 }


### PR DESCRIPTION
### Description

Critical section count/state variables are synchronised by IRQ disabling and
critical section calls themselves, so do not need to be volatile.

This eliminates a couple of unnecessary reads of the counter variable.

Saves a few bytes of ROM, and a bit of time in speed-critical code.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@scartmell-arm, @c1728p9
