### PR TITLE
Standardize Arduino form factor

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/PinNames.h
@@ -100,6 +100,7 @@ typedef enum {
 
     DAC0_OUT = PTB18,
 
+    A0 = (int)0xFFFFFFFF,
     A1 = DAC0_OUT,
     A2 = PTB2,
     A3 = PTB3,

--- a/targets/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/PinNames.h
@@ -28,6 +28,9 @@ typedef enum {
 } PinDirection;
 
 typedef enum {
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
     P0_0 = 0,
     P0_1 = 1,
     P0_2 = 2,
@@ -52,6 +55,8 @@ typedef enum {
     D2 = P0_6,
     D3 = P0_8,
     D4 = P0_9,
+    D5 = NC,
+    D6 = NC,
     
     D7 = P0_7,
     D8 = P0_17,
@@ -63,6 +68,10 @@ typedef enum {
     D14 = P0_10,
     D15 = P0_11,
     
+    A0 = NC,
+    A1 = NC,
+    A2 = NC,
+    A3 = NC,
     A4 = P0_10,
     A5 = P0_11,
     
@@ -80,9 +89,7 @@ typedef enum {
     // Serial to USB pins
     USBTX = P0_6,
     USBRX = P0_1,
-    
-    // Not connected
-    NC = (int)0xFFFFFFFF,
+
 } PinName;
 
 typedef enum {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4576,7 +4576,6 @@
         "macros_add": ["TARGET_RBLAB_BLENANO"]
     },
     "RBLAB_BLENANO2": {
-        "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52832"],
         "release_versions": ["5"],
         "device_name": "nRF52832_xxAA"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4069,7 +4069,6 @@
         "bootloader_supported": true
     },
     "FF1705_L151CC": {
-        "supported_form_factors": ["ARDUINO"],
         "inherits": ["XDOT_L151CC"],
         "detect_code": ["8080"]
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2035,7 +2035,6 @@
     },
     "NUCLEO_F031K6": {
         "inherits": ["FAMILY_STM32"],
-        "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M0",
         "default_toolchain": "uARM",
         "extra_labels_add": ["STM32F0", "STM32F031K6"],
@@ -2060,7 +2059,6 @@
     },
     "NUCLEO_F042K6": {
         "inherits": ["FAMILY_STM32"],
-        "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M0",
         "default_toolchain": "uARM",
         "extra_labels_add": ["STM32F0", "STM32F042K6"],
@@ -2245,7 +2243,6 @@
     },
     "NUCLEO_F303K8": {
         "inherits": ["FAMILY_STM32"],
-        "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32F3", "STM32F303x8", "STM32F303K8"],
         "config": {
@@ -3041,7 +3038,6 @@
         "core": "Cortex-M0+",
         "extra_labels_add": ["STM32L0", "STM32L031K6"],
         "default_toolchain": "uARM",
-        "supported_form_factors": ["ARDUINO"],
         "config": {
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
@@ -3148,7 +3144,6 @@
     },
     "NUCLEO_L432KC": {
         "inherits": ["FAMILY_STM32"],
-        "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L432xC", "STM32L432KC"],
         "config": {


### PR DESCRIPTION
### Description

Remove `ARDUINO` from `supported_form_factors` on devices which physically do not have the Arduinoform factor. Also ensure that all Arduino pins are defined for targets with the Arduino form factor, even if they are set to NC.

This PR is a subset of the pinmap work in #9449.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

