### PR TITLE
STM32L0 & STM32L1: FLASH is EEPROM

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
@@ -178,7 +178,7 @@ uint8_t flash_get_erase_value(const flash_t *obj)
 {
     (void)obj;
 
-    return 0xFF;
+    return 0x0;
 }
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
@@ -175,7 +175,7 @@ uint8_t flash_get_erase_value(const flash_t *obj)
 {
     (void)obj;
 
-    return 0xFF;
+    return 0x0;
 }
 
 #endif


### PR DESCRIPTION
### Description

STM32L0 and STM32L1 use EEPROM, then erased data becomes 0, not 0xFF

FLASHIAP test is now OK with STM32L0 and STM32L1 targets

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
