### PR TITLE
ESP8266 - fixes disconnect to check the state from modem

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -246,7 +246,7 @@ int ESP8266Interface::disconnect()
 {
     _initialized = false;
 
-    if (_conn_stat == NSAPI_STATUS_DISCONNECTED)
+    if (_conn_stat == NSAPI_STATUS_DISCONNECTED || !get_ip_address())
     {
         return NSAPI_ERROR_NO_CONNECTION;
     }


### PR DESCRIPTION


### Description
Additionally to internal bookkeeping lets check from the modem
that what is connection state in disconnect. There might be
inconsistencies.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-ipcore 

