### PR TITLE
mbed_die: Use wait_us not wait_ms

### DIFF
--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -33,16 +33,16 @@ WEAK MBED_NORETURN void mbed_die(void)
     while (1) {
         for (int i = 0; i < 4; ++i) {
             gpio_write(&led_err, 1);
-            wait_ms(150);
+            wait_us(150000);
             gpio_write(&led_err, 0);
-            wait_ms(150);
+            wait_us(150000);
         }
 
         for (int i = 0; i < 4; ++i) {
             gpio_write(&led_err, 1);
-            wait_ms(400);
+            wait_us(400000);
             gpio_write(&led_err, 0);
-            wait_ms(400);
+            wait_us(400000);
         }
     }
 }


### PR DESCRIPTION
### Description

`mbed_die` was calling `wait_ms` in a critical section - this is deprecated behaviour, and caused a fatal error in debug builds, potentially leading to an infinite reboot loop if this was caused due to a reboot limit halt.

Switch to using `wait_us` - this is safe in a critical section. This does trigger a call to `mbed_warning`, due to the large parameter, but that is harmless - it doesn't output anything to the console, and won't
overwrite the error context if it already contains something.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SenRamakri, @TeemuKultala 

