### PR TITLE
SPIF - Fix command to unlock Global Block-Protection register

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -205,7 +205,7 @@ int QSPIFBlockDevice::init()
     switch (vendor_device_ids[0]) {
         case 0xbf:
             // SST devices come preset with block protection
-            // enabled for some regions, issue write disable instruction to clear
+            // enabled for some regions, issue global protection unlock to clear
             _set_write_enable();
             _qspi_send_general_command(QSPIF_ULBPR, QSPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
             break;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -95,6 +95,7 @@ enum qspif_default_instructions {
     QSPIF_RSTEN = 0x66, // Reset Enable
     QSPIF_RST = 0x99, // Reset
     QSPIF_RDID = 0x9f, // Read Manufacturer and JDEC Device ID
+    QSPIF_ULBPR = 0x98, // Clears all write-protection bits in the Block-Protection register
 };
 
 // Local Function
@@ -206,7 +207,7 @@ int QSPIFBlockDevice::init()
             // SST devices come preset with block protection
             // enabled for some regions, issue write disable instruction to clear
             _set_write_enable();
-            _qspi_send_general_command(QSPIF_WRDI, QSPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
+            _qspi_send_general_command(QSPIF_ULBPR, QSPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
             break;
     }
 

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -67,7 +67,7 @@ int SPIFReducedBlockDevice::init()
     switch (id[0]) {
         case 0xbf:
             // SST devices come preset with block protection
-            // enabled for some regions, issue gbpu instruction to clear
+            // enabled for some regions, issue global protection unlock to clear
             _wren();
             _cmdwrite(SPIF_ULBPR, 0, 0, 0x0, NULL);
             break;

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -40,6 +40,7 @@ enum ops {
     SPIF_WRDI = 0x04, // Write Disable
     SPIF_RDSR = 0x05, // Read Status Register
     SPIF_RDID = 0x9f, // Read Manufacturer and JDEC Device ID
+    SPIF_ULBPR = 0x98, // Clears all write-protection bits in the Block-Protection register
 };
 
 // Status register from RDSR
@@ -68,7 +69,7 @@ int SPIFReducedBlockDevice::init()
             // SST devices come preset with block protection
             // enabled for some regions, issue gbpu instruction to clear
             _wren();
-            _cmdwrite(0x98, 0, 0, 0x0, NULL);
+            _cmdwrite(SPIF_ULBPR, 0, 0, 0x0, NULL);
             break;
     }
 

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -88,6 +88,7 @@ enum spif_default_instructions {
     SPIF_RSTEN = 0x66, // Reset Enable
     SPIF_RST = 0x99, // Reset
     SPIF_RDID = 0x9f, // Read Manufacturer and JDEC Device ID
+    SPIF_ULBPR = 0x98, // Clears all write-protection bits in the Block-Protection register
 };
 
 // Mutex is used for some SPI Driver commands that must be done sequentially with no other commands in between
@@ -169,7 +170,7 @@ int SPIFBlockDevice::init()
             // SST devices come preset with block protection
             // enabled for some regions, issue write disable instruction to clear
             _set_write_enable();
-            _spi_send_general_command(SPIF_WRDI, SPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
+            _spi_send_general_command(SPIF_ULBPR, SPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
             break;
     }
 

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -168,7 +168,7 @@ int SPIFBlockDevice::init()
     switch (vendor_device_ids[0]) {
         case 0xbf:
             // SST devices come preset with block protection
-            // enabled for some regions, issue write disable instruction to clear
+            // enabled for some regions, issue global protection unlock to clear
             _set_write_enable();
             _spi_send_general_command(SPIF_ULBPR, SPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0);
             break;


### PR DESCRIPTION
### Description
As described in the code of SPIFBlockDevice.cpp line 168:
> SST devices come preset with block protection enabled for some regions, issue write disable instruction to clear

But during the commit https://github.com/ARMmbed/spif-driver/commit/a821b69cd98a735ed4ee26678fe581ccdaa92d90 the command (0x98) was falsely replaced with "SPIF_WRDI" -> classical copy and paste error 😏 

Therefore I added the commend to the SPIF-Default-Instructions and replaced the wrong command "SPIF_WRDI" with "SPIF_ULBPR".

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

