### PR TITLE
Request for comments: Expand sbrk to allocate memory from two regions

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
@@ -16,7 +16,7 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 
 /* Linker script to configure memory regions. */
 MEMORY
-{ 
+{
   FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   SRAM2 (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
   SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
@@ -26,7 +26,7 @@ MEMORY
  * with other linker script that defines memory regions FLASH and RAM.
  * It references following symbols, which must be defined in code:
  *   Reset_Handler : Entry of reset handler
- * 
+ *
  * It defines following symbols, which code can use without definition:
  *   __exidx_start
  *   __exidx_end
@@ -93,7 +93,7 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
-    
+
     .crash_data_ram :
     {
         . = ALIGN(8);
@@ -173,6 +173,10 @@ SECTIONS
     .stack_dummy (COPY):
     {
         *(.stack*)
+        . += (ORIGIN(SRAM2) + STACK_SIZE - .);
+        __mbed_sbrk_start_0 = .;
+        . += (ORIGIN(SRAM2) + LENGTH(SRAM2) - .);
+        __mbed_krbs_start_0 = .;
     } > SRAM2
 
     /* Set stack top to end of RAM, and stack limit move down by


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Some MCUs, like the STM32L475, have multiple discrete RAM regions. Accessing memory across these boundaries will cause a hard fault. The current sbrk implementation for GCC only allocates heap from one of these regions, leaving unused memory in other regions unavailable. 

The change here allows sbrk to allocate from the second region once the first is full and assumes that malloc is able to handle the discontinuity in assigned heap.

**Question:** The sbrk documentation is not clear on whether this discontinuity is allowed behavior or dependent on the malloc implementation. 

From https://linux.die.net/man/2/sbrk:

> On success, sbrk() returns the previous program break. (If the break was increased, then this value is a pointer to the start of the newly allocated memory). On error, (void *) -1 is returned, and errno is set to ENOMEM.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

