### PR TITLE
STM32 Serial Flow Control

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -742,13 +742,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -613,13 +613,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -696,13 +696,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -659,13 +659,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -741,13 +741,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -700,13 +700,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32H7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/serial_device.c
@@ -700,13 +700,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -646,13 +646,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -649,13 +649,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -673,13 +673,13 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 {
     struct serial_s *obj_s = SERIAL_S(obj);
 
-    // Determine the UART to use (UART_1, UART_2, ...)
+    // Checked used UART name (UART_1, UART_2, ...)
     UARTName uart_rts = (UARTName)pinmap_peripheral(rxflow, PinMap_UART_RTS);
     UARTName uart_cts = (UARTName)pinmap_peripheral(txflow, PinMap_UART_CTS);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_cts, uart_rts);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+    if (((UARTName)pinmap_merge(uart_rts, obj_s->uart) == (UARTName)NC) || ((UARTName)pinmap_merge(uart_cts, obj_s->uart) == (UARTName)NC)) {
+        MBED_ASSERT(0);
+        return;
+    }
 
     if (type == FlowControlNone) {
         // Disable hardware flow control


### PR DESCRIPTION
### Description

This fixes #9525 

Crash occurred when the flow control is set to disabled,
i.e. when serial_set_flow_control function was called with RTS and CTS values equal to "NC"

Correction is to check that used pin is using the same UART instance as TX and RX.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@cwq9999 @LMESTM 
