### PR TITLE
Remove yotta and minar references in NCS36510

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/NCS36510.h
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/NCS36510.h
@@ -78,12 +78,7 @@ typedef enum IRQn {
 #define __NVIC_PRIO_BITS          4         /*!< Number of Bits used for Priority Levels          */
 #define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used     */
 
-//#define YOTTA_CFG_CMSIS_NVIC_USER_IRQ_OFFSET    16
-//#define YOTTA_CFG_CMSIS_NVIC_USER_IRQ_NUMBER    20
 //#define NVIC_NUM_VECTORS     (NVIC_USER_IRQ_OFFSET + NVIC_USER_IRQ_NUMBER)
-
-//#define YOTTA_CFG_CMSIS_NVIC_RAM_VECTOR_ADDRESS
-//#define YOTTA_CFG_CMSIS_NVIC_FLASH_VECTOR_ADDRESS    0x3000
 
 #include <core_cm3.h>                       /* Cortex-M3 processor and core peripherals           */
 #include "system_NCS36510.h"                  /* System Header                                      */

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/target_config.h
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/target_config.h
@@ -30,9 +30,4 @@
 
 //#define TRANSACTION_QUEUE_SIZE_SPI   16
 
-// Minar platform configuration
-
-#define MINAR_PLATFORM_TIME_BASE 1000000
-#define MINAR_PLATFORM_MINIMUM_SLEEP 10
-
 #endif


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Doing some clean up of some old Mbed OS 3 references in this code base. The references can cause some confusion (see #6417, https://github.com/ARMmbed/mbed-os-5-docs/issues/462#issuecomment-374822169).

FYI @maclobdell 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
