### PR TITLE
Put LittleFS emulated BD module under .mbedignore

### DIFF
--- a/features/storage/filesystem/littlefs/littlefs/emubd/.mbedignore
+++ b/features/storage/filesystem/littlefs/littlefs/emubd/.mbedignore
@@ -1,0 +1,1 @@
+lfs_emubd.*


### PR DESCRIPTION
### Description
Put LittleFS emulated BD module under .mbedignore. The emulated BD is required for simulation of a block device outside mbed-os, but not required in mbed-os.

Resolves #9281.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@geky 