### PR TITLE
Remove inclusion of mbed.h from USB

### DIFF
--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "stdint.h"
+#include "stdlib.h"
 #include "USBEndpointTester.h"
 #include "mbed_shared_queues.h"
 #include "EndpointResolver.h"
@@ -167,7 +168,7 @@ USBEndpointTester::USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t p
     }
     MBED_ASSERT(resolver.valid());
 
-    queue = mbed_highprio_event_queue();
+    queue = mbed::mbed_highprio_event_queue();
     configuration_desc(0);
     init();
     USBDevice::connect();

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -78,7 +78,7 @@ public:
     };
 
 protected:
-    EventQueue *queue;
+    events::EventQueue *queue;
     rtos::EventFlags flags;
     uint8_t ctrl_buf[2048];
 

--- a/TESTS/usb_device/basic/USBTester.cpp
+++ b/TESTS/usb_device/basic/USBTester.cpp
@@ -54,7 +54,7 @@ USBTester::USBTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint1
     int_in = resolver.endpoint_in(USB_EP_TYPE_INT, 64);
     int_out = resolver.endpoint_out(USB_EP_TYPE_INT, 64);
     MBED_ASSERT(resolver.valid());
-    queue = mbed_highprio_event_queue();
+    queue = mbed::mbed_highprio_event_queue();
 
     configuration_desc(0);
 

--- a/TESTS/usb_device/basic/USBTester.cpp
+++ b/TESTS/usb_device/basic/USBTester.cpp
@@ -41,9 +41,9 @@
 
 
 USBTester::USBTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release):
-                        USBDevice(phy, vendor_id, product_id, product_release), interface_0_alt_set(NONE),
-                        interface_1_alt_set(NONE), configuration_set(NONE), reset_count(0),
-                        suspend_count(0), resume_count(0)
+    USBDevice(phy, vendor_id, product_id, product_release), interface_0_alt_set(NONE),
+    interface_1_alt_set(NONE), configuration_set(NONE), reset_count(0),
+    suspend_count(0), resume_count(0)
 {
 
     EndpointResolver resolver(endpoint_table());
@@ -269,14 +269,14 @@ bool USBTester::set_configuration(uint16_t configuration)
                                  bulk_buf, sizeof(bulk_buf), &USBTester::epbulk_out_callback);
         // interface 1 alternate 0
         success &= setup_iterface(int_in, int_out, MAX_EP_SIZE, USB_EP_TYPE_INT,
-                                 int_buf, sizeof(int_buf), &USBTester::epint_out_callback);
+                                  int_buf, sizeof(int_buf), &USBTester::epint_out_callback);
     } else if (configuration == 2) {
         // interface 0 alternate 0
         success = setup_iterface(int_in, int_out, MIN_EP_SIZE, USB_EP_TYPE_INT,
                                  int_buf, sizeof(int_buf), &USBTester::epint_out_callback);
         // interface 1 alternate 0
         success &= setup_iterface(bulk_in, bulk_out, MIN_EP_SIZE, USB_EP_TYPE_BULK,
-                                 bulk_buf, sizeof(bulk_buf), &USBTester::epbulk_out_callback);
+                                  bulk_buf, sizeof(bulk_buf), &USBTester::epbulk_out_callback);
     }
     if (success) {
         configuration_set = configuration;

--- a/TESTS/usb_device/basic/USBTester.h
+++ b/TESTS/usb_device/basic/USBTester.h
@@ -47,12 +47,30 @@ public:
     const char *get_serial_desc_string();
     const char *get_iproduct_desc_string();
     const char *get_iinterface_desc_string();
-    uint32_t get_reset_count() const { return reset_count; }
-    uint32_t get_suspend_count() const { return suspend_count; }
-    uint32_t get_resume_count() const { return resume_count; }
-    void clear_reset_count() { reset_count = 0; }
-    void clear_suspend_count() { suspend_count = 0; }
-    void clear_resume_count() { resume_count = 0; }
+    uint32_t get_reset_count() const
+    {
+        return reset_count;
+    }
+    uint32_t get_suspend_count() const
+    {
+        return suspend_count;
+    }
+    uint32_t get_resume_count() const
+    {
+        return resume_count;
+    }
+    void clear_reset_count()
+    {
+        reset_count = 0;
+    }
+    void clear_suspend_count()
+    {
+        suspend_count = 0;
+    }
+    void clear_resume_count()
+    {
+        resume_count = 0;
+    }
 
 private:
 

--- a/TESTS/usb_device/basic/USBTester.h
+++ b/TESTS/usb_device/basic/USBTester.h
@@ -106,7 +106,7 @@ protected:
     uint8_t int_in;
     uint8_t int_out;
     uint8_t int_buf[64];
-    EventQueue *queue;
+    events::EventQueue *queue;
     rtos::EventFlags flags;
     volatile uint32_t reset_count;
     volatile uint32_t suspend_count;

--- a/usb/device/USBAudio/USBAudio.cpp
+++ b/usb/device/USBAudio/USBAudio.cpp
@@ -498,7 +498,7 @@ void USBAudio::callback_request_xfer_done(const setup_packet_t *setup, bool abor
     }
 
     if ((setup->wLength == 1) || (setup->wLength == 2)) {
-        uint16_t data =  (_control_receive[0] << 0) | (_control_receive[1] << 8);
+        uint16_t data = (_control_receive[0] << 0) | (_control_receive[1] << 8);
         data &= ((setup->wLength == 1) ? 0xFF : 0xFFFF);
         switch (setup->wValue >> 8) {
             case MUTE_CONTROL:
@@ -516,7 +516,7 @@ void USBAudio::callback_request_xfer_done(const setup_packet_t *setup, bool abor
                     case REQUEST_SET_CUR:
                         _vol_cur = data;
                         _volume = (float)_vol_cur / (float)_vol_max;
-                       _update_vol.call();
+                        _update_vol.call();
                         break;
                     default:
                         break;

--- a/usb/device/USBAudio/USBAudio.cpp
+++ b/usb/device/USBAudio/USBAudio.cpp
@@ -145,9 +145,9 @@ void USBAudio::_init(uint32_t frequency_rx, uint8_t channel_count_rx, uint32_t f
     _vol_max = 0x0100;
     _vol_res = 0x0004;
 
-    _update_vol = callback(stub_volume);
-    _tx_done = callback(stub_handler);
-    _rx_done = callback(stub_handler);
+    _update_vol = mbed::callback(stub_volume);
+    _tx_done = mbed::callback(stub_handler);
+    _rx_done = mbed::callback(stub_handler);
 
     _rx_overflow = 0;
     _tx_underflow = 0;
@@ -348,7 +348,7 @@ float USBAudio::get_volume()
     return ret;
 }
 
-void USBAudio::attach(Callback<void()> &cb)
+void USBAudio::attach(mbed::Callback<void()> &cb)
 {
     lock();
 
@@ -360,25 +360,25 @@ void USBAudio::attach(Callback<void()> &cb)
     unlock();
 }
 
-void USBAudio::attach_tx(Callback<void(AudioEvent)> &cb)
+void USBAudio::attach_tx(mbed::Callback<void(AudioEvent)> &cb)
 {
     lock();
 
     _tx_done = cb;
     if (!_tx_done) {
-        _tx_done = callback(stub_handler);
+        _tx_done = mbed::callback(stub_handler);
     }
 
     unlock();
 }
 
-void USBAudio::attach_rx(Callback<void(AudioEvent)> &cb)
+void USBAudio::attach_rx(mbed::Callback<void(AudioEvent)> &cb)
 {
     lock();
 
     _rx_done = cb;
     if (!_rx_done) {
-        _rx_done = callback(stub_handler);
+        _rx_done = mbed::callback(stub_handler);
     }
 
     unlock();

--- a/usb/device/USBAudio/USBAudio.h
+++ b/usb/device/USBAudio/USBAudio.h
@@ -80,7 +80,7 @@ public:
     * @param product_id Your product_id
     * @param product_release Your product_release
     */
-    USBAudio(bool connect=true, uint32_t frequency_rx = 48000, uint8_t channel_count_rx = 1, uint32_t frequency_tx = 8000, uint8_t channel_count_tx = 1, uint32_t buffer_ms=10, uint16_t vendor_id = 0x7bb8, uint16_t product_id = 0x1111, uint16_t product_release = 0x0100);
+    USBAudio(bool connect = true, uint32_t frequency_rx = 48000, uint8_t channel_count_rx = 1, uint32_t frequency_tx = 8000, uint8_t channel_count_tx = 1, uint32_t buffer_ms = 10, uint16_t vendor_id = 0x7bb8, uint16_t product_id = 0x1111, uint16_t product_release = 0x0100);
 
     /**
     * Fully featured constructor
@@ -153,7 +153,7 @@ public:
      * @param clear Reset the overflow count back to 0
      * @return Number of packets dropped due to overflow
      */
-    uint32_t read_overflows(bool clear=false);
+    uint32_t read_overflows(bool clear = false);
 
     /**
      * Check if the audio read channel is open
@@ -196,7 +196,7 @@ public:
      * @return Number of packets that should have been
      *         sent but weren't due to overflow
      */
-    uint32_t write_underflows(bool clear=false);
+    uint32_t write_underflows(bool clear = false);
 
     /**
      * Check if the audio write channel is open

--- a/usb/device/USBAudio/USBAudio.h
+++ b/usb/device/USBAudio/USBAudio.h
@@ -222,21 +222,21 @@ public:
      * @param cb Callback to attach
      *
      */
-    void attach(Callback<void()> &cb);
+    void attach(mbed::Callback<void()> &cb);
 
     /** attach a Callback to Tx Done
      *
      * @param cb Callback to attach
      *
      */
-    void attach_tx(Callback<void(AudioEvent)> &cb);
+    void attach_tx(mbed::Callback<void(AudioEvent)> &cb);
 
     /** attach a Callback to Rx Done
      *
      * @param cb Callback to attach
      *
      */
-    void attach_rx(Callback<void(AudioEvent)> &cb);
+    void attach_rx(mbed::Callback<void(AudioEvent)> &cb);
 
 protected:
 
@@ -303,13 +303,13 @@ private:
     uint16_t _vol_res;
 
     // callback to update volume
-    Callback<void()> _update_vol;
+    mbed::Callback<void()> _update_vol;
 
     // callback transmit Done
-    Callback<void(AudioEvent)> _tx_done;
+    mbed::Callback<void(AudioEvent)> _tx_done;
 
     // callback receive Done
-    Callback<void(AudioEvent)> _rx_done;
+    mbed::Callback<void(AudioEvent)> _rx_done;
 
     // Number of times data was dropped due to an overflow
     uint32_t _rx_overflow;

--- a/usb/device/USBDevice/EndpointResolver.cpp
+++ b/usb/device/USBDevice/EndpointResolver.cpp
@@ -73,7 +73,8 @@ bool EndpointResolver::valid()
     return _valid && (_cost <= _table->resources);
 }
 
-void EndpointResolver::reset() {
+void EndpointResolver::reset()
+{
     _cost = 0;
     _used = 0;
     _valid = true;

--- a/usb/device/USBDevice/EndpointResolver.cpp
+++ b/usb/device/USBDevice/EndpointResolver.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
 #include "EndpointResolver.h"
 
 static uint32_t logical_to_index(uint32_t logical, bool in_not_out)

--- a/usb/device/USBDevice/EndpointResolver.h
+++ b/usb/device/USBDevice/EndpointResolver.h
@@ -17,8 +17,6 @@
 #ifndef ENDPOINT_RESOLVER_H
 #define ENDPOINT_RESOLVER_H
 
-#include "mbed.h"
-
 #include "USBPhy.h"
 
 /**

--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-#include "stdint.h"
+#include <stdint.h>
+#include <string.h>
 
 #include "USBDevice.h"
 #include "USBDescriptor.h"
 #include "usb_phy_api.h"
+#include "mbed_assert.h"
 
 //#define DEBUG
 

--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -64,8 +64,7 @@ bool USBDevice::_request_get_descriptor()
     printf("get descr: type: %d\r\n", DESCRIPTOR_TYPE(_transfer.setup.wValue));
 #endif
     switch (DESCRIPTOR_TYPE(_transfer.setup.wValue)) {
-        case DEVICE_DESCRIPTOR:
-        {
+        case DEVICE_DESCRIPTOR: {
             if (device_desc() != NULL) {
                 if ((device_desc()[0] == DEVICE_DESCRIPTOR_LENGTH) \
                         && (device_desc()[1] == DEVICE_DESCRIPTOR)) {
@@ -80,8 +79,7 @@ bool USBDevice::_request_get_descriptor()
             }
             break;
         }
-        case CONFIGURATION_DESCRIPTOR:
-        {
+        case CONFIGURATION_DESCRIPTOR: {
             const uint8_t idx = DESCRIPTOR_INDEX(_transfer.setup.wValue);
             if (configuration_desc(idx) != NULL) {
                 if ((configuration_desc(idx)[0] == CONFIGURATION_DESCRIPTOR_LENGTH) \
@@ -91,7 +89,7 @@ bool USBDevice::_request_get_descriptor()
 #endif
                     /* Get wTotalLength */
                     _transfer.remaining = configuration_desc(idx)[2] \
-                                         | (configuration_desc(idx)[3] << 8);
+                                          | (configuration_desc(idx)[3] << 8);
 
                     _transfer.ptr = (uint8_t *)configuration_desc(idx);
                     _transfer.direction = Send;
@@ -100,8 +98,7 @@ bool USBDevice::_request_get_descriptor()
             }
             break;
         }
-        case STRING_DESCRIPTOR:
-        {
+        case STRING_DESCRIPTOR: {
 #ifdef DEBUG
             printf("str descriptor\r\n");
 #endif
@@ -163,23 +160,20 @@ bool USBDevice::_request_get_descriptor()
             }
             break;
         }
-        case INTERFACE_DESCRIPTOR:
-        {
+        case INTERFACE_DESCRIPTOR: {
 #ifdef DEBUG
             printf("interface descr\r\n");
 #endif
             break;
         }
-        case ENDPOINT_DESCRIPTOR:
-        {
+        case ENDPOINT_DESCRIPTOR: {
 #ifdef DEBUG
             printf("endpoint descr\r\n");
 #endif
             /* TODO: Support is optional, not implemented here */
             break;
         }
-        default:
-        {
+        default: {
 #ifdef DEBUG
             printf("ERROR\r\n");
 #endif
@@ -1154,7 +1148,7 @@ void USBDevice::endpoint_stall(usb_ep_t endpoint)
     _phy->endpoint_stall(endpoint);
 
     if (info->pending) {
-       endpoint_abort(endpoint);
+        endpoint_abort(endpoint);
     }
 
     unlock();
@@ -1589,7 +1583,8 @@ void USBDevice::assert_locked()
     MBED_ASSERT(_locked > 0);
 }
 
-void USBDevice::_change_state(DeviceState new_state) {
+void USBDevice::_change_state(DeviceState new_state)
+{
     assert_locked();
 
     DeviceState old_state = _device.state;

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -17,7 +17,6 @@
 #ifndef USBDEVICE_H
 #define USBDEVICE_H
 
-#include "mbed.h"
 #include "USBDevice_Types.h"
 #include "USBPhy.h"
 #include "mbed_critical.h"

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -403,7 +403,7 @@ protected:
      * @param data Buffer to send or receive if the result is Send or Receive
      * @param size Size to transfer if the result is Send or Receive
      */
-    void complete_request(RequestResult result, uint8_t *data=NULL, uint32_t size=0);
+    void complete_request(RequestResult result, uint8_t *data = NULL, uint32_t size = 0);
 
     /**
     * Called by USBDevice on data stage completion

--- a/usb/device/USBHID/USBKeyboard.h
+++ b/usb/device/USBHID/USBKeyboard.h
@@ -94,7 +94,7 @@ enum FUNCTION_KEY {
  *
  * @note Synchronization level: Thread safe
  */
-class USBKeyboard: public USBHID, public Stream {
+class USBKeyboard: public USBHID, public mbed::Stream {
 public:
 
     /**

--- a/usb/device/USBHID/USBMouse.cpp
+++ b/usb/device/USBHID/USBMouse.cpp
@@ -18,6 +18,7 @@
 #include "USBMouse.h"
 #include "PlatformMutex.h"
 #include "usb_phy_api.h"
+#include "mbed_wait_api.h"
 
 
 USBMouse::USBMouse(bool connect_blocking, MOUSE_TYPE mouse_type, uint16_t vendor_id, uint16_t product_id, uint16_t product_release):

--- a/usb/device/USBHID/USBMouseKeyboard.cpp
+++ b/usb/device/USBHID/USBMouseKeyboard.cpp
@@ -17,6 +17,7 @@
 #include "stdint.h"
 #include "USBMouseKeyboard.h"
 #include "usb_phy_api.h"
+#include "mbed_wait_api.h"
 
 typedef struct {
     unsigned char usage;

--- a/usb/device/USBHID/USBMouseKeyboard.h
+++ b/usb/device/USBHID/USBMouseKeyboard.h
@@ -68,7 +68,7 @@
  *
  * @note Synchronization level: Thread safe
  */
-class USBMouseKeyboard: public USBHID, public Stream
+class USBMouseKeyboard: public USBHID, public mbed::Stream
 {
 public:
 

--- a/usb/device/USBHID/USBMouseKeyboard.h
+++ b/usb/device/USBHID/USBMouseKeyboard.h
@@ -68,8 +68,7 @@
  *
  * @note Synchronization level: Thread safe
  */
-class USBMouseKeyboard: public USBHID, public mbed::Stream
-{
+class USBMouseKeyboard: public USBHID, public mbed::Stream {
 public:
 
     /**
@@ -86,7 +85,7 @@ public:
     * @param product_release Your preoduct_release (default: 0x0001)
     *
     */
-    USBMouseKeyboard(bool connect_blocking=true, MOUSE_TYPE mouse_type=REL_MOUSE, uint16_t vendor_id=0x0021, uint16_t product_id=0x0011, uint16_t product_release=0x0001);
+    USBMouseKeyboard(bool connect_blocking = true, MOUSE_TYPE mouse_type = REL_MOUSE, uint16_t vendor_id = 0x0021, uint16_t product_id = 0x0011, uint16_t product_release = 0x0001);
 
     /**
     * Fully featured constructor
@@ -106,7 +105,7 @@ public:
     * @param product_release Your preoduct_release (default: 0x0001)
     *
     */
-    USBMouseKeyboard(USBPhy *phy, MOUSE_TYPE mouse_type=REL_MOUSE, uint16_t vendor_id=0x0021, uint16_t product_id=0x0011, uint16_t product_release=0x0001);
+    USBMouseKeyboard(USBPhy *phy, MOUSE_TYPE mouse_type = REL_MOUSE, uint16_t vendor_id = 0x0021, uint16_t product_id = 0x0011, uint16_t product_release = 0x0001);
 
     /**
      * Destroy this object
@@ -221,7 +220,7 @@ public:
     *
     * @returns pointer to the report descriptor
     */
-    virtual const uint8_t * report_desc();
+    virtual const uint8_t *report_desc();
 
     /*
     * Called when a data is received on the OUT endpoint. Useful to switch on LED of LOCK keys

--- a/usb/device/USBMIDI/MIDIMessage.h
+++ b/usb/device/USBMIDI/MIDIMessage.h
@@ -17,7 +17,7 @@
 #ifndef MIDIMESSAGE_H
 #define MIDIMESSAGE_H
 
-#include "mbed.h"
+#include <stdint.h>
 
 #define MAX_MIDI_MESSAGE_SIZE 256 // Max message size. SysEx can be up to 65536 but 256 should be fine for most usage
 

--- a/usb/device/USBMIDI/USBMIDI.cpp
+++ b/usb/device/USBMIDI/USBMIDI.cpp
@@ -172,7 +172,7 @@ bool USBMIDI::read(MIDIMessage *m)
     return true;
 }
 
-void USBMIDI::attach(Callback<void()> callback)
+void USBMIDI::attach(mbed::Callback<void()> callback)
 {
     lock();
 

--- a/usb/device/USBMIDI/USBMIDI.h
+++ b/usb/device/USBMIDI/USBMIDI.h
@@ -134,7 +134,7 @@ public:
      *
      * @param callback code to call when a packet is received
      */
-    void attach(Callback<void()> callback);
+    void attach(mbed::Callback<void()> callback);
 
 
 protected:
@@ -173,7 +173,7 @@ private:
     usb_ep_t _bulk_out;
     uint8_t _config_descriptor[0x65];
 
-    Callback<void()> _callback;
+    mbed::Callback<void()> _callback;
 
     void _init();
     void _in_callback();

--- a/usb/device/USBMSD/USBMSD.cpp
+++ b/usb/device/USBMSD/USBMSD.cpp
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-#include "stdint.h"
+#include <stdint.h>
+#include <stdlib.h>
 #include "USBMSD.h"
 #include "EndpointResolver.h"
 #include "usb_phy_api.h"
@@ -86,11 +87,11 @@ void USBMSD::_init()
 {
     _bd->init();
 
-    _in_task = callback(this, &USBMSD::_in);
-    _out_task = callback(this, &USBMSD::_out);
-    _reset_task = callback(this, &USBMSD::_reset);
-    _control_task = callback(this, &USBMSD::_control);
-    _configure_task = callback(this, &USBMSD::_configure);
+    _in_task = mbed::callback(this, &USBMSD::_in);
+    _out_task = mbed::callback(this, &USBMSD::_out);
+    _reset_task = mbed::callback(this, &USBMSD::_reset);
+    _control_task = mbed::callback(this, &USBMSD::_control);
+    _configure_task = mbed::callback(this, &USBMSD::_configure);
 
     EndpointResolver resolver(endpoint_table());
 

--- a/usb/device/USBMSD/USBMSD.cpp
+++ b/usb/device/USBMSD/USBMSD.cpp
@@ -212,14 +212,14 @@ void USBMSD::attach(mbed::Callback<void()> cb)
     unlock();
 }
 
-int USBMSD::disk_read(uint8_t* data, uint64_t block, uint8_t count)
+int USBMSD::disk_read(uint8_t *data, uint64_t block, uint8_t count)
 {
     bd_addr_t addr =  block * _bd->get_erase_size();
     bd_size_t size = count * _bd->get_erase_size();
     return _bd->read(data, addr, size);
 }
 
-int USBMSD::disk_write(const uint8_t* data, uint64_t block, uint8_t count)
+int USBMSD::disk_write(const uint8_t *data, uint64_t block, uint8_t count)
 {
     bd_addr_t addr =  block * _bd->get_erase_size();
     bd_size_t size = count * _bd->get_erase_size();
@@ -434,7 +434,7 @@ void USBMSD::_control(const setup_packet_t *setup)
                 break;
             case MSC_REQUEST_GET_MAX_LUN:
                 result = Send;
-                data = (uint8_t*)maxLUN;
+                data = (uint8_t *)maxLUN;
                 size = 1;
                 break;
             default:

--- a/usb/device/USBMSD/USBMSD.h
+++ b/usb/device/USBMSD/USBMSD.h
@@ -237,12 +237,12 @@ private:
     uint32_t _bulk_out_size;
 
     // Interrupt to thread deferral
-    PolledQueue _queue;
-    Task<void()> _in_task;
-    Task<void()> _out_task;
-    Task<void()> _reset_task;
-    Task<void(const setup_packet_t *)> _control_task;
-    Task<void()> _configure_task;
+    events::PolledQueue _queue;
+    events::Task<void()> _in_task;
+    events::Task<void()> _out_task;
+    events::Task<void()> _reset_task;
+    events::Task<void(const setup_packet_t *)> _control_task;
+    events::Task<void()> _configure_task;
 
     BlockDevice *_bd;
     rtos::Mutex _mutex_init;

--- a/usb/device/USBMSD/USBMSD.h
+++ b/usb/device/USBMSD/USBMSD.h
@@ -181,7 +181,8 @@ private:
     };
 
     // Bulk-only CBW
-    typedef MBED_PACKED(struct) {
+    typedef MBED_PACKED(struct)
+    {
         uint32_t Signature;
         uint32_t Tag;
         uint32_t DataLength;
@@ -192,7 +193,8 @@ private:
     } CBW;
 
     // Bulk-only CSW
-    typedef MBED_PACKED(struct) {
+    typedef MBED_PACKED(struct)
+    {
         uint32_t Signature;
         uint32_t Tag;
         uint32_t DataResidue;

--- a/usb/device/USBSerial/USBSerial.h
+++ b/usb/device/USBSerial/USBSerial.h
@@ -41,7 +41,7 @@
 * }
 * @endcode
 */
-class USBSerial: public USBCDC, public Stream {
+class USBSerial: public USBCDC, public mbed::Stream {
 public:
 
     /**
@@ -149,7 +149,7 @@ public:
         USBCDC::lock();
 
         if ((mptr != NULL) && (tptr != NULL)) {
-            rx = Callback<void()>(mptr, tptr);
+            rx = mbed::Callback<void()>(mptr, tptr);
         }
 
         USBCDC::unlock();
@@ -165,7 +165,7 @@ public:
         USBCDC::lock();
 
         if (fptr != NULL) {
-            rx = Callback<void()>(fptr);
+            rx = mbed::Callback<void()>(fptr);
         }
 
         USBCDC::unlock();
@@ -176,7 +176,7 @@ public:
      *
      * @param cb Callback to attach
      */
-    void attach(Callback<void()> &cb)
+    void attach(mbed::Callback<void()> &cb)
     {
         USBCDC::lock();
 
@@ -211,7 +211,7 @@ protected:
     }
 
 private:
-    Callback<void()> rx;
+    mbed::Callback<void()> rx;
     void (*_settings_changed_callback)(int baud, int bits, int parity, int stop);
 };
 

--- a/usb/device/USBSerial/USBSerial.h
+++ b/usb/device/USBSerial/USBSerial.h
@@ -57,7 +57,7 @@ public:
     * @param product_release Your product_release (default: 0x0001)
     *
     */
-    USBSerial(bool connect_blocking=true, uint16_t vendor_id=0x1f00, uint16_t product_id=0x2012, uint16_t product_release=0x0001);
+    USBSerial(bool connect_blocking = true, uint16_t vendor_id = 0x1f00, uint16_t product_id = 0x2012, uint16_t product_release = 0x0001);
 
     /**
     * Fully featured constructor
@@ -76,7 +76,7 @@ public:
     * @param product_release Your product_release (default: 0x0001)
     *
     */
-    USBSerial(USBPhy *phy, uint16_t vendor_id=0x1f00, uint16_t product_id=0x2012, uint16_t product_release=0x0001);
+    USBSerial(USBPhy *phy, uint16_t vendor_id = 0x1f00, uint16_t product_id = 0x2012, uint16_t product_release = 0x0001);
 
     /**
      * Destroy this object

--- a/usb/device/utilities/events/TaskBase.cpp
+++ b/usb/device/utilities/events/TaskBase.cpp
@@ -18,7 +18,7 @@
 #include "events/TaskQueue.h"
 #include "events/mbed_events.h"
 #include "rtos/Semaphore.h"
-#include "mbed.h"
+#include "platform/mbed_critical.h"
 
 TaskBase::TaskBase(TaskQueue *q)
     : _queue(q), _posted(false), _start_count(0), _flush_sem(NULL)


### PR DESCRIPTION
### Description

Remove mbed.h from USB files and fix the build errors this causes. This is required to pass CI.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
