### PR TITLE
Remove redundant ifdef DEVICE_TRNG from DeviceKey

### DIFF
--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -260,7 +260,7 @@ int DeviceKey::generate_key_by_random(uint32_t *output, size_t size)
         return DEVICEKEY_INVALID_PARAM;
     }
 
-#if DEVICE_TRNG
+#if defined(DEVICE_TRNG) || defined(MBEDTLS_ENTROPY_NV_SEED)
     uint32_t test_buff[DEVICE_KEY_32BYTE / sizeof(int)];
     mbedtls_entropy_context *entropy = new mbedtls_entropy_context;
     mbedtls_entropy_init(entropy);
@@ -276,6 +276,7 @@ int DeviceKey::generate_key_by_random(uint32_t *output, size_t size)
 
     mbedtls_entropy_free(entropy);
     delete entropy;
+
 #endif
 
     return ret;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Removing the ifdef DEVICE_TRNG from the code which prevents the use of device key with pseudo-random generator supported by mbedtls entropy function.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

