### PR TITLE
Add get_connection_status() override in CellularContext

### DIFF
--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -82,6 +82,8 @@ uint32_t AT_CellularContext::get_timeout_for_operation(ContextOperation op) cons
     return timeout;
 }
 
+
+
 bool AT_CellularContext::is_connected()
 {
     return true;
@@ -195,6 +197,12 @@ void AT_CellularContext::ppp_status_cb(nsapi_event_t ev, intptr_t ptr)
 nsapi_error_t AT_CellularContext::disconnect()
 {
     return NSAPI_ERROR_OK;
+}
+
+
+nsapi_connection_status_t AT_CellularContext::get_connection_status() const
+{
+    return NSAPI_STATUS_DISCONNECTED;
 }
 
 nsapi_error_t AT_CellularContext::get_apn_backoff_timer(int &backoff_timer)

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -147,6 +147,11 @@ nsapi_error_t AT_CellularContext::check_operation(nsapi_error_t err, ContextOper
     return err;
 }
 
+nsapi_connection_status_t AT_CellularContext::get_connection_status() const
+{
+    return _connect_status;
+}
+
 uint32_t AT_CellularContext::get_timeout_for_operation(ContextOperation op) const
 {
     uint32_t timeout = NETWORK_TIMEOUT; // default timeout is 30 minutes as registration and attach may take time

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -37,6 +37,7 @@ public:
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
     virtual nsapi_error_t connect();
     virtual nsapi_error_t disconnect();
+    virtual nsapi_connection_status_t get_connection_status() const;
     virtual bool is_connected();
     // from CellularBase
     virtual void set_plmn(const char *plmn);

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -67,7 +67,7 @@ void UBLOX_AT_CellularContext::do_connect()
     _at.unlock();
 
     if (_status_cb) {
-        call_network_cb(_connect_status);
+        _status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connect_status);
     }
 }
 


### PR DESCRIPTION
### Description

The CellularContext does have the member `nsapi_connection_status_t _connect_status`, which can simple be returned to support the get_connection_status() API.

The second part is UBLOX_AT specific, where the callback never is called, as the network_callback helper method actually wants to set the status as well, and doesn't do anything if the status isn't changed.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

