### PR TITLE
Allow greentea tests to be ignored from outside TESTS

### DIFF
--- a/features/storage/FEATURE_STORAGE/TESTS/cfstore/flush2/flush2.cpp
+++ b/features/storage/FEATURE_STORAGE/TESTS/cfstore/flush2/flush2.cpp
@@ -28,6 +28,7 @@
 #include "configuration_store.h"
 #include "greentea-client/test_env.h"
 #include "cfstore_test.h"
+#include "cfstore_utest.h"
 #include "cfstore_debug.h"
 
 #include <stdio.h>

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -35,7 +35,7 @@ from __future__ import print_function, division, absolute_import
 import fnmatch
 import re
 from collections import namedtuple, defaultdict
-from copy import copy
+from copy import copy, deepcopy
 from itertools import chain
 from os import walk, sep
 from os.path import (join, splitext, dirname, relpath, basename, split, normcase,
@@ -331,6 +331,10 @@ class Resources(object):
     @property
     def json_files(self):
         return self.get_file_names(FileType.JSON)
+
+    @property
+    def ignoreset(self):
+        return self._ignoreset.clone()
 
     def add_directory(
             self,

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -35,7 +35,7 @@ from __future__ import print_function, division, absolute_import
 import fnmatch
 import re
 from collections import namedtuple, defaultdict
-from copy import copy, deepcopy
+from copy import copy
 from itertools import chain
 from os import walk, sep
 from os.path import (join, splitext, dirname, relpath, basename, split, normcase,


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixes #9419. This was broken back in 5.10.0 by https://github.com/ARMmbed/mbed-os/pull/7183/commits/545553b6bc24e9f25ad9d5afd75a033db78ce7f4. It was a subtle change in a very necessary refactoring, so this just patches the regression.

The main cause of the issue is the existing ignoreset wasn't being taken into account when scanning the `TESTS` directories, so the prior information from `.mbedignore` files outside of `TESTS` directories was dropped. I've corrected this and added some accessors based on the direction of @theotherjimmy .

FYI @Alex-EEE 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

