### PR TITLE
ARCH_PRO: add missing SPI pin definitions

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_ARCH_PRO/PinNames.h
@@ -109,6 +109,12 @@ typedef enum {
     I2C_SCL = D15,
     I2C_SDA = D14,
 
+    //SPI Pins configuration
+    SPI_MOSI = P0_9,
+    SPI_MISO = P0_8,
+    SPI_SCK  = P0_7,
+    SPI_CS   = P0_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
### Description

Add missing SPI pin definitions to ARCH_PRO target
Change moved from `feature-hal-spec-usb-device` (https://github.com/ARMmbed/mbed-os/pull/9444) on @c1728p9 request


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-hal 
