### PR TITLE
Greentea Socket test improvements

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
@@ -42,6 +42,7 @@ void ASYNCHRONOUS_DNS_CANCEL()
             count++;
         } else {
             // No memory to initiate DNS query, callback will not be called
+            printf("Error: No memory to initiate DNS query for %s\n", dns_test_hosts[i]);
             data[i].result = NSAPI_ERROR_NO_MEMORY;
             data[i].value_set = true;
         }

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -57,6 +57,15 @@ void drop_bad_packets(TCPSocket &sock, int orig_timeout)
     sock.set_timeout(orig_timeout);
 }
 
+nsapi_version_t get_ip_version()
+{
+    SocketAddress test;
+    if (!test.set_ip_address(NetworkInterface::get_default_instance()->get_ip_address())) {
+        return NSAPI_UNSPEC;
+    }
+    return test.get_ip_version();
+}
+
 static void _ifup()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -20,6 +20,7 @@
 
 NetworkInterface *get_interface();
 void drop_bad_packets(TCPSocket &sock, int orig_timeout);
+nsapi_version_t get_ip_version();
 void fill_tx_buffer_ascii(char *buff, size_t len);
 nsapi_error_t tcpsocket_connect_to_echo_srv(TCPSocket &sock);
 nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock);

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
@@ -39,7 +39,14 @@ void TCPSOCKET_BIND_ADDRESS_INVALID()
         return;
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
-    nsapi_error_t bind_result = sock->bind("190.2.3.4", 1024);
+    nsapi_error_t bind_result = NSAPI_ERROR_OK;
+    if (get_ip_version() == NSAPI_IPv4) {
+        bind_result = sock->bind("190.2.3.4", 1024);
+    } else if (get_ip_version() == NSAPI_IPv6) {
+        bind_result = sock->bind("fe80::ff01", 1024);
+    } else {
+        TEST_FAIL_MESSAGE("This stack is neither IPv4 nor IPv6");
+    }
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");
     } else {

--- a/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
@@ -40,7 +40,14 @@ void TCPSOCKET_BIND_WRONG_TYPE()
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     char addr_bytes[16] = {0xfe, 0x80, 0xff, 0x1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    SocketAddress sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
+    SocketAddress sockAddr;
+    if (get_ip_version() == NSAPI_IPv4) {
+        sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
+    } else if (get_ip_version() == NSAPI_IPv6) {
+        sockAddr = SocketAddress(addr_bytes, NSAPI_IPv6, 80);
+    } else {
+        TEST_FAIL_MESSAGE("This stack is neither IPv4 nor IPv6");
+    }
     nsapi_error_t bind_result = sock->bind(sockAddr);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -64,6 +64,15 @@ void drop_bad_packets(UDPSocket &sock, int orig_timeout)
     sock.set_timeout(orig_timeout);
 }
 
+nsapi_version_t get_ip_version()
+{
+    SocketAddress test;
+    if (!test.set_ip_address(NetworkInterface::get_default_instance()->get_ip_address())) {
+        return NSAPI_UNSPEC;
+    }
+    return test.get_ip_version();
+}
+
 void fill_tx_buffer_ascii(char *buff, size_t len)
 {
     for (size_t i = 0; i < len; ++i) {

--- a/TESTS/netsocket/udp/udp_tests.h
+++ b/TESTS/netsocket/udp/udp_tests.h
@@ -20,6 +20,7 @@
 
 NetworkInterface *get_interface();
 void drop_bad_packets(UDPSocket &sock, int orig_timeout);
+nsapi_version_t get_ip_version();
 void fill_tx_buffer_ascii(char *buff, size_t len);
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLE

--- a/TESTS/netsocket/udp/udpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_address_invalid.cpp
@@ -38,7 +38,16 @@ void UDPSOCKET_BIND_ADDRESS_INVALID()
         TEST_FAIL();
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
-    nsapi_error_t bind_result = sock->bind("190.2.3.4", 1024);
+
+    nsapi_error_t bind_result = NSAPI_ERROR_OK;
+    if (get_ip_version() == NSAPI_IPv4) {
+        bind_result = sock->bind("190.2.3.4", 1024);
+    } else if (get_ip_version() == NSAPI_IPv6) {
+        bind_result = sock->bind("fe80::ff01", 1024);
+    } else {
+        TEST_FAIL_MESSAGE("This stack is neither IPv4 nor IPv6");
+    }
+
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");
     } else {

--- a/TESTS/netsocket/udp/udpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/udp/udpsocket_bind_wrong_type.cpp
@@ -39,7 +39,14 @@ void UDPSOCKET_BIND_WRONG_TYPE()
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->open(NetworkInterface::get_default_instance()));
     char addr_bytes[16] = {0xfe, 0x80, 0xff, 0x1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    SocketAddress sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
+    SocketAddress sockAddr;
+    if (get_ip_version() == NSAPI_IPv4) {
+        sockAddr = SocketAddress(addr_bytes, NSAPI_IPv4, 80);
+    } else if (get_ip_version() == NSAPI_IPv6) {
+        sockAddr = SocketAddress(addr_bytes, NSAPI_IPv6, 80);
+    } else {
+        TEST_FAIL_MESSAGE("This stack is neither IPv4 nor IPv6");
+    }
     nsapi_error_t bind_result = sock->bind(sockAddr);
     if (bind_result == NSAPI_ERROR_UNSUPPORTED) {
         TEST_IGNORE_MESSAGE("bind() not supported");

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -62,7 +62,7 @@ void UDPSOCKET_RECV_TIMEOUT()
         if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
             osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT);
             printf("MBED: recvfrom() took: %dms\n", timer.read_ms());
-            TEST_ASSERT_INT_WITHIN(50, 150, timer.read_ms());
+            TEST_ASSERT_INT_WITHIN(51, 150, timer.read_ms());
             continue;
         } else if (recvd < 0) {
             printf("[bt#%02d] network error %d\n", i, recvd);


### PR DESCRIPTION
### Description

1) The bind tests were amended to take IPv6-specific steps.
2) UDPSOCKET_RECV_TIMEOUT was occasionally failing for nanostack with an "off-by-one" error. I followed the fix applied to TCP version of this test a couple of months ago and increased the tolerance from 50 to 51. This is to much extent caused by rounding error in the assertion function, but sometimes the time really is slightly higher than 50 ms. I suppose the time measurement might be inaccurate in more ways than just the overly simplistic rounding and it makes sense to add a minimal grace period, like we did for TCP_RECV_TIMEOUT.
3) I added a debug message that could help us check why are ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC and ASYNCHRONOUS_DNS_CANCEL failing from time to time. I couldn't reproduce the issue locally, it happens rather rarely.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@KariHaapalehto 
@mtomczykmobica 

