### PR TITLE
Tests: USB: Fix endpoint halt test

### DIFF
--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -139,9 +139,9 @@ USBEndpointTester::ep_config_t USBEndpointTester::_intf_config4[NUM_ENDPOINTS] =
 };
 
 USBEndpointTester::USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release,
-        bool abort_transfer_test) :
-        USBDevice(phy, vendor_id, product_id, product_release), _abort_transfer_test(abort_transfer_test), _endpoint_configs(
-                &_intf_config_max)
+                                     bool abort_transfer_test) :
+    USBDevice(phy, vendor_id, product_id, product_release), _abort_transfer_test(abort_transfer_test), _endpoint_configs(
+        &_intf_config_max)
 {
     _cnt_cb_set_conf = 0;
     _cnt_cb_set_intf = 0;
@@ -447,48 +447,48 @@ const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_OUT],    // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config0[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config0[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config0[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config0[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_IN],     // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config0[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config0[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config0[EP_BULK_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config0[EP_BULK_IN].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_OUT],     // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config0[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config0[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config0[EP_INT_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config0[EP_INT_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_IN],      // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config0[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config0[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config0[EP_INT_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config0[EP_INT_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_OUT],     // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config0[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config0[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config0[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config0[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_IN],      // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config0[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config0[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config0[EP_ISO_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config0[EP_ISO_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
 
         // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
@@ -506,48 +506,48 @@ const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_OUT],    // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config1[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config1[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config1[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config1[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_IN],     // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config1[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config1[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config1[EP_BULK_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config1[EP_BULK_IN].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_OUT],     // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config1[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config1[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config1[EP_INT_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config1[EP_INT_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_IN],      // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config1[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config1[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config1[EP_INT_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config1[EP_INT_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_OUT],     // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config1[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config1[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config1[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config1[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_IN],      // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config1[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config1[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config1[EP_ISO_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config1[EP_ISO_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
 
         // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
@@ -565,48 +565,48 @@ const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_OUT],    // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config2[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config2[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config2[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config2[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_IN],     // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config2[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config2[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config2[EP_BULK_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config2[EP_BULK_IN].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_OUT],     // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config2[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config2[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config2[EP_INT_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config2[EP_INT_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_IN],      // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config2[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config2[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config2[EP_INT_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config2[EP_INT_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_OUT],     // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config2[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config2[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config2[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config2[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_IN],      // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config2[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config2[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config2[EP_ISO_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config2[EP_ISO_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
 
         // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
@@ -624,48 +624,48 @@ const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_OUT],    // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config3[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config3[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config3[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config3[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_IN],     // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config3[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config3[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config3[EP_BULK_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config3[EP_BULK_IN].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_OUT],     // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config3[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config3[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config3[EP_INT_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config3[EP_INT_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_IN],      // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config3[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config3[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config3[EP_INT_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config3[EP_INT_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_OUT],     // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config3[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config3[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config3[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config3[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_IN],      // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config3[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config3[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config3[EP_ISO_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config3[EP_ISO_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
 
         // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
@@ -683,48 +683,48 @@ const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_OUT],    // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config4[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config4[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config4[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config4[EP_BULK_OUT].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_BULK_IN],     // bEndpointAddress
         E_BULK,                     // bmAttributes
-        (uint8_t) (LSB(_intf_config4[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config4[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config4[EP_BULK_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config4[EP_BULK_IN].max_packet)),  // wMaxPacketSize (MSB)
         0,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_OUT],     // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config4[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config4[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config4[EP_INT_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config4[EP_INT_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_INT_IN],      // bEndpointAddress
         E_INTERRUPT,                // bmAttributes
-        (uint8_t) (LSB(_intf_config4[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config4[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config4[EP_INT_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config4[EP_INT_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_OUT],     // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config4[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config4[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config4[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config4[EP_ISO_OUT].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         ENDPOINT_DESCRIPTOR_LENGTH, // bLength
         ENDPOINT_DESCRIPTOR,        // bDescriptorType
         _endpoints[EP_ISO_IN],      // bEndpointAddress
         E_ISOCHRONOUS,              // bmAttributes
-        (uint8_t) (LSB(_intf_config4[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
-        (uint8_t) (MSB(_intf_config4[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        (uint8_t)(LSB(_intf_config4[EP_ISO_IN].max_packet)),  // wMaxPacketSize (LSB)
+        (uint8_t)(MSB(_intf_config4[EP_ISO_IN].max_packet)),  // wMaxPacketSize (MSB)
         1,                          // bInterval
     };
     if (index == 0) {

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -103,7 +103,7 @@ protected:
 
 private:
     const char *get_desc_string(const uint8_t *desc);
-    bool _request_read_start(const setup_packet_t *setup);
+    bool _request_rw_restart(const setup_packet_t *setup);
     bool _request_abort_buff_check(const setup_packet_t *setup);
 };
 

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -32,19 +32,43 @@ class USBEndpointTester: public USBDevice {
 
 public:
     USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release,
-            bool abort_transfer_test);
+                      bool abort_transfer_test);
     virtual ~USBEndpointTester();
     const char *get_serial_desc_string();
     void start_ep_in_abort_test();
 
-    uint32_t get_cnt_cb_set_conf() const { return _cnt_cb_set_conf; }
-    uint32_t get_cnt_cb_set_intf() const { return _cnt_cb_set_intf; }
-    uint32_t get_cnt_cb_bulk_out() const { return _cnt_cb_bulk_out; }
-    uint32_t get_cnt_cb_bulk_in() const { return _cnt_cb_bulk_in; }
-    uint32_t get_cnt_cb_int_out() const { return _cnt_cb_int_out; }
-    uint32_t get_cnt_cb_int_in() const { return _cnt_cb_int_in; }
-    uint32_t get_cnt_cb_iso_out() const { return _cnt_cb_iso_out; }
-    uint32_t get_cnt_cb_iso_in() const { return _cnt_cb_iso_in; }
+    uint32_t get_cnt_cb_set_conf() const
+    {
+        return _cnt_cb_set_conf;
+    }
+    uint32_t get_cnt_cb_set_intf() const
+    {
+        return _cnt_cb_set_intf;
+    }
+    uint32_t get_cnt_cb_bulk_out() const
+    {
+        return _cnt_cb_bulk_out;
+    }
+    uint32_t get_cnt_cb_bulk_in() const
+    {
+        return _cnt_cb_bulk_in;
+    }
+    uint32_t get_cnt_cb_int_out() const
+    {
+        return _cnt_cb_int_out;
+    }
+    uint32_t get_cnt_cb_int_in() const
+    {
+        return _cnt_cb_int_in;
+    }
+    uint32_t get_cnt_cb_iso_out() const
+    {
+        return _cnt_cb_iso_out;
+    }
+    uint32_t get_cnt_cb_iso_in() const
+    {
+        return _cnt_cb_iso_in;
+    }
 
     struct ep_config_t {
         bool dir_in;


### PR DESCRIPTION
### Description

This patch fixes intermittent `tests-usb_device-basic/endpoint test halt` failures caused by not terminating all pending endpoint operations before repeating the test.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@c1728p9, @studavekar 

