### PR TITLE
ESP8266: prevent WOULD BLOCK from TX if UDP

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -506,7 +506,7 @@ int ESP8266Interface::socket_send(void *handle, const void *data, unsigned size)
             && (status != NSAPI_ERROR_OK));
 
     if (status == NSAPI_ERROR_WOULD_BLOCK && socket->proto == NSAPI_TCP) {
-        debug("Enqueuing the event call");
+        tr_debug("ESP8266Interface::socket_send(): enqueuing the event call");
         _global_event_queue->call_in(100, callback(this, &ESP8266Interface::event));
     } else if (status == NSAPI_ERROR_WOULD_BLOCK && socket->proto == NSAPI_UDP) {
         status = NSAPI_ERROR_DEVICE_ERROR;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -505,9 +505,11 @@ int ESP8266Interface::socket_send(void *handle, const void *data, unsigned size)
     } while ((sendStartTime - rtos::Kernel::get_ms_count() < 50)
             && (status != NSAPI_ERROR_OK));
 
-    if (status == NSAPI_ERROR_WOULD_BLOCK) {
+    if (status == NSAPI_ERROR_WOULD_BLOCK && socket->proto == NSAPI_TCP) {
         debug("Enqueuing the event call");
         _global_event_queue->call_in(100, callback(this, &ESP8266Interface::event));
+    } else if (status == NSAPI_ERROR_WOULD_BLOCK && socket->proto == NSAPI_UDP) {
+        status = NSAPI_ERROR_DEVICE_ERROR;
     }
 
     return status != NSAPI_ERROR_OK ? status : size;


### PR DESCRIPTION
### Description

[ESP8266] Drop signalling SIGIO artificially if UDP send fails
    
With TCP it's desirable that SIGIO wakes up the application to check
if there is buffer space available on the mode. With UDP the
behavior is not acceptable as we don't know if the other endpoint is
there as connection establishment is missing. Hence buffers might
stay full forever.

Fix a debug print

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
@SeppoTakalo 
@michalpasztamobica 

