### PR TITLE
Fix KVStore high memory consumption 

### DIFF
--- a/features/storage/kvstore/kv_map/KVMap.cpp
+++ b/features/storage/kvstore/kv_map/KVMap.cpp
@@ -82,21 +82,52 @@ void KVMap::deinit_partition(kv_map_entry_t *partition)
         return;
     }
 
-    if (partition->kv_config->external_store != NULL) {
-        partition->kv_config->external_store->deinit();
+    if (partition->kv_config->kvstore_main_instance != NULL) {
+        partition->kv_config->kvstore_main_instance->deinit();
+        delete partition->kv_config->kvstore_main_instance;
+        partition->kv_config->kvstore_main_instance = NULL;
     }
 
-    // TODO: this should be removed after FS APIs are standardized
-    if (partition->kv_config->external_fs != NULL) {
-        partition->kv_config->external_fs->unmount();
+    if (partition->kv_config->external_store != NULL) {
+        partition->kv_config->external_store->deinit();
+        delete partition->kv_config->external_store;
+        partition->kv_config->external_store = NULL;
     }
 
     if (partition->kv_config->internal_store != NULL) {
         partition->kv_config->internal_store->deinit();
+        delete partition->kv_config->internal_store;
+        partition->kv_config->internal_store = NULL;
     }
 
-    if (partition->kv_config->kvstore_main_instance != NULL) {
-        partition->kv_config->kvstore_main_instance->deinit();
+    if (partition->kv_config->internal_bd != NULL) {
+        partition->kv_config->internal_bd->deinit();
+        delete partition->kv_config->internal_bd;
+        partition->kv_config->internal_bd = NULL;
+    }
+
+    if (partition->kv_config->external_fs != NULL) {
+        partition->kv_config->external_fs->unmount();
+        delete partition->kv_config->external_fs;
+        partition->kv_config->external_fs = NULL;
+    }
+
+    if (partition->kv_config->external_flashsim_bd != NULL) {
+        partition->kv_config->external_flashsim_bd->deinit();
+        delete partition->kv_config->external_flashsim_bd;
+        partition->kv_config->external_flashsim_bd = NULL;
+    }
+
+    if (partition->kv_config->external_slicing_bd != NULL) {
+        partition->kv_config->external_slicing_bd->deinit();
+        delete partition->kv_config->external_slicing_bd;
+        partition->kv_config->external_slicing_bd = NULL;
+    }
+
+    if (partition->kv_config->external_base_bd != NULL) {
+        partition->kv_config->external_base_bd->deinit();
+        delete partition->kv_config->external_base_bd;
+        partition->kv_config->external_base_bd = NULL;
     }
 
     delete [] partition->partition_name;

--- a/features/storage/kvstore/kv_map/KVMap.h
+++ b/features/storage/kvstore/kv_map/KVMap.h
@@ -67,6 +67,22 @@ typedef struct {
      * prevent errors in case the user choose an different security level.
      */
     uint32_t flags_mask;
+
+    /**
+     * A pointer for the external most lower level blockdevice.
+     */
+    BlockDevice *external_base_bd;
+
+    /**
+     * A pointer for the external flashsim blockdevice when and if it is used.
+     */
+    BlockDevice *external_flashsim_bd;
+
+    /**
+     * A pointer for the external slicing blockdevice when and if it is used.
+     */
+    BlockDevice *external_slicing_bd;
+
 } kvstore_config_t;
 
 /**


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
The table below shows the current KVStore memory consumption which is too high.

| Module  |       .text |     .data |         .bss |
|-----------|----------|----------|-----------|
| features/storage/kvstore/conf/kv_config.o                                                                  |  2066(+398) |   72(+64) |  2412(+2324) |
| features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.o                                   |     418(+0) |     0(+0) |        0(+0) |
| features/storage/kvstore/filesystemstore/FileSystemStore.o                                                 |   2046(-42) |     0(+0) |        0(+0) |
| features/storage/kvstore/global_api/kvstore_global_api.o                                                   |     622(+0) |     0(+0) |        0(+0) |
| features/storage/kvstore/kv_map/KVMap.o                                                                    |   596(-176) |     0(+0) |        0(+0) |
| features/storage/kvstore/securestore/SecureStore.o                                                         |   2695(-14) |     5(+0) |        0(+0) |
| features/storage/kvstore/tdbstore/TDBStore.o                                                               |   5589(-14) |     4(+0) |        0(+0) |
| features/storage/system_storage/SystemStorage.o                                                            |      92(+0) |    16(+0) |      676(+0) |

That happens because the kv_config is allocating statically all object for all configurations even if a specific configuration is not used. The linker is indeed cleaning the unused function but in ARM compiler and IAR compiler, it is not cleaning the unused allocation. This phenomenon is not happening in GCC_ARM and the unused space is clean.

By moving from static allocation to dynamic allocation the memory consumption has been decreased **and also ensure that only the relevant object for a specific configuration will be allocated.** 

The memory table after the change is below.

| Module  |       .text |     .data |         .bss |
|-----------|----------|----------|-----------|
| features/storage/kvstore/conf/kv_config.o                                                                  |     1668(+1668) |       8(+8) |       88(+88) |
| features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.o                                   |       418(+418) |       0(+0) |         0(+0) |
| features/storage/kvstore/filesystemstore/FileSystemStore.o                                                 |     2088(+2088) |       0(+0) |         0(+0) |
| features/storage/kvstore/global_api/kvstore_global_api.o                                                   |       622(+622) |       0(+0) |         0(+0) |
| features/storage/kvstore/kv_map/KVMap.o                                                                    |       772(+772) |       0(+0) |         0(+0) |
| features/storage/kvstore/securestore/SecureStore.o                                                         |     2709(+2709) |       5(+5) |         0(+0) |
| features/storage/kvstore/tdbstore/TDBStore.o                                                               |     5603(+5603) |       4(+4) |         0(+0) |
| features/storage/system_storage/SystemStorage.o                                                            |         92(+92) |     16(+16) |     676(+676) |


This PR fixes internal defect [IOTSTOR-773](https://jira.arm.com/browse/IOTSTOR-773) 
### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

