### PR TITLE
Asynchronous Serial API fixes and refactoring

### DIFF
--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -179,57 +179,85 @@ public:
 
 #if DEVICE_SERIAL_ASYNCH
 
-    /** Begin asynchronous write using 8bit buffer. The completion invokes registered TX event callback
+    /** Begin asynchronous write using 8bit buffer.
      *
-     *  This function locks the deep sleep until any event has occurred
+     *  The write operation ends with any of the enabled events and invokes
+     *  registered callback function (which can be NULL to not receive callback at all).
+     *  Events that are not enabled by event argument are simply ignored.
+     *  Operation has to be ended explicitly by calling abort_write() when
+     *  no events are enabled.
+     *  This function locks the deep sleep until any event has occurred.
      *
      *  @param buffer   The buffer where received data will be stored
      *  @param length   The buffer length in bytes
      *  @param callback The event callback function
-     *  @param event    The logical OR of TX events
+     *  @param event    The logical OR of TX events that should end operation
+     *  @return Zero if new transaction was started, -1 if transaction is already on-going
      */
     int write(const uint8_t *buffer, int length, const event_callback_t &callback, int event = SERIAL_EVENT_TX_COMPLETE);
 
-    /** Begin asynchronous write using 16bit buffer. The completion invokes registered TX event callback
+    /** Begin asynchronous write using 16bit buffer.
      *
-     *  This function locks the deep sleep until any event has occurred
+     *  The write operation ends with any of the enabled events and invokes
+     *  registered callback function (which can be NULL to not receive callback at all).
+     *  Events that are not enabled by event argument are simply ignored.
+     *  Operation has to be ended explicitly by calling abort_write() when
+     *  no events are enabled.
+     *  This function locks the deep sleep until any event has occurred.
      *
      *  @param buffer   The buffer where received data will be stored
      *  @param length   The buffer length in bytes
      *  @param callback The event callback function
-     *  @param event    The logical OR of TX events
+     *  @param event    The logical OR of TX events that should end operation
+     *  @return Zero if new transaction was started, -1 if transaction is already on-going
      */
     int write(const uint16_t *buffer, int length, const event_callback_t &callback, int event = SERIAL_EVENT_TX_COMPLETE);
 
     /** Abort the on-going write transfer
+     *
+     *  It is safe to call abort_write() when there is no on-going transaction.
      */
     void abort_write();
 
-    /** Begin asynchronous reading using 8bit buffer. The completion invokes registered RX event callback.
+    /** Begin asynchronous reading using 8bit buffer.
      *
-     *  This function locks the deep sleep until any event has occurred
+     *  The read operation ends with any of the enabled events and invokes registered
+     *  callback function (which can be NULL to not receive callback at all).
+     *  Events that are not enabled by event argument are simply ignored.
+     *  Operation has to be ended explicitly by calling abort_read() when
+     *  no events are enabled.
+     *  This function locks the deep sleep until any event has occurred.
      *
      *  @param buffer     The buffer where received data will be stored
      *  @param length     The buffer length in bytes
      *  @param callback   The event callback function
-     *  @param event      The logical OR of RX events
+     *  @param event      The logical OR of RX events that should end operation
      *  @param char_match The matching character
+     *  @return Zero if new transaction was started, -1 if transaction is already on-going
      */
     int read(uint8_t *buffer, int length, const event_callback_t &callback, int event = SERIAL_EVENT_RX_COMPLETE, unsigned char char_match = SERIAL_RESERVED_CHAR_MATCH);
 
-    /** Begin asynchronous reading using 16bit buffer. The completion invokes registered RX event callback.
+    /** Begin asynchronous reading using 16bit buffer.
      *
-     *  This function locks the deep sleep until any event has occurred
+     *  The read operation ends with any of the enabled events and invokes registered
+     *  callback function (which can be NULL to not receive callback at all).
+     *  Events that are not enabled by event argument are simply ignored.
+     *  Operation has to be ended explicitly by calling abort_read() when
+     *  no events are enabled.
+     *  This function locks the deep sleep until any event has occurred.
      *
      *  @param buffer     The buffer where received data will be stored
      *  @param length     The buffer length in bytes
      *  @param callback   The event callback function
-     *  @param event      The logical OR of RX events
+     *  @param event      The logical OR of RX events that should end operation
      *  @param char_match The matching character
+     *  @return Zero if new transaction was started, -1 if transaction is already on-going
      */
     int read(uint16_t *buffer, int length, const event_callback_t &callback, int event = SERIAL_EVENT_RX_COMPLETE, unsigned char char_match = SERIAL_RESERVED_CHAR_MATCH);
 
     /** Abort the on-going read transfer
+     *
+     *  It is safe to call abort_read() when there is no on-going transaction.
      */
     void abort_read();
 

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -269,6 +269,8 @@ protected:
     DMAUsage _rx_usage;
     event_callback_t _tx_callback;
     event_callback_t _rx_callback;
+    bool _tx_asynch_set;
+    bool _rx_asynch_set;
 #endif
 
     serial_t         _serial;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

1. As RX and TX flows are separate on Serial device, read and write
   functionalities should be completely separate, including any deep
   sleep locking etc.
2. Aborting of asynchronous operation is necessarily hazardous, as
   operation can end in interrupt anywhere from the point of decision
   until it is actually aborted down the abort_...() method.
   Proper deep sleep unlocking requires then use of the critical
   section and should be contained completely within API implementation.
3. Because of point 2, API user should be able to call abort_..()
   operation independently of whether the operation is pending or not.
4. User may want to use asynchronous API without a callback (especially
   for write operations), for example in a command-response scheme
   end of write operation is usually meaningless. The intuitive
   method is to submit NULL pointer for a callback. For this reason
   depending on the _callback field in determining whether the
   operation is in progress seems to be uncertain.
5. Updated API documentation to cover above issues and to explicitly
   point out that any event ends the operation.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
 
<!-- 
    Optional
    Request additional reviewers with @username
-->

@0xc0170 