### PR TITLE
ESP8266: Set HW reset time to 2ms

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -371,7 +371,7 @@ void ESP8266Interface::_hw_reset()
     _rst_pin.rst_assert();
     // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
     // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
-    wait_us(200);
+    wait_ms(2); // Documentation says 200 us should have been enough, but experimentation shows that 1ms was not enough
     _rst_pin.rst_deassert();
 }
 


### PR DESCRIPTION
### Description

Documentation says 200 us should have been enough, but experimentation shows that 1 ms was not enough, but 2 ms is.

Maybe there is RC effect on the shield I'm using.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@VeijoPesonen 
