### PR TITLE
Disable reboot limit

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -216,7 +216,7 @@ mbed_error_status_t mbed_error_initialize(void)
             mbed_error_reboot_callback(report_error_ctx);
 
             //We let the callback reset the error info, so check if its still valid and do the rest only if its still valid.
-            if (report_error_ctx->error_reboot_count > 0) {
+            if (report_error_ctx->error_reboot_count < 0) {
 
                 //Enforce max-reboot only if auto reboot is enabled
 #if MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED


### PR DESCRIPTION
### Description

Partially revert commit cc5969b1 from PR #9296, which started enforcing reboot limits by correcting the comparison against zero. Now that it's working, the reboot limit is causing a problem because once it's hit the board will repeatedly halt before entering main until something corrupts or clears the error context.

This is a minimal workaround to restore the broken behaviour in 5.11.2, so that the reboot limit is again not enforced.

An alternative attempt to fix the problem properly is in PR #9544.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SenRamakri, @TeemuKultala 
