### PR TITLE
Add C++ class that automatically initialises mbed_trace library.

### DIFF
--- a/features/frameworks/mbed-trace/MbedTraceInitialiser.cpp
+++ b/features/frameworks/mbed-trace/MbedTraceInitialiser.cpp
@@ -1,0 +1,12 @@
+#include "mbed_trace.h"
+
+class MbedTraceInitialiser {
+public:
+    MbedTraceInitialiser() {
+        mbed_trace_init();
+    }
+};
+
+#if MBED_CONF_MBED_TRACE_ENABLE
+MbedTraceInitialiser initialiser;
+#endif


### PR DESCRIPTION
### Description

Turning on the "mbed-trace.enable": true, causes now this class
initialiser called before we enter the main(). Allows us to
turn on traces on any application without inserting this
mbed_trace_init() call on every main.cpp that we wan't to debug.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jupe @kjbracey-arm 

