### PR TITLE
PSOC6.py: generate hex files with 16 bytes per row

### DIFF
--- a/tools/targets/PSOC6.py
+++ b/tools/targets/PSOC6.py
@@ -91,7 +91,7 @@ def complete_func(message_func, elf0, hexf0, hexf1=None, dest=None):
     message_func("Postprocessing %s -> %s" % (elf0, hexf0))
     ihex = merge_images(hexf0, hexf1)
     patch(message_func, ihex, hexf0)
-    ihex.write_hex_file(dest if dest else hexf0, write_start_addr=False, byte_count=64)
+    ihex.write_hex_file(dest if dest else hexf0, write_start_addr=False, byte_count=16)
 
 # Find Cortex M0 image.
 def find_cm0_image(toolchain, resources, elf, hexf):


### PR DESCRIPTION
### Description

PSOC6.py post binary hook implemented for FUTURE_SEQUANA board produces Intelhex file with 64 bytes per row. ARM DAPLink implementation can handle up to 32 bytes per row ([intelhex.c](https://github.com/ARMmbed/DAPLink/blob/ad083201aea14221ef4e53063da346b5c7a4f3d1/source/daplink/drag-n-drop/intelhex.c#L43)).
Produce hex files with 16 bytes per row: this is compatible with Cypress and Future boards.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@lrusinowicz @theotherjimmy 