### PR TITLE
Add user's config file for mbedtls to avoid UBLOX RTC issues.

### DIFF
--- a/features/netsocket/mbedtls_config.h
+++ b/features/netsocket/mbedtls_config.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NETSOCKET_MBEDTLS_CONFIG_H
+#define NETSOCKET_MBEDTLS_CONFIG_H
+
+// UBLOX fails with TLSSockets if it uses its RTC for mbedtls'es RNG.
+#ifdef TARGET_MODULE_UBLOX_ODIN_W2
+#undef MBEDTLS_HAVE_TIME
+#endif // TARGET_MODULE_UBLOX_ODIN_W2
+
+#endif // NETSOCKET_MBEDTLS_CONFIG_H
+


### PR DESCRIPTION
### Description

By default UBLOX's RTC is used during the RNG procedure in TLSSocket connect. This does not work reliably on UBLOX. When this config is set to MBEDTLS_USER_CONFIG_FILE in mbed_app.json mbedtls will not use the RTC functions for RNG.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

