### PR TITLE
Cellular clean logging

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -499,7 +499,29 @@ TEST_F(TestAT_CellularContext, connect_disconnect_sync)
     ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
     EXPECT_TRUE(ctx1.is_connected() == false);
 
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
     ASSERT_EQ(ctx1.connect("1234", "internet", "usern", "pwd"), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+    EXPECT_TRUE(ctx1.is_connected() == true);
+    ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ctx1.is_connected() == false);
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
+    ASSERT_EQ(ctx1.connect("1234", "internet", "usern", "pwd"), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
+    EXPECT_TRUE(ctx1.is_connected() == true);
+    ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ctx1.is_connected() == false);
 
     // More connect test after we are re-writted getting of PDP context...
 }

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
@@ -59,6 +59,22 @@ TEST_F(TestAT_CellularSIM, Create)
     delete sim;
 }
 
+TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin_verify_debug)
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularSIM sim(at);
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    at.set_debug(true);
+    EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin("12"));
+
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+}
+
 TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin)
 {
     EventQueue que;

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
@@ -169,12 +169,42 @@ TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin_query)
 
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin_query("12", true));
-    EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin_query(NULL, true));
 
-    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
+    EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin_query("12", true));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
+    EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin_query(NULL, true));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin_query("12", false));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin_query(NULL, false));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
 
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_DEVICE_ERROR;
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == sim.set_pin_query("12", false));

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
@@ -67,13 +67,23 @@ TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin_verify_debug)
 
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
     ATHandler_stub::debug_call_count_clear();
     at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin("12"));
-
     EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
     EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
     EXPECT_TRUE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
+    EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin("11"));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
 }
 
 TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin)
@@ -104,6 +114,8 @@ TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_change_pin)
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
 
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
     ATHandler_stub::debug_call_count_clear();
     at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.change_pin("12", "34"));

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
@@ -67,6 +67,7 @@ TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin_verify_debug)
 
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    ATHandler_stub::debug_call_count_clear();
     at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin("12"));
 
@@ -102,13 +103,50 @@ TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_change_pin)
 
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.change_pin("12", "34"));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.change_pin(NULL, "34"));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.change_pin("12", NULL));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.change_pin(NULL, NULL));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
 
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_DEVICE_ERROR;
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == sim.change_pin("12", "34"));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
 }
 
 TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin_query)

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsim/at_cellularsimtest.cpp
@@ -89,8 +89,6 @@ TEST_F(TestAT_CellularSIM, test_AT_CellularSIM_set_pin)
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == sim.set_pin("12"));
 
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    ATHandler_stub::read_string_value = (char *)"READY";
-    ATHandler_stub::ssize_value = 5;
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin("12"));
 
     EXPECT_TRUE(NSAPI_ERROR_OK == sim.set_pin(NULL));

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -57,6 +57,19 @@ int ATHandler_stub::urc_amount = 0;
 mbed::Callback<void()> ATHandler_stub::callback[kATHandler_urc_table_max_size];
 char *ATHandler_stub::urc_string_table[kATHandler_urc_table_max_size];
 
+bool ATHandler_stub::get_debug_flag = false;
+uint8_t ATHandler_stub::set_debug_call_count = 0;
+
+bool ATHandler_stub::is_get_debug_run()
+{
+    return ATHandler_stub::get_debug_flag;
+}
+
+uint8_t ATHandler_stub::set_debug_call_count_get()
+{
+    return ATHandler_stub::set_debug_call_count;
+}
+
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const char *output_delimiter, uint16_t send_delay) :
     _nextATHandler(0),
     _fileHandle(fh),
@@ -76,7 +89,15 @@ ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const 
 
 void ATHandler::set_debug(bool debug_on)
 {
+    ++ATHandler_stub::set_debug_call_count;
     ATHandler_stub::debug_on = debug_on;
+}
+
+bool ATHandler::get_debug() const
+{
+    ATHandler_stub::get_debug_flag = true;
+
+    return ATHandler_stub::debug_on;
 }
 
 ATHandler::~ATHandler()

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -65,9 +65,19 @@ bool ATHandler_stub::is_get_debug_run()
     return ATHandler_stub::get_debug_flag;
 }
 
+void ATHandler_stub::get_debug_clear()
+{
+    ATHandler_stub::get_debug_flag = false;
+}
+
 uint8_t ATHandler_stub::set_debug_call_count_get()
 {
     return ATHandler_stub::set_debug_call_count;
+}
+
+void ATHandler_stub::debug_call_count_clear()
+{
+    ATHandler_stub::set_debug_call_count = 0;
 }
 
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const char *output_delimiter, uint16_t send_delay) :

--- a/UNITTESTS/stubs/ATHandler_stub.h
+++ b/UNITTESTS/stubs/ATHandler_stub.h
@@ -65,8 +65,10 @@ extern char *urc_string_table[kATHandler_urc_table_max_size];
 
 extern bool get_debug_flag;
 bool is_get_debug_run();
+void get_debug_clear();
 extern uint8_t set_debug_call_count;
 uint8_t set_debug_call_count_get();
+void debug_call_count_clear();
 }
 
 #endif

--- a/UNITTESTS/stubs/ATHandler_stub.h
+++ b/UNITTESTS/stubs/ATHandler_stub.h
@@ -62,6 +62,11 @@ extern int resp_stop_success_count;
 extern bool process_oob_urc;
 extern int urc_amount;
 extern char *urc_string_table[kATHandler_urc_table_max_size];
+
+extern bool get_debug_flag;
+bool is_get_debug_run();
+extern uint8_t set_debug_call_count;
+uint8_t set_debug_call_count_get();
 }
 
 #endif

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -116,6 +116,11 @@ void ATHandler::set_debug(bool debug_on)
     _debug_on = debug_on;
 }
 
+bool ATHandler::get_debug() const
+{
+    return _debug_on;
+}
+
 ATHandler::~ATHandler()
 {
     while (_oobs) {

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -434,6 +434,13 @@ public: // just for debugging
      */
     void set_debug(bool debug_on);
 
+    /**
+     * Get degug state set by @ref set_debug
+     *
+     *  @return current state of debug
+     */
+    bool get_debug() const;
+
     /** Set debug_on for all ATHandlers in the _atHandlers list
      *
      *  @param debug_on Set true to enable debug traces

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -295,8 +295,15 @@ nsapi_error_t AT_CellularContext::do_user_authentication()
         _at.cmd_start("AT+CGAUTH=");
         _at.write_int(_cid);
         _at.write_int(_authentication_type);
+
+        const bool stored_debug_state = _at.get_debug();
+        _at.set_debug(false);
+
         _at.write_string(_uname);
         _at.write_string(_pwd);
+
+        _at.set_debug(stored_debug_state);
+
         _at.cmd_stop_read_resp();
         if (_at.get_last_error() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_AUTH_FAILURE;

--- a/features/cellular/framework/AT/AT_CellularSIM.cpp
+++ b/features/cellular/framework/AT/AT_CellularSIM.cpp
@@ -127,14 +127,28 @@ nsapi_error_t AT_CellularSIM::set_pin_query(const char *sim_pin, bool query_pin)
         _at.cmd_start("AT+CLCK=");
         _at.write_string("SC");
         _at.write_int(1);
+
+        const bool stored_debug_state = _at.get_debug();
+        _at.set_debug(false);
+
         _at.write_string(sim_pin);
+
+        _at.set_debug(stored_debug_state);
+
         _at.cmd_stop_read_resp();
     } else {
         /* use the SIM unlocked */
         _at.cmd_start("AT+CLCK=");
         _at.write_string("SC");
         _at.write_int(0);
+
+        const bool stored_debug_state = _at.get_debug();
+        _at.set_debug(false);
+
         _at.write_string(sim_pin);
+
+        _at.set_debug(stored_debug_state);
+
         _at.cmd_stop_read_resp();
     }
     return _at.unlock_return_error();

--- a/features/cellular/framework/AT/AT_CellularSIM.cpp
+++ b/features/cellular/framework/AT/AT_CellularSIM.cpp
@@ -89,7 +89,14 @@ nsapi_error_t AT_CellularSIM::set_pin(const char *sim_pin)
 
     _at.lock();
     _at.cmd_start("AT+CPIN=");
+
+    const bool stored_debug_state = _at.get_debug();
+    _at.set_debug(false);
+
     _at.write_string(sim_pin);
+
+    _at.set_debug(stored_debug_state);
+
     _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }

--- a/features/cellular/framework/AT/AT_CellularSIM.cpp
+++ b/features/cellular/framework/AT/AT_CellularSIM.cpp
@@ -106,8 +106,15 @@ nsapi_error_t AT_CellularSIM::change_pin(const char *sim_pin, const char *new_pi
     _at.lock();
     _at.cmd_start("AT+CPWD=");
     _at.write_string("SC");
+
+    const bool stored_debug_state = _at.get_debug();
+    _at.set_debug(false);
+
     _at.write_string(sim_pin);
     _at.write_string(new_pin);
+
+    _at.set_debug(stored_debug_state);
+
     _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }


### PR DESCRIPTION
### Description

    Remove sensitive information from cellular subsystem trace logs.
    - SIM pin
    - APN username and password
    Test coverage: 
    - unit tests. All pass
    - MTB_MTS_DRAGONFLY ontarget gt tests. No regression, 1 failing TC, same one as in master


### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarvte 