### PR TITLE
Fix Python 3 syntax in rtc host test

### DIFF
--- a/TESTS/host_tests/rtc_calc_auto.py
+++ b/TESTS/host_tests/rtc_calc_auto.py
@@ -117,7 +117,7 @@ class RTC_time_calc_test(BaseHostTest):
             self.send_kv("passed", str(response))
         else:
             self.send_kv("failed", 0)
-            print "expected = %d, result = %d" %  (expected_timestamp , actual_timestamp)
+            print("expected = %d, result = %d" %  (expected_timestamp , actual_timestamp))
 
         # calculate next date
         if (self.first):


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This host test does not currently run Python 3. This fixes the print syntax to be compatible with Python 3.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

