### PR TITLE
Fixing folder path for KVStore FILESYSTEM configuration.

### DIFF
--- a/features/storage/TESTS/kvstore/static_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/static_tests/main.cpp
@@ -910,6 +910,7 @@ static void iterator_close_right_after_iterator_open()
 utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason)
 {
     greentea_case_failure_abort_handler(source, reason);
+    UnityConcludeTest();
     return STATUS_CONTINUE;
 }
 

--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -134,6 +134,8 @@ int _storage_config_FILESYSTEM_NO_RBP();
 int _storage_config_tdb_external_common();
 int _storage_config_filesystem_common();
 
+static const char *filesystemstore_folder_path = NULL;
+
 using namespace mbed;
 
 
@@ -881,6 +883,9 @@ int _storage_config_FILESYSTEM()
 #if !SECURESTORE_ENABLED
     return MBED_ERROR_UNSUPPORTED;
 #endif
+
+    filesystemstore_folder_path = STR(MBED_CONF_STORAGE_FILESYSTEM_FOLDER_PATH);
+
     bd_size_t internal_rbp_size = MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
     bd_addr_t internal_start_address = MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS;
 
@@ -962,6 +967,12 @@ int _storage_config_FILESYSTEM()
 
 int _storage_config_FILESYSTEM_NO_RBP()
 {
+#if !SECURESTORE_ENABLED
+    return MBED_ERROR_UNSUPPORTED;
+#endif
+
+    filesystemstore_folder_path = STR(MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH);
+
     bd_size_t size = MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_SIZE;
     bd_addr_t address = MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_BASE_ADDRESS;
     const char *mount_point = STR(MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_MOUNT_POINT);
@@ -1060,6 +1071,11 @@ int _storage_config_default()
 #else
     return MBED_ERROR_UNSUPPORTED;
 #endif
+}
+
+const char *get_filesystemstore_folder_path()
+{
+    return filesystemstore_folder_path;
 }
 
 MBED_WEAK int kv_init_storage_config()

--- a/features/storage/kvstore/conf/kv_config.h
+++ b/features/storage/kvstore/conf/kv_config.h
@@ -20,12 +20,6 @@
 extern "C" {
 #endif
 
-#if MBED_CONF_STORAGE_STORAGE_TYPE == FILESYSTEM
-#define FSST_FOLDER_PATH MBED_CONF_STORAGE_FILESYSTEM_FOLDER_PATH
-#elif MBED_CONF_STORAGE_STORAGE_TYPE == FILESYSTEM_NO_RBP
-#define FSST_FOLDER_PATH MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH
-#endif
-
 #ifndef MBED_CONF_STORAGE_STORAGE
 #define MBED_CONF_STORAGE_STORAGE USER_DEFINED
 #endif
@@ -40,6 +34,13 @@ extern "C" {
  * @returns 0 on success or negative value on failure.
  */
 int kv_init_storage_config();
+
+/**
+ * @brief A getter for filesystemstore folder path configuration
+ *
+ * @returns string with the file folder path or NULL if not set
+ */
+const char *get_filesystemstore_folder_path();
 
 #ifdef __cplusplus
 } // closing brace for extern "C"

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "FileSystemStore.h"
+#include "kv_config.h"
 #include "Dir.h"
 #include "File.h"
 #include "BlockDevice.h"
@@ -31,9 +32,7 @@
 #define FSST_REVISION 1
 #define FSST_MAGIC 0x46535354 // "FSST" hex 'magic' signature
 
-#ifndef FSST_FOLDER_PATH
-#define FSST_FOLDER_PATH "kvstore" //default FileSystemStore folder path on fs
-#endif
+#define FSST_DEFAULT_FOLDER_PATH "kvstore" //default FileSystemStore folder path on fs
 
 static const uint32_t supported_flags = mbed::KVStore::WRITE_ONCE_FLAG;
 
@@ -73,9 +72,15 @@ int FileSystemStore::init()
     int status = MBED_SUCCESS;
 
     _mutex.lock();
+    const char *temp_path = get_filesystemstore_folder_path();
+    if (temp_path == NULL) {
+        _cfg_fs_path_size = strlen(FSST_DEFAULT_FOLDER_PATH);
+        _cfg_fs_path = string_ndup(FSST_DEFAULT_FOLDER_PATH, _cfg_fs_path_size);
+    } else {
+        _cfg_fs_path_size = strlen(temp_path);
+        _cfg_fs_path = string_ndup(temp_path, _cfg_fs_path_size);
+    }
 
-    _cfg_fs_path_size = strlen(FSST_FOLDER_PATH);
-    _cfg_fs_path = string_ndup(FSST_FOLDER_PATH, _cfg_fs_path_size);
     _full_path_key = new char[_cfg_fs_path_size + KVStore::MAX_KEY_SIZE + 1];
     memset(_full_path_key, 0, (_cfg_fs_path_size + KVStore::MAX_KEY_SIZE + 1));
     strncpy(_full_path_key, _cfg_fs_path, _cfg_fs_path_size);


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR fix folder path for KVStore FILESYSTEM configuration and default configuration (under SD component). The folder path has always been constant "kvstore" instead of getting the value from configuration parameters.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

