### PR TITLE
TDBStore: fix bug in sector blank check for variant sized sectors

### DIFF
--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -1409,7 +1409,7 @@ void TDBStore::offset_in_erase_unit(uint8_t area, uint32_t offset,
     }
 
     uint32_t agg_offset = 0;
-    while (bd_offset < agg_offset + _buff_bd->get_erase_size(agg_offset)) {
+    while (bd_offset >= agg_offset + _buff_bd->get_erase_size(agg_offset)) {
         agg_offset += _buff_bd->get_erase_size(agg_offset);
     }
     offset_from_start = bd_offset - agg_offset;


### PR DESCRIPTION
### Description
TDBStore performs erase unit (sector) blank checking before writing new data. This blank check works differently for boards having uniform sector map (all having the same size) and variant ones. This check had a bug in the variant case (reverse condition). Fixed now.

Tested on NUCLEO_F429ZI.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

