### PR TITLE
STM32L496xG: increase IAR heap size

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_IAR/stm32l496xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_IAR/stm32l496xx.icf
@@ -23,7 +23,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 }
 
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __size_heap__   = 0xa000;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };


### PR DESCRIPTION
### Description

STM32L496xG RAM size is 320k

So heap size default value should/can be increased in order to make all the mbed-os tests OK with IAR.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
