### PR TITLE
SD default configuration for ST boards is already defined in TARGET_STM

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -12,24 +12,6 @@
         "CRC_ENABLED": 1
     },
     "target_overrides": {
-        "DISCO_F051R8": {
-             "SPI_MOSI": "SPI_MOSI",
-             "SPI_MISO": "SPI_MISO",
-             "SPI_CLK":  "SPI_SCK",
-             "SPI_CS":   "SPI_CS"
-        },
-        "DISCO_L475VG_IOT01A": {
-             "SPI_MOSI": "SPI_MOSI",
-             "SPI_MISO": "SPI_MISO",
-             "SPI_CLK":  "SPI_SCK",
-             "SPI_CS":   "SPI_CS"
-        },
-        "DISCO_L476VG": {
-          "SPI_MOSI": "PE_15",
-          "SPI_MISO": "PE_14",
-          "SPI_CLK":  "PE_13",
-          "SPI_CS":   "PE_12"
-        },
         "K20D50M": {
              "SPI_MOSI": "PTD2",
              "SPI_MISO": "PTD3",
@@ -77,48 +59,6 @@
              "SPI_MISO": "p12",
              "SPI_CLK":  "p13",
              "SPI_CS":   "p14"
-        },
-         "NUCLEO_F411RE": {
-             "SPI_MOSI": "PC_3",
-             "SPI_MISO": "PC_2",
-             "SPI_CLK":  "PC_7",
-             "SPI_CS":   "PB_9"
-         },
-         "NUCLEO_F429ZI": {
-             "SPI_MOSI": "PC_12",
-             "SPI_MISO": "PC_11",
-             "SPI_CLK":  "PC_10",
-             "SPI_CS":   "PA_15"
-         },
-         "DISCO_F429ZI": {
-            "SPI_MOSI": "PC_12",
-            "SPI_MISO": "PC_11",
-            "SPI_CLK":  "PC_10",
-            "SPI_CS":   "PA_15"
-        },
-         "NUCLEO_F746ZG": {
-            "SPI_MOSI": "PC_12",
-            "SPI_MISO": "PC_11",
-            "SPI_CLK":  "PC_10",
-            "SPI_CS":   "PA_15"
-        },
-         "NUCLEO_F767ZI": {
-            "SPI_MOSI": "PC_12",
-            "SPI_MISO": "PC_11",
-            "SPI_CLK":  "PC_10",
-            "SPI_CS":   "PA_15"
-        },
-        "NUCLEO_L031K6": {
-             "SPI_MOSI": "SPI_MOSI",
-             "SPI_MISO": "SPI_MISO",
-             "SPI_CLK":  "SPI_SCK",
-             "SPI_CS":   "SPI_CS"
-        },
-        "NUCLEO_L476RG": {
-             "SPI_MOSI": "SPI_MOSI",
-             "SPI_MISO": "SPI_MISO",
-             "SPI_CLK":  "SPI_SCK",
-             "SPI_CS":   "SPI_CS"
         },
         "NUMAKER_PFM_M453": {
              "SPI_MOSI": "PD_13",
@@ -203,13 +143,6 @@
             "SPI_MISO": "D12",
             "SPI_CLK": "D13",
             "SPI_CS": "D10"
-        },
-        "NUCLEO_F207ZG": {
-             "SPI_MOSI": "PC_12",
-             "SPI_MISO": "PC_11",
-             "SPI_CLK":  "PC_10",
-             "SPI_CS":   "PA_15"
         }
-        
     }
 }


### PR DESCRIPTION
### Description

Default configuration is:
        "SPI_CS": "SPI_CS",
        "SPI_MOSI": "SPI_MOSI",
        "SPI_MISO": "SPI_MISO",
        "SPI_CLK": "SPI_SCK",

As all these SPI_xx are defined for all STM NUCLEO and DISCO targets,
we don't need extra configuration to support component_sd

If some user uses other SPI pins, better way is to configure it at application side.


### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
