### PR TITLE
PSOC6: Fixes for serial hal driver, asynchronous mode.

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/serial_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/serial_api.c
@@ -788,11 +788,14 @@ int serial_irq_handler_asynch(serial_t *obj_in)
             }
         }
         if (obj_in->rx_buff.pos == obj_in->rx_buff.length) {
-            serial_finish_rx_asynch(obj);
             cur_events |= SERIAL_EVENT_RX_COMPLETE & obj->rx_events;
         }
     }
 
+    // Any event should end operation.
+    if (cur_events & SERIAL_EVENT_RX_ALL) {
+        serial_finish_rx_asynch(obj);
+    }
 
     Cy_SCB_ClearRxInterrupt(obj->base, rx_status);
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/serial_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/serial_api.c
@@ -650,6 +650,7 @@ int serial_tx_asynch(serial_t *obj_in, const void *tx, size_t tx_length, uint8_t
         return 0;
     }
 
+    obj->tx_events = event;
     obj->async_handler = (cy_israddress)handler;
     if (serial_irq_setup_channel(obj) < 0) {
         return 0;
@@ -662,17 +663,16 @@ int serial_tx_asynch(serial_t *obj_in, const void *tx, size_t tx_length, uint8_t
     }
 
     if (tx_length > 0) {
-        obj->tx_events = event;
         obj_in->tx_buff.buffer = (void *)p_buf;
         obj_in->tx_buff.length = tx_length;
         obj_in->tx_buff.pos = 0;
         obj->tx_pending = true;
         // Enable interrupts to complete transmission.
-        Cy_SCB_SetRxInterruptMask(obj->base, CY_SCB_TX_INTR_LEVEL | CY_SCB_UART_TX_DONE);
+        Cy_SCB_SetTxInterruptMask(obj->base, CY_SCB_TX_INTR_LEVEL | CY_SCB_UART_TX_DONE);
 
     } else {
         // Enable interrupt to signal completing of the transmission.
-        Cy_SCB_SetRxInterruptMask(obj->base, CY_SCB_UART_TX_DONE);
+        Cy_SCB_SetTxInterruptMask(obj->base, CY_SCB_UART_TX_DONE);
     }
     return tx_length;
 }
@@ -739,7 +739,7 @@ int serial_irq_handler_asynch(serial_t *obj_in)
             // No more bytes to follow; check to see if we need to signal completion.
             if (obj->tx_events & SERIAL_EVENT_TX_COMPLETE) {
                 // Disable FIFO interrupt as there are no more bytes to follow.
-                Cy_SCB_SetRxInterruptMask(obj->base, CY_SCB_UART_TX_DONE);
+                Cy_SCB_SetTxInterruptMask(obj->base, CY_SCB_UART_TX_DONE);
             } else {
                 // Nothing more to do, mark end of transmission.
                 serial_finish_tx_asynch(obj);
@@ -770,13 +770,12 @@ int serial_irq_handler_asynch(serial_t *obj_in)
     if (rx_status & CY_SCB_RX_INTR_LEVEL) {
         uint8_t *ptr = obj_in->rx_buff.buffer;
         ptr += obj_in->rx_buff.pos;
-        while (obj_in->rx_buff.pos < obj_in->rx_buff.length) {
+        uint32_t fifo_cnt = Cy_SCB_UART_GetNumInRxFifo(obj->base);
+        while ((obj_in->rx_buff.pos < obj_in->rx_buff.length) && fifo_cnt) {
             uint32_t c = Cy_SCB_UART_Get(obj->base);
-            if (c == CY_SCB_UART_RX_NO_DATA) {
-                break;
-            }
             *ptr++ = (uint8_t)c;
             ++(obj_in->rx_buff.pos);
+            --fifo_cnt;
             // Check for character match condition.
             if (obj_in->char_match != SERIAL_RESERVED_CHAR_MATCH) {
                 if (c == obj_in->char_match) {
@@ -788,11 +787,12 @@ int serial_irq_handler_asynch(serial_t *obj_in)
                 }
             }
         }
+        if (obj_in->rx_buff.pos == obj_in->rx_buff.length) {
+            serial_finish_rx_asynch(obj);
+            cur_events |= SERIAL_EVENT_RX_COMPLETE & obj->rx_events;
+        }
     }
 
-    if (obj_in->rx_buff.pos == obj_in->rx_buff.length) {
-        serial_finish_rx_asynch(obj);
-    }
 
     Cy_SCB_ClearRxInterrupt(obj->base, rx_status);
 


### PR DESCRIPTION
### Description
This commit fixes a number of more and less subtle bugs in a serial hal driver for PSoC6. Mostly TX/RX typos and incorrect events processing. 

mbed tests log: 
[tests_sequana_gcc_20190114.log](https://github.com/ARMmbed/mbed-os/files/2754961/tests_sequana_gcc_20190114.log)

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

