### PR TITLE
Fix valgrind defects from cellular

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -112,7 +112,6 @@ TEST_F(TestATHandler, test_ATHandler_list)
     EXPECT_TRUE(at1->close() == NSAPI_ERROR_OK);
     EXPECT_TRUE(at2->get_ref_count() == 1);
     EXPECT_TRUE(at2->close() == NSAPI_ERROR_OK);
-    EXPECT_TRUE(at1->close() == NSAPI_ERROR_PARAMETER);
 
     ATHandler::set_at_timeout_list(1000, false);
     ATHandler::set_debug_list(false);

--- a/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
+++ b/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
@@ -138,8 +138,7 @@ TEST_F(Testutil, prefer_ipv6)
 
 TEST_F(Testutil, separate_ip_addresses)
 {
-    char *s = (char *)malloc(128);
-
+    char s[128] = {'\0'};
     char ip[64] = {0};
     char subnet[64] = {0};
 

--- a/UNITTESTS/features/cellular/framework/device/cellulardevice/cellulardevicetest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellulardevice/cellulardevicetest.cpp
@@ -184,11 +184,11 @@ TEST_F(TestCellularDevice, test_get_context_list)
     CellularContext *ctx = dev->create_context();
     EXPECT_TRUE(dev->get_context_list());
     delete dev;
-    dev = NULL;
 
     dev = new myCellularDevice(&fh1);
     EXPECT_TRUE(dev);
     EXPECT_FALSE(dev->get_context_list());
+    delete dev;
 }
 
 TEST_F(TestCellularDevice, test_stop)

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -51,11 +51,11 @@ int ATHandler_stub::int_count = kRead_int_table_size;
 bool ATHandler_stub::process_oob_urc = false;
 
 int ATHandler_stub::read_string_index = kRead_string_table_size;
-const char *ATHandler_stub::read_string_table[kRead_string_table_size];
+const char *ATHandler_stub::read_string_table[kRead_string_table_size] = {'\0'};
 int ATHandler_stub::resp_stop_success_count = kResp_stop_count_default;
 int ATHandler_stub::urc_amount = 0;
 mbed::Callback<void()> ATHandler_stub::callback[kATHandler_urc_table_max_size];
-char *ATHandler_stub::urc_string_table[kATHandler_urc_table_max_size];
+char *ATHandler_stub::urc_string_table[kATHandler_urc_table_max_size] = {'\0'};
 
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const char *output_delimiter, uint16_t send_delay) :
     _nextATHandler(0),

--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -24,7 +24,6 @@ const int DEFAULT_AT_TIMEOUT = 1000;
 
 using namespace mbed;
 
-
 int AT_CellularDevice_stub::failure_count = 0;
 nsapi_error_t AT_CellularDevice_stub::nsapi_error_value = 0;
 int AT_CellularDevice_stub::init_module_failure_count = 0;
@@ -33,8 +32,7 @@ int AT_CellularDevice_stub::get_sim_failure_count = 0;
 bool AT_CellularDevice_stub::pin_needed = false;
 
 AT_CellularDevice::AT_CellularDevice(FileHandle *fh) : CellularDevice(fh), _network(0), _sms(0),
-    _information(0), _context_list(0), _default_timeout(DEFAULT_AT_TIMEOUT),
-    _modem_debug_on(false)
+    _information(0), _context_list(0), _default_timeout(DEFAULT_AT_TIMEOUT), _modem_debug_on(false)
 {
 }
 
@@ -77,7 +75,13 @@ void delete_context(CellularContext *context)
 
 CellularNetwork *AT_CellularDevice::open_network(FileHandle *fh)
 {
-    return new AT_CellularNetwork(*ATHandler::get_instance(fh, _queue, _default_timeout, "\r", get_send_delay(), _modem_debug_on));
+    _network = new AT_CellularNetwork(*ATHandler::get_instance(fh,
+                                                               _queue,
+                                                               _default_timeout,
+                                                               "\r",
+                                                               get_send_delay(),
+                                                               _modem_debug_on));
+    return _network;
 }
 
 CellularSMS *AT_CellularDevice::open_sms(FileHandle *fh)
@@ -92,6 +96,9 @@ CellularInformation *AT_CellularDevice::open_information(FileHandle *fh)
 
 void AT_CellularDevice::close_network()
 {
+    delete _network;
+
+    _network = NULL;
 }
 
 void AT_CellularDevice::close_sms()
@@ -123,7 +130,9 @@ void AT_CellularDevice::delete_context(CellularContext *context)
 
 AT_CellularNetwork *AT_CellularDevice::open_network_impl(ATHandler &at)
 {
-    return new AT_CellularNetwork(at);
+    _network = new AT_CellularNetwork(at);
+
+    return _network;
 }
 
 AT_CellularSMS *AT_CellularDevice::open_sms_impl(ATHandler &at)

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -599,13 +599,11 @@ int32_t ATHandler::read_int()
     }
 
     char buff[BUFF_SIZE];
-    char *first_no_digit;
-
-    if (read_string(buff, (size_t)sizeof(buff)) == 0) {
+    if (read_string(buff, sizeof(buff)) == 0) {
         return -1;
     }
 
-    return std::strtol(buff, &first_no_digit, 10);
+    return std::strtol(buff, NULL, 10);
 }
 
 void ATHandler::set_delimiter(char delimiter)
@@ -1211,8 +1209,9 @@ void ATHandler::debug_print(const char *p, int len)
 #if MBED_CONF_MBED_TRACE_ENABLE
         mbed_cellular_trace::mutex_wait();
 #endif
+        char c;
         for (ssize_t i = 0; i < len; i++) {
-            char c = *p++;
+            c = *p++;
             if (!isprint(c)) {
                 if (c == '\r') {
                     debug("\n");

--- a/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
@@ -1,5 +1,6 @@
 personal_ws-1.1 en 1600 utf-8
 _code_
+unconfigured
 mbed
 rtos
 malloc


### PR DESCRIPTION
### Description

    Fixed cellular unit tests regarding valgrind reported memory leaks.

    Test coverage includes unit tests on CI and on-target cellular tests on MTB_MTS_DRAGONFLY target 
     with GCC_ARM. No new failures (the existing one still fails in master)

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x ] Test update
    [ ] Breaking change

### Reviewers

