### PR TITLE
tests-netsocket-udp UDPSOCKET_SENDTO_INVALID allow unsupported empty UDP packet

### DIFF
--- a/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
@@ -32,7 +32,12 @@ void UDPSOCKET_SENDTO_INVALID()
     TEST_ASSERT(sock.sendto(NULL, 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 0, NULL, 0) < 0);
-    TEST_ASSERT_EQUAL(0, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, NULL, 0));
+
+    nsapi_error_t result = sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, NULL, 0);
+    if (result != NSAPI_ERROR_UNSUPPORTED) {
+        TEST_ASSERT_EQUAL(0, result);
+    }
+
     TEST_ASSERT_EQUAL(5, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, "hello", 5));
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -568,6 +568,11 @@ int ESP8266Interface::socket_send(void *handle, const void *data, unsigned size)
         return NSAPI_ERROR_NO_SOCKET;
     }
 
+    if (!size) {
+        // Firmware limitation
+        return socket->proto == NSAPI_TCP ? 0 : NSAPI_ERROR_UNSUPPORTED;
+    }
+
     unsigned long int sendStartTime = rtos::Kernel::get_ms_count();
     do {
         status = _esp.send(socket->id, data, size);


### PR DESCRIPTION
### Description
With ESP8266 you can't send empty UDP packets. In case of TCP zero length causes immediate return with return value set as zero. UDP test case checking for empty packet fixed.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-ipcore 
@mirelachirica
@TeemuKultala 

