### PR TITLE
Crypto IPC 64 bit key ids for ITS

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -29,7 +29,12 @@
 #include "crypto.h"
 #include "crypto_platform_spe.h"
 
+#include "mbed_assert.h"
+
 #define MINOR_VER 1
+#define CLIENT_PSA_KEY_ID_SIZE_IN_BYTES 4
+
+MBED_STATIC_ASSERT(sizeof(psa_key_id_t) == CLIENT_PSA_KEY_ID_SIZE_IN_BYTES, "Unexpected psa_key_id_t size");
 
 psa_status_t psa_crypto_init(void)
 {

--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -23,6 +23,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+
 #include "psa_crypto_srv_ifs.h"
 #include "psa/client.h"
 #include "crypto.h"
@@ -32,7 +33,7 @@
 
 psa_status_t psa_crypto_init(void)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_handle_t handle = PSA_NULL_HANDLE;
 
     handle = psa_connect(PSA_CRYPTO_INIT_ID, MINOR_VER);
@@ -40,10 +41,10 @@ psa_status_t psa_crypto_init(void)
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, NULL, 0, NULL, 0);
+    status = psa_call(handle, NULL, 0, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 /****************************************************************/
@@ -52,7 +53,7 @@ psa_status_t psa_crypto_init(void)
 
 psa_status_t psa_mac_abort(psa_mac_operation_t *operation)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     if (operation->handle <= 0) {
@@ -63,11 +64,11 @@ psa_status_t psa_mac_abort(psa_mac_operation_t *operation)
 
     psa_invec in_vec = { &psa_crypto_ipc, sizeof(psa_crypto_ipc) };
 
-    err_call = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 static psa_status_t psa_mac_setup(psa_mac_operation_t *operation,
@@ -75,7 +76,7 @@ static psa_status_t psa_mac_setup(psa_mac_operation_t *operation,
                                   psa_algorithm_t alg,
                                   psa_sec_function_t func)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = func;
@@ -90,9 +91,8 @@ static psa_status_t psa_mac_setup(psa_mac_operation_t *operation,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err = psa_call(operation->handle, &in_vec, 1, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_mac_sign_setup(psa_mac_operation_t *operation,
@@ -119,7 +119,7 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
                             const uint8_t *input,
                             size_t input_length)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_MAC_UPDATE;
@@ -132,9 +132,8 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err = psa_call(operation->handle, in_vec, 2, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, in_vec, 2, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
@@ -142,7 +141,7 @@ psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
                                  size_t mac_size,
                                  size_t *mac_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_MAC_SIGN_FINISH;
@@ -156,18 +155,18 @@ psa_status_t psa_mac_sign_finish(psa_mac_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(operation->handle, in_vec, 2, out_vec, 2);
+    status = psa_call(operation->handle, in_vec, 2, out_vec, 2);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
                                    const uint8_t *mac,
                                    size_t mac_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_MAC_VERIFY_FINISH;
@@ -181,11 +180,11 @@ psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(operation->handle, in_vec, 3, NULL, 0);
+    status = psa_call(operation->handle, in_vec, 3, NULL, 0);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 
@@ -195,7 +194,7 @@ psa_status_t psa_mac_verify_finish(psa_mac_operation_t *operation,
 
 psa_status_t psa_hash_abort(psa_hash_operation_t *operation)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     if (operation->handle <= 0) {
@@ -206,17 +205,17 @@ psa_status_t psa_hash_abort(psa_hash_operation_t *operation)
 
     psa_invec in_vec = { &psa_crypto_ipc, sizeof(psa_crypto_ipc) };
 
-    err_call = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
                             psa_algorithm_t alg)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_HASH_SETUP;
@@ -229,16 +228,15 @@ psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err = psa_call(operation->handle, &in_vec, 1, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_hash_update(psa_hash_operation_t *operation,
                              const uint8_t *input,
                              size_t input_length)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_HASH_UPDATE;
@@ -251,9 +249,8 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err = psa_call(operation->handle, in_vec, 2, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, in_vec, 2, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
@@ -261,7 +258,7 @@ psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
                              size_t hash_size,
                              size_t *hash_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_HASH_FINISH;
@@ -277,18 +274,18 @@ psa_status_t psa_hash_finish(psa_hash_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(operation->handle, in_vec, 2, out_vec, 2);
+    status = psa_call(operation->handle, in_vec, 2, out_vec, 2);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
                              const uint8_t *hash,
                              size_t hash_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
 
     psa_crypto_ipc.func = PSA_HASH_VERIFY;
@@ -302,17 +299,17 @@ psa_status_t psa_hash_verify(psa_hash_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(operation->handle, in_vec, 3, NULL, 0);
+    status = psa_call(operation->handle, in_vec, 3, NULL, 0);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_hash_clone(const psa_hash_operation_t *source_operation,
                             psa_hash_operation_t *target_operation)
 {
-    psa_status_t err_call = 0;
+    psa_status_t status = 0;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     size_t index;
 
@@ -332,20 +329,20 @@ psa_status_t psa_hash_clone(const psa_hash_operation_t *source_operation,
     }
 
     psa_crypto_ipc.func = PSA_HASH_CLONE_BEGIN;
-    err_call = psa_call(source_operation->handle, in_vec, 1, &out_vec, 1);
-    if (err_call != 0) {
+    status = psa_call(source_operation->handle, in_vec, 1, &out_vec, 1);
+    if (status != PSA_SUCCESS) {
         goto exit;
     }
 
     psa_crypto_ipc.func = PSA_HASH_CLONE_END;
-    err_call = psa_call(target_operation->handle, in_vec, 2, NULL, 0);
+    status = psa_call(target_operation->handle, in_vec, 2, NULL, 0);
 
 exit:
-    if (err_call != 0) {
+    if (status != PSA_SUCCESS) {
         psa_close(target_operation->handle);
         target_operation->handle = PSA_NULL_HANDLE;
     }
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 /****************************************************************/
@@ -364,7 +361,7 @@ psa_status_t psa_aead_encrypt(psa_key_handle_t key_handle,
                               size_t *ciphertext_length)
 {
     psa_handle_t handle = PSA_NULL_HANDLE;
-    psa_status_t call_error = PSA_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     psa_crypto_ipc_aead_t psa_crypto_ipc = { 0, 0, 0, 0, 0, 0, { 0 } };
     psa_invec in_vec[2];
     psa_outvec out_vec[2];
@@ -413,11 +410,10 @@ psa_status_t psa_aead_encrypt(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    call_error = psa_call(handle, in_vec, 2, out_vec, 2);
-
+    status = psa_call(handle, in_vec, 2, out_vec, 2);
     psa_close(handle);
 
-    return ((psa_status_t)call_error);
+    return (status);
 }
 
 
@@ -434,7 +430,7 @@ psa_status_t psa_aead_decrypt(psa_key_handle_t key_handle,
                               size_t *plaintext_length)
 {
     psa_handle_t handle = PSA_NULL_HANDLE;
-    psa_status_t call_error = PSA_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     psa_crypto_ipc_aead_t psa_crypto_ipc = { 0, 0, 0, 0, 0, 0, { 0 } };
     psa_invec in_vec[2];
     psa_outvec out_vec[2];
@@ -482,11 +478,10 @@ psa_status_t psa_aead_decrypt(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    call_error = psa_call(handle, in_vec, 2, out_vec, 2);
-
+    status = psa_call(handle, in_vec, 2, out_vec, 2);
     psa_close(handle);
 
-    return ((psa_status_t)call_error);
+    return (status);
 }
 
 /****************************************************************/
@@ -502,7 +497,7 @@ psa_status_t psa_asymmetric_sign(psa_key_handle_t key_handle,
                                  size_t *signature_length)
 {
     psa_handle_t handle = PSA_NULL_HANDLE;
-    psa_status_t call_error = PSA_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     psa_crypto_ipc_asymmetric_t psa_crypto_ipc = { 0, 0, 0, 0, 0 };
     psa_invec in_vec[2];
     psa_outvec out_vec[2];
@@ -530,11 +525,10 @@ psa_status_t psa_asymmetric_sign(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    call_error = psa_call(handle, in_vec, 2, out_vec, 2);
-
+    status = psa_call(handle, in_vec, 2, out_vec, 2);
     psa_close(handle);
 
-    return ((psa_status_t)call_error);
+    return (status);
 }
 
 psa_status_t psa_asymmetric_verify(psa_key_handle_t key_handle,
@@ -545,7 +539,7 @@ psa_status_t psa_asymmetric_verify(psa_key_handle_t key_handle,
                                    size_t signature_size)
 {
     psa_handle_t handle = PSA_NULL_HANDLE;
-    psa_status_t call_error = PSA_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     psa_crypto_ipc_asymmetric_t psa_crypto_ipc = { 0, 0, 0, 0, 0 };
     psa_invec in_vec[3];
 
@@ -567,10 +561,10 @@ psa_status_t psa_asymmetric_verify(psa_key_handle_t key_handle,
     if (handle <= 0) {
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
-    call_error = psa_call(handle, in_vec, 3, NULL, 0);
+    status = psa_call(handle, in_vec, 3, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t)call_error);
+    return (status);
 }
 
 static psa_status_t psa_asymmetric_operation(psa_sec_function_t func,
@@ -585,7 +579,7 @@ static psa_status_t psa_asymmetric_operation(psa_sec_function_t func,
                                              size_t *output_length)
 {
     psa_handle_t handle = PSA_NULL_HANDLE;
-    psa_status_t call_error = PSA_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     psa_crypto_ipc_asymmetric_t psa_crypto_ipc = { 0, 0, 0, 0, 0 };
     psa_invec in_vec[2];
     psa_outvec out_vec[2];
@@ -624,11 +618,10 @@ static psa_status_t psa_asymmetric_operation(psa_sec_function_t func,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    call_error = psa_call(handle, in_vec, 2, out_vec, 2);
-
+    status = psa_call(handle, in_vec, 2, out_vec, 2);
     psa_close(handle);
 
-    return ((psa_status_t)call_error);
+    return (status);
 }
 
 psa_status_t psa_asymmetric_encrypt(psa_key_handle_t key_handle,
@@ -673,7 +666,7 @@ psa_status_t psa_asymmetric_decrypt(psa_key_handle_t key_handle,
 
 psa_status_t psa_allocate_key(psa_key_handle_t *key_handle)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = *key_handle;
     psa_key_mng_ipc.func = PSA_ALLOCATE_KEY;
@@ -690,17 +683,17 @@ psa_status_t psa_allocate_key(psa_key_handle_t *key_handle)
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, out_vec, 1);
+    status = psa_call(handle, in_vec, 1, out_vec, 1);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_create_key(psa_key_lifetime_t lifetime,
                             psa_key_id_t id,
                             psa_key_handle_t *key_handle)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = *key_handle;
     psa_key_mng_ipc.lifetime = lifetime;
@@ -720,17 +713,17 @@ psa_status_t psa_create_key(psa_key_lifetime_t lifetime,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 2, out_vec, 1);
+    status = psa_call(handle, in_vec, 2, out_vec, 1);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_open_key(psa_key_lifetime_t lifetime,
                           psa_key_id_t id,
                           psa_key_handle_t *key_handle)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = *key_handle;
     psa_key_mng_ipc.lifetime = lifetime;
@@ -750,15 +743,15 @@ psa_status_t psa_open_key(psa_key_lifetime_t lifetime,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 2, out_vec, 1);
+    status = psa_call(handle, in_vec, 2, out_vec, 1);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_close_key(psa_key_handle_t key_handle)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = PSA_CLOSE_KEY;
@@ -772,16 +765,16 @@ psa_status_t psa_close_key(psa_key_handle_t key_handle)
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, NULL, 0);
+    status = psa_call(handle, in_vec, 1, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_get_key_lifetime(psa_key_handle_t key_handle,
                                   psa_key_lifetime_t *lifetime)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = PSA_GET_KEY_LIFETIME;
@@ -800,10 +793,10 @@ psa_status_t psa_get_key_lifetime(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, out_vec, 1);
+    status = psa_call(handle, in_vec, 1, out_vec, 1);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_key_usage_t psa_key_policy_get_usage(const psa_key_policy_t *policy)
@@ -827,7 +820,7 @@ void psa_key_policy_set_usage(psa_key_policy_t *policy,
 psa_status_t psa_set_key_policy(psa_key_handle_t key_handle,
                                 const psa_key_policy_t *policy)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = PSA_SET_KEY_POLICY;
@@ -842,16 +835,16 @@ psa_status_t psa_set_key_policy(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 2, NULL, 0);
+    status = psa_call(handle, in_vec, 2, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_get_key_policy(psa_key_handle_t key_handle,
                                 psa_key_policy_t *policy)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = PSA_GET_KEY_POLICY;
@@ -872,10 +865,10 @@ psa_status_t psa_get_key_policy(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, out_vec, 1);
+    status = psa_call(handle, in_vec, 1, out_vec, 1);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_import_key(psa_key_handle_t key_handle,
@@ -883,7 +876,7 @@ psa_status_t psa_import_key(psa_key_handle_t key_handle,
                             const uint8_t *data,
                             size_t data_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.type = type;
@@ -899,15 +892,15 @@ psa_status_t psa_import_key(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 2, NULL, 0);
+    status = psa_call(handle, in_vec, 2, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_destroy_key(psa_key_handle_t key_handle)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = PSA_DESTROY_KEY;
@@ -921,17 +914,17 @@ psa_status_t psa_destroy_key(psa_key_handle_t key_handle)
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, NULL, 0);
+    status = psa_call(handle, in_vec, 1, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_get_key_information(psa_key_handle_t key_handle,
                                      psa_key_type_t *type,
                                      size_t *bits)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = PSA_GET_KEY_INFORMATION;
@@ -956,10 +949,10 @@ psa_status_t psa_get_key_information(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, out_vec, 2);
+    status = psa_call(handle, in_vec, 1, out_vec, 2);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 static psa_status_t psa_export_key_common(psa_key_handle_t key_handle,
@@ -968,7 +961,7 @@ static psa_status_t psa_export_key_common(psa_key_handle_t key_handle,
                                           size_t *data_length,
                                           psa_sec_function_t func)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.func = func;
@@ -984,10 +977,10 @@ static psa_status_t psa_export_key_common(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 1, out_vec, 2);
+    status = psa_call(handle, in_vec, 1, out_vec, 2);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_export_key(psa_key_handle_t key_handle,
@@ -1017,7 +1010,7 @@ psa_status_t psa_generate_key(psa_key_handle_t key_handle,
                               const void *parameters,
                               size_t parameters_size)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_key_mng_ipc_t psa_key_mng_ipc = { 0, 0, 0, 0 };
     psa_key_mng_ipc.handle = key_handle;
     psa_key_mng_ipc.type = type;
@@ -1041,10 +1034,10 @@ psa_status_t psa_generate_key(psa_key_handle_t key_handle,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, in_vec, 3, NULL, 0);
+    status = psa_call(handle, in_vec, 3, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 /****************************************************************/
@@ -1054,7 +1047,7 @@ psa_status_t psa_generate_key(psa_key_handle_t key_handle,
 psa_status_t psa_generate_random(uint8_t *output,
                                  size_t output_size)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_handle_t handle = PSA_NULL_HANDLE;
     psa_outvec out_vec[1] = { { output, output_size } };
 
@@ -1063,10 +1056,10 @@ psa_status_t psa_generate_random(uint8_t *output,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, NULL, 0, out_vec, 1);
+    status = psa_call(handle, NULL, 0, out_vec, 1);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 /****************************************************************/
@@ -1076,7 +1069,7 @@ psa_status_t psa_generate_random(uint8_t *output,
 psa_status_t mbedtls_psa_inject_entropy(const unsigned char *seed,
                                         size_t seed_size)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_handle_t handle = PSA_NULL_HANDLE;
     psa_invec in_vec = { seed, seed_size };
 
@@ -1085,10 +1078,10 @@ psa_status_t mbedtls_psa_inject_entropy(const unsigned char *seed,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(handle, &in_vec, 1, NULL, 0);
+    status = psa_call(handle, &in_vec, 1, NULL, 0);
     psa_close(handle);
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 /****************************************************************/
 /* PSA Generator */
@@ -1096,7 +1089,7 @@ psa_status_t mbedtls_psa_inject_entropy(const unsigned char *seed,
 psa_status_t psa_get_generator_capacity(const psa_crypto_generator_t *generator,
                                         size_t *capacity)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_derivation_ipc_t psa_crypto_ipc = { 0, 0, 0, 0 };
     psa_crypto_ipc.func = PSA_GET_GENERATOR_CAPACITY;
     psa_invec in_vec = { &psa_crypto_ipc, sizeof(psa_crypto_ipc) };
@@ -1106,16 +1099,15 @@ psa_status_t psa_get_generator_capacity(const psa_crypto_generator_t *generator,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(generator->handle, &in_vec, 1, &out_vec, 1);
-
-    return ((psa_status_t) err_call);
+    status = psa_call(generator->handle, &in_vec, 1, &out_vec, 1);
+    return (status);
 }
 
 psa_status_t psa_generator_read(psa_crypto_generator_t *generator,
                                 uint8_t *output,
                                 size_t output_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_derivation_ipc_t psa_crypto_ipc = { 0, 0, 0, 0 };
     psa_crypto_ipc.func = PSA_GENERATOR_READ;
     psa_invec in_vec = { &psa_crypto_ipc, sizeof(psa_crypto_ipc) };
@@ -1125,9 +1117,8 @@ psa_status_t psa_generator_read(psa_crypto_generator_t *generator,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(generator->handle, &in_vec, 1, &out_vec, 1);
-
-    return ((psa_status_t) err_call);
+    status = psa_call(generator->handle, &in_vec, 1, &out_vec, 1);
+    return (status);
 }
 
 psa_status_t psa_generator_import_key(psa_key_handle_t key_handle,
@@ -1135,7 +1126,7 @@ psa_status_t psa_generator_import_key(psa_key_handle_t key_handle,
                                       size_t bits,
                                       psa_crypto_generator_t *generator)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_derivation_ipc_t psa_crypto_ipc = { 0, 0, 0, 0 };
     psa_crypto_ipc.handle = key_handle;
     psa_crypto_ipc.func = PSA_GENERATOR_IMPORT_KEY;
@@ -1148,9 +1139,8 @@ psa_status_t psa_generator_import_key(psa_key_handle_t key_handle,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(generator->handle, in_vec, 3, NULL, 0);
-
-    return ((psa_status_t) err_call);
+    status = psa_call(generator->handle, in_vec, 3, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_key_derivation(psa_crypto_generator_t *generator,
@@ -1162,7 +1152,7 @@ psa_status_t psa_key_derivation(psa_crypto_generator_t *generator,
                                 size_t label_length,
                                 size_t capacity)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_derivation_ipc_t psa_crypto_ipc = { 0, 0, 0, 0 };
     psa_crypto_ipc.handle = key_handle;
     psa_crypto_ipc.alg = alg;
@@ -1179,9 +1169,8 @@ psa_status_t psa_key_derivation(psa_crypto_generator_t *generator,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(generator->handle, in_vec, 3, NULL, 0);
-
-    return ((psa_status_t) err_call);
+    status = psa_call(generator->handle, in_vec, 3, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_key_agreement(psa_crypto_generator_t *generator,
@@ -1190,7 +1179,7 @@ psa_status_t psa_key_agreement(psa_crypto_generator_t *generator,
                                size_t peer_key_length,
                                psa_algorithm_t alg)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_derivation_ipc_t psa_crypto_ipc = { 0, 0, 0, 0 };
     psa_crypto_ipc.handle = private_key_handle;
     psa_crypto_ipc.alg = alg;
@@ -1205,25 +1194,23 @@ psa_status_t psa_key_agreement(psa_crypto_generator_t *generator,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err_call = psa_call(generator->handle, in_vec, 2, NULL, 0);
-
-    return ((psa_status_t) err_call);
+    status = psa_call(generator->handle, in_vec, 2, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_generator_abort(psa_crypto_generator_t *generator)
 {
-    psa_status_t err_call = PSA_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     psa_crypto_derivation_ipc_t psa_crypto_ipc = { 0, 0, 0, 0 };
     psa_crypto_ipc.func = PSA_GENERATOR_ABORT;
     psa_invec in_vec = { &psa_crypto_ipc, sizeof(psa_crypto_ipc) };
     if (generator->handle != PSA_NULL_HANDLE) {
-        err_call = psa_call(generator->handle, &in_vec, 1, NULL, 0);
+        status = psa_call(generator->handle, &in_vec, 1, NULL, 0);
         psa_close(generator->handle);
         generator->handle = PSA_NULL_HANDLE;
     }
 
-    return ((psa_status_t) err_call);
-
+    return (status);
 }
 
 /****************************************************************/
@@ -1234,7 +1221,7 @@ psa_status_t psa_cipher_encrypt_setup(psa_cipher_operation_t *operation,
                                       psa_key_handle_t key_handle,
                                       psa_algorithm_t alg)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec;
 
@@ -1250,16 +1237,15 @@ psa_status_t psa_cipher_encrypt_setup(psa_cipher_operation_t *operation,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err = psa_call(operation->handle, &in_vec, 1, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_cipher_decrypt_setup(psa_cipher_operation_t *operation,
                                       psa_key_handle_t key_handle,
                                       psa_algorithm_t alg)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec;
 
@@ -1277,9 +1263,8 @@ psa_status_t psa_cipher_decrypt_setup(psa_cipher_operation_t *operation,
         return (PSA_ERROR_COMMUNICATION_FAILURE);
     }
 
-    err = psa_call(operation->handle, &in_vec, 1, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
@@ -1287,7 +1272,7 @@ psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
                                     size_t iv_size,
                                     size_t *iv_length)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec;
     psa_outvec out_vec[2];
@@ -1309,16 +1294,15 @@ psa_status_t psa_cipher_generate_iv(psa_cipher_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err = psa_call(operation->handle, &in_vec, 1, out_vec, 2);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, &in_vec, 1, out_vec, 2);
+    return (status);
 }
 
 psa_status_t psa_cipher_set_iv(psa_cipher_operation_t *operation,
                                const unsigned char *iv,
                                size_t iv_length)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec[2];
 
@@ -1335,9 +1319,8 @@ psa_status_t psa_cipher_set_iv(psa_cipher_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err = psa_call(operation->handle, in_vec, 2, NULL, 0);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, in_vec, 2, NULL, 0);
+    return (status);
 }
 
 psa_status_t psa_cipher_update(psa_cipher_operation_t *operation,
@@ -1347,7 +1330,7 @@ psa_status_t psa_cipher_update(psa_cipher_operation_t *operation,
                                size_t output_size,
                                size_t *output_length)
 {
-    psa_status_t err;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec[2];
     psa_outvec out_vec[2];
@@ -1373,9 +1356,8 @@ psa_status_t psa_cipher_update(psa_cipher_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err = psa_call(operation->handle, in_vec, 2, out_vec, 2);
-
-    return ((psa_status_t) err);
+    status = psa_call(operation->handle, in_vec, 2, out_vec, 2);
+    return (status);
 }
 
 psa_status_t psa_cipher_finish(psa_cipher_operation_t *operation,
@@ -1383,7 +1365,7 @@ psa_status_t psa_cipher_finish(psa_cipher_operation_t *operation,
                                size_t output_size,
                                size_t *output_length)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec;
     psa_outvec out_vec[2];
@@ -1406,16 +1388,16 @@ psa_status_t psa_cipher_finish(psa_cipher_operation_t *operation,
         return (PSA_ERROR_BAD_STATE);
     }
 
-    err_call = psa_call(operation->handle, &in_vec, 1, out_vec, 2);
+    status = psa_call(operation->handle, &in_vec, 1, out_vec, 2);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation)
 {
-    psa_status_t err_call;
+    psa_status_t status;
     psa_crypto_ipc_t psa_crypto_ipc = { 0, 0, 0 };
     psa_invec in_vec;
 
@@ -1429,11 +1411,11 @@ psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation)
         &psa_crypto_ipc, sizeof(psa_crypto_ipc)
     };
 
-    err_call = psa_call(operation->handle, &in_vec, 1, NULL, 0);
+    status = psa_call(operation->handle, &in_vec, 1, NULL, 0);
     psa_close(operation->handle);
     operation->handle = PSA_NULL_HANDLE;
 
-    return ((psa_status_t) err_call);
+    return (status);
 }
 
 void mbedtls_psa_crypto_free(void)

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/crypto_spe.h
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/crypto_spe.h
@@ -65,6 +65,8 @@ extern "C" {
 #define psa_close_key  psa_sec_close_key
 #define psa_hash_clone  psa_sec_hash_clone
 
+#define MBEDTLS_PSA_CRYPTO_KEY_FILE_ID_ENCODES_OWNER 1
+
 #include "crypto.h"
 
 #ifdef __cplusplus

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -5,8 +5,6 @@
 #include "psa/service.h"
 #include "psa/client.h"
 
-#include "psa/client.h"
-#include "psa/service.h"
 #if defined(TARGET_TFM)
 #define SPM_PANIC(format, ...) \
 { \

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -1,5 +1,9 @@
 // ---------------------------------- Includes ---------------------------------
+#include <stdint.h>
+#include <string.h>
 
+#include "psa/service.h"
+#include "psa/client.h"
 
 #include "psa/client.h"
 #include "psa/service.h"
@@ -144,7 +148,7 @@ static void psa_crypto_init_operation(void)
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 static void psa_crypto_free_operation(void)
@@ -181,7 +185,7 @@ static void psa_crypto_free_operation(void)
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 static void psa_mac_operation(void)
@@ -352,7 +356,7 @@ static void psa_mac_operation(void)
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 static void psa_hash_operation(void)
@@ -737,7 +741,7 @@ static void psa_asymmetric_operation(void)
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 static void psa_aead_operation()
@@ -846,7 +850,7 @@ static void psa_aead_operation()
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 static void psa_symmetric_operation(void)
@@ -1016,7 +1020,7 @@ static void psa_symmetric_operation(void)
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 
@@ -1214,14 +1218,9 @@ static void psa_key_management_operation(void)
 
                 case PSA_CREATE_KEY: {
                     psa_key_id_t id = 0;
-                    size_t max_bits = 0;
 
                     bytes_read = psa_read(msg.handle, 1, &id, msg.in_size[1]);
                     if (bytes_read != msg.in_size[1]) {
-                        SPM_PANIC("SPM read length mismatch");
-                    }
-                    bytes_read = psa_read(msg.handle, 2, &max_bits, msg.in_size[2]);
-                    if (bytes_read != msg.in_size[2]) {
                         SPM_PANIC("SPM read length mismatch");
                     }
 
@@ -1535,7 +1534,7 @@ void psa_crypto_generator_operations(void)
         }
     }
 
-    psa_reply(msg.handle, (psa_status_t) status);
+    psa_reply(msg.handle, status);
 }
 
 


### PR DESCRIPTION
### Description
Support 64 bit crypto key ids for TARGET_PSA systems.

Crypto type `psa_key_id_t` is defined differently between client and server, this PR is here to provide the key owner (i.e. the calling partition) for use by the crypto library.

This PR assures that a crypto key can be opened only by the key owner/creator, i.e. the partition which created the key in the first place.

~~**Please do not merge or run CI** - depends on https://github.com/ARMmbed/mbed-crypto/pull/32 and also https://github.com/ARMmbed/mbed-crypto/pull/59. 
Once 32 and 59 have been merged to mbed-crypto this PR will need to be re-imported via crypto importer into Mbed OS.~~

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@avolinski @Patater 
<!-- 
    Optional
    Request additional reviewers with @username
-->

