### PR TITLE
RTX V8M: no TZ when MBED_TZ_DEFAULT_ACCESS not present

### DIFF
--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M33/irq_armv8mml.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M33/irq_armv8mml.S
@@ -58,10 +58,12 @@ SVC_Handler     PROC
                 IF       :DEF:MPU_LOAD
                 IMPORT   osRtxMpuLoad
                 ENDIF
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 IMPORT   TZ_LoadContext_S
                 IMPORT   TZ_StoreContext_S
                 ENDIF
+#endif
 
                 TST      LR,#0x04               ; Determine return stack from EXC_RETURN bit 2
                 ITE      EQ
@@ -100,6 +102,7 @@ SVC_Context
                 ENDIF
 
 SVC_ContextSave
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 LDR      R0,[R1,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,SVC_ContextSave1    ; Branch if there is no secure context
@@ -107,6 +110,7 @@ SVC_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 POP      {R1,R2,R3,LR}          ; Restore registers and EXC_RETURN
                 ENDIF
+#endif
 
 SVC_ContextSave1
                 MRS      R0,PSP                 ; Get PSP
@@ -132,6 +136,7 @@ SVC_ContextSwitch
                 ENDIF
 
 SVC_ContextRestore
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 LDR      R0,[R2,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,SVC_ContextRestore1 ; Branch if there is no secure context
@@ -139,6 +144,7 @@ SVC_ContextRestore
                 BL       TZ_LoadContext_S       ; Load secure context
                 POP      {R2,R3}                ; Restore registers
                 ENDIF
+#endif
 
 SVC_ContextRestore1
                 LDR      R0,[R2,#TCB_SM_OFS]    ; Load stack memory base
@@ -147,10 +153,12 @@ SVC_ContextRestore1
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
                 ORR      LR,R1,#0xFFFFFF00      ; Set EXC_RETURN
 
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 TST      LR,#0x40               ; Check domain of interrupted thread
                 BNE      SVC_ContextRestore2    ; Branch if secure
                 ENDIF
+#endif
 
                 IF       __FPU_USED = 1
                 TST      LR,#0x10               ; Check if extended stack frame
@@ -216,10 +224,12 @@ Sys_Context     PROC
                 IF       :DEF:MPU_LOAD
                 IMPORT   osRtxMpuLoad
                 ENDIF
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 IMPORT   TZ_LoadContext_S
                 IMPORT   TZ_StoreContext_S
                 ENDIF
+#endif
 
                 LDR      R3,=osRtxInfo+I_T_RUN_OFS; Load address of osRtxInfo.run
                 LDM      R3,{R1,R2}             ; Load osRtxInfo.thread.run: curr & next
@@ -228,6 +238,7 @@ Sys_Context     PROC
                 BXEQ     LR                     ; Exit when threads are the same
 
 Sys_ContextSave
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 LDR      R0,[R1,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,Sys_ContextSave1    ; Branch if there is no secure context
@@ -239,6 +250,7 @@ Sys_ContextSave
                 MRSNE    R0,PSP                 ; Get PSP
                 BNE      Sys_ContextSave2       ; Branch if secure
                 ENDIF
+#endif
 
 Sys_ContextSave1
                 MRS      R0,PSP                 ; Get PSP
@@ -264,6 +276,7 @@ Sys_ContextSwitch
                 ENDIF
 
 Sys_ContextRestore
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 LDR      R0,[R2,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,Sys_ContextRestore1 ; Branch if there is no secure context
@@ -271,6 +284,7 @@ Sys_ContextRestore
                 BL       TZ_LoadContext_S       ; Load secure context
                 POP      {R2,R3}                ; Restore registers
                 ENDIF
+#endif
 
 Sys_ContextRestore1
                 LDR      R0,[R2,#TCB_SM_OFS]    ; Load stack memory base
@@ -279,10 +293,12 @@ Sys_ContextRestore1
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
                 ORR      LR,R1,#0xFFFFFF00      ; Set EXC_RETURN
 
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
                 IF       DOMAIN_NS = 1
                 TST      LR,#0x40               ; Check domain of interrupted thread
                 BNE      Sys_ContextRestore2    ; Branch if secure
                 ENDIF
+#endif
 
                 IF       __FPU_USED = 1
                 TST      LR,#0x10               ; Check if extended stack frame

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml.S
@@ -96,6 +96,7 @@ SVC_Context:
         .endif
 
 SVC_ContextSave:
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
         .if      DOMAIN_NS == 1
         LDR      R0,[R1,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,SVC_ContextSave1    // Branch if there is no secure context
@@ -103,6 +104,7 @@ SVC_ContextSave:
         BL       TZ_StoreContext_S      // Store secure context
         POP      {R1,R2,R3,LR}          // Restore registers and EXC_RETURN
         .endif
+#endif
 
 SVC_ContextSave1:
         MRS      R0,PSP                 // Get PSP
@@ -121,6 +123,7 @@ SVC_ContextSwitch:
         STR      R2,[R3]                // osRtxInfo.thread.run: curr = next
 
 SVC_ContextRestore:
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
         .if      DOMAIN_NS == 1
         LDR      R0,[R2,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,SVC_ContextRestore1 // Branch if there is no secure context
@@ -128,6 +131,7 @@ SVC_ContextRestore:
         BL       TZ_LoadContext_S       // Load secure context
         POP      {R2,R3}                // Restore registers
         .endif
+#endif
 
 SVC_ContextRestore1:
         LDR      R0,[R2,#TCB_SM_OFS]    // Load stack memory base
@@ -219,6 +223,7 @@ Sys_Context:
         BXEQ     LR                     // Exit when threads are the same
 
 Sys_ContextSave:
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
         .if      DOMAIN_NS == 1
         LDR      R0,[R1,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,Sys_ContextSave1    // Branch if there is no secure context
@@ -230,6 +235,7 @@ Sys_ContextSave:
         MRSNE    R0,PSP                 // Get PSP
         BNE      Sys_ContextSave2       // Branch if secure
         .endif
+#endif
 
 Sys_ContextSave1:
         MRS      R0,PSP                 // Get PSP
@@ -248,6 +254,7 @@ Sys_ContextSwitch:
         STR      R2,[R3]                // osRtxInfo.run: curr = next
 
 Sys_ContextRestore:
+#if (MBED_TZ_DEFAULT_ACCESS == 1)
         .if      DOMAIN_NS == 1
         LDR      R0,[R2,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,Sys_ContextRestore1 // Branch if there is no secure context
@@ -255,6 +262,7 @@ Sys_ContextRestore:
         BL       TZ_LoadContext_S       // Load secure context
         POP      {R2,R3}                // Restore registers
         .endif
+#endif
 
 Sys_ContextRestore1:
         LDR      R0,[R2,#TCB_SM_OFS]    // Load stack memory base

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c
@@ -92,7 +92,7 @@ static osStatus_t svcRtxKernelInitialize (void) {
     return osError;
   }
 
-#if (DOMAIN_NS == 1)
+#if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
   // Initialize Secure Process Stack
   if (TZ_InitContextSystem_S() == 0U) {
     EvrRtxKernelError(osRtxErrorTZ_InitContext_S);

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_thread.c
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_thread.c
@@ -594,7 +594,7 @@ static osThreadId_t svcRtxThreadNew (osThreadFunc_t func, void *argument, const 
   const char   *name;
   uint32_t     *ptr;
   uint32_t      n;
-#if (DOMAIN_NS == 1)
+#if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
   TZ_ModuleId_t tz_module;
   TZ_MemoryId_t tz_memory;
 #endif
@@ -616,7 +616,7 @@ static osThreadId_t svcRtxThreadNew (osThreadFunc_t func, void *argument, const 
     stack_mem  = attr->stack_mem;
     stack_size = attr->stack_size;
     priority   = attr->priority;
-#if (DOMAIN_NS == 1)
+#if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
     tz_module  = attr->tz_module;
 #endif
     if (thread != NULL) {
@@ -657,7 +657,7 @@ static osThreadId_t svcRtxThreadNew (osThreadFunc_t func, void *argument, const 
     stack_mem  = NULL;
     stack_size = 0U;
     priority   = osPriorityNormal;
-#if (DOMAIN_NS == 1)
+#if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
     tz_module  = 0U;
 #endif
   }
@@ -727,7 +727,7 @@ static osThreadId_t svcRtxThreadNew (osThreadFunc_t func, void *argument, const 
     flags |= osRtxFlagSystemMemory;
   }
 
-#if (DOMAIN_NS == 1)
+#if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
   // Allocate secure process stack
   if ((thread != NULL) && (tz_module != 0U)) {
     tz_memory = TZ_AllocModuleContext_S(tz_module);
@@ -784,7 +784,7 @@ static osThreadId_t svcRtxThreadNew (osThreadFunc_t func, void *argument, const 
     thread->stack_size    = stack_size;
     thread->sp            = (uint32_t)stack_mem + stack_size - 64U;
     thread->thread_addr   = (uint32_t)func;
-  #if (DOMAIN_NS == 1)
+  #if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
     thread->tz_memory     = tz_memory;
   #ifdef RTX_TF_M_EXTENSION
     thread->tz_module     = tz_module;
@@ -1104,7 +1104,7 @@ static void osRtxThreadFree (os_thread_t *thread) {
   thread->state = osRtxThreadInactive;
   thread->id    = osRtxIdInvalid;
 
-#if (DOMAIN_NS == 1)
+#if (DOMAIN_NS == 1) && (MBED_TZ_DEFAULT_ACCESS == 1)
   // Free secure process stack
   if (thread->tz_memory != 0U) {
     (void)TZ_FreeModuleContext_S(thread->tz_memory);


### PR DESCRIPTION
### Description

For V8M targets, MBED_TZ_DEFAULT_ACCESS macro is defined when TZ is used.

So if this TZ macro is not defined, target has to be used as default cortex M targets.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@deepikabhavnani 
@LMESTM 