### PR TITLE
NUCLEO_H743ZI : enable TICKLESS

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2984,7 +2984,10 @@
                 "macro_name": "HSE_VALUE"
             }
         },
-        "overrides": { "lpticker_delay_ticks": 3 },
+        "macros_add": [
+            "MBED_TICKLESS"
+        ],
+        "overrides": { "lpticker_delay_ticks": 4 },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0813"],
         "device_has_add": [


### PR DESCRIPTION
### Description

This is following #9134 

TICKLESS can be enabled for STM32 targets which are using LPTIM feature for LPTICKER.


### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
