### PR TITLE
Flush ESP8266 serial input buffers after HW reset

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1114,6 +1114,13 @@ int8_t ESP8266::default_wifi_mode()
     return 0;
 }
 
+void ESP8266::flush()
+{
+    _smutex.lock();
+    _parser.flush();
+    _smutex.unlock();
+}
+
 bool ESP8266::set_default_wifi_mode(const int8_t mode)
 {
     _smutex.lock();

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -367,6 +367,15 @@ public:
      */
     void bg_process_oob(uint32_t timeout, bool all);
 
+    /**
+     * Flush the serial port input buffers.
+     *
+     * If you do HW reset for ESP module, you should
+     * flush the input buffers from existing responses
+     * from the device.
+     */
+    void flush();
+
     static const int8_t WIFIMODE_STATION = 1;
     static const int8_t WIFIMODE_SOFTAP = 2;
     static const int8_t WIFIMODE_STATION_SOFTAP = 3;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -368,11 +368,14 @@ nsapi_error_t ESP8266Interface::_init(void)
 
 void ESP8266Interface::_hw_reset()
 {
-    _rst_pin.rst_assert();
-    // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
-    // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
-    wait_ms(2); // Documentation says 200 us should have been enough, but experimentation shows that 1ms was not enough
-    _rst_pin.rst_deassert();
+    if (_rst_pin.is_connected()) {
+        _rst_pin.rst_assert();
+        // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
+        // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
+        wait_ms(2); // Documentation says 200 us should have been enough, but experimentation shows that 1ms was not enough
+        _esp.flush();
+        _rst_pin.rst_deassert();
+    }
 }
 
 struct esp8266_socket {


### PR DESCRIPTION
### Description

Flush ESP8266 serial input buffers after HW reset.

Without flushing the input buffers, there was a sight change that partially outputted lines were already in UARTSerial buffers, causing some wrong OOB handlers to be called and leading to parsing failures.

Problem reported in https://jira.arm.com/browse/ONME-4120

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@VeijoPesonen @michalpasztamobica 

