### PR TITLE
 Correct the floating options for Cortex-M7 and Cortex-M4

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/system_M2351.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/system_M2351.h
@@ -130,19 +130,6 @@ extern void SystemInit(void);
 extern void SystemCoreClockUpdate(void);
 
 
-
-
-#if defined (__ICCARM__)
-uint32_t __TZ_get_PSP_NS(void);
-void __TZ_set_PSP_NS(uint32_t topOfProcStack);
-int32_t __TZ_get_MSP_NS(void);
-void __TZ_set_MSP_NS(uint32_t topOfMainStack);
-uint32_t __TZ_get_PRIMASK_NS(void);
-void __TZ_set_PRIMASK_NS(uint32_t priMask);
-#endif
-
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -341,5 +341,8 @@
         "GBECoreSlave": 39,
         "FPU2": 6,
         "GFPUCoreSlave2": 39
+    },
+    "M2351KIAAEES": {
+        "OGChipSelectEditMenu": "M2351\tNuvoton M2351"
     }
 }

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -47,10 +47,12 @@ class IAR(mbedToolchain):
                                build_profile=build_profile)
         if target.core == "Cortex-M7F" or target.core == "Cortex-M7FD":
             cpuchoice = "Cortex-M7"
-        elif target.core.startswith("Cortex-M23"):
-            cpuchoice = "8-M.baseline"
+        elif target.core.startswith("Cortex-M33FD"):
+            cpuchoice = "Cortex-M33"
         elif target.core.startswith("Cortex-M33"):
-            cpuchoice = "8-M.mainline"
+            cpuchoice = "Cortex-M33.no_dsp"
+        elif target.core.startswith("Cortex-M23"):
+            cpuchoice = "Cortex-M23"
         else:
             cpuchoice = target.core
 
@@ -74,12 +76,15 @@ class IAR(mbedToolchain):
         elif target.core == "Cortex-M7F":
             asm_flags_cmd += ["--fpu", "VFPv5_sp"]
             c_flags_cmd.append("--fpu=VFPv5_sp")
-        elif target.core == "Cortex-M23" or target.core == "Cortex-M33" or target.core == "Cortex-M33F":
-            self.flags["asm"] += ["--cmse"]
-            self.flags["common"] += ["--cmse"]
+        elif target.core.startswith("Cortex-M33F"):
+            asm_flags_cmd += ["--fpu", "VFPv5_sp"]
+            c_flags_cmd.append("--fpu=VFPv5_sp")
 
         # Create Secure library
-        if target.core == "Cortex-M23" or self.target.core == "Cortex-M33" or self.target.core == "Cortex-M33F":
+        if ((target.core.startswith("Cortex-M23") or target.core.startswith("Cortex-M33"))
+            and not target.core.endswith("-NS")):
+            self.flags["asm"] += ["--cmse"]
+            self.flags["common"] += ["--cmse"]
             secure_file = join(build_dir, "cmse_lib.o")
             self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -19,6 +19,7 @@ from os import remove
 from os.path import join, splitext, exists
 from distutils.version import LooseVersion
 
+from tools.targets import CORE_ARCH
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 from tools.utils import run_cmd, NotSupportedException
@@ -81,8 +82,7 @@ class IAR(mbedToolchain):
             c_flags_cmd.append("--fpu=VFPv5_sp")
 
         # Create Secure library
-        if ((target.core.startswith("Cortex-M23") or target.core.startswith("Cortex-M33"))
-            and not target.core.endswith("-NS")):
+        if CORE_ARCH[target.core] == 8 and not target.core.endswith("-NS"):
             self.flags["asm"] += ["--cmse"]
             self.flags["common"] += ["--cmse"]
             secure_file = join(build_dir, "cmse_lib.o")

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -46,8 +46,10 @@ class IAR(mbedToolchain):
                  build_dir=None):
         mbedToolchain.__init__(self, target, notify, macros, build_dir=build_dir,
                                build_profile=build_profile)
-        if target.core == "Cortex-M7F" or target.core == "Cortex-M7FD":
-            cpuchoice = "Cortex-M7"
+        if target.core == "Cortex-M7FD":
+            cpuchoice = "Cortex-M7.fp.dp"
+        elif target.core == "Cortex-M7F":
+            cpuchoice = "Cortex-M7.fp.sp"
         elif target.core.startswith("Cortex-M33FD"):
             cpuchoice = "Cortex-M33.fp"
         elif target.core.startswith("Cortex-M33F"):
@@ -73,12 +75,6 @@ class IAR(mbedToolchain):
         cxx_flags_cmd = [
             "--c++", "--no_rtti", "--no_exceptions"
         ]
-        if target.core == "Cortex-M7FD":
-            asm_flags_cmd += ["--fpu", "VFPv5"]
-            c_flags_cmd.append("--fpu=VFPv5")
-        elif target.core == "Cortex-M7F":
-            asm_flags_cmd += ["--fpu", "VFPv5_sp"]
-            c_flags_cmd.append("--fpu=VFPv5_sp")
 
         # Create Secure library
         if CORE_ARCH[target.core] == 8 and not target.core.endswith("-NS"):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -49,7 +49,9 @@ class IAR(mbedToolchain):
         if target.core == "Cortex-M7F" or target.core == "Cortex-M7FD":
             cpuchoice = "Cortex-M7"
         elif target.core.startswith("Cortex-M33FD"):
-            cpuchoice = "Cortex-M33"
+            cpuchoice = "Cortex-M33.fp"
+        elif target.core.startswith("Cortex-M33F"):
+            cpuchoice = "Cortex-M33.fp.no_dsp"
         elif target.core.startswith("Cortex-M33"):
             cpuchoice = "Cortex-M33.no_dsp"
         elif target.core.startswith("Cortex-M23"):
@@ -75,9 +77,6 @@ class IAR(mbedToolchain):
             asm_flags_cmd += ["--fpu", "VFPv5"]
             c_flags_cmd.append("--fpu=VFPv5")
         elif target.core == "Cortex-M7F":
-            asm_flags_cmd += ["--fpu", "VFPv5_sp"]
-            c_flags_cmd.append("--fpu=VFPv5_sp")
-        elif target.core.startswith("Cortex-M33F"):
             asm_flags_cmd += ["--fpu", "VFPv5_sp"]
             c_flags_cmd.append("--fpu=VFPv5_sp")
 


### PR DESCRIPTION
### Description

As per the IAR Development guide, below options for CPU are valid and separate --fpu is not needed.

1. Cortex-M4
2. Cortex-M4F
3. Cortex-M7
4. Cortex-M7.fp.dp (floating-point unit with support for double precision)
5. Cortex-M7.fp.sp (floating-point unit with support for single precision)

Commit for this PR is https://github.com/ARMmbed/mbed-os/commit/afb559b06a79044a2bd1563132e962542e872a4c

Dependent on : https://github.com/ARMmbed/mbed-os/pull/9431


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kjbracey-arm 
