### PR TITLE
Revert "Warn with ARMC6 and not v8m"

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -25,7 +25,6 @@ from tempfile import mkstemp
 from shutil import rmtree
 from distutils.version import LooseVersion
 
-from tools.targets import CORE_ARCH
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 from tools.utils import mkdir, NotSupportedException, run_cmd
@@ -377,14 +376,6 @@ class ARMC6(ARM_STD):
         if target.core not in self.SUPPORTED_CORES:
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
-        if CORE_ARCH[target.core] < 8:
-            self.notify.cc_info({
-                'severity': "Error", 'file': "", 'line': "", 'col': "",
-                'message': "ARMC6 does not support ARM architecture v{}"
-                " targets".format(CORE_ARCH[target.core]),
-                'text': '', 'target_name': self.target.name,
-                'toolchain_name': self.name
-            })
 
         if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")


### PR DESCRIPTION
### Description

A requested change from the toolchain guys, who are working on getting ARMC6 support online - the the misleading message "ARMC6 does not support ARM architecture v7" is winding them up.

Not clear we need any message at this point, at least on master. Maybe we will need something more specific about targets later, once we can pin down restrictions.

This reverts commit 3f684113b0611674d4def765450b82453fd7fb92.

Marked it as a "docs update", as it doesn't change the build result, just what the build prints. That probably doesn't make any sense.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@theotherjimmy
