### PR TITLE
Correcting the error-case trace from mesh-api interfaces

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -184,7 +184,7 @@ MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
     if (!inited) {
         nsapi_error_t result = interface.initialize(&NanostackRfPhy::get_default_instance());
         if (result != 0) {
-            tr_error("LoWPANND initialize failed: %d", error);
+            tr_error("LoWPANND initialize failed: %d", result);
             singleton_unlock();
             return NULL;
         }

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -278,7 +278,7 @@ MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
     if (!inited) {
         nsapi_error_t result = interface.initialize(&NanostackRfPhy::get_default_instance());
         if (result != 0) {
-            tr_error("Thread initialize failed: %d", error);
+            tr_error("Thread initialize failed: %d", result);
             singleton_unlock();
             return NULL;
         }

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -184,7 +184,7 @@ MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
     if (!inited) {
         nsapi_error_t result = interface.initialize(&NanostackRfPhy::get_default_instance());
         if (result != 0) {
-            tr_error("Wi-SUN initialize failed: %d", error);
+            tr_error("Wi-SUN initialize failed: %d", result);
             singleton_unlock();
             return NULL;
         }


### PR DESCRIPTION
### Description

If someting goes wrong with get_default:instance-call, the error code is in result variable.
So result-variable shoud be printed out.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

