### PR TITLE
fix bug for RDA UNO_91H：calling us ticker functions without init.

### DIFF
--- a/targets/TARGET_RDA/TARGET_UNO_91H/trng_api.c
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/trng_api.c
@@ -70,6 +70,8 @@ void trng_init(trng_t *obj)
     regval = rTRNG_CTRL |  ((0x01UL << 4) | (0xFFUL << 16));
     rTRNG_CTRL = regval & ~((0x01UL << 1) | (0x01UL << 2) | (0x01UL << 3));
 
+    us_ticker_init();
+
     /*Entropy data was mixed by TRNG seed and noise, so we add one 32us delay to
       ensure all 32 bits of seed is entropy when init and 
       another delay to update noise data when get data. 


### PR DESCRIPTION
### Description
fix bug for RDA UNO_91H：calling us ticker functions without init.
solution: init us ticker when init TRNG, because we use us ticker read to delay and wait for TRNG seed ready.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

