### PR TITLE
Mutex-protect mbedtls_hardware_poll

### DIFF
--- a/features/mbedtls/platform/src/mbed_trng.cpp
+++ b/features/mbedtls/platform/src/mbed_trng.cpp
@@ -17,12 +17,17 @@
 #if DEVICE_TRNG
 
 #include "hal/trng_api.h"
+#include "platform/PlatformMutex.h"
 
+extern "C"
 int mbedtls_hardware_poll( void *data, unsigned char *output, size_t len, size_t *olen ) {
+    static PlatformMutex trng_mutex;
     trng_t trng_obj;
+    trng_mutex.lock();
     trng_init(&trng_obj);
     int ret = trng_get_bytes(&trng_obj, output, len, olen);
     trng_free(&trng_obj);
+    trng_mutex.unlock();
     return ret;
 }
 


### PR DESCRIPTION
### Description
Like all HAL APIs, the calls in trng_api.h are not expected to be thread-safe.

All current accesses to the TRNG HAL are currently via `mbedtls_hardware_poll`.  Mbed TLS does not currently serialise these calls itself, as `MBEDTLS_THREADING_C` is not enabled. But even if Mbed TLS's own accesses were serialised, there are other direct users of `mbedtls_hardware_poll` such as randLIB, that need to use direct calls due to lack of API to extract entropy from Mbed TLS.

As such it makes sense to treat `mbedtls_hardware_poll` as a de facto public Mbed OS API, akin to the C++ veneers on top of the HAL, and add a `PlatformMutex` there so that it is safe for multithreaded use.

Fixes #9513 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

