### PR TITLE
ESP8266: treats reset-ready-message as OOB

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -187,6 +187,7 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
     bool done = true;
 
 #if DEVICE_SERIAL_FC
+    _smutex.lock();
     if (_serial_rts != NC && _serial_cts != NC) {
         // Start ESP8266's flow control
         done = _parser.send("AT+UART_CUR=%u,8,1,0,3", ESP8266_DEFAULT_BAUD_RATE)
@@ -212,6 +213,11 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
         if (done) {
             _serial.set_flow_control(SerialBase::CTS, NC, _serial_cts);
         }
+    }
+    _smutex.unlock();
+
+    if (!done) {
+        tr_debug("Enable UART HW flow control: FAIL");
     }
 #else
     if (_serial_rts != NC || _serial_cts != NC) {

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -74,7 +74,7 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
     _parser.oob("UNLINK", callback(this, &ESP8266::_oob_socket_close_err));
     _parser.oob("ALREADY CONNECTED", callback(this, &ESP8266::_oob_conn_already));
     _parser.oob("ERROR", callback(this, &ESP8266::_oob_err));
-    _parser.oob("ready", callback(this, &ESP8266::_oob_reset));
+    _parser.oob("ready", callback(this, &ESP8266::_oob_ready));
     // Don't expect to find anything about the watchdog reset in official documentation
     //https://techtutorialsx.com/2017/01/21/esp8266-watchdog-functions/
     _parser.oob("wdt reset", callback(this, &ESP8266::_oob_watchdog_reset));
@@ -978,7 +978,7 @@ void ESP8266::_oob_watchdog_reset()
                "_oob_watchdog_reset() modem watchdog reset triggered\n");
 }
 
-void ESP8266::_oob_reset()
+void ESP8266::_oob_ready()
 {
 
     _rmutex.lock();

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -188,12 +188,14 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
 
 #if DEVICE_SERIAL_FC
     if (_serial_rts != NC && _serial_cts != NC) {
-       // Start board's flow control
-        _serial.set_flow_control(SerialBase::RTSCTS, _serial_rts, _serial_cts);
-
         // Start ESP8266's flow control
         done = _parser.send("AT+UART_CUR=%u,8,1,0,3", ESP8266_DEFAULT_BAUD_RATE)
                && _parser.recv("OK\n");
+
+        if (done) {
+            // Start board's flow control
+             _serial.set_flow_control(SerialBase::RTSCTS, _serial_rts, _serial_cts);
+        }
 
     } else if (_serial_rts != NC) {
         _serial.set_flow_control(SerialBase::RTS, _serial_rts, NC);
@@ -207,7 +209,9 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
         done = _parser.send("AT+UART_CUR=%u,8,1,0,1", ESP8266_DEFAULT_BAUD_RATE)
                && _parser.recv("OK\n");
 
-        _serial.set_flow_control(SerialBase::CTS, NC, _serial_cts);
+        if (done) {
+            _serial.set_flow_control(SerialBase::CTS, NC, _serial_cts);
+        }
     }
 #else
     if (_serial_rts != NC || _serial_cts != NC) {

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -27,6 +27,7 @@
 #include "platform/ATCmdParser.h"
 #include "platform/Callback.h"
 #include "platform/mbed_error.h"
+#include "rtos/ConditionVariable.h"
 #include "rtos/Mutex.h"
 
 // Various timeouts for different ESP8266 operations
@@ -396,6 +397,7 @@ private:
     PinName _serial_rts;
     PinName _serial_cts;
     rtos::Mutex _smutex; // Protect serial port access
+    rtos::Mutex _rmutex; // Reset protection
 
     // AT Command Parser
     mbed::ATCmdParser _parser;
@@ -435,6 +437,7 @@ private:
     void _oob_watchdog_reset();
     void _oob_busy();
     void _oob_tcp_data_hdlr();
+    void _oob_reset();
 
     // OOB state variables
     int _connect_error;
@@ -444,6 +447,8 @@ private:
     bool _closed;
     bool _error;
     bool _busy;
+    rtos::ConditionVariable _reset_check;
+    bool _reset_done;
 
     // Modem's address info
     char _ip_buffer[16];

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -437,7 +437,7 @@ private:
     void _oob_watchdog_reset();
     void _oob_busy();
     void _oob_tcp_data_hdlr();
-    void _oob_reset();
+    void _oob_ready();
 
     // OOB state variables
     int _connect_error;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -577,6 +577,10 @@ int ESP8266Interface::socket_send(void *handle, const void *data, unsigned size)
         return NSAPI_ERROR_NO_SOCKET;
     }
 
+    if (!_sock_i[socket->id].open) {
+        return NSAPI_ERROR_CONNECTION_LOST;
+    }
+
     if (!size) {
         // Firmware limitation
         return socket->proto == NSAPI_TCP ? 0 : NSAPI_ERROR_UNSUPPORTED;
@@ -602,6 +606,10 @@ int ESP8266Interface::socket_recv(void *handle, void *data, unsigned size)
 
     if (!socket) {
         return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if (!_sock_i[socket->id].open) {
+        return NSAPI_ERROR_CONNECTION_LOST;
     }
 
     int32_t recv;
@@ -791,6 +799,10 @@ void ESP8266Interface::update_conn_state_cb()
         default:
             _initialized = false;
             _conn_stat = NSAPI_STATUS_DISCONNECTED;
+            for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
+                _sock_i[i].open = false;
+                _sock_i[i].sport = 0;
+            }
     }
 
     // Inform upper layers

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -365,10 +365,10 @@ private:
 
     // Driver's state
     int _initialized;
+    nsapi_error_t _connect_retval;
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
-    void _hw_reset();
-    nsapi_error_t _connect_retval;
+    nsapi_error_t _reset();
 
     //sigio
     struct {

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -328,7 +328,7 @@ protected:
 private:
     // AT layer
     ESP8266 _esp;
-    void update_conn_state_cb();
+    void refresh_conn_state_cb();
 
     // HW reset pin
     class ResetPin {


### PR DESCRIPTION
### Description
Makes possible to detect if modem gets reset by handling the reset-ready-message as OOB.

Fixes the network status update callback to not report a state change if a state change hasn't really occurred.

Prevent's running reset twice in a row if reset pin is connected to a known pin.

Fixes UART HW flow control enabling sequence - adds also mutex.


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@michalpasztamobica 
@kjbracey-arm 


