### PR TITLE
Improve error message for exports for OS2-only targets

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -380,8 +380,8 @@ def main():
                 ignore=options.ignore
             )
         except NotSupportedException as exc:
-            args_error(parser, "%s not supported by %s" % (mcu, ide))
             print("[Not Supported] %s" % str(exc))
+            exit(1)
     exit(0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Addresses the issue raised in #8977.

If you try to export an Mbed OS 5 project (includes the rtos) for an OS2-only target, a "not supported" message is supposed to be printed in response to the command. This is currently what you get:

```
[mbed] Working path "/Users/user/Desktop/test/mbed-os-example-blinky" (program)
Scan: mbed-os-example-blinky
usage: project.py [-h] [-m MCU] [-i IDE] [-c] [-p PROGRAM] [-n PROGRAM] [-b]
                  [-L] [-S [{matrix,ides}]] [--update-packs] [-E]
                  [--build BUILD_DIR] [--source SOURCE_DIR] [-D MACROS]
                  [--profile PROFILE] [--app-config APP_CONFIG] [-z]
                  [--ignore IGNORE]
project.py: error: LPC11U68 not supported by mcuxpresso
[mbed] ERROR: "/Applications/MBEDCLI.app/Contents/Resources/miniconda/bin/python" returned error.
       Code: 2
       Path: "/Users/user/Desktop/test/mbed-os-example-blinky"
       Command: "/Applications/MBEDCLI.app/Contents/Resources/miniconda/bin/python -u /Users/user/Desktop/test/mbed-os-example-blinky/mbed-os/tools/project.py -i mcuxpresso -m LPC11U68 --source ."
       Tip: You could retry the last command with "-v" flag for verbose output
```

This PR changes the error message to something more relevant:

```
[mbed] Working path "C:\Users\bridan01\onedrive_arm\Documents\dev\mbed-os-example-blinky" (program)
Scan: mbed-os-example-blinky
[Not Supported] Target does not support mbed OS 5
[mbed] ERROR: "c:\python27\python.exe" returned error.
       Code: 1
       Path: "C:\Users\bridan01\onedrive_arm\Documents\dev\mbed-os-example-blinky"
       Command: "c:\python27\python.exe -u C:\Users\bridan01\onedrive_arm\Documents\dev\mbed-os-example-blinky\mbed-os\tools\project.py -i mcuxpresso -m LPC11U68 --source ."
       Tip: You could retry the last command with "-v" flag for verbose output
---
```

FYI @fluidblue 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

