### PR TITLE
NRF5x: Allow placement of GattCharacteristic value into USER memory

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/btle/custom/custom_helper.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/btle/custom/custom_helper.cpp
@@ -281,7 +281,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
     attr_md.rd_auth = readAuthorization;
     attr_md.wr_auth = writeAuthorization;
 
-#if MBED_CONF_NORDIC_BLE_GATT_CHAR_VLOC_LOCATION
+#if MBED_CONF_NORDIC_BLE_USER_MANAGED_GATT_CHARACTERISTIC_MEMORY
     attr_md.vloc = BLE_GATTS_VLOC_USER;
 #else
     attr_md.vloc = BLE_GATTS_VLOC_STACK;

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/btle/custom/custom_helper.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/btle/custom/custom_helper.cpp
@@ -281,7 +281,12 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
     attr_md.rd_auth = readAuthorization;
     attr_md.wr_auth = writeAuthorization;
 
+#if MBED_CONF_NORDIC_BLE_GATT_CHAR_VLOC_LOCATION
+    attr_md.vloc = BLE_GATTS_VLOC_USER;
+#else
     attr_md.vloc = BLE_GATTS_VLOC_STACK;
+#endif 
+
     /* Always set variable size */
     attr_md.vlen = has_variable_len;
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/mbed_lib.json
@@ -40,6 +40,10 @@
             "help": "Sets the maximum number of descriptors that can be registered",
             "value": "8",
             "macro_name": "NRF_SDH_BLE_TOTAL_DESCRIPTORS"
+        },
+        "gatt_char_vloc_location": {
+            "help": "Sets the default VLOC location for GattCharacteristic memory buffers, 0 = stack, 1 = user",
+            "value": "0"
         }
     }
 }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/mbed_lib.json
@@ -41,7 +41,7 @@
             "value": "8",
             "macro_name": "NRF_SDH_BLE_TOTAL_DESCRIPTORS"
         },
-        "gatt_char_vloc_location": {
+        "user_managed_gatt_characteristic_memory": {
             "help": "Sets the default VLOC location for GattCharacteristic memory buffers, 0 = stack, 1 = user",
             "value": "0"
         }


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

The Nordic SDK allows you to specify which memory location you would like to use to store the data used by the GattCharacteristic. These VLOC locations are defined as `BLE_GATTS_VLOC_STACK` or `BLE_GATTS_VLOC_USER`. However, the current implementation of `custom_helper.cpp` forces a
custom GattCharacteristic to always use STACK memory. We recently ran into an issue where we were using GattCharacteristics that use large arrays for holding their values and subsequently ran out of
stack space. This change allows the custom helper to choose whether the USER or STACK memory locations are used for the GattCharacteristic value.

~As noted by the comment next to the `BLE_GATTS_VLOC_USER` definition, this change will require the user to maintain a valid buffer through the lifetime of the attribute.~

~If the size of the GattCharacteristic value is < 20 bytes, then the VLOC location defaults to `BLE_GATTS_VLOC_STACK`.~

Here's where the `BLE_GATTS_VLOC` locations are defined: https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_S132_FULL/headers/ble_gatts.h#L157

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

### Release notes

The Nordic SDK allows you to specify which memory location you would like to use to store the data used by the GattCharacteristic. These VLOC locations are defined as `BLE_GATTS_VLOC_STACK` or `BLE_GATTS_VLOC_USER`. Adding a config parameter to the Nordic BLE Softdevice `mbed_lib.json` allows the custom helper to choose whether the USER or STACK memory locations are used for the GattCharacteristic. The default value of the `MBED_CONF_NORDIC_BLE_USER_MANAGED_GATT_CHARACTERISTIC_MEMORY` configuration parameter is `0` indicating the value will be stored in STACK memory. You can change the value of this configuration parameter in an `mbed_app.json` file, where `1` indicates USER memory:
```
{
    "target_overrides": {
        "*": {
            "nordic-ble.user_managed_gatt_characteristic_memory": "1"
        }
    }
}
```