### PR TITLE
Fix Out-Of-Band (OOB) data generation for BLE OOB pairing

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <stdint.h>
+#include "platform/mbed_assert.h"
 #include "nRF5xPalSecurityManager.h"
 #include "nRF5xn.h"
 #include "ble/Gap.h"
@@ -734,7 +735,9 @@ ble_error_t nRF5xSecurityManager::generate_secure_connections_oob()
     ble_gap_lesc_p256_pk_t own_secret;
     ble_gap_lesc_oob_data_t oob_data;
 
-    memcpy(own_secret.pk, secret.data(), secret.size());
+    MBED_ASSERT(sizeof(own_secret.pk) >= X.size() + Y.size());
+    memcpy(own_secret.pk, X.data(), X.size());
+    memcpy(own_secret.pk + X.size(), Y.data(), Y.size());
 
     uint32_t err = sd_ble_gap_lesc_oob_data_get(
         BLE_CONN_HANDLE_INVALID,


### PR DESCRIPTION
### Description

OOB data is cryptographic material exchanged by two peers prior to pairing with the BLE OOB pairing method.  After trading OOB data, during the BLE OOB pairing process, peers exchange their public keys, validate the previously exchanged OOB data against the peer's public key, and calculate encryption keys using a combination of the peer's public key and OOB data and the local private key.  In this way, man in the middle attacks and passive eavesdropping are prevented.

There are a few bugs in the BLE GenericSecurityManager and Nordic PAL SecurityManager that prevent OOB data from being generated correctly such that a peer is unable to mathematically validate the OOB data and public key received from the Nordic device.

These issues occur on a Nordic nRF52-DK and prevent the nRF52-DK from pairing with a Linux device using the OOB pairing method.  With these fixes, the Nordic nRF52-DK successfully pairs with a Linux device using the OOB pairing method.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


