### PR TITLE
Remove printf completely and fix the optimization check

### DIFF
--- a/TESTS/host_tests/crash_reporting.py
+++ b/TESTS/host_tests/crash_reporting.py
@@ -60,7 +60,7 @@ class CrashReportingTest(BaseHostTest):
         wait_after_reset = wait_after_reset if wait_after_reset is not None else DEFAULT_CYCLE_PERIOD
 
         #Wait 2 seconds for system to init
-        time.sleep(2.0)
+        time.sleep(7.0)
         #self.send_kv(MSG_KEY_SYNC, MSG_VALUE_DUMMY)
         self.send_kv(MSG_KEY_DEVICE_ERROR, MSG_VALUE_DUMMY)
         time.sleep(5.0)

--- a/TESTS/mbed_platform/crash_reporting/main.cpp
+++ b/TESTS/mbed_platform/crash_reporting/main.cpp
@@ -53,12 +53,17 @@ void test_crash_reporting()
 
     // Report readiness
     greentea_send_kv(MSG_KEY_DEVICE_READY, MSG_VALUE_DUMMY);
+    printf("\nMessage sent: %s\n", MSG_KEY_DEVICE_READY);
 
     static char _key[MSG_KEY_LEN + 1] = { };
     static char _value[MSG_VALUE_LEN + 1] = { };
 
+    printf("\nWaiting for crash inject error message: %s\n", MSG_KEY_DEVICE_ERROR);
     greentea_parse_kv(_key, _value, MSG_KEY_LEN, MSG_VALUE_LEN);
+    printf("\nCrash inject error message received\n");
+
     if (strcmp(_key, MSG_KEY_DEVICE_ERROR) == 0) {
+        printf("\nForcing error\n");
         MBED_ERROR1(MBED_ERROR_OUT_OF_MEMORY, "Executing crash reporting test.", 0xDEADBAD);
         TEST_ASSERT_MESSAGE(0, "crash_reporting() error call failed.");
     }

--- a/TESTS/mbed_platform/crash_reporting/main.cpp
+++ b/TESTS/mbed_platform/crash_reporting/main.cpp
@@ -67,7 +67,7 @@ void test_crash_reporting()
 
 int main(void)
 {
-    GREENTEA_SETUP(30, "crash_reporting");
+    GREENTEA_SETUP(40, "crash_reporting");
     test_crash_reporting();
     GREENTEA_TESTSUITE_RESULT(0);
 

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -292,11 +292,13 @@ WEAK MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_stat
     core_util_critical_section_exit();
     //We need not call delete_mbed_crc(crc_obj) here as we are going to reset the system anyway, and calling delete while handling a fatal error may cause nested exception
 #if MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED && (MBED_CONF_PLATFORM_ERROR_REBOOT_MAX > 0)
+#ifndef NDEBUG
     mbed_error_printf("\n= System will be rebooted due to a fatal error =\n");
     if (report_error_ctx->error_reboot_count >= MBED_CONF_PLATFORM_ERROR_REBOOT_MAX) {
         //We have rebooted more than enough, hold the system here.
         mbed_error_printf("= Reboot count(=%ld) reached maximum, system will halt after rebooting =\n", report_error_ctx->error_reboot_count);
     }
+#endif
     system_reset();//do a system reset to get the system rebooted
 #endif
 #endif

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -211,24 +211,16 @@ mbed_error_status_t mbed_error_initialize(void)
         //Read report_error_ctx and check if CRC is correct, and with valid status code
         if ((report_error_ctx->crc_error_ctx == crc_val) && (report_error_ctx->is_error_processed == 0)) {
             is_reboot_error_valid = true;
-            //Report the error info
-#ifndef NDEBUG
-            printf("\n== The system has been rebooted due to a fatal error. ==\n");
-#endif
 
             //Call the mbed_error_reboot_callback, this enables applications to do some handling before we do the handling
             mbed_error_reboot_callback(report_error_ctx);
 
             //We let the callback reset the error info, so check if its still valid and do the rest only if its still valid.
-            if (report_error_ctx->error_reboot_count < 0) {
+            if (report_error_ctx->error_reboot_count > 0) {
 
                 //Enforce max-reboot only if auto reboot is enabled
 #if MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED
                 if (report_error_ctx->error_reboot_count >= MBED_CONF_PLATFORM_ERROR_REBOOT_MAX) {
-                    //We have rebooted more than enough, hold the system here.
-#ifndef NDEBUG
-                    printf("\n== Reboot count(=%ld) exceeded maximum, system halting ==\n", report_error_ctx->error_reboot_count);
-#endif
                     mbed_halt_system();
                 }
 #endif
@@ -300,6 +292,11 @@ WEAK MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_stat
     core_util_critical_section_exit();
     //We need not call delete_mbed_crc(crc_obj) here as we are going to reset the system anyway, and calling delete while handling a fatal error may cause nested exception
 #if MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED && (MBED_CONF_PLATFORM_ERROR_REBOOT_MAX > 0)
+    mbed_error_printf("\n= System will be rebooted due to a fatal error =\n");
+    if (report_error_ctx->error_reboot_count >= MBED_CONF_PLATFORM_ERROR_REBOOT_MAX) {
+        //We have rebooted more than enough, hold the system here.
+        mbed_error_printf("= Reboot count(=%ld) reached maximum, system will halt after rebooting =\n", report_error_ctx->error_reboot_count);
+    }
     system_reset();//do a system reset to get the system rebooted
 #endif
 #endif


### PR DESCRIPTION
### Description
printf call from mbed_error.c has been causing elevated rom usage for GCC builds for develop profile. This change refactor the code to use mbed_error_print before rebooting to avoid using printf. Also contains a fix for optimization check.


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@bulislaw
