### PR TITLE
tests-netsocket-udp: UDPSOCKET_ECHOTEST_NONBLOCK fixes

### DIFF
--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -33,10 +33,26 @@
 
 using namespace utest::v1;
 
+namespace {
+Timer tc_bucket; // Timer to limit a test cases run time
+}
+
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE
 mbed_stats_socket_t udp_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
 #endif
 
+void drop_bad_packets(UDPSocket &sock, int orig_timeout)
+{
+    nsapi_error_t err;
+    sock.set_timeout(0);
+    while (true) {
+        err = sock.recv(NULL, 0);
+        if (err == NSAPI_ERROR_WOULD_BLOCK) {
+            break;
+        }
+    }
+    sock.set_timeout(orig_timeout);
+}
 static void _ifup()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
@@ -51,24 +67,17 @@ static void _ifdown()
     printf("MBED: ifdown\n");
 }
 
-void drop_bad_packets(UDPSocket &sock, int orig_timeout)
-{
-    nsapi_error_t err;
-    sock.set_timeout(0);
-    while (true) {
-        err = sock.recvfrom(NULL, 0, 0);
-        if (err == NSAPI_ERROR_WOULD_BLOCK) {
-            break;
-        }
-    }
-    sock.set_timeout(orig_timeout);
-}
 
 void fill_tx_buffer_ascii(char *buff, size_t len)
 {
     for (size_t i = 0; i < len; ++i) {
         buff[i] = (rand() % 43) + '0';
     }
+}
+
+int split2half_rmng_udp_test_time()
+{
+    return (udp_global::TESTS_TIMEOUT - tc_bucket.read()) / 2;
 }
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE
@@ -81,20 +90,20 @@ int fetch_stats()
 // Test setup
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(480, "default_auto");
+    GREENTEA_SETUP(udp_global::TESTS_TIMEOUT, "default_auto");
     _ifup();
+    tc_bucket.start();
     return greentea_test_setup_handler(number_of_cases);
 }
 
 void greentea_teardown(const size_t passed, const size_t failed, const failure_t failure)
 {
+    tc_bucket.stop();
     _ifdown();
     return greentea_test_teardown_handler(passed, failed, failure);
 }
 
 Case cases[] = {
-    Case("UDPSOCKET_ECHOTEST", UDPSOCKET_ECHOTEST),
-    Case("UDPSOCKET_ECHOTEST_NONBLOCK", UDPSOCKET_ECHOTEST_NONBLOCK),
     Case("UDPSOCKET_OPEN_CLOSE_REPEAT", UDPSOCKET_OPEN_CLOSE_REPEAT),
     Case("UDPSOCKET_OPEN_LIMIT", UDPSOCKET_OPEN_LIMIT),
     Case("UDPSOCKET_RECV_TIMEOUT", UDPSOCKET_RECV_TIMEOUT),
@@ -110,10 +119,11 @@ Case cases[] = {
     Case("UDPSOCKET_BIND_WRONG_TYPE", UDPSOCKET_BIND_WRONG_TYPE),
     Case("UDPSOCKET_BIND_UNOPENED", UDPSOCKET_BIND_UNOPENED),
     Case("UDPSOCKET_SENDTO_INVALID", UDPSOCKET_SENDTO_INVALID),
-    Case("UDPSOCKET_ECHOTEST", UDPSOCKET_ECHOTEST),
-    Case("UDPSOCKET_ECHOTEST_BURST", UDPSOCKET_ECHOTEST_BURST),
+    Case("UDPSOCKET_ECHOTEST_NONBLOCK", UDPSOCKET_ECHOTEST_NONBLOCK),
     Case("UDPSOCKET_ECHOTEST_BURST_NONBLOCK", UDPSOCKET_ECHOTEST_BURST_NONBLOCK),
     Case("UDPSOCKET_SENDTO_REPEAT", UDPSOCKET_SENDTO_REPEAT),
+    Case("UDPSOCKET_ECHOTEST", UDPSOCKET_ECHOTEST),
+    Case("UDPSOCKET_ECHOTEST_BURST", UDPSOCKET_ECHOTEST_BURST),
 };
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);

--- a/TESTS/netsocket/udp/udp_tests.h
+++ b/TESTS/netsocket/udp/udp_tests.h
@@ -27,6 +27,15 @@ extern mbed_stats_socket_t udp_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
 int fetch_stats(void);
 #endif
 
+/**
+ * Single testcase might take only half of the remaining execution time
+ */
+int split2half_rmng_udp_test_time(); // [s]
+
+namespace udp_global {
+static const int TESTS_TIMEOUT = 480;
+}
+
 /*
  * Test cases
  */

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -118,7 +118,7 @@ void udpsocket_echotest_nonblock_receiver(void *receive_bytes)
         }
     }
 
-    drop_bad_packets(sock, -1); // timeout equivalent to set_blocking(false)
+    drop_bad_packets(sock, 0); // timeout equivalent to set_blocking(false)
 
     tx_sem.release();
 }


### PR DESCRIPTION
### Description
tests-netsocket-udp: UDPSOCKET_ECHOTEST_NONBLOCK execution time limit
    
Test case is allowed to take not more than a half what has been given
for the whole UDP suite.
    
UDP test cases reorganized so that the longest running ones are
executed last.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-ipcore 
@TeemuKultala 
@mirelachirica 
@AriParkkila 
@kivaisan 

