### PR TITLE
TCP/UDP greentea tests refactoring and cleanup

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -243,6 +243,10 @@ content at minimum:
             "help" : "Port of echo server",
             "value" : "7"
         }
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        }
     }
 }
 ```

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -34,7 +34,6 @@
 using namespace utest::v1;
 
 namespace {
-NetworkInterface *net;
 Timer tc_bucket; // Timer to limit a test cases run time
 }
 
@@ -44,11 +43,6 @@ mbed_stats_socket_t tcp_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
 
 char tcp_global::rx_buffer[RX_BUFF_SIZE];
 char tcp_global::tx_buffer[TX_BUFF_SIZE];
-
-NetworkInterface *get_interface()
-{
-    return net;
-}
 
 void drop_bad_packets(TCPSocket &sock, int orig_timeout)
 {
@@ -65,7 +59,7 @@ void drop_bad_packets(TCPSocket &sock, int orig_timeout)
 
 static void _ifup()
 {
-    net = NetworkInterface::get_default_instance();
+    NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
     printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
@@ -73,38 +67,42 @@ static void _ifup()
 
 static void _ifdown()
 {
-    net->disconnect();
+    NetworkInterface::get_default_instance()->disconnect();
     printf("MBED: ifdown\n");
+}
+
+nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
+{
+    SocketAddress tcp_addr;
+
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
+    tcp_addr.set_port(port);
+
+    printf("MBED: Server '%s', port %d\n", tcp_addr.get_ip_address(), tcp_addr.get_port());
+
+    nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
+    if (err != NSAPI_ERROR_OK) {
+        printf("Error from sock.open: %d\n", err);
+        return err;
+    }
+
+    err = sock.connect(tcp_addr);
+    if (err != NSAPI_ERROR_OK) {
+        printf("Error from sock.connect: %d\n", err);
+        return err;
+    }
+
+    return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t tcpsocket_connect_to_echo_srv(TCPSocket &sock)
 {
-    SocketAddress tcp_addr;
-
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
-    tcp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
-
-    nsapi_error_t err = sock.open(get_interface());
-    if (err != NSAPI_ERROR_OK) {
-        return err;
-    }
-
-    return sock.connect(tcp_addr);
+    return tcpsocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_PORT);
 }
 
 nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock)
 {
-    SocketAddress tcp_addr;
-
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
-    tcp_addr.set_port(9);
-
-    nsapi_error_t err = sock.open(get_interface());
-    if (err != NSAPI_ERROR_OK) {
-        return err;
-    }
-
-    return sock.connect(tcp_addr);
+    return tcpsocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT);
 }
 
 void fill_tx_buffer_ascii(char *buff, size_t len)

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address.cpp
@@ -36,9 +36,10 @@ void TCPSOCKET_BIND_ADDRESS()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    SocketAddress sockAddr = SocketAddress(get_interface()->get_ip_address(), 80);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
+    SocketAddress sockAddr = SocketAddress(NetworkInterface::get_default_instance()->get_ip_address(), 80);
     nsapi_error_t bind_result = sock->bind(sockAddr);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
@@ -36,8 +36,9 @@ void TCPSOCKET_BIND_ADDRESS_INVALID()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind("190.2.3.4", 1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_null.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_null.cpp
@@ -36,8 +36,9 @@ void TCPSOCKET_BIND_ADDRESS_NULL()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind(NULL, 1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_port.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_port.cpp
@@ -36,9 +36,10 @@ void TCPSOCKET_BIND_ADDRESS_PORT()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    nsapi_error_t bind_result = sock->bind(get_interface()->get_ip_address(), 80);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
+    nsapi_error_t bind_result = sock->bind(NetworkInterface::get_default_instance()->get_ip_address(), 80);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");
     } else {

--- a/TESTS/netsocket/tcp/tcpsocket_bind_port.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_port.cpp
@@ -36,8 +36,9 @@ void TCPSOCKET_BIND_PORT()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind(1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/tcp/tcpsocket_bind_port_fail.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_port_fail.cpp
@@ -36,8 +36,9 @@ void TCPSOCKET_BIND_PORT_FAIL()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind(1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");
@@ -51,7 +52,7 @@ void TCPSOCKET_BIND_PORT_FAIL()
     if (!sock2) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock2->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock2->open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock2->bind(1024));
 
     delete sock;

--- a/TESTS/netsocket/tcp/tcpsocket_bind_unopened.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_unopened.cpp
@@ -36,6 +36,7 @@ void TCPSOCKET_BIND_UNOPENED()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
     nsapi_error_t bind_result = sock->bind(1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {

--- a/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
@@ -36,8 +36,9 @@ void TCPSOCKET_BIND_WRONG_TYPE()
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();
+        return;
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     char addr_bytes[16] = {0xfe, 0x80, 0xff, 0x1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     SocketAddress sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
     nsapi_error_t bind_result = sock->bind(sockAddr);

--- a/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
@@ -27,7 +27,7 @@ using namespace utest::v1;
 void TCPSOCKET_CONNECT_INVALID()
 {
     TCPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     TEST_ASSERT(sock.connect(NULL, 9) < 0);
     TEST_ASSERT(sock.connect("", 9) < 0);

--- a/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
@@ -78,8 +78,7 @@ void TCPSOCKET_ECHOTEST_BURST()
         }
 
         if (bt_left != 0) {
-            drop_bad_packets(sock, 0);
-            TEST_FAIL();
+            TEST_FAIL_MESSAGE("bt_left != 0");
             goto END;
         }
 
@@ -142,7 +141,6 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
 
         if (bt_left != 0) {
             printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
-            drop_bad_packets(sock, -1);
             TEST_FAIL();
             goto END;
         }

--- a/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -38,10 +38,10 @@ static nsapi_error_t _tcpsocket_connect_to_daytime_srv(TCPSocket &sock)
 {
     SocketAddress tcp_addr;
 
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(13);
 
-    nsapi_error_t err = sock.open(get_interface());
+    nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
         return err;
     }

--- a/TESTS/netsocket/tcp/tcpsocket_open_close_repeat.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_close_repeat.cpp
@@ -38,7 +38,7 @@ void TCPSOCKET_OPEN_CLOSE_REPEAT()
     }
 
     for (int i = 0; i < 2; i++) {
-        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
     }
     delete sock;

--- a/TESTS/netsocket/tcp/tcpsocket_open_destruct.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_destruct.cpp
@@ -38,7 +38,7 @@ void TCPSOCKET_OPEN_DESTRUCT()
         if (!sock) {
             TEST_FAIL();
         }
-        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
         delete sock;
     }
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE

--- a/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
@@ -46,7 +46,7 @@ void TCPSOCKET_OPEN_LIMIT()
             if (!sock) {
                 break;
             }
-            ret = sock->open(get_interface());
+            ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
                 printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
                 delete sock;

--- a/TESTS/netsocket/tcp/tcpsocket_open_twice.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_twice.cpp
@@ -37,8 +37,8 @@ void TCPSOCKET_OPEN_TWICE()
         TEST_FAIL();
     }
 
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->open(NetworkInterface::get_default_instance()));
 
     delete sock;
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -33,10 +33,10 @@ static nsapi_error_t _tcpsocket_connect_to_chargen_srv(TCPSocket &sock)
 {
     SocketAddress tcp_addr;
 
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(19);
 
-    nsapi_error_t err = sock.open(get_interface());
+    nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
         return err;
     }

--- a/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
@@ -27,7 +27,7 @@ using namespace utest::v1;
 void TCPSOCKET_SETSOCKOPT_KEEPALIVE_VALID()
 {
     TCPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     int32_t seconds = 7200;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.setsockopt(NSAPI_SOCKET, NSAPI_KEEPALIVE, &seconds, sizeof(int)));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, 9));

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -33,22 +33,13 @@
 
 using namespace utest::v1;
 
-namespace {
-NetworkInterface *net;
-}
-
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE
 mbed_stats_socket_t udp_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
 #endif
 
-NetworkInterface *get_interface()
-{
-    return net;
-}
-
 static void _ifup()
 {
-    net = NetworkInterface::get_default_instance();
+    NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
     printf("MBED: UDPClient IP address is '%s'\n", net->get_ip_address());
@@ -56,7 +47,7 @@ static void _ifup()
 
 static void _ifdown()
 {
-    net->disconnect();
+    NetworkInterface::get_default_instance()->disconnect();
     printf("MBED: ifdown\n");
 }
 

--- a/TESTS/netsocket/udp/udpsocket_bind_address.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address.cpp
@@ -37,8 +37,8 @@ void UDPSOCKET_BIND_ADDRESS()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    SocketAddress sockAddr = SocketAddress(get_interface()->get_ip_address(), 80);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
+    SocketAddress sockAddr = SocketAddress(NetworkInterface::get_default_instance()->get_ip_address(), 80);
     nsapi_error_t bind_result = sock->bind(sockAddr);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/udp/udpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_invalid.cpp
@@ -37,7 +37,7 @@ void UDPSOCKET_BIND_ADDRESS_INVALID()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind("190.2.3.4", 1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/udp/udpsocket_bind_address_null.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_null.cpp
@@ -37,7 +37,7 @@ void UDPSOCKET_BIND_ADDRESS_NULL()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind(NULL, 1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/udp/udpsocket_bind_address_port.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_port.cpp
@@ -37,8 +37,8 @@ void UDPSOCKET_BIND_ADDRESS_PORT()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    nsapi_error_t bind_result = sock->bind(get_interface()->get_ip_address(), 80);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
+    nsapi_error_t bind_result = sock->bind(NetworkInterface::get_default_instance()->get_ip_address(), 80);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");
     } else {

--- a/TESTS/netsocket/udp/udpsocket_bind_port.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_port.cpp
@@ -37,7 +37,7 @@ void UDPSOCKET_BIND_PORT()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind(1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/udp/udpsocket_bind_port_fail.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_port_fail.cpp
@@ -37,7 +37,7 @@ void UDPSOCKET_BIND_PORT_FAIL()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     nsapi_error_t bind_result = sock->bind(1024);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");
@@ -51,7 +51,7 @@ void UDPSOCKET_BIND_PORT_FAIL()
     if (!sock2) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock2->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock2->open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock2->bind(1024));
 
     delete sock;

--- a/TESTS/netsocket/udp/udpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_wrong_type.cpp
@@ -37,7 +37,7 @@ void UDPSOCKET_BIND_WRONG_TYPE()
     if (!sock) {
         TEST_FAIL();
     }
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     char addr_bytes[16] = {0xfe, 0x80, 0xff, 0x1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     SocketAddress sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
     nsapi_error_t bind_result = sock->bind(sockAddr);

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -55,11 +55,11 @@ static void _sigio_handler(osThreadId id)
 void UDPSOCKET_ECHOTEST()
 {
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
 
     UDPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     int recvd;
     int sent;
@@ -130,10 +130,10 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
 #endif
 
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
 
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     sock.set_blocking(false);
     sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -71,12 +71,12 @@ static void _sigio_handler(osThreadId id)
 void UDPSOCKET_ECHOTEST_BURST()
 {
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
 
     UDPSocket sock;
     const int TIMEOUT = 5000; // [ms]
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     sock.set_timeout(TIMEOUT);
     sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
@@ -150,11 +150,11 @@ void UDPSOCKET_ECHOTEST_BURST()
 void UDPSOCKET_ECHOTEST_BURST_NONBLOCK()
 {
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
 
     UDPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     sock.set_blocking(false);
     sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 

--- a/TESTS/netsocket/udp/udpsocket_open_close_repeat.cpp
+++ b/TESTS/netsocket/udp/udpsocket_open_close_repeat.cpp
@@ -38,7 +38,7 @@ void UDPSOCKET_OPEN_CLOSE_REPEAT()
     }
 
     for (int i = 0; i < 2; i++) {
-        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
     }
     delete sock;

--- a/TESTS/netsocket/udp/udpsocket_open_destruct.cpp
+++ b/TESTS/netsocket/udp/udpsocket_open_destruct.cpp
@@ -38,7 +38,7 @@ void UDPSOCKET_OPEN_DESTRUCT()
         if (!sock) {
             TEST_FAIL();
         }
-        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
         delete sock;
     }
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE

--- a/TESTS/netsocket/udp/udpsocket_open_limit.cpp
+++ b/TESTS/netsocket/udp/udpsocket_open_limit.cpp
@@ -47,7 +47,7 @@ void UDPSOCKET_OPEN_LIMIT()
             if (!sock) {
                 break;
             }
-            ret = sock->open(get_interface());
+            ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
                 printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
                 delete sock;

--- a/TESTS/netsocket/udp/udpsocket_open_twice.cpp
+++ b/TESTS/netsocket/udp/udpsocket_open_twice.cpp
@@ -37,8 +37,8 @@ void UDPSOCKET_OPEN_TWICE()
         TEST_FAIL();
     }
 
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(get_interface()));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_PARAMETER, sock->open(NetworkInterface::get_default_instance()));
 
     delete sock;
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -37,14 +37,14 @@ static void _sigio_handler(osThreadId id)
 void UDPSOCKET_RECV_TIMEOUT()
 {
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
 
     static const int DATA_LEN = 100;
     char buff[DATA_LEN] = {0};
 
     UDPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     sock.set_timeout(100);
     sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 

--- a/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
@@ -27,7 +27,7 @@ using namespace utest::v1;
 void UDPSOCKET_SENDTO_INVALID()
 {
     UDPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     TEST_ASSERT(sock.sendto(NULL, 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 9, NULL, 0) < 0);

--- a/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
@@ -27,10 +27,10 @@ using namespace utest::v1;
 void UDPSOCKET_SENDTO_REPEAT()
 {
     UDPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(9);
 
     int sent;

--- a/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
@@ -30,10 +30,10 @@ void UDPSOCKET_SENDTO_TIMEOUT()
     fill_tx_buffer_ascii(tx_buffer, sizeof(tx_buffer));
 
     UDPSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     SocketAddress udp_addr;
-    get_interface()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(9);
 
     Timer timer;

--- a/tools/test_configs/6lowpanInterface_host.json
+++ b/tools/test_configs/6lowpanInterface_host.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
         }
     },
     "target_overrides": {

--- a/tools/test_configs/6lowpanInterface_router.json
+++ b/tools/test_configs/6lowpanInterface_router.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
         }
     },
     "target_overrides": {

--- a/tools/test_configs/ESP8266Interface.json
+++ b/tools/test_configs/ESP8266Interface.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
         }
     },
     "target_overrides": {

--- a/tools/test_configs/EthernetInterface.json
+++ b/tools/test_configs/EthernetInterface.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
         }
     },
     "target_overrides": {

--- a/tools/test_configs/HeapBlockDeviceAndEthernetInterface.json
+++ b/tools/test_configs/HeapBlockDeviceAndEthernetInterface.json
@@ -8,6 +8,10 @@
             "help" : "Port of echo server",
             "value" : "7"
         },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        },
         "sim-blockdevice": {
             "help": "Simulated block device, requires sufficient heap",
             "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",

--- a/tools/test_configs/HeapBlockDeviceAndWifiInterface.json
+++ b/tools/test_configs/HeapBlockDeviceAndWifiInterface.json
@@ -8,6 +8,10 @@
             "help" : "Port of echo server",
             "value" : "7"
         },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        },
         "sim-blockdevice": {
             "help": "Simulated block device, requires sufficient heap",
             "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",

--- a/tools/test_configs/ISM43362Interface.json
+++ b/tools/test_configs/ISM43362Interface.json
@@ -8,6 +8,10 @@
             "help" : "Port of echo server",
             "value" : "7"
         },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        },
         "wifi-secure-ssid": {
             "help": "WiFi SSID for WPA2 secured network",
             "value": "\"SSID-SECURE\""

--- a/tools/test_configs/SpwfSAInterface.json
+++ b/tools/test_configs/SpwfSAInterface.json
@@ -8,6 +8,10 @@
             "help" : "Port of echo server",
             "value" : "7"
         },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        },
         "WIFI-TX" : {
             "help" : "Wifi TX pin",
             "value" : "D8"

--- a/tools/test_configs/ThreadInterface_end_device.json
+++ b/tools/test_configs/ThreadInterface_end_device.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
         }
     },
     "target_overrides": {

--- a/tools/test_configs/ThreadInterface_router.json
+++ b/tools/test_configs/ThreadInterface_router.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
         }
     },
     "target_overrides": {

--- a/tools/test_configs/no_network.json
+++ b/tools/test_configs/no_network.json
@@ -7,6 +7,10 @@
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : null
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : null
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Description

When adding TLSSocket greentea tests recently in #9283, there was a number of review remarks. Those tests were based on TCPSocket, so most of the review remarks apply there and some to UDPSocket greentea tests, too.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
