### PR TITLE
BLE: fix missing null checks on Gap event handler

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -1782,7 +1782,8 @@ void GenericGap::on_disconnection_complete(const pal::GapDisconnectionCompleteEv
 void GenericGap::on_connection_parameter_request(const pal::GapRemoteConnectionParameterRequestEvent &e)
 {
     if (_user_manage_connection_parameter_requests) {
-        _eventHandler->onUpdateConnectionParametersRequest(
+        if (_eventHandler) {
+            _eventHandler->onUpdateConnectionParametersRequest(
                 UpdateConnectionParametersRequestEvent(
                     e.connection_handle,
                     conn_interval_t(e.min_connection_interval),
@@ -1791,6 +1792,7 @@ void GenericGap::on_connection_parameter_request(const pal::GapRemoteConnectionP
                     supervision_timeout_t(e.supervision_timeout)
                 )
             );
+        }
     } else {
         _pal_gap.accept_connection_parameter_request(
             e.connection_handle,
@@ -1806,6 +1808,10 @@ void GenericGap::on_connection_parameter_request(const pal::GapRemoteConnectionP
 
 void GenericGap::on_connection_update(const pal::GapConnectionUpdateEvent &e)
 {
+    if (!_eventHandler) {
+        return;
+    }
+
     _eventHandler->onConnectionParametersUpdateComplete(
         ConnectionParametersUpdateCompleteEvent(
             e.status == pal::hci_error_code_t::SUCCESS ? BLE_ERROR_NONE : BLE_ERROR_UNSPECIFIED,

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -64,6 +64,10 @@ static const GapScanningParams default_scan_params;
 static const mbed_error_status_t mixed_scan_api_error =
     MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_USE_INCOMPATIBLE_API);
 
+static const mbed_error_status_t illegal_state_error =
+    MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_ILLEGAL_STATE);
+
+
 /*
  * Return true if value is included in the range [lower_bound : higher_bound]
  */
@@ -1792,6 +1796,8 @@ void GenericGap::on_connection_parameter_request(const pal::GapRemoteConnectionP
                     supervision_timeout_t(e.supervision_timeout)
                 )
             );
+        } else {
+            MBED_ERROR(illegal_state_error, "Event handler required if connection params are user handled");
         }
     } else {
         _pal_gap.accept_connection_parameter_request(

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -792,6 +792,7 @@ typedef enum _mbed_error_code {
     MBED_DEFINE_SYSTEM_ERROR(AUTHENTICATION_FAILED, 69),                /* 325      Authentication Failed */
     MBED_DEFINE_SYSTEM_ERROR(RBP_AUTHENTICATION_FAILED, 70),            /* 326      Rollback Protection Authentication Failed */
     MBED_DEFINE_SYSTEM_ERROR(BLE_USE_INCOMPATIBLE_API, 71),             /* 327      Concurrent use of incompatible versions of a BLE API */
+    MBED_DEFINE_SYSTEM_ERROR(BLE_ILLEGAL_STATE, 72),                    /* 328      BLE stack entered illegal state */
 
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on


### PR DESCRIPTION
### Description

There are two missing null checks for the event handler. This may cause a hardfault as the event handler is optional.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

