### PR TITLE
Define USBTX and USBRX for targets without them

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U37H_401/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U37H_401/PinNames.h
@@ -147,9 +147,13 @@ typedef enum {
     SDMISO = P0_8,
     SDSCLK = P1_29,
     SDSSEL = P1_12,
-    
+
     // Not connected
     NC = (int)0xFFFFFFFF,
+
+    // Standard but not supported pins
+    USBTX = NC,
+    USBRX = NC,
 } PinName;
 
 typedef enum {

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/PinNames.h
@@ -140,7 +140,12 @@ typedef enum {
     USB_OTG_HS_ULPI_NXT = PC_3,
 
     // Not connected
-    NC = (int)0xFFFFFFFF
+    NC = (int)0xFFFFFFFF,
+
+    // Standard but not supported pins
+    USBTX = NC,
+    USBRX = NC
+
 } PinName;
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description

Define USBTX and USBRX for the LPC11U37H and the MTS_MDOT_F405RG.

This PR is a subset of the pinmap work in #9449.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

