### PR TITLE
RTOS: SysTimer: Fix test timing issues

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -245,7 +245,10 @@ void test_handler_called_once(void)
     int32_t sem_slots = st.sem_wait(0);
     TEST_ASSERT_EQUAL_INT32(0, sem_slots);
 
-    sem_slots = st.sem_wait(osWaitForever);
+    // Wait in a busy loop to prevent entering sleep or deepsleep modes.
+    while (sem_slots != 1) {
+        sem_slots = st.sem_wait(0);
+    }
     us_timestamp_t t2 = st.get_time();
     TEST_ASSERT_EQUAL_INT32(1, sem_slots);
     TEST_ASSERT_EQUAL_UINT32(1, st.get_tick());


### PR DESCRIPTION

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Use a busy loop with non-blocking `Semaphore::wait(0)` calls instead of a
single `Semaphore::wait(osWaitForever)` to improve time measurement
accuracy.

This should resolve #9400.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@c1728p9 @jeromecoutant 
