### PR TITLE
Fix for Issue #7308 (Deep_sleep_lock Ticker.h Issue)

### DIFF
--- a/drivers/Ticker.cpp
+++ b/drivers/Ticker.cpp
@@ -53,4 +53,16 @@ void Ticker::handler()
     }
 }
 
+void Ticker::attach_us(Callback<void()> func, us_timestamp_t t)
+{
+    core_util_critical_section_enter();
+    // lock only for the initial callback setup and this is not low power ticker
+    if (!_function && _lock_deepsleep) {
+        sleep_manager_lock_deep_sleep();
+    }
+    _function = func;
+    setup(t);
+    core_util_critical_section_exit();
+}
+
 } // namespace mbed

--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -117,17 +117,7 @@ public:
      *  for threads scheduling.
      *
      */
-    void attach_us(Callback<void()> func, us_timestamp_t t)
-    {
-        core_util_critical_section_enter();
-        // lock only for the initial callback setup and this is not low power ticker
-        if (!_function && _lock_deepsleep) {
-            sleep_manager_lock_deep_sleep();
-        }
-        _function = func;
-        setup(t);
-        core_util_critical_section_exit();
-    }
+    void attach_us(Callback<void()> func, us_timestamp_t t);
 
     /** Attach a member function to be called by the Ticker, specifying the interval in microseconds
      *


### PR DESCRIPTION
### Description

Provide fix for issue #7308.

Code used to reproduce the issue:

```
void test()
{
    Ticker ticker;

    ticker.attach_us(callback(stop_gtimer_set_flag), 1000);
    while (!ticker_callback_flag);
    ticker.detach();
}
```
Test has been built with `MBED_SLEEP_TRACING_ENABLED` flag. Usage of `Ticker` should result in locking deep sleep.

Results on master without fix:
```
[1548322380.64][CONN][INF] found KV pair in stream: {{__testcase_name;Test}}, queued...
[1548322380.71][CONN][RXD] >>> Running case #1: 'Test'...
[1548322380.78][CONN][INF] found KV pair in stream: {{__testcase_start;Test}}, queued...
-> [1548322380.83][CONN][RXD] LOCK: Ticker.h, ln: 125, lock count: 1
-> [1548322380.89][CONN][RXD] Unlocking sleep for driver that was not previously locked: Ticker.cpp, ln: 32
[1548322380.97][CONN][INF] found KV pair in stream: {{__testcase_finish;Test;1;0}}, queued...
```

Results with this fix:

```
[1548322463.11][CONN][INF] found KV pair in stream: {{__testcase_name;Test}}, queued...
[1548322463.18][CONN][RXD] >>> Running case #1: 'Test'...
[1548322463.24][CONN][INF] found KV pair in stream: {{__testcase_start;Test}}, queued...
-> [1548322463.28][CONN][RXD] LOCK: Ticker.cpp, ln: 61, lock count: 1
-> [1548322463.32][CONN][RXD] UNLOCK: Ticker.cpp, ln: 32, lock count: 0
[1548322463.39][CONN][INF] found KV pair in stream: {{__testcase_finish;Test;1;0}}, queued...
```

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
