### PR TITLE
ESP8266: implements possibility to decide between non-blocking/blocking connect.

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -29,6 +29,7 @@
 #include "features/netsocket/WiFiAccessPoint.h"
 #include "features/netsocket/WiFiInterface.h"
 #include "platform/Callback.h"
+#include "rtos/Mutex.h"
 
 #define ESP8266_SOCKET_COUNT 5
 
@@ -372,8 +373,12 @@ private:
     // Use global EventQueue
     events::EventQueue *_global_event_queue;
     int _oob_event_id;
+    int _connect_event_id;
     void proc_oob_evnt();
     void _oob2global_event_queue();
+    void _connect_async();
+    rtos::Mutex _cmutex; // Protect asynchronous connection logic
+
 };
 #endif
 #endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -29,6 +29,7 @@
 #include "features/netsocket/WiFiAccessPoint.h"
 #include "features/netsocket/WiFiInterface.h"
 #include "platform/Callback.h"
+#include "rtos/ConditionVariable.h"
 #include "rtos/Mutex.h"
 
 #define ESP8266_SOCKET_COUNT 5
@@ -317,6 +318,13 @@ protected:
         return this;
     }
 
+    /** Set blocking status of connect() which by default should be blocking.
+     *
+     *  @param blocking Use true to make connect() blocking.
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    virtual nsapi_error_t set_blocking(bool blocking);
+
 private:
     // AT layer
     ESP8266 _esp;
@@ -341,6 +349,9 @@ private:
     static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1]; /* The longest possible passphrase; +1 for the \0 */
     nsapi_security_t _ap_sec;
+
+    bool _if_blocking; // NetworkInterface, blocking or not
+    rtos::ConditionVariable _if_connected;
 
     // connect status reporting
     nsapi_error_t _conn_status_to_error();

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -341,6 +341,9 @@ private:
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1]; /* The longest possible passphrase; +1 for the \0 */
     nsapi_security_t _ap_sec;
 
+    // connect status reporting
+    nsapi_error_t _conn_status_to_error();
+
     // Drivers's socket info
     struct _sock_info {
         bool open;


### PR DESCRIPTION
### Description
Checks for already existing connection when trying to set credentials for a new connection or when trying to call connect. This is done to avoid the situation where an already established connection would get disrupted.

Implements possibility to decide between non-blocking/blocking connect.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@michalpasztamobica
@marcuschangarm 
@karsev 
@teetak01 

