### PR TITLE
Fix links to https://os.mbed.com documentation

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -19,7 +19,7 @@
 <!--
     Required
     Add detailed description of what you are reporting.
-    Good example: https://os.mbed.com/docs/latest/reference/workflow.html
+    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html
     Things to consider sharing:
     - What target does this relate to?
     - What toolchain (name + version) are you using?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 <!-- 
     Required
     Add here detailed changes summary, testing results, dependencies 
-    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
+    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
 -->
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Mbed OS is an open-source, device software platform for the Internet of Things. Contributions are an important part of the platform, and our goal is to make it as simple as possible to become a contributor.
 
-To encourage productive collaboration, as well as robust, consistent and maintainable code, we have a set of guidelines for [contributing to Mbed OS](https://os.mbed.com/docs/latest/reference/contributing.html).
+To encourage productive collaboration, as well as robust, consistent and maintainable code, we have a set of guidelines for [contributing to Mbed OS](https://os.mbed.com/docs/mbed-os/latest/contributing/index.html).

--- a/UNITTESTS/README.md
+++ b/UNITTESTS/README.md
@@ -32,7 +32,7 @@ In a terminal window:
    sudo easy_install pip
    ```
 
-1. Install Gcovr and [Mbed CLI](https://os.mbed.com/docs/latest/tools/developing-arm-mbed-cli.html) with `pip install "gcovr>=4.1" mbed-cli`.
+1. Install Gcovr and [Mbed CLI](https://os.mbed.com/docs/mbed-os/latest/tools/developing-mbed-cli.html) with `pip install "gcovr>=4.1" mbed-cli`.
 
 #### Installing dependencies on macOS
 
@@ -48,7 +48,7 @@ In a terminal window:
    sudo easy_install pip
    ```
 
-1. Install Gcovr and [Mbed CLI](https://os.mbed.com/docs/latest/tools/developing-arm-mbed-cli.html) with `pip install "gcovr>=4.1" mbed-cli`.
+1. Install Gcovr and [Mbed CLI](https://os.mbed.com/docs/mbed-os/latest/tools/developing-mbed-cli.html) with `pip install "gcovr>=4.1" mbed-cli`.
 1. (Optional) Install GCC with `brew install gcc`.
 
 #### Installing dependencies on Windows
@@ -59,7 +59,7 @@ In a terminal window:
 1. Download CMake binaries from https://cmake.org/download/, and run the installer.
 1. Download Python 2.7 or Python 3 from https://www.python.org/getit/, and run the installer.
 1. Add MinGW, CMake and Python into system PATH.
-1. Install Gcovr and [Mbed CLI](https://os.mbed.com/docs/latest/tools/developing-arm-mbed-cli.html) with `pip install "gcovr>=4.1" mbed-cli`.
+1. Install Gcovr and [Mbed CLI](https://os.mbed.com/docs/mbed-os/latest/tools/developing-mbed-cli.html) with `pip install "gcovr>=4.1" mbed-cli`.
 
 ### Test code structure
 
@@ -79,7 +79,7 @@ The build system automatically generates names of test suites. The name is const
 
 ### Unit testing with Mbed CLI
 
-Mbed CLI supports unit tests through the `mbed test --unittests` command. For information on using Mbed CLI, please see the [CLI documentation](https://os.mbed.com/docs/latest/tools/developing-arm-mbed-cli.html).
+Mbed CLI supports unit tests through the `mbed test --unittests` command. For information on using Mbed CLI, please see the [CLI documentation](https://os.mbed.com/docs/mbed-os/latest/tools/developing-mbed-cli.html).
 
 ### Writing unit tests
 


### PR DESCRIPTION
### Description

Various URLs in the markdown documentation and github templates return 404 since https://os.mbed.com/docs/latest redirects to https://os.mbed.com/docs/mbed-os/v5.11 now. Fix the URLs to point to the updated locations.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnotherButler 