### PR TITLE
Add pyocd depencency to resolve Travis CI issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ future==0.16.0
 six==1.11.0
 git+https://github.com/armmbed/manifest-tool.git@v1.4.6
 mbed-cloud-sdk==2.0.1
+pyocd>=0.14,<0.15
 icetea>=1.0.2,<1.1


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

0.15 release of `pyOCD` cauesd some dependency resolution between it and `icetea`. `icetea` unit tests fail when pyOCD is installed due to the invoked `icetea` command failing to generate JSON.

Reverting pyOCD appears to resolve the issue.

Once 0.15.1 is out (fix has been merged: https://github.com/mbedmicro/pyOCD/pull/511), this is not specifically needed, but becomes a nice-to-have, and can be removed if desired.

Issues opened related to this PR:
- https://github.com/ARMmbed/mbed-os/issues/9390: The test error that the user experiences was completely unintuitive and irritating to root-cause.
- https://github.com/ARMmbed/icetea/issues/69: `icetea` does not ues version pinning with their *requirements.txt files
- https://github.com/ARMmbed/mbed-os/pull/9389: Work was already underway to seek out and pin remaining modules, but the update caused one (last? big stir.

**NOTE**: This is needed for the 5.11.2 RC PR to pass: https://travis-ci.org/ARMmbed/mbed-os/jobs/480215050

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

