### PR TITLE
Travis CI: Corrected astyle job behavior with non-master base branch PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,9 +144,12 @@ matrix:
           export PATH=$PWD/bin:$PATH;
           cd -
         - astyle --version
+        # Fetch remaining information needed for branch comparison
+        - git fetch --all --unshallow --tags
+        - git fetch origin "${TRAVIS_BRANCH}"
       script:
         - >-
-          git diff --name-only --diff-filter=d HEAD..${TRAVIS_BRANCH} \
+          git diff --name-only --diff-filter=d FETCH_HEAD..HEAD \
             | ( grep '.\(c\|cpp\|h\|hpp\)$' || true ) \
             | ( fgrep -v -f .astyleignore || true ) \
             | while read file; do astyle -n --options=.astylerc "${file}"; done


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Consolidated efforts from PR #9336.

Previous job's env vars would not be populated correctly if the base branch of a PR was not master.
Corected by pulling remaining respository information to perform comparison between read-only instance of PR and base branch.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

