### PR TITLE
BLE: fix possible truncation

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/btle/btle.cpp
@@ -355,9 +355,10 @@ void btle_handler(const ble_evt_t *p_ble_evt)
             uint8_t const data_length_peer =
                 p_gap_evt->params.data_length_update_request.peer_params.max_tx_octets;
 
-            const uint8_t max_data_length = NRF_SDH_BLE_GATT_MAX_MTU_SIZE + 4 /* L2CAP header size */;
-
-            uint8_t const data_length = MIN(max_data_length, data_length_peer);
+            uint8_t const data_length = MIN(
+                NRF_SDH_BLE_GATT_MAX_MTU_SIZE + 4 /* L2CAP header size */,
+                data_length_peer
+            );
 
             ble_gap_data_length_params_t const dlp =
             {


### PR DESCRIPTION
### Description

Possible truncation of a value if the value does not fit uint8. The result is a uint8 but one of the components may be larger but due to truncation could end up limiting the result by more than needed.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

