### PR TITLE
Initialize platform in trng test

### DIFF
--- a/TESTS/mbed_hal/trng/main.cpp
+++ b/TESTS/mbed_hal/trng/main.cpp
@@ -43,6 +43,8 @@
 #include "base64b.h"
 #include "pithy.h"
 #include <stdio.h>
+#include "mbedtls/config.h"
+#include "mbedtls/platform.h"
 
 #if !DEVICE_TRNG
 #error [NOT_SUPPORTED] TRNG API not supported for this target
@@ -268,11 +270,17 @@ Specification specification(greentea_test_setup, cases, greentea_test_teardown_h
 
 int main()
 {
+    int ret = 0;
+#if defined(MBEDTLS_PLATFORM_C)
+    ret = mbedtls_platform_setup(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
 #if (defined(TARGET_PSA) && defined(COMPONENT_PSA_SRV_IPC) && defined(MBEDTLS_PSA_CRYPTO_C))
     inject_entropy_for_psa();
 #endif
-    bool ret = !Harness::run(specification);
-
+    ret = !Harness::run(specification);
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
     return ret;
 }
 

--- a/UNITTESTS/features/lorawan/loramaccrypto/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loramaccrypto/unittest.cmake
@@ -35,6 +35,7 @@ set(unittest-test-sources
   stubs/cipher_stub.c
   stubs/aes_stub.c
   stubs/cmac_stub.c
+  ../features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
 
 )
 

--- a/UNITTESTS/stubs/LoRaMacCrypto_stub.cpp
+++ b/UNITTESTS/stubs/LoRaMacCrypto_stub.cpp
@@ -30,6 +30,10 @@ LoRaMacCrypto::LoRaMacCrypto()
 {
 }
 
+LoRaMacCrypto::~LoRaMacCrypto()
+{
+}
+
 int LoRaMacCrypto::compute_mic(const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint32_t,
                                uint8_t dir, uint32_t, uint32_t *)
 {

--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -19,6 +19,7 @@
 #if DEVICEKEY_ENABLED
 #include "mbedtls/config.h"
 #include "mbedtls/cmac.h"
+#include "mbedtls/platform.h"
 #include "KVStore.h"
 #include "TDBStore.h"
 #include "KVMap.h"
@@ -59,15 +60,25 @@ namespace mbed {
 
 DeviceKey::DeviceKey()
 {
+
     int ret = kv_init_storage_config();
     if (ret != MBED_SUCCESS) {
         tr_error("DeviceKey: Fail to initialize KvStore configuration.");
     }
+#if defined(MBEDTLS_PLATFORM_C)
+    ret = mbedtls_platform_setup(NULL);
+    if (ret != MBED_SUCCESS) {
+        tr_error("DeviceKey: Fail in mbedtls_platform_setup.");
+    }
+#endif /* MBEDTLS_PLATFORM_C */
     return;
 }
 
 DeviceKey::~DeviceKey()
 {
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
     return;
 }
 

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
@@ -28,12 +28,26 @@
 
 #include "LoRaMacCrypto.h"
 #include "system/lorawan_data_structures.h"
+#include "mbedtls/platform.h"
 
 
 #if defined(MBEDTLS_CMAC_C) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
 
 LoRaMacCrypto::LoRaMacCrypto()
 {
+#if defined(MBEDTLS_PLATFORM_C)
+    int ret = mbedtls_platform_setup(NULL);
+    if (ret != 0) {
+        MBED_ASSERT(0 && "LoRaMacCrypto: Fail in mbedtls_platform_setup.");
+    }
+#endif /* MBEDTLS_PLATFORM_C */
+}
+
+LoRaMacCrypto::~LoRaMacCrypto()
+{
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
 }
 
 int LoRaMacCrypto::compute_mic(const uint8_t *buffer, uint16_t size,
@@ -289,6 +303,10 @@ exit:
 LoRaMacCrypto::LoRaMacCrypto()
 {
     MBED_ASSERT(0 && "[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+}
+
+LoRaMacCrypto::~LoRaMacCrypto()
+{
 }
 
 // If mbedTLS is not configured properly, these dummies will ensure that

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.h
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.h
@@ -30,6 +30,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #ifndef MBED_LORAWAN_MAC_LORAMAC_CRYPTO_H__
 #define MBED_LORAWAN_MAC_LORAMAC_CRYPTO_H__
 
+#include "mbedtls/config.h"
 #include "mbedtls/aes.h"
 #include "mbedtls/cmac.h"
 
@@ -40,6 +41,11 @@ public:
      * Constructor
      */
     LoRaMacCrypto();
+
+    /**
+     * Destructor
+     */
+    ~LoRaMacCrypto();
 
     /**
      * Computes the LoRaMAC frame MIC field

--- a/features/mbedtls/platform/src/mbed_trng.cpp
+++ b/features/mbedtls/platform/src/mbed_trng.cpp
@@ -17,17 +17,19 @@
 #if DEVICE_TRNG
 
 #include "hal/trng_api.h"
+#include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
+
+SingletonPtr<PlatformMutex> mbedtls_mutex;
 
 extern "C"
 int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen ) {
-    static PlatformMutex trng_mutex;
     trng_t trng_obj;
-    trng_mutex.lock();
+    mbedtls_mutex->lock();
     trng_init(&trng_obj);
     int ret = trng_get_bytes(&trng_obj, output, len, olen);
     trng_free(&trng_obj);
-    trng_mutex.unlock();
+    mbedtls_mutex->unlock();
     return ret;
 }
 

--- a/features/nanostack/coap-service/source/coap_security_handler.c
+++ b/features/nanostack/coap-service/source/coap_security_handler.c
@@ -102,6 +102,11 @@ static int coap_security_handler_init(coap_security_t *sec)
     const int entropy_source_type = MBEDTLS_ENTROPY_SOURCE_WEAK;
 #endif
 
+#if defined(MBEDTLS_PLATFORM_C)
+    if (mbedtls_platform_setup(NULL) != 0)
+        return -1;
+#endif /* MBEDTLS_PLATFORM_C */
+
     mbedtls_ssl_init(&sec->_ssl);
     mbedtls_ssl_config_init(&sec->_conf);
     mbedtls_ctr_drbg_init(&sec->_ctr_drbg);
@@ -153,6 +158,9 @@ static void coap_security_handler_reset(coap_security_t *sec)
     mbedtls_ctr_drbg_free(&sec->_ctr_drbg);
     mbedtls_ssl_config_free(&sec->_conf);
     mbedtls_ssl_free(&sec->_ssl);
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
 }
 
 

--- a/features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -386,3 +386,15 @@ int mbedtls_ssl_session_reset(mbedtls_ssl_context *ssl)
 
 void mbedtls_strerror( int ret, char *buf, size_t buflen ){
 }
+
+int mbedtls_platform_setup( mbedtls_platform_context *ctx )
+{
+    (void)ctx;
+
+    return( 0 );
+}
+
+void mbedtls_platform_teardown( mbedtls_platform_context *ctx )
+{
+    (void)ctx;
+}

--- a/features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.h
+++ b/features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.h
@@ -28,7 +28,7 @@
 #include "mbedtls/sha256.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/pk.h"
-
+#include "mbedtls/platform.h"
 
 
 #define HANDSHAKE_FINISHED_VALUE 8888

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_random.c
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_random.c
@@ -26,9 +26,15 @@ uint32_t arm_random_seed_get(void)
 {
     uint32_t result = 0;
 #ifdef MBEDTLS_ENTROPY_HARDWARE_ALT
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_setup(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
     /* Grab a seed from a function we provide for mbedtls */
     size_t len;
     mbedtls_hardware_poll(NULL, (uint8_t *) &result, sizeof result, &len);
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
 #endif
     return result;
 }

--- a/features/netsocket/TLSSocketWrapper.cpp
+++ b/features/netsocket/TLSSocketWrapper.cpp
@@ -23,6 +23,7 @@
 #define TRACE_GROUP "TLSW"
 #include "mbed-trace/mbed_trace.h"
 #include "mbedtls/debug.h"
+#include "mbedtls/platform.h"
 #include "mbed_error.h"
 #include "Kernel.h"
 
@@ -45,6 +46,12 @@ TLSSocketWrapper::TLSSocketWrapper(Socket *transport, const char *hostname, cont
     _clicert_allocated(false),
     _ssl_conf_allocated(false)
 {
+#if defined(MBEDTLS_PLATFORM_C)
+    int ret = mbedtls_platform_setup(NULL);
+    if (ret != 0) {
+        print_mbedtls_error("mbedtls_platform_setup()", ret);
+    }
+#endif /* MBEDTLS_PLATFORM_C */
     mbedtls_entropy_init(&_entropy);
     mbedtls_ctr_drbg_init(&_ctr_drbg);
     mbedtls_ssl_init(&_ssl);
@@ -71,6 +78,9 @@ TLSSocketWrapper::~TLSSocketWrapper()
     set_ca_chain(NULL);
 #endif
     set_ssl_config(NULL);
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
 }
 
 void TLSSocketWrapper::set_hostname(const char *hostname)

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -22,6 +22,7 @@
 
 #include "aes.h"
 #include "cmac.h"
+#include "mbedtls/platform.h"
 #include "entropy.h"
 #include "DeviceKey.h"
 #include "mbed_assert.h"
@@ -737,6 +738,12 @@ int SecureStore::init()
     MBED_ASSERT(!(scratch_buf_size % enc_block_size));
 
     _mutex.lock();
+#if defined(MBEDTLS_PLATFORM_C)
+    ret = mbedtls_platform_setup(NULL);
+    if (ret) {
+        goto fail;
+    }
+#endif /* MBEDTLS_PLATFORM_C */
 
     _entropy = new mbedtls_entropy_context;
     mbedtls_entropy_init(static_cast<mbedtls_entropy_context *>(_entropy));
@@ -775,6 +782,9 @@ int SecureStore::deinit()
     }
 
     _is_initialized = false;
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(NULL);
+#endif /* MBEDTLS_PLATFORM_C */
     _mutex.unlock();
 
     return MBED_SUCCESS;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Add calls to `mbedtls_platform_setup()` and
`mbedtls_platform_terminate()` to the trng greentea test, to
initialize the hardware acceleration engines, in some platforms.
However, this involves hal test including Mbed TLS API, which I am not sure is architecturally correct. On the other hand, `mbedtls_platform_setup()` is intended for initializing the HW acceleration engines, where needed.

This should fix IOTPART-6810

@ashok-rao Could you please check that this resolves the issue you encountered on LAIRD BL654, and if it does, please return the usage of Cryptocell in that library?

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

@ARMmbed/mbed-os-crypto 