### PR TITLE
tools: support cases where bootloader is in chunks

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -742,6 +742,7 @@ class mbedToolchain:
         if self.config.has_regions:
             try:
                 regions = list(self.config.regions)
+                regions.sort(key=lambda x:x.start)
                 self.notify.info("Using ROM region%s %s in this build." % (
                     "s" if len(regions) > 1 else "",
                     ", ".join(r.name for r in regions)


### PR DESCRIPTION
Bootloader can be placed beyond the application. Support this requirement.
With FEATURE_BOOTLOADER support, the bootloader can be placed at a
high address. Add support to the tools so that Application can be placed in
the available space before the beginning of the Bootloader.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change