### PR TITLE
KVSTORE: disable small RAM ST targets

### DIFF
--- a/features/storage/kvstore/mbed_lib.json
+++ b/features/storage/kvstore/mbed_lib.json
@@ -29,6 +29,36 @@
         "NUCLEO_F410RB": {
             "enabled": false
         },
+        "NUCLEO_F303RE": {
+            "enabled": false
+        },
+        "NUCLEO_F303ZE": {
+            "enabled": false
+        },
+        "NUCLEO_L432KC": {
+            "enabled": false
+        },
+        "NUCLEO_L433RC_P": {
+            "enabled": false
+        },
+        "NUCLEO_L152RE": {
+            "enabled": false
+        },
+        "NUCLEO_F401RE": {
+            "enabled": false
+        },
+        "NUCLEO_L476RG": {
+            "enabled": false
+        },
+        "DISCO_L475VG_IOT01A": {
+            "enabled": false
+        },
+        "DISCO_L476VG": {
+            "enabled": false
+        },
+        "NUCLEO_L486RG": {
+            "enabled": false
+        },
         "REALTEK_RTL8195AM": {
             "enabled": false
         },

--- a/features/storage/kvstore/mbed_lib.json
+++ b/features/storage/kvstore/mbed_lib.json
@@ -8,6 +8,27 @@
         }
     },
     "target_overrides": {
+        "NUCLEO_F070RB": {
+            "enabled": false
+        },
+        "NUCLEO_F072RB": {
+            "enabled": false
+        },
+        "NUCLEO_F103RB": {
+            "enabled": false
+        },
+        "NUCLEO_L073RZ": {
+            "enabled": false
+        },
+        "DISCO_L072CZ_LRWAN1": {
+            "enabled": false
+        },
+        "NUCLEO_F091RC": {
+            "enabled": false
+        },
+        "NUCLEO_F410RB": {
+            "enabled": false
+        },
         "REALTEK_RTL8195AM": {
             "enabled": false
         },


### PR DESCRIPTION
### Description

Seems that KVSTORE should be disabled for small RAM targets.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

