### PR TITLE
Implement Linker command/response files in make export

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -135,9 +135,9 @@ $(PROJECT).link_script{{link_script_ext}}: $(LINKER_SCRIPT)
 
 {% block target_project_elf %}
 $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) {% if pp_cmd -%} $(PROJECT).link_script{{link_script_ext}} {% else%} $(LINKER_SCRIPT) {% endif %}
-	$(file > $@.in, $(filter %.o, $^))
+	+@echo "$(filter %.o, $^)" > .link_options.txt
 	+@echo "link: $(notdir $@)"
-	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ {{response_option}}$@.in $(LIBRARIES) $(LD_SYS_LIBS)
+	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ {{response_option}}.link_options.txt $(LIBRARIES) $(LD_SYS_LIBS)
 {% endblock %}
 
 $(PROJECT).bin: $(PROJECT).elf

--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -135,8 +135,9 @@ $(PROJECT).link_script{{link_script_ext}}: $(LINKER_SCRIPT)
 
 {% block target_project_elf %}
 $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) {% if pp_cmd -%} $(PROJECT).link_script{{link_script_ext}} {% else%} $(LINKER_SCRIPT) {% endif %}
+	$(file > $@.in, $(filter %.o, $^))
 	+@echo "link: $(notdir $@)"
-	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ $(filter %.o, $^) $(LIBRARIES) $(LD_SYS_LIBS)
+	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ {{response_option}}$@.in $(LIBRARIES) $(LD_SYS_LIBS)
 {% endblock %}
 
 $(PROJECT).bin: $(PROJECT).elf

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -113,6 +113,7 @@ class Makefile(Exporter):
             'user_library_flag': self.USER_LIBRARY_FLAG,
             'needs_asm_preproc': self.PREPROCESS_ASM,
             'shell_escape': shell_escape,
+            'response_option': self.RESPONSE_OPTION,
         }
 
         if hasattr(self.toolchain, "preproc"):
@@ -233,6 +234,7 @@ class GccArm(Makefile):
     TOOLCHAIN = "GCC_ARM"
     LINK_SCRIPT_OPTION = "-T"
     USER_LIBRARY_FLAG = "-L"
+    RESPONSE_OPTION = "@"
 
     @staticmethod
     def prepare_lib(libname):
@@ -250,6 +252,7 @@ class Arm(Makefile):
     LINK_SCRIPT_OPTION = "--scatter"
     USER_LIBRARY_FLAG = "--userlibpath "
     TEMPLATE = 'make-arm'
+    RESPONSE_OPTION = "--via "
 
     @staticmethod
     def prepare_lib(libname):
@@ -289,6 +292,7 @@ class IAR(Makefile):
     TOOLCHAIN = "IAR"
     LINK_SCRIPT_OPTION = "--config"
     USER_LIBRARY_FLAG = "-L"
+    RESPONSE_OPTION = "-f "
 
     @staticmethod
     def prepare_lib(libname):


### PR DESCRIPTION
### Description

This is a rebased version of https://github.com/ARMmbed/mbed-os/pull/7583/commits/387747f8b5c6e4429dc60b1917633978a908ae6c from https://github.com/ARMmbed/mbed-os/pull/7583 that can be applied to the latest master. Two other commits from that PR are no longer needed.

The original PR was closed since "it's really hard to find make > 3.81 for windows."
Compatible version of make utility for windows is documented in https://github.com/ARMmbed/mbed-os-5-docs/pull/935
Cygwin make and MSYS2 make (both at version 4.2.1) are confirmed to work fine with makefiles produced by `mbed export -i eclipse_gcc_arm`.

The fix allows to build the mbed projects exported under Windows to environments that use the generated makefile: make_gcc_arm, make_iar, make_armc5, make_armc6, eclipse_gcc_arm, eclipse_iar, eclipse_armc5, vscode_gcc_arm, vscode_iar, vscode_armc5.

The error happens due to the list of the object files passed to the linker process exceeding Windows limit for the command line length.
Error code:
make (e=87): The parameter is incorrect.

Fixes the following issues:
* Exporting to Makefile fails to build on Windows #6335 
* Exporting to Makefile fails to build on Windows due to command line limit being exceeded #9140 
* [OoB_5.11.0-RC2]: Debugging with exporting eclipse_gcc_arm failed #9015 
* [OoB_5.11.0-RC2]: Debugging with exporting vscode_gcc_arm failed #9000 
* MBED-OS 5.10 OOB - export to make_armc5, error in linking phase #8101 
* GCC Windows export does not build as of #6577 #7112 


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@theotherjimmy (who is the author of the original commit on the PR)
