### PR TITLE
PB_1 is not connected to D4 in R412M above

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
@@ -118,7 +118,11 @@ typedef enum {
     D1      = PD_8,   // UART3-TX
     D2      = PD_11,  // UART3-CTS
     D3      = PB_14,  // UART3-RTS
+#if defined(TARGET_UBLOX_C030_N211) || defined(TARGET_UBLOX_C030_R410M) || defined(TARGET_UBLOX_C030_U201)
     D4      = PB_1,
+#else
+    D4      = PC_8,
+#endif
     D5      = PA_5,
     D6      = PB_8,   // UART3-CTS
     D7      = PB_15,  // UART3-RTS


### PR DESCRIPTION
### Description

PB_1 is not connected to D4 in C030-R412M above

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@RobMeades 
