### PR TITLE
COMPONENT_SD tests update for small RAM targets

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/dirs/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/dirs/main.cpp
@@ -49,10 +49,6 @@ using namespace utest::v1;
 #define MBED_TEST_DIRS 4
 #endif
 
-#ifndef MBED_TEST_BUFFER
-#define MBED_TEST_BUFFER 8192
-#endif
-
 #ifndef MBED_TEST_TIMEOUT
 #define MBED_TEST_TIMEOUT 120
 #endif
@@ -76,9 +72,7 @@ FILE *fd[MBED_TEST_FILES];
 struct dirent ent;
 struct dirent *ed;
 size_t size;
-uint8_t buffer[MBED_TEST_BUFFER];
-uint8_t rbuffer[MBED_TEST_BUFFER];
-uint8_t wbuffer[MBED_TEST_BUFFER];
+uint8_t buffer[MBED_CONF_SD_TEST_BUFFER];
 
 
 // tests

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/seek/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/seek/main.cpp
@@ -49,10 +49,6 @@ using namespace utest::v1;
 #define MBED_TEST_DIRS 4
 #endif
 
-#ifndef MBED_TEST_BUFFER
-#define MBED_TEST_BUFFER 8192
-#endif
-
 #ifndef MBED_TEST_TIMEOUT
 #define MBED_TEST_TIMEOUT 120
 #endif
@@ -75,9 +71,7 @@ DIR *dd[MBED_TEST_DIRS];
 FILE *fd[MBED_TEST_FILES];
 struct dirent ent;
 struct dirent *ed;
-uint8_t buffer[MBED_TEST_BUFFER];
-uint8_t rbuffer[MBED_TEST_BUFFER];
-uint8_t wbuffer[MBED_TEST_BUFFER];
+uint8_t buffer[MBED_CONF_SD_TEST_BUFFER];
 
 
 // tests

--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -9,9 +9,31 @@
         "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
         "INIT_FREQUENCY": 100000,
-        "CRC_ENABLED": 1
+        "CRC_ENABLED": 1,
+        "TEST_BUFFER": 8192
     },
     "target_overrides": {
+        "NUCLEO_F070RB": {
+             "TEST_BUFFER": 4096
+        },
+        "NUCLEO_F072RB": {
+             "TEST_BUFFER": 4096
+        },
+        "NUCLEO_F103RB": {
+             "TEST_BUFFER": 4096
+        },
+        "NUCLEO_L073RZ": {
+             "TEST_BUFFER": 4096
+        },
+        "DISCO_L072CZ_LRWAN1": {
+             "TEST_BUFFER": 4096
+        },
+        "NUCLEO_F091RC": {
+             "TEST_BUFFER": 4096
+        },
+        "NUCLEO_F410RB": {
+             "TEST_BUFFER": 4096
+        },
         "K20D50M": {
              "SPI_MOSI": "PTD2",
              "SPI_MISO": "PTD3",


### PR DESCRIPTION
### Description

DIRS and SEEK tests are FAIL for targets with small RAM.

Buffer size can now be specified for each target.
Default size is not changed with that patch.

It has been divided by 2 for some small RAM targets.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
