### PR TITLE
Fix for asserion failing in BLE::callDispatcher with gcc debug profile.

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -423,10 +423,10 @@ void BLE::callDispatcher()
 
     wsfOsDispatcher();
 
+    static Timeout nextTimeout;
     CriticalSectionLock critical_section;
 
     if (wsfOsReadyToSleep()) {
-        static Timeout nextTimeout;
         // setup an mbed timer for the next Cordio timeout
         bool_t pTimerRunning;
         timestamp_t nextTimestamp = (timestamp_t) (WsfTimerNextExpiration(&pTimerRunning) * WSF_MS_PER_TICK) * 1000;


### PR DESCRIPTION
Initialization of Timeout object used in  BLE::callDispatcher() contains critical section inside a constructor. It's initialization inside a critical section caused assertion failing under "debug" profile.

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

