### PR TITLE
Improve PSoC 6 post-build hooks, whitelist makefile export

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7837,12 +7837,11 @@
     },
     "FUTURE_SEQUANA": {
         "inherits": ["MCU_PSOC6_M4"],
-        "sub_target": "FUTURE_SEQUANA_M0",
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["CY8C63XX", "CORDIO"],
         "macros_add": ["CY8C6347BZI_BLD53"],
         "detect_code": ["6000"],
-        "m0_core_img": "psoc63_m0_default_1.02.hex",
+        "hex_filename": "psoc63_m0_default_1.02.hex",
         "post_binary_hook": {
             "function": "PSOC6Code.complete"
         },
@@ -7892,12 +7891,11 @@
     },
     "FUTURE_SEQUANA_PSA": {
         "inherits": ["NSPE_Target", "FUTURE_SEQUANA"],
-        "sub_target": "FUTURE_SEQUANA_M0_PSA",
         "extra_labels_add": ["PSA"],
         "extra_labels_remove": ["CORDIO"],
         "components_add": ["SPM_MAILBOX"],
         "macros_add": ["PSOC6_DYNSRM_DISABLE=1", "MBEDTLS_PSA_CRYPTO_C"],
-        "m0_core_img": "psa_release_1.0.hex",
+        "hex_filename": "psa_release_1.0.hex",
         "overrides": {
             "secure-rom-start": "0x10000000",
             "secure-rom-size": "0x80000",

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -54,7 +54,8 @@ class Makefile(Exporter):
         "MCU_NRF51Code.binary_hook",
         "TEENSY3_1Code.binary_hook",
         "LPCTargetCode.lpc_patch",
-        "LPC4088Code.binary_hook"
+        "LPC4088Code.binary_hook",
+        "PSOC6Code.complete"
     ])
 
     @classmethod
@@ -83,6 +84,11 @@ class Makefile(Exporter):
         sys_libs = [self.prepare_sys_lib(lib) for lib
                     in self.toolchain.sys_libs]
 
+        hex_files = self.resources.hex_files
+        if hasattr(self.toolchain.target, 'hex_filename'):
+            hex_filename = self.toolchain.target.hex_filename
+            hex_files = list(f for f in hex_files if basename(f) == hex_filename)
+
         ctx = {
             'name': self.project_name,
             'to_be_compiled': to_be_compiled,
@@ -92,7 +98,7 @@ class Makefile(Exporter):
             'linker_script': self.resources.linker_script,
             'libraries': libraries,
             'ld_sys_libs': sys_libs,
-            'hex_files': self.resources.hex_files,
+            'hex_files': hex_files,
             'vpath': (["../../.."]
                       if (basename(dirname(dirname(self.export_dir)))
                           == "projectfiles")

--- a/tools/targets/PSOC6.py
+++ b/tools/targets/PSOC6.py
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2017-2018 Future Electronics
+# Copyright (c) 2018-2019 Cypress Semiconductor Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -114,18 +115,18 @@ def complete_func(message_func, elf0, hexf0, hexf1=None, dest=None):
     ihex.write_hex_file(dest if dest else hexf0, write_start_addr=False, byte_count=64)
 
 # Find Cortex M0 image.
-def find_cm0_image(toolchain, resources, elf, hexf):
+def find_cm0_image(toolchain, resources, elf, hexf, hex_filename):
     # Locate user-specified image
     from tools.resources import FileType
     hex_files = resources.get_file_paths(FileType.HEX)
-    m0hexf = next((f for f in hex_files if os.path.basename(f) == toolchain.target.m0_core_img), None)
+    m0hexf = next((f for f in hex_files if os.path.basename(f) == hex_filename), None)
     if toolchain.target.name.endswith('_PSA'):
         m0hexf = next((f for f in hex_files if os.path.basename(f) == os.path.basename(hexf)), m0hexf)
 
     if m0hexf:
         toolchain.notify.debug("M0 core image file found: %s." % os.path.basename(m0hexf))
     else:
-        toolchain.notify.debug("M0 core hex image file %s not found. Aborting." % toolchain.target.m0_core_img)
+        toolchain.notify.debug("M0 core hex image file %s not found. Aborting." % hex_filename)
         raise ConfigException("Required M0 core hex image not found.")
 
     return m0hexf

--- a/tools/targets/PSOC6.py
+++ b/tools/targets/PSOC6.py
@@ -26,7 +26,6 @@ from intelhex import IntelHex
 from intelhex.compat import asbytes
 
 from ..config import ConfigException
-from ..targets import HookError
 
 
 # Patch Cypress hex file:
@@ -76,14 +75,8 @@ def merge_images(hexf0, hexf1=None):
     ihex.padding = 0x00
     ihex.loadfile(hexf0, "hex")
     if  hexf1 is not None:
-        # get chip ID from metadata and compare
+        # Merge the CM0+ image
         ihex1 = IntelHex(hexf1)
-        type0 = ihex.tobinarray(start=0x90500002, size=4)
-        type1 = ihex1.tobinarray(start=0x90500002, size=4)
-        if type0 != type1:
-            raise HookError(
-                "Incompatible processor type: %s in '%s' and 0x%s in '%s'"
-                 % (hexf0, type0, hexf1, type1))
         ihex.merge(ihex1, 'ignore')
     return ihex
 

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -583,10 +583,11 @@ class PSOC6Code:
     @staticmethod
     def complete(t_self, resources, elf, binf):
         from tools.targets.PSOC6 import complete as psoc6_complete
-        if hasattr(t_self.target, "sub_target"):
+        if hasattr(t_self.target, "hex_filename"):
+            hex_filename = t_self.target.hex_filename
             # Completing main image involves merging M0 image.
             from tools.targets.PSOC6 import find_cm0_image
-            m0hexf = find_cm0_image(t_self, resources, elf, binf)
+            m0hexf = find_cm0_image(t_self, resources, elf, binf, hex_filename)
             psoc6_complete(t_self, elf, binf, m0hexf)
         else:
             psoc6_complete(t_self, elf, binf)


### PR DESCRIPTION
### Description

Various improvements to the Cypress PSoC 6 post-build python hooks that bring compatibility with Cypress PSoC 6 boards (pull request pending). The fixes have no functional impact on FUTURE_SEQUANA port and enable export to makefile of PSoC 6 targeting projects.

This pull request addresses some review feedback from #8491 related to hex file discovery in the exported projects.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@theotherjimmy @lrusinowicz @orenc17 