### PR TITLE
Use mbed_error_printf instead of debug for ISR friendly prints 

### DIFF
--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -20,14 +20,13 @@
 #include "platform/mbed_critical.h"
 #include "sleep_api.h"
 #include "platform/mbed_error.h"
-#include "platform/mbed_debug.h"
 #include "platform/mbed_stats.h"
 #include "us_ticker_api.h"
 #include "lp_ticker_api.h"
 #include <limits.h>
 #include <stdio.h>
 #include "platform/mbed_stats.h"
-
+#include "platform/mbed_interface.h"
 
 #if DEVICE_SLEEP
 
@@ -105,14 +104,14 @@ static sleep_statistic_t *sleep_tracker_add(const char *const filename)
         }
     }
 
-    debug("No free indexes left to use in mbed sleep tracker.\r\n");
+    mbed_error_printf("No free indexes left to use in mbed sleep tracker.\r\n");
 
     return NULL;
 }
 
 static void sleep_tracker_print_stats(void)
 {
-    debug("Sleep locks held:\r\n");
+    mbed_error_printf("Sleep locks held:\r\n");
     for (int i = 0; i < STATISTIC_COUNT; ++i) {
         if (sleep_stats[i].count == 0) {
             continue;
@@ -122,8 +121,8 @@ static void sleep_tracker_print_stats(void)
             return;
         }
 
-        debug("[id: %s, count: %u]\r\n", sleep_stats[i].identifier,
-              sleep_stats[i].count);
+        mbed_error_printf("[id: %s, count: %u]\r\n", sleep_stats[i].identifier,
+                          sleep_stats[i].count);
     }
 }
 
@@ -138,7 +137,7 @@ void sleep_tracker_lock(const char *const filename, int line)
 
     core_util_atomic_incr_u8(&stat->count, 1);
 
-    debug("LOCK: %s, ln: %i, lock count: %u\r\n", filename, line, deep_sleep_lock);
+    mbed_error_printf("LOCK: %s, ln: %i, lock count: %u\r\n", filename, line, deep_sleep_lock);
 }
 
 void sleep_tracker_unlock(const char *const filename, int line)
@@ -147,13 +146,13 @@ void sleep_tracker_unlock(const char *const filename, int line)
 
     // Entry for this driver does not exist, something went wrong.
     if (stat == NULL) {
-        debug("Unlocking sleep for driver that was not previously locked: %s, ln: %i\r\n", filename, line);
+        mbed_error_printf("Unlocking sleep for driver that was not previously locked: %s, ln: %i\r\n", filename, line);
         return;
     }
 
     core_util_atomic_decr_u8(&stat->count, 1);
 
-    debug("UNLOCK: %s, ln: %i, lock count: %u\r\n", filename, line, deep_sleep_lock);
+    mbed_error_printf("UNLOCK: %s, ln: %i, lock count: %u\r\n", filename, line, deep_sleep_lock);
 }
 
 #endif // MBED_SLEEP_TRACING_ENABLED


### PR DESCRIPTION
### Description

Resolves: https://github.com/ARMmbed/mbed-os/issues/9216

All the `debug` calls in sleep manager for sleep tracing should be changed to `mbed_error_printf` since most sleep API's and calls are interrupt and thread safe. Fixed here.

Issue was seen only with `debug` profile and was not captured in `develop` profile because `MBED_TRAP_ERRORS_ENABLED` flag was not set in `develop` profile. PR #9277

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kjbracey-arm
