### PR TITLE
InternetSocket: use atomics, not volatile

### DIFF
--- a/UNITTESTS/features/netsocket/DTLSSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/DTLSSocket/unittest.cmake
@@ -22,6 +22,7 @@ set(unittest-test-sources
   features/netsocket/DTLSSocket/test_DTLSSocket.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   ../features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
   stubs/EventQueue_stub.cpp

--- a/UNITTESTS/features/netsocket/DTLSSocketWrapper/unittest.cmake
+++ b/UNITTESTS/features/netsocket/DTLSSocketWrapper/unittest.cmake
@@ -21,6 +21,7 @@ set(unittest-test-sources
   features/netsocket/DTLSSocketWrapper/test_DTLSSocketWrapper.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   ../features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
   stubs/EventQueue_stub.cpp

--- a/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
+++ b/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
@@ -79,14 +79,6 @@ public:
     {
         _writers--;
     }
-    void add_pending(void)
-    {
-        _pending++;
-    }
-    void rem_pending(void)
-    {
-        _pending--;
-    }
 
 protected:
     virtual nsapi_protocol_t get_proto()

--- a/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
@@ -18,6 +18,7 @@ set(unittest-test-sources
   features/netsocket/InternetSocket/test_InternetSocket.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_shared_queues_stub.cpp

--- a/UNITTESTS/features/netsocket/TCPServer/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPServer/unittest.cmake
@@ -22,6 +22,7 @@ set(unittest-sources
 set(unittest-test-sources
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_shared_queues_stub.cpp

--- a/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
@@ -19,6 +19,7 @@ set(unittest-test-sources
   features/netsocket/TCPSocket/test_TCPSocket.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_shared_queues_stub.cpp

--- a/UNITTESTS/features/netsocket/TLSSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TLSSocket/unittest.cmake
@@ -21,6 +21,7 @@ set(unittest-test-sources
   features/netsocket/TLSSocket/test_TLSSocket.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   ../features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
   stubs/EventQueue_stub.cpp

--- a/UNITTESTS/features/netsocket/TLSSocketWrapper/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TLSSocketWrapper/unittest.cmake
@@ -20,6 +20,7 @@ set(unittest-test-sources
   features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   ../features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
   stubs/EventQueue_stub.cpp

--- a/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
@@ -19,6 +19,7 @@ set(unittest-test-sources
   features/netsocket/UDPSocket/test_UDPSocket.cpp
   stubs/Mutex_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_shared_queues_stub.cpp

--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -207,9 +207,9 @@ void InternetSocket::event()
 
 void InternetSocket::sigio(Callback<void()> callback)
 {
-    _lock.lock();
+    core_util_critical_section_enter();
     _callback = callback;
-    _lock.unlock();
+    core_util_critical_section_exit();
 }
 
 void InternetSocket::attach(Callback<void()> callback)

--- a/features/netsocket/InternetSocket.h
+++ b/features/netsocket/InternetSocket.h
@@ -25,6 +25,7 @@
 #include "rtos/Mutex.h"
 #include "rtos/EventFlags.h"
 #include "Callback.h"
+#include "mbed_critical.h"
 #include "mbed_toolchain.h"
 #include "SocketStats.h"
 
@@ -168,7 +169,7 @@ protected:
     SocketAddress _remote_peer;
     uint8_t _readers;
     uint8_t _writers;
-    volatile unsigned _pending;
+    core_util_atomic_flag _pending;
     bool _factory_allocated;
 
     // Event flags

--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -38,7 +38,7 @@ nsapi_error_t TCPServer::accept(TCPSocket *connection, SocketAddress *address)
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         void *socket;
         ret = _stack->socket_accept(_socket, &socket, address);
 

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -62,7 +62,7 @@ nsapi_error_t TCPSocket::connect(const SocketAddress &address)
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         ret = _stack->socket_connect(_socket, address);
         if ((_timeout == 0) || !(ret == NSAPI_ERROR_IN_PROGRESS || ret == NSAPI_ERROR_ALREADY)) {
             _socket_stats.stats_update_socket_state(this, SOCK_CONNECTED);
@@ -143,7 +143,7 @@ nsapi_size_or_error_t TCPSocket::send(const void *data, nsapi_size_t size)
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         ret = _stack->socket_send(_socket, data_ptr + written, size - written);
         if (ret >= 0) {
             written += ret;
@@ -210,7 +210,7 @@ nsapi_size_or_error_t TCPSocket::recv(void *data, nsapi_size_t size)
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         ret = _stack->socket_recv(_socket, data, size);
         if ((_timeout == 0) || (ret != NSAPI_ERROR_WOULD_BLOCK)) {
             _socket_stats.stats_update_recv_bytes(this, ret);
@@ -281,7 +281,7 @@ TCPSocket *TCPSocket::accept(nsapi_error_t *error)
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         void *socket;
         SocketAddress address;
         ret = _stack->socket_accept(_socket, &socket, &address);

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -70,7 +70,7 @@ nsapi_size_or_error_t UDPSocket::sendto(const SocketAddress &address, const void
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         nsapi_size_or_error_t sent = _stack->socket_sendto(_socket, address, data, size);
         if ((0 == _timeout) || (NSAPI_ERROR_WOULD_BLOCK != sent)) {
             _socket_stats.stats_update_sent_bytes(this, sent);
@@ -130,7 +130,7 @@ nsapi_size_or_error_t UDPSocket::recvfrom(SocketAddress *address, void *buffer, 
             break;
         }
 
-        _pending = 0;
+        core_util_atomic_flag_clear(&_pending);
         nsapi_size_or_error_t recv = _stack->socket_recvfrom(_socket, address, buffer, size);
 
         // Filter incomming packets using connected peer address


### PR DESCRIPTION
### Description

Use a better tool for the job for the `_pending` counter, and properly protect `_callback`.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
