### PR TITLE
FLASHIAP test: skip test if test region overlaps code

### DIFF
--- a/TESTS/mbed_drivers/flashiap/main.cpp
+++ b/TESTS/mbed_drivers/flashiap/main.cpp
@@ -128,6 +128,7 @@ void flashiap_cross_sector_program_test()
         agg_size += sector_size;
         address -= sector_size;
     }
+    utest_printf("ROM ends at 0x%lx, test starts at 0x%lx\n", FLASHIAP_APP_ROM_END_ADDR, address);
     TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_APP_ROM_END_ADDR, "Test skipped. Test region overlaps code.");
     ret = flash_device.erase(address, agg_size);
     TEST_ASSERT_EQUAL_INT32(0, ret);
@@ -184,6 +185,7 @@ void flashiap_program_error_test()
     TEST_ASSERT_TRUE(address != 0UL);
 
     // unaligned address
+    utest_printf("ROM ends at 0x%lx, test starts at 0x%lx\n", FLASHIAP_APP_ROM_END_ADDR, address);
     TEST_SKIP_UNLESS_MESSAGE(address >= FLASHIAP_APP_ROM_END_ADDR, "Test skipped. Test region overlaps code.");
     ret = flash_device.erase(address + 1, sector_size);
     TEST_ASSERT_EQUAL_INT32(-1, ret);
@@ -220,6 +222,9 @@ void flashiap_timing_test()
     utest_printf("\nFlash timing:\n");
     uint32_t sector_size = flash_device.get_sector_size(end_address - 1UL);
     uint32_t base_address = end_address - sector_size;
+    utest_printf("ROM ends at 0x%lx, test starts at 0x%lx\n", FLASHIAP_APP_ROM_END_ADDR, base_address);
+    TEST_SKIP_UNLESS_MESSAGE(base_address >= FLASHIAP_APP_ROM_END_ADDR, "Test skipped. Test region overlaps code.");
+
     timer.start();
     for (num_write_sizes = 0; num_write_sizes < max_write_sizes; num_write_sizes++) {
         if (write_size > sector_size) {


### PR DESCRIPTION
### Description

Test region check was made for all test cases except "FlashIAP - timing" one


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

