### PR TITLE
FlashIAP Block device: Assert if default constructor is used without setting config parameters

### DIFF
--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -18,6 +18,7 @@
 
 #include "FlashIAPBlockDevice.h"
 #include "mbed_critical.h"
+#include "mbed_error.h"
 
 using namespace mbed;
 #include <inttypes.h>
@@ -38,7 +39,10 @@ using namespace mbed;
 FlashIAPBlockDevice::FlashIAPBlockDevice(uint32_t address, uint32_t size)
     : _flash(), _base(address), _size(size), _is_initialized(false), _init_ref_count(0)
 {
-
+    if ((address == 0xFFFFFFFF) || (size == 0)) {
+        MBED_ERROR(MBED_ERROR_INVALID_ARGUMENT,
+                   "Base address and size need to be set in flashiap-block-device configuration in order to use default constructor");
+    }
 }
 
 FlashIAPBlockDevice::~FlashIAPBlockDevice()


### PR DESCRIPTION
### Description
FlashIAP block device's constructor has two parameters - base address and size (of the block device). Their default values are taken from the configuration, making it function as a default constructor. This PR produces an error if default constructor is used with unchanged config values (which are illegal).
Resolves #9468.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@tommikas 

