### PR TITLE
NVStore: fix area calculation function

### DIFF
--- a/features/storage/nvstore/TESTS/nvstore/functionality/main.cpp
+++ b/features/storage/nvstore/TESTS/nvstore/functionality/main.cpp
@@ -109,11 +109,11 @@ static void nvstore_basic_functionality_test()
     TEST_SKIP_UNLESS_MESSAGE(max_possible_keys >= max_possible_keys_threshold,
                              "Max possible keys below threshold. Test skipped.");
 
-    nvstore.set_max_keys(max_test_keys);
-    TEST_ASSERT_EQUAL(max_test_keys, nvstore.get_max_keys());
-
     result = nvstore.reset();
     TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, result);
+
+    nvstore.set_max_keys(max_test_keys);
+    TEST_ASSERT_EQUAL(max_test_keys, nvstore.get_max_keys());
 
     printf("Max keys %d (out of %d possible ones)\n", nvstore.get_max_keys(), max_possible_keys);
 
@@ -503,16 +503,12 @@ static void nvstore_multi_thread_test()
         TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, ret);
     }
 
-    dummy = new (std::nothrow) char[thr_test_num_threads * thr_test_stack_size];
-    delete[] dummy;
-    if (!dummy) {
-        goto mem_fail;
-    }
-
     for (i = 0; i < thr_test_num_threads; i++) {
         threads[i] = new (std::nothrow) rtos::Thread((osPriority_t)((int)osPriorityBelowNormal - thr_test_num_threads + i),
                                                      thr_test_stack_size);
-        if (!threads[i]) {
+        dummy = new (std::nothrow) char[thr_test_stack_size];
+        delete[] dummy;
+        if (!threads[i] || !dummy) {
             goto mem_fail;
         }
         threads[i]->start(mbed::callback(thread_test_worker));

--- a/features/storage/nvstore/source/nvstore.cpp
+++ b/features/storage/nvstore/source/nvstore.cpp
@@ -264,32 +264,29 @@ int NVStore::flash_erase_area(uint8_t area)
 
 void NVStore::calc_validate_area_params()
 {
-    int num_sectors = 0;
-
-    size_t flash_addr = _flash->get_flash_start();
+    size_t flash_start_addr = _flash->get_flash_start();
     size_t flash_size = _flash->get_flash_size();
+    size_t flash_addr;
     size_t sector_size;
-    int max_sectors = flash_size / _flash->get_sector_size(flash_addr) + 1;
-    size_t *sector_map = new size_t[max_sectors];
 
     int area = 0;
     size_t left_size = flash_size;
 
     memcpy(_flash_area_params, initial_area_params, sizeof(_flash_area_params));
-    int user_config = (_flash_area_params[0].size != 0);
-    int in_area = 0;
+    bool user_config = (_flash_area_params[0].size != 0);
+    bool in_area = false;
     size_t area_size = 0;
 
-    while (left_size) {
-        sector_size = _flash->get_sector_size(flash_addr);
-        sector_map[num_sectors++] = flash_addr;
+    if (user_config) {
+        flash_addr = flash_start_addr;
+        while (left_size) {
+            sector_size = _flash->get_sector_size(flash_addr);
 
-        if (user_config) {
             // User configuration - here we validate it
             // Check that address is on a sector boundary, that size covers complete sector sizes,
             // and that areas don't overlap.
             if (_flash_area_params[area].address == flash_addr) {
-                in_area = 1;
+                in_area = true;
             }
             if (in_area) {
                 area_size += sector_size;
@@ -298,18 +295,13 @@ void NVStore::calc_validate_area_params()
                     if (area == NVSTORE_NUM_AREAS) {
                         break;
                     }
-                    in_area = 0;
+                    in_area = false;
                     area_size = 0;
                 }
             }
+            flash_addr += sector_size;
+            left_size -= sector_size;
         }
-
-        flash_addr += sector_size;
-        left_size -= sector_size;
-    }
-    sector_map[num_sectors] = flash_addr;
-
-    if (user_config) {
         // Valid areas were counted. Assert if not the expected number.
         MBED_ASSERT(area == NVSTORE_NUM_AREAS);
     } else {
@@ -317,23 +309,20 @@ void NVStore::calc_validate_area_params()
         // Take last two sectors by default. If their sizes aren't big enough, take
         // a few consecutive ones.
         area = 1;
-        _flash_area_params[area].size = 0;
-        int i;
-        for (i = num_sectors - 1; i >= 0; i--) {
-            sector_size = sector_map[i + 1] - sector_map[i];
+        flash_addr = flash_start_addr + flash_size;
+        _flash_area_params[0].size = 0;
+        _flash_area_params[1].size = 0;
+        while (area >= 0) {
+            MBED_ASSERT(flash_addr > flash_start_addr);
+            sector_size = _flash->get_sector_size(flash_addr - 1);
+            flash_addr -= sector_size;
             _flash_area_params[area].size += sector_size;
             if (_flash_area_params[area].size >= min_area_size) {
-                _flash_area_params[area].address = sector_map[i];
+                _flash_area_params[area].address = flash_addr;
                 area--;
-                if (area < 0) {
-                    break;
-                }
-                _flash_area_params[area].size = 0;
             }
         }
     }
-
-    delete[] sector_map;
 }
 
 


### PR DESCRIPTION
### Description
NVStore includes a function (`calc_validate_area_params`) that either calculates or validates the addresses and sizes of both areas. This function allocates a sector map array used in both calculation/validation of areas. While this generally worked, it had a few problems: First of all, it allocated and deallocated the sector map inside the function, while a more efficient code wouldn't need it. Second, it had a potential bug - number of of entries in the array was calculated according to the first sector size, but in case of a variant sector size, with a large first sector, the array size could have been smaller than required (this probably will never happen, but it's still a bug).
This PR removes the allocation and usage of sector map array. Instead it traverses the flash sectors on the fly (forwards in the validation case, backwards in the calculation case).
In addition, fix tests to get over failures in low end boards.
Tested with K64F (both default and user configured), K82F, K66F, NUCLEO_F429ZI and UBLOX_EVK_ODIN_W2. 

Resolves #8513.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@jeromecoutant 

