### PR TITLE
Fix bug in templated attach function

### DIFF
--- a/features/unsupported/USBDevice/USBSerial/USBSerial.h
+++ b/features/unsupported/USBDevice/USBSerial/USBSerial.h
@@ -126,8 +126,8 @@ public:
      */
     template<typename T>
     void attach(T* tptr, void (T::*mptr)(void)) {
-        if((mptr != NULL) && (tptr != NULL)) {
-            rx = Callback<void()>(mptr, tptr);
+        if((tptr != NULL) && (mptr != NULL)) {
+            rx = Callback<void()>(tptr, mptr);
         }
     }
 


### PR DESCRIPTION
### Description

Fixes a compile-time bug that was preventing `USBSerial::attach` from being instantiated.
The arguments passed to `Callback<void()>`'s constructor were the wrong way round,
this patch corrects that by switching the order of the arguments to correctly match `Callback<void()>`'s constructor.

Example:
```cpp
class Example
{
private:
	bool received;
	
public:
	Example()
		: received(false)
	{
	}

	bool dataIsReceived() const
	{
		return this->received;
	}
	
	void receiveData()
	{
		this->received = true;
	}
};

// May require vendor id and product id
USBSerial serial = USBSerial()
Example example = Example();

void test()
{
	// Before patch: failure to compile
	// After patch: compiles correctly
	serial.attach(example, &Example::receiveData);
}
```
(Would require device-specific code to illustrate that `dataIsReceived` has changed to `true`.)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

