### PR TITLE
MBRBlockDevice: When partitioning, clear the rest of first erase unit

### DIFF
--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -92,8 +92,9 @@ static int partition_absolute(
         return err;
     }
 
+    uint32_t table_start_offset = buffer_size - sizeof(struct mbr_table);
     struct mbr_table *table = reinterpret_cast<struct mbr_table *>(
-                                  &buffer[buffer_size - sizeof(struct mbr_table)]);
+                                      &buffer[table_start_offset]);
     if (table->signature[0] != 0x55 || table->signature[1] != 0xaa) {
         // Setup default values for MBR
         table->signature[0] = 0x55;
@@ -141,6 +142,16 @@ static int partition_absolute(
             (void)neighbor_lba_offset;
             (void)neighbor_lba_size;
         }
+    }
+
+    // As the erase operation may do nothing, erase remainder of the buffer, to eradicate
+    // any remaining programmed data (such as previously programmed file systems).
+    if (table_start_offset > 0) {
+        memset(buffer, 0xFF, table_start_offset);
+    }
+    if (table_start_offset + sizeof(struct mbr_table) < buffer_size) {
+        memset(buffer + table_start_offset + sizeof(struct mbr_table), 0xFF,
+               buffer_size - (table_start_offset + sizeof(struct mbr_table)));
     }
 
     // Write out MBR


### PR DESCRIPTION
### Description
In MBRBlockDevice, when performing the partition operation, make sure that the rest of the first erase unit (one that holds the partition table) is cleared. This serves for ensuring that no other data (like previously programmed file systems) is present in this erase unit. Trigger for this PR was a failures in CI, which alternately programmed LittleFS (without MBR) and FAT FS (with MBR), making LittleFS think that the FAT format was a valid one.


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

