### PR TITLE
DeviceKey: [Security Fix] Generated ROT-key is still used when TRNG fails

### DIFF
--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -267,11 +267,12 @@ int DeviceKey::generate_key_by_random(uint32_t *output, size_t size)
     ret = mbedtls_entropy_func(entropy, (unsigned char *)output, size);
     if (ret != MBED_SUCCESS) {
         ret = DEVICEKEY_GENERATE_RANDOM_ERROR;
+    } else {
+        ret = DEVICEKEY_SUCCESS;
     }
 
     mbedtls_entropy_free(entropy);
     delete entropy;
-    ret = DEVICEKEY_SUCCESS;
 #endif
 
     return ret;


### PR DESCRIPTION
### Description

Fix security bug in DeviceKey's implementation.
With the current implementation, a possible failure of the TRNG cannot be noticed, as the return value in line 269 is immediately overriden in line 274.
When the TRNG somehow fails (e. g. not (yet) ready), the key may stay zeroed out. This is falsely reported back to the generation logic as a success, thus making the RootOfTrust possibly predictable.

This fix ensures that a failed TRNG is properly propagated back to the caller, and that the output is not used as ROT.

@SecurityTeam (if any): I'd suggest a small security notice to the users that the DeviceKey **may** be insecure, as the TRNG may have unknowingly failed.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
