### PR TITLE
ESP8266: calls MBED_ERROR if modem's watchdog reset gets triggered

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -959,13 +959,8 @@ bool ESP8266::_recv_ap(nsapi_wifi_ap_t *ap)
 
 void ESP8266::_oob_watchdog_reset()
 {
-    for (int i = 0; i < SOCKET_COUNT; i++) {
-        _sock_i[i].open = false;
-    }
-
-    // Makes possible to reinitialize
-    _conn_status = NSAPI_STATUS_ERROR_UNSUPPORTED;
-    _conn_stat_cb();
+    MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_ETIME), \
+               "_oob_watchdog_reset() modem watchdog reset triggered\n");
 }
 
 void ESP8266::_oob_busy()


### PR DESCRIPTION
### Description
ESP8266: calls MBED_ERROR if modem's watchdog reset gets triggered. Addresses the issue #9425

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@kjbracey-arm 
@michalpasztamobica 

