### PR TITLE
BLE: Fix SafeEnum type safety

### DIFF
--- a/features/FEATURE_BLE/ble/SafeEnum.h
+++ b/features/FEATURE_BLE/ble/SafeEnum.h
@@ -112,13 +112,15 @@ struct SafeEnum {
 	 */
 	typedef LayoutType representation_t;
 
+protected:
     /**
      * Construction of an enumeration value.
      */
-	SafeEnum(LayoutType value) : _value(value) { }
+	explicit SafeEnum(LayoutType value) : _value(value) { }
 
+public:
     /**
-     * Equal to operator for SafeEnum instances.
+     * Equal to operator for Target instances.
      *
      * @param lhs left hand side of the comparison
      * @param rhs right hand side of the comparison
@@ -126,12 +128,12 @@ struct SafeEnum {
      * @return true if the inner value of lhs and rhs are equal and false
      * otherwise.
      */
-	friend bool operator==(SafeEnum lhs, SafeEnum rhs) {
+	friend bool operator==(Target lhs, Target rhs) {
 		return lhs._value == rhs._value;
 	}
 
     /**
-     * Not equal to operator for SafeEnum instances.
+     * Not equal to operator for Target instances.
      *
      * @param lhs left hand side of the comparison
      * @param rhs right hand side of the comparison
@@ -139,24 +141,24 @@ struct SafeEnum {
      * @return true if the inner value of lhs and rhs are not equal and false
      * otherwise.
      */
-	friend bool operator!=(SafeEnum lhs, SafeEnum rhs) {
+	friend bool operator!=(Target lhs, Target rhs) {
 		return !(lhs == rhs);
 	}
 
 	/**
-	 * Less than operator for SafeEnum instances.
+	 * Less than operator for Target instances.
 	 *
      * @param lhs left hand side of the comparison
      * @param rhs right hand side of the comparison
      *
      * @return true if the inner value of lhs is less than rhs and false otherwise.
 	 */
-	friend bool operator<(SafeEnum lhs, SafeEnum rhs) {
+	friend bool operator<(Target lhs, Target rhs) {
 	    return lhs.value() < rhs.value();
 	}
 
     /**
-     * Less than or equal to operator for SafeEnum instances.
+     * Less than or equal to operator for Target instances.
      *
      * @param lhs left hand side of the comparison
      * @param rhs right hand side of the comparison
@@ -164,12 +166,12 @@ struct SafeEnum {
      * @return true if the inner value of lhs is less than or equal to rhs and
      * false otherwise.
      */
-	friend bool operator<=(SafeEnum lhs, SafeEnum rhs) {
+	friend bool operator<=(Target lhs, Target rhs) {
 	    return lhs.value() < rhs.value() || lhs == rhs;
 	}
 
     /**
-     * Greater than operator for SafeEnum instances.
+     * Greater than operator for Target instances.
      *
      * @param lhs left hand side of the comparison
      * @param rhs right hand side of the comparison
@@ -177,12 +179,12 @@ struct SafeEnum {
      * @return true if the inner value of lhs is greater than rhs; false
      * otherwise.
      */
-    friend bool operator>(SafeEnum lhs, SafeEnum rhs) {
+    friend bool operator>(Target lhs, Target rhs) {
         return !(lhs <= rhs);
     }
 
     /**
-     * Greater than or equal to operator for SafeEnum instances.
+     * Greater than or equal to operator for Target instances.
      *
      * @param lhs left hand side of the comparison
      * @param rhs right hand side of the comparison
@@ -190,7 +192,7 @@ struct SafeEnum {
      * @return true if the inner value of lhs is greater than or equal to rhs;
      * false otherwise.
      */
-    friend bool operator>=(SafeEnum lhs, SafeEnum rhs) {
+    friend bool operator>=(Target lhs, Target rhs) {
         return !(lhs < rhs);
     }
 

--- a/features/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp
+++ b/features/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp
@@ -331,7 +331,7 @@ uint8_t *AdvertisingDataBuilder::findField(adv_data_type_t type)
     for (uint8_t idx = 0; idx < _payload_length;) {
         uint8_t fieldType = _buffer[idx + FIELD_TYPE_INDEX];
 
-        if (fieldType == type) {
+        if (fieldType == type.value()) {
             return _buffer.data() + idx;
         }
 


### PR DESCRIPTION
### Description

The relational operators were targeting the base class which defines an implicit constructor to an integral value. This is wrong as it allows SafeEnum instances to be compared against integers.

The fix is simple: define relationnal operators for the derived class. The derived class is known as it is passed as a template parameter of the base class.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm @paul-szczepanek-arm 
<!-- 
    Optional
    Request additional reviewers with @username
-->