### PR TITLE
Use atomics for double-checked locks (SingletonPtr + __cxa_guard)

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1426,32 +1426,35 @@ extern "C" void __env_unlock(struct _reent *_r)
 extern "C" int __cxa_guard_acquire(int *guard_object_p)
 {
     uint8_t *guard_object = (uint8_t *)guard_object_p;
-    if (CXA_GUARD_INIT_DONE == (*guard_object & CXA_GUARD_MASK)) {
+    if ((core_util_atomic_load_u8(guard_object) & CXA_GUARD_MASK) == CXA_GUARD_INIT_DONE) {
         return 0;
     }
     singleton_lock();
-    if (CXA_GUARD_INIT_DONE == (*guard_object & CXA_GUARD_MASK)) {
+    uint8_t guard = *guard_object;
+    if ((guard & CXA_GUARD_MASK) == CXA_GUARD_INIT_DONE) {
         singleton_unlock();
         return 0;
     }
-    MBED_ASSERT(0 == (*guard_object & CXA_GUARD_MASK));
-    *guard_object = *guard_object | CXA_GUARD_INIT_IN_PROGRESS;
+    MBED_ASSERT((guard & CXA_GUARD_MASK) == 0);
+    core_util_atomic_store_u8(guard_object, guard | CXA_GUARD_INIT_IN_PROGRESS);
     return 1;
 }
 
 extern "C" void __cxa_guard_release(int *guard_object_p)
 {
     uint8_t *guard_object = (uint8_t *)guard_object_p;
-    MBED_ASSERT(CXA_GUARD_INIT_IN_PROGRESS == (*guard_object & CXA_GUARD_MASK));
-    *guard_object = (*guard_object & ~CXA_GUARD_MASK) | CXA_GUARD_INIT_DONE;
+    uint8_t guard = *guard_object;
+    MBED_ASSERT((guard & CXA_GUARD_MASK) == CXA_GUARD_INIT_IN_PROGRESS);
+    core_util_atomic_store_u8(guard_object, (guard & ~CXA_GUARD_MASK) | CXA_GUARD_INIT_DONE);
     singleton_unlock();
 }
 
 extern "C" void __cxa_guard_abort(int *guard_object_p)
 {
     uint8_t *guard_object = (uint8_t *)guard_object_p;
-    MBED_ASSERT(CXA_GUARD_INIT_IN_PROGRESS == (*guard_object & CXA_GUARD_MASK));
-    *guard_object = *guard_object & ~CXA_GUARD_INIT_IN_PROGRESS;
+    uint8_t guard = *guard_object;
+    MBED_ASSERT((guard & CXA_GUARD_MASK) == CXA_GUARD_INIT_IN_PROGRESS);
+    core_util_atomic_store_u8(guard_object, guard & ~CXA_GUARD_INIT_IN_PROGRESS);
     singleton_unlock();
 }
 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1417,7 +1417,7 @@ extern "C" void __env_unlock(struct _reent *_r)
 
 #endif
 
-#if defined (__GNUC__) || defined(__CC_ARM) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+#if defined (__GNUC__) || defined (__ARMCC_VERSION)
 
 #define CXA_GUARD_INIT_DONE             (1 << 0)
 #define CXA_GUARD_INIT_IN_PROGRESS      (1 << 1)
@@ -1460,7 +1460,7 @@ extern "C" void __cxa_guard_abort(int *guard_object_p)
 
 #endif
 
-#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
+#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__ARMCC_VERSION) || defined(__ICCARM__))
 
 // If the memory tracing is enabled, the wrappers in mbed_alloc_wrappers.cpp
 // provide the implementation for these. Note: this needs to use the wrappers


### PR DESCRIPTION
### Description

#### Make SingletonPtr safe using atomics

`SingletonPtr`'s implementation wasn't totally safe - see "_[C++ and the Perils of Double-Checked Locking](https://www.aristeia.com/Papers/DDJ_Jul_Aug_2004_revised.pdf)_" by Meyers and Alexandrescu. No problems observed in practice, but it was potentially susceptible to compiler optimisation (or maybe even SMP issues).

Now that we have atomic loads and stores, the function can be made safe, avoiding any potential races for threads that don't take the lock: ensure that the unlocked load is atomic, and that the pointer store is
atomic.

See https://preshing.com/20130930/double-checked-locking-is-fixed-in-cpp11/ for more discussion.

####  Use atomics in __cxa_guard functions

Similar to `SingletonPtr`, use atomic accesses when loading the guard word outside the lock, and when storing, to ensure no races for threads that don't take the lock.

Lack of atomics unlikely to be a problem in current builds, but code could conceivably be subject to reordering if link-time optimisation was enabled.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan-, @c1728p9 