### PR TITLE
thread_mle_message_handler: fix build warning

### DIFF
--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_mle_message_handler.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_mle_message_handler.c
@@ -759,7 +759,7 @@ static void thread_host_child_update_request_process(protocol_interface_info_ent
     uint64_t pending_timestamp = 0;// means no pending timestamp
     mac_neighbor_table_entry_t *entry_temp;
     bool data_request_needed = false;
-    mle_tlv_info_t tlv_info = {0};
+    mle_tlv_info_t tlv_info = {MLE_TYPE_SRC_ADDRESS, 0, 0};
 
     tr_debug("Child update request");
     entry_temp = mac_neighbor_entry_get_by_ll64(mac_neighbor_info(cur), mle_msg->packet_src_address, false, NULL);
@@ -831,7 +831,7 @@ static void thread_parse_child_update_response(protocol_interface_info_entry_t *
     thread_leader_data_t leaderData = {0};
     uint8_t status;
     bool leader_data_received;
-    mle_tlv_info_t tlv_info = {0};
+    mle_tlv_info_t tlv_info = {MLE_TYPE_SRC_ADDRESS, 0, 0};
 
     if (cur->thread_info->thread_endnode_parent == NULL) {
         return;


### PR DESCRIPTION
Fix the following build warning found when building with
ARMC6 toolchain for NRF52_DK with mbed cli version 1.8.3

[Warning] thread_mle_message_handler.c@762,0:  #188-D: enumerated type mixed with another type
[Warning] thread_mle_message_handler.c@834,0:  #188-D: enumerated type mixed with another type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
