### PR TITLE
BLE: fix missing scan timeout for 4.2 controllers using new API

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -1482,14 +1482,14 @@ BLE_DEPRECATED_API_USE_END()
 
 void GenericGap::on_scan_timeout()
 {
+    if (!_scan_enabled) {
+        return;
+    }
+
     /* if timeout happened on a 4.2 chip we need to stop the scan manually */
     if (is_extended_advertising_available()) {
         _pal_gap.scan_enable(false, false);
         set_random_address_rotation(false);
-    }
-
-    if (!_scan_enabled) {
-        return;
     }
 
     _scan_enabled = false;

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -591,6 +591,7 @@ ble_error_t GenericGap::stopScan()
     set_random_address_rotation(false);
 
     _scan_timeout.detach();
+
     return BLE_ERROR_NONE;
 }
 
@@ -1487,7 +1488,7 @@ void GenericGap::on_scan_timeout()
     }
 
     /* if timeout happened on a 4.2 chip we need to stop the scan manually */
-    if (is_extended_advertising_available()) {
+    if (!is_extended_advertising_available()) {
         _pal_gap.scan_enable(false, false);
         set_random_address_rotation(false);
     }
@@ -2983,8 +2984,6 @@ ble_error_t GenericGap::startScan(
         if (err) {
             return err;
         }
-
-        _scan_enabled = true;
     } else {
         if (period.value() != 0) {
             return BLE_ERROR_INVALID_PARAM;
@@ -2999,8 +2998,6 @@ ble_error_t GenericGap::startScan(
             return err;
         }
 
-        _scan_enabled = true;
-
         _scan_timeout.detach();
         if (duration.value()) {
             _scan_timeout.attach_us(
@@ -3009,6 +3006,8 @@ ble_error_t GenericGap::startScan(
             );
         }
     }
+
+    _scan_enabled = true;
 
     return BLE_ERROR_NONE;
 }

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -570,25 +570,21 @@ ble_error_t GenericGap::stopScan()
 {
     ble_error_t err;
 
+    if (!_scan_enabled) {
+        return BLE_ERROR_NONE;
+    }
+
+    _scan_enabled = false;
+
     if (is_extended_advertising_available()) {
-        if (!_scan_enabled) {
-            return BLE_ERROR_NONE;
-        }
-
-        _scan_enabled = false;
-
         err = _pal_gap.extended_scan_enable(false, pal::duplicates_filter_t::DISABLE, 0, 0);
-
-        if (err) {
-            _scan_enabled = true;
-            return err;
-        }
     } else {
         err = _pal_gap.scan_enable(false, false);
+    }
 
-        if (err) {
-            return err;
-        }
+    if (err) {
+        _scan_enabled = true;
+        return err;
     }
 
     // Stop address rotation if required
@@ -1210,6 +1206,8 @@ ble_error_t GenericGap::startRadioScan(const GapScanningParams &scanningParams)
         return err;
     }
 
+    _scan_enabled = true;
+
     _scan_timeout.detach();
     uint16_t timeout = scanningParams.getTimeout();
     if (timeout) {
@@ -1484,6 +1482,12 @@ BLE_DEPRECATED_API_USE_END()
 
 void GenericGap::on_scan_timeout()
 {
+    /* if timeout happened on a 4.2 chip we need to stop the scan manually */
+    if (is_extended_advertising_available()) {
+        _pal_gap.scan_enable(false, false);
+        set_random_address_rotation(false);
+    }
+
     if (!_scan_enabled) {
         return;
     }
@@ -2969,8 +2973,6 @@ ble_error_t GenericGap::startScan(
     }
 
     if (is_extended_advertising_available()) {
-        _scan_enabled = true;
-
         ble_error_t err = _pal_gap.extended_scan_enable(
             /* enable */true,
             filtering,
@@ -2979,9 +2981,10 @@ ble_error_t GenericGap::startScan(
         );
 
         if (err) {
-            _scan_enabled = false;
             return err;
         }
+
+        _scan_enabled = true;
     } else {
         if (period.value() != 0) {
             return BLE_ERROR_INVALID_PARAM;
@@ -2995,6 +2998,8 @@ ble_error_t GenericGap::startScan(
         if (err) {
             return err;
         }
+
+        _scan_enabled = true;
 
         _scan_timeout.detach();
         if (duration.value()) {


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Controllers that don't support extended advertising don't create an event on advertising timeout and need extra support to behave correctly with the new API. This fix creates the event on on the user side making the behaviour consistent for older controllers.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

