### PR TITLE
DirectAccess DeviceKey: add support for default storage type

### DIFF
--- a/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
+++ b/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
@@ -245,7 +245,7 @@ void test_direct_access_to_device_inject_root()
     uint32_t key[DEVICE_KEY_16BYTE / sizeof(uint32_t)];
     KVMap &kv_map = KVMap::get_instance();
     KVStore *inner_store = kv_map.get_internal_kv_instance(NULL);
-    TEST_ASSERT_NOT_EQUAL(NULL, inner_store);
+    TEST_SKIP_UNLESS_MESSAGE(inner_store != NULL, "Test skipped. No KVStore Internal");
 
     BlockDevice *flash_bd = kv_map.get_internal_blockdevice_instance("");
     TEST_ASSERT_NOT_EQUAL(NULL, flash_bd);
@@ -271,6 +271,20 @@ void test_direct_access_to_device_inject_root()
         internal_start_address =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
         internal_rbp_size =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
         is_conf_tdb_internal = true;
+    } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "default") == 0) {
+#if COMPONENT_QSPIF || COMPONENT_SPIF || COMPONENT_DATAFLASH
+        internal_start_address =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
+        internal_rbp_size =  MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
+#elif COMPONENT_SD
+        internal_start_address =  MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS;
+        internal_rbp_size =  MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
+#elif COMPONENT_FLASHIAP
+        internal_start_address =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
+        internal_rbp_size =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
+        is_conf_tdb_internal = true;
+#else
+        TEST_SKIP_UNLESS_MESSAGE(false, "Test skipped. No KVStore Internal");
+#endif
     } else {
         TEST_SKIP_UNLESS_MESSAGE(false, "Test skipped. No KVStore Internal");
     }

--- a/features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.cpp
+++ b/features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.cpp
@@ -123,6 +123,15 @@ int  get_expected_internal_TDBStore_position(uint32_t *out_tdb_start_offset, uin
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_EXTERNAL") == 0) {
         *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
         tdb_size = MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
+    } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "default") == 0) {
+#if COMPONENT_QSPIF || COMPONENT_SPIF || COMPONENT_DATAFLASH
+        *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
+        tdb_size = MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
+#elif COMPONENT_SD
+        tdb_size = MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
+#else
+        return MBED_ERROR_UNSUPPORTED;
+#endif
     } else {
         return MBED_ERROR_UNSUPPORTED;
     }


### PR DESCRIPTION
### Description
DirectAccess DeviceKey added support for default storage type, which depends
on Component type.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-maintainers
@ARMmbed/mbed-os-storage 
