### PR TITLE
uARM targets now build in correct ARM_MICRO directory

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -121,6 +121,15 @@ def add_result_to_report(report, result):
     result_wrap = {0: result}
     report[target][toolchain][id_name].append(result_wrap)
 
+def get_toolchain_name(target, toolchain_name):
+    if toolchain_name == "ARM":
+        if CORE_ARCH[target.core] == 8:
+            return "ARMC6"
+        elif getattr(target, "default_toolchain", None) == "uARM":
+            return "uARM"
+
+    return toolchain_name
+
 def get_config(src_paths, target, toolchain_name=None, app_config=None):
     """Get the configuration object for a target-toolchain combination
 
@@ -316,8 +325,8 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
         raise NotSupportedException(
             "Target {} is not supported by toolchain {}".format(
                 target.name, toolchain_name))
-    if (toolchain_name == "ARM" and CORE_ARCH[target.core] == 8):
-        toolchain_name = "ARMC6"
+
+    toolchain_name = get_toolchain_name(target, toolchain_name)
 
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
@@ -941,6 +950,8 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
 
     Return - True if target + toolchain built correctly, False if not supported
     """
+
+    toolchain_name = get_toolchain_name(target, toolchain_name)
 
     if report is not None:
         start = time()


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Fixes #9138.

This is for OS2 testing. Previously, targets that were configured with
the option "default_toolchain": "uARM" would still build to a
TOOLCHAIN_ARM_STD directory. This fixes these targets to build into
TOOLCHAIN_ARM_MICRO.

@theotherjimmy I'm not 100% in love with how I have to fudge the toolchain names, do you have any other ideas on how to patch this?

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

