### PR TITLE
LoRAWAN: volatile bool -> atomic_flag

### DIFF
--- a/UNITTESTS/features/lorawan/lorawanstack/unittest.cmake
+++ b/UNITTESTS/features/lorawan/lorawanstack/unittest.cmake
@@ -35,6 +35,7 @@ set(unittest-test-sources
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaMac_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/LoRaMacCrypto_stub.cpp
   stubs/LoRaMacChannelPlan_stub.cpp
   stubs/LoRaWANTimer_stub.cpp

--- a/UNITTESTS/stubs/LoRaWANStack_stub.cpp
+++ b/UNITTESTS/stubs/LoRaWANStack_stub.cpp
@@ -39,7 +39,6 @@ LoRaWANStack::LoRaWANStack()
       _app_port(12),
       _link_check_requested(false),
       _automatic_uplink_ongoing(false),
-      _ready_for_rx(true),
       _queue(NULL)
 {
 }

--- a/UNITTESTS/stubs/mbed_critical_stub.c
+++ b/UNITTESTS/stubs/mbed_critical_stub.c
@@ -49,6 +49,15 @@ void core_util_critical_section_exit(void)
 {
 }
 
+bool core_util_atomic_flag_test_and_set(volatile core_util_atomic_flag *flagPtr)
+{
+    return false;
+}
+
+void core_util_atomic_flag_clear(volatile core_util_atomic_flag *flagPtr)
+{
+}
+
 bool core_util_atomic_cas_u8(volatile uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {
     return false;

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -73,11 +73,11 @@ LoRaWANStack::LoRaWANStack()
       _app_port(INVALID_PORT),
       _link_check_requested(false),
       _automatic_uplink_ongoing(false),
-      _ready_for_rx(true),
       _queue(NULL)
 {
     _tx_metadata.stale = true;
     _rx_metadata.stale = true;
+    core_util_atomic_flag_clear(&_rx_payload_in_use);
 
 #ifdef MBED_CONF_LORA_APP_PORT
     if (is_port_valid(MBED_CONF_LORA_APP_PORT)) {
@@ -519,11 +519,10 @@ void LoRaWANStack::tx_interrupt_handler(void)
 void LoRaWANStack::rx_interrupt_handler(const uint8_t *payload, uint16_t size,
                                         int16_t rssi, int8_t snr)
 {
-    if (!_ready_for_rx || size > sizeof _rx_payload) {
+    if (size > sizeof _rx_payload || core_util_atomic_flag_test_and_set(&_rx_payload_in_use)) {
         return;
     }
 
-    _ready_for_rx = false;
     memcpy(_rx_payload, payload, size);
 
     const uint8_t *ptr = _rx_payload;
@@ -709,13 +708,13 @@ void LoRaWANStack::process_reception(const uint8_t *const payload, uint16_t size
         mlme_confirm_handler();
 
         if (_loramac.get_mlme_confirmation()->req_type == MLME_JOIN) {
-            _ready_for_rx = true;
+            core_util_atomic_flag_clear(&_rx_payload_in_use);
             return;
         }
     }
 
     if (!_loramac.nwk_joined()) {
-        _ready_for_rx = true;
+        core_util_atomic_flag_clear(&_rx_payload_in_use);
         return;
     }
 
@@ -744,7 +743,7 @@ void LoRaWANStack::process_reception(const uint8_t *const payload, uint16_t size
         mlme_indication_handler();
     }
 
-    _ready_for_rx = true;
+    core_util_atomic_flag_clear(&_rx_payload_in_use);
 }
 
 void LoRaWANStack::process_reception_timeout(bool is_timeout)

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -42,6 +42,7 @@
 
 #include <stdint.h>
 #include "events/EventQueue.h"
+#include "platform/mbed_critical.h"
 #include "platform/Callback.h"
 #include "platform/NonCopyable.h"
 #include "platform/ScopedLock.h"
@@ -504,7 +505,7 @@ private:
     uint8_t _app_port;
     bool _link_check_requested;
     bool _automatic_uplink_ongoing;
-    volatile bool _ready_for_rx;
+    core_util_atomic_flag _rx_payload_in_use;
     uint8_t _rx_payload[LORAMAC_PHY_MAXPAYLOAD];
     events::EventQueue *_queue;
     lorawan_time_t _tx_timestamp;


### PR DESCRIPTION
### Description

Now we have a proper atomic flag API, use it rather than a volatile cheat.

More in my "eliminate volatile" quest.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
