### PR TITLE
targets: QUECTEL: Fix build warning

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -361,10 +361,10 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
                                                                     const void *data, nsapi_size_t size)
 {
     int sent_len = (size > M26_SENT_BYTE_MAX) ? M26_SENT_BYTE_MAX : size;
-    int sent_acked = 0;
     int sent_nacked = 0;
     int sent_len_before = 0;
     int sent_len_after = 0;
+    int sent_acked;
     nsapi_error_t error;
 
     tr_debug("QUECTEL_M26_CellularStack:%s:%u:[%d-%d]", __FUNCTION__, __LINE__, sent_len, size);


### PR DESCRIPTION
Fix the following warning seen when built with GCC_ARM with mbed-cli v1.8.3

$ mbed compile -c -t GCC_ARM -m K64F
<snip>
[Warning] QUECTEL_M26_CellularStack.cpp@364,9: variable 'sent_acked' set but not used [-Wunused-but-set-variable]
<snip>

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

