### PR TITLE
Remove yotta references within testing frameworks

### DIFF
--- a/features/frameworks/greentea-client/README.md
+++ b/features/frameworks/greentea-client/README.md
@@ -55,6 +55,7 @@ For example, the `{{timeout;120}}}` string is a key-value message where the key 
 ## Test example
 
 ```c++
+#include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "utest/utest.h"
 #include "unity/unity.h"
@@ -83,7 +84,7 @@ status_t greentea_setup(const size_t number_of_cases) {
     return greentea_test_setup_handler(number_of_cases);
 }
 
-void app_start(int, char*[]) {
+void main(int, char*[]) {
     Harness::run(specification);
 }
 ```

--- a/features/frameworks/greentea-client/greentea-client/test_env.h
+++ b/features/frameworks/greentea-client/greentea-client/test_env.h
@@ -22,11 +22,7 @@
 #define GREENTEA_CLIENT_TEST_ENV_H_
 
 #ifdef __cplusplus
-#ifdef YOTTA_GREENTEA_CLIENT_VERSION_STRING
-#define MBED_GREENTEA_CLIENT_VERSION_STRING YOTTA_GREENTEA_CLIENT_VERSION_STRING
-#else
 #define MBED_GREENTEA_CLIENT_VERSION_STRING "1.3.0"
-#endif
 
 #include <stdio.h>
 
@@ -41,7 +37,7 @@
 #endif
 
 /**
- *  Auxilary macros to keep mbed-drivers compatibility with utest before greentea-client
+ * Ensure compatibility with utest
  */
 #define TEST_ENV_TESTCASE_COUNT     GREENTEA_TEST_ENV_TESTCASE_COUNT
 #define TEST_ENV_TESTCASE_START     GREENTEA_TEST_ENV_TESTCASE_START

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -158,8 +158,8 @@ extern bool coverage_report;
  *
  *        Generates preamble of message sent to notify host about code coverage data dump.
  *
- *        This function is used by mbedOS software
- *        (see: mbed-drivers/source/retarget.cpp file) to generate code coverage
+ *        This function is used by Mbed OS
+ *        (see: mbed-os/platform/mbed_retarget.cpp) to generate code coverage
  *        messages to host. When code coverage feature is turned on slave will
  *        print-out code coverage data in form of key-value protocol.
  *        Message with code coverage data will contain message name, path to code
@@ -176,8 +176,8 @@ void greentea_notify_coverage_start(const char *path) {
 /**
  *  \brief Sufix for code coverage message to master (closing statement)
  *
- *         This function is used by mbedOS software
- *         (see: mbed-drivers/source/retarget.cpp file) to generate code coverage
+ *         This function is used by Mbed OS
+ *         (see: mbed-os/platform/mbed_retarget.cpp) to generate code coverage
  *         messages to host. When code coverage feature is turned on slave will
  *         print-out code coverage data in form of key-value protocol.
  *         Message with code coverage data will contain message name, path to code

--- a/features/frameworks/utest/TESTS/unit_tests/minimal_async_scheduler/main.cpp
+++ b/features/frameworks/utest/TESTS/unit_tests/minimal_async_scheduler/main.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// define this to get rid of the minar dependency.
-#define YOTTA_CFG_UTEST_USE_CUSTOM_SCHEDULER 1
 
 #include "mbed.h"
 #include "greentea-client/test_env.h"

--- a/features/frameworks/utest/TESTS/unit_tests/minimal_scheduler/main.cpp
+++ b/features/frameworks/utest/TESTS/unit_tests/minimal_scheduler/main.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// define this to get rid of the minar dependency.
-#define YOTTA_CFG_UTEST_USE_CUSTOM_SCHEDULER 1
 
 #include "mbed.h"
 #include "greentea-client/test_env.h"

--- a/features/frameworks/utest/utest/utest_harness.h
+++ b/features/frameworks/utest/utest/utest_harness.h
@@ -41,11 +41,6 @@ namespace v1 {
      * The harness executes the test specification in an asynchronous fashion, therefore
      * `run()` returns immediately.
      *
-     * By default, this harness uses the MINAR scheduler for asynchronous callbacks.
-     * If you wamt to provide your own custom scheduler, set `config.utest.use_custom_scheduler` to `true`
-     * inside your yotta config and set a custom scheduler implementation using the `set_scheduler()` function.
-     * You must set the scheduler before running a specification.
-     *
      * @note In case of an test abort, the harness will busy-wait and never finish.
      */
     class Harness

--- a/features/frameworks/utest/utest/utest_shim.h
+++ b/features/frameworks/utest/utest/utest_shim.h
@@ -27,50 +27,22 @@
 #include <stdio.h>
 #include "utest/utest_scheduler.h"
 
-#ifdef YOTTA_CFG
-#   include "compiler-polyfill/attributes.h"
-#else
-#   ifndef __deprecated_message
-#       if defined(__CC_ARM)
-#           define __deprecated_message(msg) __attribute__((deprecated))
-#       elif defined (__ICCARM__)
-#           define __deprecated_message(msg)
-#       else
-#           define __deprecated_message(msg) __attribute__((deprecated(msg)))
-#       endif
-#   endif
-#endif
-
-#ifdef YOTTA_CORE_UTIL_VERSION_STRING
-#   include "core-util/CriticalSectionLock.h"
-#   define UTEST_ENTER_CRITICAL_SECTION mbed::util::CriticalSectionLock lock
-#   define UTEST_LEAVE_CRITICAL_SECTION
-#else
-#   ifndef UTEST_ENTER_CRITICAL_SECTION
-#   	define UTEST_ENTER_CRITICAL_SECTION utest_v1_enter_critical_section()
-#   endif
-#   ifndef UTEST_LEAVE_CRITICAL_SECTION
-#   	define UTEST_LEAVE_CRITICAL_SECTION utest_v1_leave_critical_section()
-#   endif
-#endif
-
-#ifndef YOTTA_CFG_UTEST_USE_CUSTOM_SCHEDULER
-#   ifdef YOTTA_MINAR_VERSION_STRING
-#       define UTEST_MINAR_AVAILABLE 1
+#ifndef __deprecated_message
+#   if defined(__CC_ARM)
+#       define __deprecated_message(msg) __attribute__((deprecated))
+#   elif defined (__ICCARM__)
+#       define __deprecated_message(msg)
 #   else
-#       define UTEST_MINAR_AVAILABLE 0
+#       define __deprecated_message(msg) __attribute__((deprecated(msg)))
 #   endif
-#   ifndef UTEST_SHIM_SCHEDULER_USE_MINAR
-#       define UTEST_SHIM_SCHEDULER_USE_MINAR UTEST_MINAR_AVAILABLE
-#   endif
-#   ifndef UTEST_SHIM_SCHEDULER_USE_US_TICKER
-#       ifdef __MBED__
-#           define UTEST_SHIM_SCHEDULER_USE_US_TICKER 1
-#       else
-#           define UTEST_SHIM_SCHEDULER_USE_US_TICKER 0
-#       endif
-#   endif
-#endif  // YOTTA_CFG_UTEST_USE_CUSTOM_SCHEDULER
+#endif
+
+#ifndef UTEST_ENTER_CRITICAL_SECTION
+#	define UTEST_ENTER_CRITICAL_SECTION utest_v1_enter_critical_section()
+#endif
+#ifndef UTEST_LEAVE_CRITICAL_SECTION
+#	define UTEST_LEAVE_CRITICAL_SECTION utest_v1_leave_critical_section()
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Doing some clean up of some old Mbed OS 3 references in this code base. The references can cause some confusion (see #6417, https://github.com/ARMmbed/mbed-os-5-docs/issues/462#issuecomment-374822169).

Specifically removed usage of yotta cfg macros, minar functions, and anything related to the mbed-drivers package.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

