### PR TITLE
Add binary hook for ARMC6 which use --bincombined for .bin outputs

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -511,3 +511,21 @@ class ARMC6(ARM_STD):
         cmd.extend(["-o", object, source])
         cmd = self.hook.get_cmdline_compiler(cmd)
         return [cmd]
+
+    @hook_tool
+    def binary(self, resources, elf, bin):
+        _, fmt = splitext(bin)
+        # On .hex format, combine multiple .hex files (for multiple load regions) into one 
+        bin_arg = {".bin": "--bincombined", ".hex": "--i32combined"}[fmt]
+        cmd = [self.elf2bin, bin_arg, '-o', bin, elf]
+        cmd = self.hook.get_cmdline_binary(cmd)
+
+        # remove target binary file/path
+        if exists(bin):
+            if isfile(bin):
+                remove(bin)
+            else:
+                rmtree(bin)
+
+        self.notify.cc_verbose("FromELF: %s" % ' '.join(cmd))
+        self.default_cmd(cmd)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -304,12 +304,11 @@ class ARM(mbedToolchain):
     @hook_tool
     def binary(self, resources, elf, bin):
         _, fmt = splitext(bin)
-        # On .hex format, combine multiple .hex files (for multiple load regions) into one
-        bin_arg = {".bin": "--bin", ".hex": "--i32combined"}[fmt]
+        # Combine multiple .hex/.bin files (for multiple load regions) into one
+        bin_arg = {".bin": "--bincombined", ".hex": "--i32combined"}[fmt]
         cmd = [self.elf2bin, bin_arg, '-o', bin, elf]
         cmd = self.hook.get_cmdline_binary(cmd)
 
-        # remove target binary file/path
         if exists(bin):
             if isfile(bin):
                 remove(bin)
@@ -511,21 +510,3 @@ class ARMC6(ARM_STD):
         cmd.extend(["-o", object, source])
         cmd = self.hook.get_cmdline_compiler(cmd)
         return [cmd]
-
-    @hook_tool
-    def binary(self, resources, elf, bin):
-        _, fmt = splitext(bin)
-        # On .hex format, combine multiple .hex files (for multiple load regions) into one 
-        bin_arg = {".bin": "--bincombined", ".hex": "--i32combined"}[fmt]
-        cmd = [self.elf2bin, bin_arg, '-o', bin, elf]
-        cmd = self.hook.get_cmdline_binary(cmd)
-
-        # remove target binary file/path
-        if exists(bin):
-            if isfile(bin):
-                remove(bin)
-            else:
-                rmtree(bin)
-
-        self.notify.cc_verbose("FromELF: %s" % ' '.join(cmd))
-        self.default_cmd(cmd)


### PR DESCRIPTION
### Description

This is needed in order to generate one output file for an image containing multiple load regions, instead of a .bin for each load region.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-tools

<!-- 
    Optional
    Request additional reviewers with @username
-->

