### PR TITLE
Add QSPIF as default storage for LPCXpresso546XX

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2001,7 +2001,8 @@
         "inherits": ["MCU_LPC546XX"],
         "extra_labels_add": ["LPCXpresso"],
         "detect_code": ["1056"],
-        "release_versions": ["2", "5"]
+        "release_versions": ["2", "5"],
+        "components_add": ["QSPIF"]        
     },
     "FF_LPC546XX": {
         "inherits": ["MCU_LPC546XX"],


### PR DESCRIPTION
### Description

LPC546XX supports Quad SPI.  The default QSPIF configuration is working.  Just needs to be enabled.  

This change sets QSPIF driver as the default block device interface for this platform.

This was tested with https://github.com/ARMmbed/mbed-os-example-filesystem with only a small modification to change "BUTTON1" to "SW4".  

Results are attached. 
[lpc546xx_qspif_log.txt](https://github.com/ARMmbed/mbed-os/files/2757234/lpc546xx_qspif_log.txt)


### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mmahadevan108 