### PR TITLE
Fix warning in Crypto when using boot seed injection

### DIFF
--- a/features/mbedtls/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/inc/default_random_seed.h
+++ b/features/mbedtls/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/inc/default_random_seed.h
@@ -3,6 +3,8 @@
 #ifndef DEFAULT_RANDOM_SEED_H
 #define DEFAULT_RANDOM_SEED_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -17,6 +17,10 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+
+#ifndef __PLATFORM_MBED__H__
+#define __PLATFORM_MBED__H__
+
 #if defined(TARGET_PSA)
 #include "default_random_seed.h"
 #endif
@@ -35,3 +39,5 @@
 #define MBEDTLS_ERR_PLATFORM_HW_FAILED       -0x0080
 
 #define MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED -0x0070
+
+#endif  // __PLATFORM_MBED__H__

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -17,6 +17,10 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+#if defined(TARGET_PSA)
+#include "default_random_seed.h"
+#endif
+
 #if DEVICE_TRNG
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -21,9 +21,19 @@
 #ifndef __PLATFORM_MBED__H__
 #define __PLATFORM_MBED__H__
 
-#if defined(TARGET_PSA)
+#if (defined(TARGET_PSA) && defined(MBEDTLS_ENTROPY_NV_SEED))
+
 #include "default_random_seed.h"
+
+#if !defined(MBEDTLS_PLATFORM_NV_SEED_READ_MACRO)
+#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO mbed_default_seed_read
 #endif
+
+#if !defined(MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO)
+#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO mbed_default_seed_write
+#endif
+
+#endif  // (defined(TARGET_PSA) && defined(MBEDTLS_ENTROPY_NV_SEED))
 
 #if DEVICE_TRNG
 #define MBEDTLS_ENTROPY_HARDWARE_ALT

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7904,9 +7904,7 @@
             "PSOC6_DYNSRM_DISABLE=1",
             "MBEDTLS_PSA_CRYPTO_SPM",
             "MBEDTLS_PSA_CRYPTO_C",
-            "MBEDTLS_ENTROPY_NV_SEED",
-            "MBEDTLS_PLATFORM_NV_SEED_READ_MACRO=mbed_default_seed_read",
-            "MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO=mbed_default_seed_write"
+            "MBEDTLS_ENTROPY_NV_SEED"
         ],
         "deliver_to_target": "FUTURE_SEQUANA_PSA",
         "overrides": {


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

When enabling boot seed injection (e.g. FUTURE_SEQUANA_M0_PSA) entropy read & write callbacks are injected via macros and cause implicit declaration compilation warning.
```txt
Compile [ 37.1%]: entropy.c
[Warning] <command-line>@0,38: implicit declaration of function 'mbed_default_seed_write' [-Wimplicit-function-declaration]
...
Compile [ 37.1%]: entropy.c
[Warning] <command-line>@0,38: implicit declaration of function 'mbed_default_seed_write' [-Wimplicit-function-declaration]
```

This PR fixes the warning by adding include to a `platfrom_mbed.h`

In addition this PR suggests simplified and user friendly way of wiring NVSEED read/write callbacks.
`MBEDTLS_ENTROPY_NV_SEED` macro is sufficient since the callbacks have fixed values for all PSA targets.

The option for advanced user to inject custom version of `MBEDTLS_PLATFORM_NV_SEED_READ_MACRO` and `MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO` is preserved.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@netanelgonen @Patater @avolinski @sbutcher-arm 
