### PR TITLE
Add TRNG checkup in devicekey

### DIFF
--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -30,6 +30,7 @@
 #include "entropy.h"
 #include "platform_mbed.h"
 #include "mbed_trace.h"
+#include "ssl_internal.h"
 
 #define TRACE_GROUP "DEVKEY"
 
@@ -260,12 +261,14 @@ int DeviceKey::generate_key_by_random(uint32_t *output, size_t size)
     }
 
 #if DEVICE_TRNG
+    uint32_t test_buff[DEVICE_KEY_32BYTE / sizeof(int)];
     mbedtls_entropy_context *entropy = new mbedtls_entropy_context;
     mbedtls_entropy_init(entropy);
     memset(output, 0, size);
+    memset(test_buff, 0, size);
 
     ret = mbedtls_entropy_func(entropy, (unsigned char *)output, size);
-    if (ret != MBED_SUCCESS) {
+    if (ret != MBED_SUCCESS || mbedtls_ssl_safer_memcmp(test_buff, (unsigned char *)output, size) == 0) {
         ret = DEVICEKEY_GENERATE_RANDOM_ERROR;
     } else {
         ret = DEVICEKEY_SUCCESS;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
To eliminate the case in which TRNG return success but actually fail and did nothing I have added a check that test if the device key buffer has changed after calling entropy function.
This checkup is not a bulletproof mechanism but we believe that it should decrease the chances for such an error in substantially.

This PR is dependant on #9278 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

