### PR TITLE
mbed_boot_arm_std.c: remove redundant compiler check

### DIFF
--- a/rtos/TARGET_CORTEX/TOOLCHAIN_ARM_STD/mbed_boot_arm_std.c
+++ b/rtos/TARGET_CORTEX/TOOLCHAIN_ARM_STD/mbed_boot_arm_std.c
@@ -28,12 +28,10 @@ __value_in_regs struct __argc_argv __rt_lib_init(unsigned heapbase, unsigned hea
 void _platform_post_stackheap_init(void);
 
 #if !defined(ISR_STACK_SIZE)
-#if (defined(__CC_ARM))
 extern uint32_t               Image$$ARM_LIB_STACK$$ZI$$Base[];
 extern uint32_t               Image$$ARM_LIB_STACK$$ZI$$Length[];
 #define ISR_STACK_START       ((unsigned char*)Image$$ARM_LIB_STACK$$ZI$$Base)
 #define ISR_STACK_SIZE        ((uint32_t)Image$$ARM_LIB_STACK$$ZI$$Length)
-#endif
 #endif
 
 #if !defined(HEAP_START)

--- a/rtos/TARGET_CORTEX/TOOLCHAIN_GCC_ARM/mbed_boot_gcc_arm.c
+++ b/rtos/TARGET_CORTEX/TOOLCHAIN_GCC_ARM/mbed_boot_gcc_arm.c
@@ -30,12 +30,10 @@ static mbed_rtos_storage_mutex_t env_mutex_obj;
 static osMutexAttr_t             env_mutex_attr;
 
 #if !defined(ISR_STACK_SIZE)
-#if (defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC_VERSION))
 extern uint32_t               __StackLimit;
 extern uint32_t               __StackTop;
 #define ISR_STACK_START       ((unsigned char*)&__StackLimit)
 #define ISR_STACK_SIZE        ((uint32_t)((uint32_t)&__StackTop - (uint32_t)&__StackLimit))
-#endif
 #endif
 
 #if !defined(HEAP_START)


### PR DESCRIPTION
### Description

Fix for `ARMC6` compiler.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

