### PR TITLE
GD32_F450ZI: Support boot stack size configuration option

### DIFF
--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/device/TOOLCHAIN_ARM_STD/gd32f450zi.sct
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/device/TOOLCHAIN_ARM_STD/gd32f450zi.sct
@@ -11,6 +11,12 @@
   #define MBED_APP_SIZE 0x200000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
+#define Stack_Size MBED_BOOT_STACK_SIZE
+
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region (3*1024K)
 
   ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
@@ -20,7 +26,10 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region (3*1024K)
   }
 
   ; 107 vectors (16 core + 91 peripheral) * 4 bytes = 428 bytes to reserve (0x1B0, 8-byte aligned)
-  RW_IRAM1 (0x20000000+0x1B0) (0x30000-0x1B0)  {  ; RW data
+  RW_IRAM1 (0x20000000+0x1B0) (0x30000-0x1B0-Stack_Size)  {  ; RW data
    .ANY (+RW +ZI)
+  }
+
+  ARM_LIB_STACK 0x20000000+0x30000 EMPTY -Stack_Size { ; Stack region growing down
   }
 }

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/device/TOOLCHAIN_GCC_ARM/GD32F450xI.ld
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/device/TOOLCHAIN_GCC_ARM/GD32F450xI.ld
@@ -6,6 +6,10 @@
   #define MBED_APP_SIZE 2048k
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
 /* specify memory regions */
 MEMORY
 {
@@ -113,6 +117,7 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*)
+        . = ORIGIN(RAM) + LENGTH(RAM) - MBED_BOOT_STACK_SIZE;
         __HeapLimit = .;
     } > RAM
 
@@ -124,7 +129,7 @@ SECTIONS
     /* initializes stack on the end of block */
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
     _estack = __StackTop;
-    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    __StackLimit = __StackTop - MBED_BOOT_STACK_SIZE;
     PROVIDE(__stack = __StackTop);
 
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/device/TOOLCHAIN_IAR/gd32f450zi.icf
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/device/TOOLCHAIN_IAR/gd32f450zi.icf
@@ -4,6 +4,7 @@
 
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
 if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) { define symbol MBED_BOOT_STACK_SIZE = 0x400; }
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
@@ -17,7 +18,7 @@ define symbol __ICFEDIT_region_RAM_start__  = 0x200001B0;
 define symbol __ICFEDIT_region_RAM_end__    = 0x2002FFFF;
 
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x400;
+define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_heap__   = 0x10000;
 /**** End of ICF editor section. ###ICF###*/
 


### PR DESCRIPTION
### Description

New target (`GD32_F450ZI`) has been added just before PR https://github.com/ARMmbed/mbed-os/pull/9092 has been merged.
This PR adapts linker scripts for the new target.

Build Mbed successfully on `GD32_F450ZI` and all compilers locally. 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

