### PR TITLE
Configuration options for STM_EMAC buffer counts

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/mbed_lib.json
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/mbed_lib.json
@@ -1,0 +1,13 @@
+{
+    "name": "stm32-emac",
+    "config": {
+        "eth-rxbufnb": 4,
+        "eth-txbufnb": 4
+    },
+    "target_overrides": {
+        "NUCLEO_F207ZG": {
+            "eth-rxbufnb": 1,
+            "eth-txbufnb": 4
+        }
+    }
+}

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_conf.h
@@ -164,8 +164,14 @@ extern "C" {
 /* Definition of the Ethernet driver buffers size and count */
 #define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
 #define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
-#define ETH_RXBUFNB                    8U                  /* 8 Rx buffers of size ETH_RX_BUF_SIZE  */
-#define ETH_TXBUFNB                    4U                  /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_RXBUFNB
+#define ETH_RXBUFNB                       MBED_CONF_STM32_EMAC_ETH_RXBUFNB  /* Rx buffers of size ETH_RX_BUF_SIZE  */
+#endif
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_TXBUFNB
+#define ETH_TXBUFNB                       MBED_CONF_STM32_EMAC_ETH_TXBUFNB  /* Tx buffers of size ETH_TX_BUF_SIZE  */
+#endif
 
 /* Section 2: PHY configuration section */
 

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_conf.h
@@ -175,8 +175,14 @@
 /* Definition of the Ethernet driver buffers size and count */   
 #define ETH_RX_BUF_SIZE                   ETH_MAX_PACKET_SIZE /* buffer size for receive               */
 #define ETH_TX_BUF_SIZE                   ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
-#define ETH_RXBUFNB                       4U       /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
-#define ETH_TXBUFNB                       4U       /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_RXBUFNB
+#define ETH_RXBUFNB                       MBED_CONF_STM32_EMAC_ETH_RXBUFNB  /* Rx buffers of size ETH_RX_BUF_SIZE  */
+#endif
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_TXBUFNB
+#define ETH_TXBUFNB                       MBED_CONF_STM32_EMAC_ETH_TXBUFNB  /* Tx buffers of size ETH_TX_BUF_SIZE  */
+#endif
 
 /* Section 2: PHY configuration section */
 

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_conf.h
@@ -183,8 +183,14 @@
 /* Definition of the Ethernet driver buffers size and count */
 #define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
 #define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
-#define ETH_RXBUFNB                    4U                  /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
-#define ETH_TXBUFNB                    4U                  /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_RXBUFNB
+#define ETH_RXBUFNB                       MBED_CONF_STM32_EMAC_ETH_RXBUFNB  /* Rx buffers of size ETH_RX_BUF_SIZE  */
+#endif
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_TXBUFNB
+#define ETH_TXBUFNB                       MBED_CONF_STM32_EMAC_ETH_TXBUFNB  /* Tx buffers of size ETH_TX_BUF_SIZE  */
+#endif
 
 /* Section 2: PHY configuration section */
 

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_conf.h
@@ -189,9 +189,14 @@
 /* Definition of the Ethernet driver buffers size and count */
 #define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
 #define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
-#define ETH_RXBUFNB                    4U       /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
-#define ETH_TXBUFNB                    4U       /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */
 
+#ifdef MBED_CONF_STM32_EMAC_ETH_RXBUFNB
+#define ETH_RXBUFNB                       MBED_CONF_STM32_EMAC_ETH_RXBUFNB  /* Rx buffers of size ETH_RX_BUF_SIZE  */
+#endif
+
+#ifdef MBED_CONF_STM32_EMAC_ETH_TXBUFNB
+#define ETH_TXBUFNB                       MBED_CONF_STM32_EMAC_ETH_TXBUFNB  /* Tx buffers of size ETH_TX_BUF_SIZE  */
+#endif
 /* Section 2: PHY configuration section */
 
 /* DP83848 PHY Address*/


### PR DESCRIPTION
### Description

Configuration options for STM_EMAC buffer counts. 

Add configurable options for STM_EMAC buffer.  For all STM_EMAC board targets added mbed_lib.jeson with configurable: eth-rxbufnb and eth-txbufnb used in stm32f1xx_hal_conf.h.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo
<!-- 
    Optional
    Request additional reviewers with @SeppoTakalo 
-->

