### PR TITLE
Fix TCPSOCKET_ENDPOINT_CLOSE: Cannot accept WOULD_BLOCK

### DIFF
--- a/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -24,16 +24,6 @@
 
 using namespace utest::v1;
 
-namespace {
-static const int SIGNAL_SIGIO = 0x1;
-static const int SIGIO_TIMEOUT = 20000; //[ms]
-}
-
-static void _sigio_handler(osThreadId id)
-{
-    osSignalSet(id, SIGNAL_SIGIO);
-}
-
 static nsapi_error_t _tcpsocket_connect_to_daytime_srv(TCPSocket &sock)
 {
     SocketAddress tcp_addr;
@@ -49,7 +39,6 @@ static nsapi_error_t _tcpsocket_connect_to_daytime_srv(TCPSocket &sock)
     return sock.connect(tcp_addr);
 }
 
-
 void TCPSOCKET_ENDPOINT_CLOSE()
 {
     static const int MORE_THAN_AVAILABLE = 30;
@@ -63,24 +52,16 @@ void TCPSOCKET_ENDPOINT_CLOSE()
         TEST_FAIL();
         return;
     }
-    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     int recvd = 0;
     int recvd_total = 0;
     while (true) {
-        recvd = sock.recv(&(buff[recvd_total]), MORE_THAN_AVAILABLE);
+        recvd = sock.recv(buff, MORE_THAN_AVAILABLE);
         if (recvd_total > 0 && recvd == 0) {
             break; // Endpoint closed socket, success
         } else if (recvd <= 0) {
-            TEST_FAIL();
+            TEST_ASSERT_EQUAL(0, recvd);
             break;
-        } else if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
-            if (tc_exec_time.read() >= time_allotted ||
-                    osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
-                TEST_FAIL();
-                break;
-            }
-            continue;
         }
         recvd_total += recvd;
         TEST_ASSERT(recvd_total < MORE_THAN_AVAILABLE);


### PR DESCRIPTION
### Description

This testcase uses Socket in blocking mode, and therefore
WOULD_BLOCK should not be accepted.
The logic was wrong anyway, because return value was tested
to be negative before testing with WOULD_BLOCK which is negative
as well.

Also replaced TEST_FAIL() macro with TEST_ASSERT_EQUAL() to
make the return code visible in test log.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@VeijoPesonen @KariHaapalehto 

