### PR TITLE
Second barrier for core_util_atomic_flag_clear

### DIFF
--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -142,6 +142,7 @@ MBED_FORCEINLINE void core_util_atomic_flag_clear(volatile core_util_atomic_flag
 {
     MBED_BARRIER();
     flagPtr->_flag = false;
+    MBED_BARRIER();
 }
 
 /**


### PR DESCRIPTION
### Description

As barriers were added in #9247, review comments pointed out that atomic stores needed a second barrier, and they got one. But `atomic_flag_clear` was missed.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
