### PR TITLE
Allow NSAPI_ERROR_UNSUPPORTED from Socket::setsockopt()

### DIFF
--- a/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
@@ -29,7 +29,16 @@ void TCPSOCKET_SETSOCKOPT_KEEPALIVE_VALID()
     TCPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
     int32_t seconds = 7200;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.setsockopt(NSAPI_SOCKET, NSAPI_KEEPALIVE, &seconds, sizeof(int)));
+
+    int ret = sock.setsockopt(NSAPI_SOCKET, NSAPI_KEEPALIVE, &seconds, sizeof(int));
+
+    if (ret == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("NSAPI_KEEPALIVE option not supported");
+        sock.close();
+        return;
+    }
+
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, ret);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, 9));
     // LWIP stack does not support getsockopt so the part below is commented out
     //    int32_t optval;


### PR DESCRIPTION
### Description

Test case TCPSOCKET_SETSOCKOPT_KEEPALIVE_VALID currently expects `sock.setsockopt(NSAPI_SOCKET, NSAPI_KEEPALIVE, &seconds, sizeof(int))` to work.

This might not be true for all stacks, and documentation allows NSAPI_ERROR_UNSUPPORTED to be returned.

Fixed the testcase.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant 

