### PR TITLE
STM32F2: Enable TRNG

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -145,6 +145,10 @@ struct can_s {
 };
 #endif
 
+struct trng_s {
+    RNG_HandleTypeDef handle;
+};
+
 #if DEVICE_FLASH
 struct flash_s {
     /*  nothing to be stored for now */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2209,6 +2209,7 @@
             "SERIAL_ASYNCH",
             "SERIAL_FC",
             "FLASH",
+            "TRNG",
             "MPU"
         ],
         "device_has_remove": ["LPTICKER"],


### PR DESCRIPTION
### Description

Goal is to enable TRNG which is needed for TLS

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
