### PR TITLE
Increases events.shared-stacksize to 2K

### DIFF
--- a/events/mbed_lib.json
+++ b/events/mbed_lib.json
@@ -4,7 +4,7 @@
         "present": 1,
         "shared-stacksize": {
             "help": "Stack size (bytes) for shared event queue thread",
-            "value": 1024
+            "value": 2048
         },
         "shared-eventsize": {
             "help": "Event buffer size (bytes) for shared event queue",


### PR DESCRIPTION
This has become as an issue at least with ESP8266.

### Description
ESP8266 driver started to use global event queue to handle some AT parsing and call Socket::sigio() events.
It turned out that when running DNS tests, or Pelion Client, the stack space (1kB) is not enough for the purpose.

Therefore we propose that this is raised to 2kB, as the assumption is that event loop should allow as equivalently complex code than any other threads.

In Mbed OS, the default Thread stack size is 4kB, but we assume 2kB to be enough for non-blocking event purposes.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
@SeppoTakalo 

