### PR TITLE
STM32: Enable SERIAL_FC for all

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1866,6 +1866,7 @@
             "PORTOUT",
             "PWMOUT",
             "SERIAL",
+            "SERIAL_FC",
             "SLEEP",
             "SPI",
             "SPISLAVE",
@@ -2027,7 +2028,7 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CRC", "SERIAL_FC"],
+        "device_has_add": ["CRC"],
         "device_has_remove": ["LPTICKER"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -2052,7 +2053,7 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CRC", "SERIAL_FC"],
+        "device_has_add": ["CRC"],
         "device_has_remove": ["LPTICKER"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -2077,7 +2078,7 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CAN", "CRC", "SERIAL_FC"],
+        "device_has_add": ["CAN", "CRC"],
         "device_has_remove": ["LPTICKER"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -2100,7 +2101,7 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CRC", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": ["CRC", "SERIAL_ASYNCH", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F070RB"
     },
@@ -2125,7 +2126,6 @@
             "ANALOGOUT",
             "CAN",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "FLASH"
         ],
@@ -2153,7 +2153,6 @@
             "ANALOGOUT",
             "CAN",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "FLASH"
         ],
@@ -2178,7 +2177,7 @@
             }
         },
         "detect_code": ["0700"],
-        "device_has_add": ["CAN", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": ["CAN", "SERIAL_ASYNCH", "FLASH"],
         "device_has_remove": ["LPTICKER"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F103RB"
@@ -2207,7 +2206,6 @@
             "CAN",
             "EMAC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "FLASH",
             "MPU"
         ],
@@ -2236,8 +2234,7 @@
             "ANALOGOUT",
             "CAN",
             "CRC",
-            "SERIAL_ASYNCH",
-            "SERIAL_FC"
+            "SERIAL_ASYNCH"
         ],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -2258,7 +2255,7 @@
         "overrides": { "lse_available": 0 },
         "detect_code": ["0775"],
         "default_lib": "small",
-        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "SERIAL_FC"],
+        "device_has_add": ["ANALOGOUT", "CAN", "CRC"],
         "release_versions": ["2"],
         "device_name": "STM32F303K8"
     },
@@ -2280,7 +2277,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "FLASH",
             "MPU"
         ],
@@ -2322,8 +2318,7 @@
             "ANALOGOUT",
             "CAN",
             "CRC",
-            "SERIAL_ASYNCH",
-            "SERIAL_FC"
+            "SERIAL_ASYNCH"
         ],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -2343,7 +2338,7 @@
         },
         "detect_code": ["0720"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "FLASH", "MPU"],
+        "device_has_add": ["SERIAL_ASYNCH", "FLASH", "MPU"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F401RE"
     },
@@ -2359,7 +2354,7 @@
             }
         },
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "HSE_VALUE=25000000"],
-        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "FLASH", "MPU"],
+        "device_has_add": ["SERIAL_ASYNCH", "FLASH", "MPU"],
         "overrides": { "lse_available": 0 },
         "release_versions": ["2", "5"],
         "device_name": "STM32F401VE"
@@ -2393,7 +2388,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2421,7 +2415,7 @@
             }
         },
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "FLASH", "MPU"],
+        "device_has_add": ["SERIAL_ASYNCH", "FLASH", "MPU"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F411RE",
         "bootloader_supported": true
@@ -2443,7 +2437,6 @@
         "device_has_add": [
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2466,7 +2459,6 @@
         "device_has_add": [
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2501,7 +2493,6 @@
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": [
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2572,7 +2563,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "QSPI",
@@ -2614,7 +2604,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2632,6 +2621,7 @@
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "detect_code": ["----"],
         "device_has_add": ["MPU"],
+        "device_has_remove": ["SERIAL_FC"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32F411RE"
@@ -2676,7 +2666,6 @@
             "CAN",
             "EMAC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2728,7 +2717,6 @@
             "CAN",
             "EMAC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -2759,7 +2747,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "FLASH",
             "MPU"
         ],
@@ -2785,7 +2772,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "FLASH",
             "MPU"
         ],
@@ -2802,7 +2788,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "FLASH",
             "MPU"
         ],
@@ -3031,7 +3016,7 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0780"],
-        "device_has_add": ["CRC", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["CRC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L011K4"
@@ -3055,7 +3040,7 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0790"],
-        "device_has_add": ["CRC", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["CRC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L031K6"
@@ -3081,7 +3066,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "FLASH",
             "MPU"
@@ -3114,7 +3098,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
@@ -3139,7 +3122,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "FLASH",
             "MPU"
         ],
@@ -3170,7 +3152,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "CAN",
             "TRNG",
@@ -3205,7 +3186,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "CAN",
             "TRNG",
@@ -3232,7 +3212,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CRC",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "CAN",
             "TRNG",
@@ -3273,7 +3252,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3301,7 +3279,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3338,7 +3315,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3374,7 +3350,6 @@
             "ANALOGOUT",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3399,7 +3374,10 @@
             "STM_EMAC"
         ],
         "device_has_add": ["ANALOGOUT", "TRNG", "FLASH", "EMAC", "MPU"],
-        "device_has_remove": ["LPTICKER"],
+        "device_has_remove": [
+            "LPTICKER",
+            "SERIAL_FC"
+        ],
         "macros_add": ["USB_STM_HAL"],
         "config": {
             "clock_source": {
@@ -3456,7 +3434,6 @@
             "ANALOGOUT",
             "CAN",
             "LOWPOWERTIMER",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3496,7 +3473,7 @@
         },
         "extra_labels_add": ["STM32F4", "STM32F439", "STM32F439VI", "STM32F439xx", "STM32F439xI"],
         "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT"],
-        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "MPU"],
+        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH", "MPU"],
         "detect_code": ["9015"],
         "release_versions": ["2", "5"],
         "device_name" : "STM32F439VI",
@@ -3522,7 +3499,7 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CRC", "SERIAL_FC", "MPU"],
+        "device_has_add": ["CRC", "MPU"],
         "device_has_remove": ["LPTICKER"],
         "device_name": "STM32F051R8"
     },
@@ -3554,7 +3531,7 @@
         },
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "release_versions": ["2", "5"],
-        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "SERIAL_FC", "MPU"],
+        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "MPU"],
         "device_name": "STM32F303VC"
     },
     "DISCO_F334C8": {
@@ -3570,7 +3547,7 @@
         },
         "overrides": { "lse_available": 0 },
         "detect_code": ["0810"],
-        "device_has_add": ["ANALOGOUT", "CRC", "SERIAL_ASYNCH", "SERIAL_FC"],
+        "device_has_add": ["ANALOGOUT", "CRC", "SERIAL_ASYNCH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32F334C8"
@@ -3626,7 +3603,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3659,7 +3635,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "QSPI",
@@ -3688,7 +3663,7 @@
             "lse_available": 0,
             "lpticker_delay_ticks": 4
         },
-        "device_has_add": ["ANALOGOUT", "CRC", "SERIAL_FC", "FLASH", "MPU"],
+        "device_has_add": ["ANALOGOUT", "CRC", "FLASH", "MPU"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L053C8"
@@ -3721,7 +3696,6 @@
         "detect_code": ["0833"],
         "device_has_add": [
             "ANALOGOUT",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
@@ -3742,7 +3716,6 @@
         "detect_code": ["0456"],
         "device_has_add": [
             "ANALOGOUT",
-            "SERIAL_FC",
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
@@ -3881,7 +3854,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "QSPI",
@@ -3917,7 +3889,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "QSPI",
@@ -3951,6 +3922,9 @@
             "toolchains": ["GCC_ARM", "ARM_STD", "ARM_MICRO", "IAR"]
         },
         "device_has_add": ["MPU"],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
         "release_versions": ["2", "5"],
         "device_name": "STM32F411RE"
     },
@@ -3977,6 +3951,9 @@
             "toolchains": ["GCC_ARM", "ARM_STD", "ARM_MICRO", "IAR"]
         },
         "device_has_add": ["MPU"],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
         "release_versions": ["2", "5"],
         "device_name": "STM32F411RE"
     },
@@ -4013,7 +3990,6 @@
             "ANALOGOUT",
             "CAN",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -4043,6 +4019,9 @@
         },
         "macros_add": ["HSE_VALUE=26000000", "VECT_TAB_OFFSET=0x08010000"],
         "device_has_add": ["MPU"],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
         "post_binary_hook": {
             "function": "MTSCode.combine_bins_mtb_mts_dragonfly",
             "toolchains": ["GCC_ARM", "ARM_STD", "ARM_MICRO", "IAR"]
@@ -4064,6 +4043,9 @@
         },
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "device_has_add": ["ANALOGOUT", "FLASH", "MPU"],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
         "release_versions": ["5"],
         "device_name": "STM32L151CC",
         "bootloader_supported": true
@@ -4090,6 +4072,9 @@
         },
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "device_has_add": ["ANALOGOUT", "FLASH", "MPU"],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
         "release_versions": ["5"],
         "device_name": "STM32L151CC",
         "bootloader_supported": true
@@ -4101,6 +4086,9 @@
         "extra_labels_add": ["STM32L1", "STM32L151xBA", "STM32L151CBA"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "device_has_add": ["ANALOGOUT", "MPU"],
+        "device_has_remove": [
+            "SERIAL_FC"
+        ],
         "release_versions": ["5"],
         "device_name": "STM32L151CBxxA",
         "bootloader_supported": true
@@ -4114,6 +4102,7 @@
         "extra_labels_add": ["STM32L1", "STM32L152RC"],
         "detect_code": ["4100"],
         "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "FLASH", "MPU"],
+        "device_has_remove": ["SERIAL_FC"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L152RC"
     },
@@ -4167,7 +4156,6 @@
             "TRNG",
             "FLASH",
             "WIFI",
-            "SERIAL_FC",
             "SERIAL"
         ],
         "features": ["BLE"],
@@ -4261,7 +4249,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "EMAC",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -6895,7 +6882,7 @@
         "default_toolchain": "GCC_ARM",
         "extra_labels_add": ["STM32F1", "STM32F103C8"],
         "supported_toolchains": ["GCC_ARM"],
-        "device_has_add": ["CAN", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": ["CAN", "SERIAL_ASYNCH", "FLASH"],
         "device_has_remove": ["STDIO_MESSAGES", "LPTICKER"]
     },
     "NUMAKER_PFM_NUC472": {
@@ -7311,7 +7298,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU",
@@ -7347,7 +7333,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -7386,7 +7371,6 @@
             "CAN",
             "CRC",
             "SERIAL_ASYNCH",
-            "SERIAL_FC",
             "TRNG",
             "FLASH",
             "MPU"
@@ -7541,7 +7525,7 @@
                 "macro_name": "CLOCK_SOURCE"
             }
         },
-        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["SERIAL_ASYNCH", "FLASH"],
         "release_versions": ["2"],
         "device_name": "STM32F411RE"
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2078,7 +2078,10 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CAN", "CRC"],
+        "device_has_add": [
+            "CAN",
+            "CRC"
+        ],
         "device_has_remove": ["LPTICKER"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -2101,7 +2104,11 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CRC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": [
+            "CRC",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
         "release_versions": ["2", "5"],
         "device_name": "STM32F070RB"
     },
@@ -2177,7 +2184,11 @@
             }
         },
         "detect_code": ["0700"],
-        "device_has_add": ["CAN", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": [
+            "CAN",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
         "device_has_remove": ["LPTICKER"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F103RB"
@@ -2255,7 +2266,11 @@
         "overrides": { "lse_available": 0 },
         "detect_code": ["0775"],
         "default_lib": "small",
-        "device_has_add": ["ANALOGOUT", "CAN", "CRC"],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC"
+        ],
         "release_versions": ["2"],
         "device_name": "STM32F303K8"
     },
@@ -2338,7 +2353,11 @@
         },
         "detect_code": ["0720"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["SERIAL_ASYNCH", "FLASH", "MPU"],
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
         "release_versions": ["2", "5"],
         "device_name": "STM32F401RE"
     },
@@ -2354,7 +2373,11 @@
             }
         },
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "HSE_VALUE=25000000"],
-        "device_has_add": ["SERIAL_ASYNCH", "FLASH", "MPU"],
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
         "overrides": { "lse_available": 0 },
         "release_versions": ["2", "5"],
         "device_name": "STM32F401VE"
@@ -2415,7 +2438,11 @@
             }
         },
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["SERIAL_ASYNCH", "FLASH", "MPU"],
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH",
+            "MPU"
+        ],
         "release_versions": ["2", "5"],
         "device_name": "STM32F411RE",
         "bootloader_supported": true
@@ -3016,7 +3043,10 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0780"],
-        "device_has_add": ["CRC", "FLASH"],
+        "device_has_add": [
+            "CRC",
+            "FLASH"
+        ],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L011K4"
@@ -3040,7 +3070,10 @@
         },
         "overrides": { "lpticker_delay_ticks": 4 },
         "detect_code": ["0790"],
-        "device_has_add": ["CRC", "FLASH"],
+        "device_has_add": [
+            "CRC",
+            "FLASH"
+        ],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L031K6"
@@ -3472,7 +3505,13 @@
         },
         "extra_labels_add": ["STM32F4", "STM32F439", "STM32F439VI", "STM32F439xx", "STM32F439xI"],
         "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "TRNG", "FLASH", "MPU"],
+        "device_has_add": [
+            "ANALOGOUT",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
         "detect_code": ["9015"],
         "release_versions": ["2", "5"],
         "device_name" : "STM32F439VI",
@@ -3498,7 +3537,10 @@
             "CMSIS_VECTAB_VIRTUAL",
             "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""
         ],
-        "device_has_add": ["CRC", "MPU"],
+        "device_has_add": [
+            "CRC",
+            "MPU"
+        ],
         "device_has_remove": ["LPTICKER"],
         "device_name": "STM32F051R8"
     },
@@ -3530,7 +3572,12 @@
         },
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "release_versions": ["2", "5"],
-        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "MPU"],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "CRC",
+            "MPU"
+        ],
         "device_name": "STM32F303VC"
     },
     "DISCO_F334C8": {
@@ -3546,7 +3593,11 @@
         },
         "overrides": { "lse_available": 0 },
         "detect_code": ["0810"],
-        "device_has_add": ["ANALOGOUT", "CRC", "SERIAL_ASYNCH"],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "SERIAL_ASYNCH"
+        ],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32F334C8"
@@ -3662,7 +3713,12 @@
             "lse_available": 0,
             "lpticker_delay_ticks": 4
         },
-        "device_has_add": ["ANALOGOUT", "CRC", "FLASH", "MPU"],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CRC",
+            "FLASH",
+            "MPU"
+        ],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L053C8"
@@ -6881,7 +6937,11 @@
         "default_toolchain": "GCC_ARM",
         "extra_labels_add": ["STM32F1", "STM32F103C8"],
         "supported_toolchains": ["GCC_ARM"],
-        "device_has_add": ["CAN", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": [
+            "CAN",
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
         "device_has_remove": ["STDIO_MESSAGES", "LPTICKER"]
     },
     "NUMAKER_PFM_NUC472": {
@@ -7524,7 +7584,10 @@
                 "macro_name": "CLOCK_SOURCE"
             }
         },
-        "device_has_add": ["SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": [
+            "SERIAL_ASYNCH",
+            "FLASH"
+        ],
         "release_versions": ["2"],
         "device_name": "STM32F411RE"
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3433,7 +3433,6 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
-            "LOWPOWERTIMER",
             "TRNG",
             "FLASH",
             "MPU"
@@ -3473,7 +3472,7 @@
         },
         "extra_labels_add": ["STM32F4", "STM32F439", "STM32F439VI", "STM32F439xx", "STM32F439xI"],
         "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT"],
-        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH", "MPU"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "TRNG", "FLASH", "MPU"],
         "detect_code": ["9015"],
         "release_versions": ["2", "5"],
         "device_name" : "STM32F439VI",


### PR DESCRIPTION
### Description

This fixes #8626 

There is no restriction to enable SERIAL_FC at FAMILY_STM32 level,
and not for all targets 1 by 1.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

