### PR TITLE
STM32H743ZI: iar removal as not supported in v7.x

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -285,9 +285,6 @@
         "GFPUCoreSlave": 24,
         "GBECoreSlave": 24
     },
-    "STM32H743ZI": {
-        "OGChipSelectEditMenu": "STM32H743ZI\tST STM32H743ZI"
-    },
     "STM32F446VE": {
         "OGChipSelectEditMenu": "STM32F446VE\tST STM32F446VE"
     },


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Fixes #9426. Disable exporting to non supported MCU (at least at the moment, with update to iar 8, this can be reverted)


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

@ARMmbed/team-st-mcd 
