### PR TITLE
Atomic extensions: 64-bit, bool, exchange

### DIFF
--- a/UNITTESTS/stubs/mbed_critical_stub.c
+++ b/UNITTESTS/stubs/mbed_critical_stub.c
@@ -71,6 +71,22 @@ bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentV
 }
 
 
+uint8_t core_util_atomic_exchange_u8(volatile uint8_t *ptr, uint8_t desiredValue)
+{
+    return 0;
+}
+
+uint16_t core_util_atomic_exchange_u16(volatile uint16_t *ptr, uint16_t desiredValue)
+{
+    return 0;
+}
+
+uint32_t core_util_atomic_exchange_u32(volatile uint32_t *ptr, uint32_t desiredValue)
+{
+    return 0;
+}
+
+
 uint8_t core_util_atomic_incr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 {
     return 0;
@@ -112,6 +128,11 @@ void core_util_atomic_store_u64(volatile uint64_t *valuePtr, uint64_t desiredVal
 {
 }
 
+uint64_t core_util_atomic_exchange_u64(volatile uint64_t *valuePtr, uint64_t desiredValue)
+{
+    return 0;
+}
+
 bool core_util_atomic_cas_u64(volatile uint64_t *ptr, uint64_t *expectedCurrentValue, uint64_t desiredValue)
 {
     return false;
@@ -131,6 +152,11 @@ uint64_t core_util_atomic_decr_u64(volatile uint64_t *valuePtr, uint64_t delta)
 bool core_util_atomic_cas_ptr(void *volatile *ptr, void **expectedCurrentValue, void *desiredValue)
 {
     return false;
+}
+
+void *core_util_atomic_exchange_ptr(void *volatile *valuePtr, void *desiredValue)
+{
+    return NULL;
 }
 
 void *core_util_atomic_incr_ptr(void *volatile *valuePtr, ptrdiff_t delta)

--- a/UNITTESTS/stubs/mbed_critical_stub.c
+++ b/UNITTESTS/stubs/mbed_critical_stub.c
@@ -103,6 +103,31 @@ uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 }
 
 
+uint64_t core_util_atomic_load_u64(const volatile uint64_t *valuePtr)
+{
+    return 0;
+}
+
+void core_util_atomic_store_u64(volatile uint64_t *valuePtr, uint64_t desiredValue)
+{
+}
+
+bool core_util_atomic_cas_u64(volatile uint64_t *ptr, uint64_t *expectedCurrentValue, uint64_t desiredValue)
+{
+    return false;
+}
+
+uint64_t core_util_atomic_incr_u64(volatile uint64_t *valuePtr, uint64_t delta)
+{
+    return 0;
+}
+
+uint64_t core_util_atomic_decr_u64(volatile uint64_t *valuePtr, uint64_t delta)
+{
+    return 0;
+}
+
+
 bool core_util_atomic_cas_ptr(void *volatile *ptr, void **expectedCurrentValue, void *desiredValue)
 {
     return false;

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -109,8 +109,8 @@ void core_util_critical_section_exit(void)
 
 bool core_util_atomic_flag_test_and_set(volatile core_util_atomic_flag *flagPtr)
 {
-    uint8_t currentValue;
     MBED_BARRIER();
+    uint8_t currentValue;
     do {
         currentValue = __LDREXB(&flagPtr->_flag);
     } while (__STREXB(true, &flagPtr->_flag));
@@ -188,8 +188,8 @@ uint16_t core_util_atomic_incr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 
 uint32_t core_util_atomic_incr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 {
-    uint32_t newValue;
     MBED_BARRIER();
+    uint32_t newValue;
     do {
         newValue = __LDREXW(valuePtr) + delta;
     } while (__STREXW(newValue, valuePtr));
@@ -200,8 +200,8 @@ uint32_t core_util_atomic_incr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 
 uint8_t core_util_atomic_decr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 {
-    uint8_t newValue;
     MBED_BARRIER();
+    uint8_t newValue;
     do {
         newValue = __LDREXB(valuePtr) - delta;
     } while (__STREXB(newValue, valuePtr));
@@ -211,8 +211,8 @@ uint8_t core_util_atomic_decr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 
 uint16_t core_util_atomic_decr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 {
-    uint16_t newValue;
     MBED_BARRIER();
+    uint16_t newValue;
     do {
         newValue = __LDREXH(valuePtr) - delta;
     } while (__STREXH(newValue, valuePtr));
@@ -222,8 +222,8 @@ uint16_t core_util_atomic_decr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 
 uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 {
-    uint32_t newValue;
     MBED_BARRIER();
+    uint32_t newValue;
     do {
         newValue = __LDREXW(valuePtr) - delta;
     } while (__STREXW(newValue, valuePtr));

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -358,6 +358,58 @@ uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 
 #endif
 
+/* No architecture we support has LDREXD/STREXD, so must always disable IRQs for 64-bit operations */
+uint64_t core_util_atomic_load_u64(const volatile uint64_t *valuePtr)
+{
+    core_util_critical_section_enter();
+    uint64_t currentValue = *valuePtr;
+    core_util_critical_section_exit();
+    return currentValue;
+}
+
+void core_util_atomic_store_u64(volatile uint64_t *valuePtr, uint64_t desiredValue)
+{
+    core_util_critical_section_enter();
+    *valuePtr = desiredValue;
+    core_util_critical_section_exit();
+}
+
+bool core_util_atomic_cas_u64(volatile uint64_t *ptr, uint64_t *expectedCurrentValue, uint64_t desiredValue)
+{
+    bool success;
+    uint64_t currentValue;
+    core_util_critical_section_enter();
+    currentValue = *ptr;
+    if (currentValue == *expectedCurrentValue) {
+        *ptr = desiredValue;
+        success = true;
+    } else {
+        *expectedCurrentValue = currentValue;
+        success = false;
+    }
+    core_util_critical_section_exit();
+    return success;
+}
+
+uint64_t core_util_atomic_incr_u64(volatile uint64_t *valuePtr, uint64_t delta)
+{
+    uint64_t newValue;
+    core_util_critical_section_enter();
+    newValue = *valuePtr + delta;
+    *valuePtr = newValue;
+    core_util_critical_section_exit();
+    return newValue;
+}
+
+uint64_t core_util_atomic_decr_u64(volatile uint64_t *valuePtr, uint64_t delta)
+{
+    uint64_t newValue;
+    core_util_critical_section_enter();
+    newValue = *valuePtr - delta;
+    *valuePtr = newValue;
+    core_util_critical_section_exit();
+    return newValue;
+}
 
 bool core_util_atomic_cas_ptr(void *volatile *ptr, void **expectedCurrentValue, void *desiredValue)
 {

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -100,6 +100,9 @@ void core_util_critical_section_exit(void)
     }
 }
 
+/* Inline bool implementations in the header use uint8_t versions to manipulate the bool */
+MBED_STATIC_ASSERT(sizeof(bool) == sizeof(uint8_t), "Surely bool is a byte");
+
 #if MBED_EXCLUSIVE_ACCESS
 
 /* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -212,6 +212,29 @@ bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentV
 bool core_util_atomic_cas_u64(volatile uint64_t *ptr, uint64_t *expectedCurrentValue, uint64_t desiredValue);
 
 /** \copydoc core_util_atomic_cas_u8 */
+MBED_FORCEINLINE int8_t core_util_atomic_cas_s8(volatile int8_t *ptr, int8_t *expectedCurrentValue, int8_t desiredValue)
+{
+    return (int8_t)core_util_atomic_cas_u8((volatile uint8_t *)ptr, (uint8_t *)expectedCurrentValue, (uint8_t)desiredValue);
+}
+
+/** \copydoc core_util_atomic_cas_u8 */
+MBED_FORCEINLINE int16_t core_util_atomic_cas_s16(volatile int16_t *ptr, int16_t *expectedCurrentValue, int16_t desiredValue)
+{
+    return (int16_t)core_util_atomic_cas_u16((volatile uint16_t *)ptr, (uint16_t *)expectedCurrentValue, (uint16_t)desiredValue);
+}
+/** \copydoc core_util_atomic_cas_u8 */
+MBED_FORCEINLINE int32_t core_util_atomic_cas_s32(volatile int32_t *ptr, int32_t *expectedCurrentValue, int32_t desiredValue)
+{
+    return (int32_t)core_util_atomic_cas_u32((volatile uint32_t *)ptr, (uint32_t *)expectedCurrentValue, (uint32_t)desiredValue);
+}
+
+/** \copydoc core_util_atomic_cas_u8 */
+MBED_FORCEINLINE int64_t core_util_atomic_cas_s64(volatile int64_t *ptr, int64_t *expectedCurrentValue, int64_t desiredValue)
+{
+    return (int64_t)core_util_atomic_cas_u64((volatile uint64_t *)ptr, (uint64_t *)expectedCurrentValue, (uint64_t)desiredValue);
+}
+
+/** \copydoc core_util_atomic_cas_u8 */
 MBED_FORCEINLINE bool core_util_atomic_cas_bool(volatile bool *ptr, bool *expectedCurrentValue, bool desiredValue)
 {
     return (bool)core_util_atomic_cas_u8((volatile uint8_t *)ptr, (uint8_t *)expectedCurrentValue, desiredValue);
@@ -262,6 +285,52 @@ MBED_FORCEINLINE uint32_t core_util_atomic_load_u32(const volatile uint32_t *val
  * @return          The loaded value.
  */
 uint64_t core_util_atomic_load_u64(const volatile uint64_t *valuePtr);
+
+/**
+ * Atomic load.
+ * @param  valuePtr Target memory location.
+ * @return          The loaded value.
+ */
+MBED_FORCEINLINE int8_t core_util_atomic_load_s8(const volatile int8_t *valuePtr)
+{
+    int8_t value = *valuePtr;
+    MBED_BARRIER();
+    return value;
+}
+
+/**
+ * Atomic load.
+ * @param  valuePtr Target memory location.
+ * @return          The loaded value.
+ */
+MBED_FORCEINLINE int16_t core_util_atomic_load_s16(const volatile int16_t *valuePtr)
+{
+    int16_t value = *valuePtr;
+    MBED_BARRIER();
+    return value;
+}
+
+/**
+ * Atomic load.
+ * @param  valuePtr Target memory location.
+ * @return          The loaded value.
+ */
+MBED_FORCEINLINE int32_t core_util_atomic_load_s32(const volatile int32_t *valuePtr)
+{
+    int32_t value = *valuePtr;
+    MBED_BARRIER();
+    return value;
+}
+
+/**
+ * Atomic load.
+ * @param  valuePtr Target memory location.
+ * @return          The loaded value.
+ */
+MBED_FORCEINLINE int64_t core_util_atomic_load_s64(const volatile int64_t *valuePtr)
+{
+    return (int64_t)core_util_atomic_load_u64((const volatile uint64_t *)valuePtr);
+}
 
 /**
  * Atomic load.
@@ -335,6 +404,52 @@ void core_util_atomic_store_u64(volatile uint64_t *valuePtr, uint64_t desiredVal
  * @param  valuePtr     Target memory location.
  * @param  desiredValue The value to store.
  */
+MBED_FORCEINLINE void core_util_atomic_store_s8(volatile int8_t *valuePtr, int8_t desiredValue)
+{
+    MBED_BARRIER();
+    *valuePtr = desiredValue;
+    MBED_BARRIER();
+}
+
+/**
+ * Atomic store.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ */
+MBED_FORCEINLINE void core_util_atomic_store_s16(volatile int16_t *valuePtr, int16_t desiredValue)
+{
+    MBED_BARRIER();
+    *valuePtr = desiredValue;
+    MBED_BARRIER();
+}
+
+/**
+ * Atomic store.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ */
+MBED_FORCEINLINE void core_util_atomic_store_s32(volatile int32_t *valuePtr, int32_t desiredValue)
+{
+    MBED_BARRIER();
+    *valuePtr = desiredValue;
+    MBED_BARRIER();
+}
+
+/**
+ * Atomic store.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ */
+MBED_FORCEINLINE void core_util_atomic_store_s64(volatile int64_t *valuePtr, int64_t desiredValue)
+{
+    core_util_atomic_store_u64((volatile uint64_t *)valuePtr, (uint64_t)desiredValue);
+}
+
+/**
+ * Atomic store.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ */
 MBED_FORCEINLINE void core_util_atomic_store_bool(volatile bool *valuePtr, bool desiredValue)
 {
     MBED_BARRIER();
@@ -392,6 +507,50 @@ uint64_t core_util_atomic_exchange_u64(volatile uint64_t *valuePtr, uint64_t des
  * @param  desiredValue The value to store.
  * @return              The previous value.
  */
+MBED_FORCEINLINE int8_t core_util_atomic_exchange_s8(volatile int8_t *valuePtr, int8_t desiredValue)
+{
+    return (int8_t)core_util_atomic_exchange_u8((volatile uint8_t *)valuePtr, (uint8_t)desiredValue);
+}
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+MBED_FORCEINLINE int16_t core_util_atomic_exchange_s16(volatile int16_t *valuePtr, int16_t desiredValue)
+{
+    return (int16_t)core_util_atomic_exchange_u16((volatile uint16_t *)valuePtr, (uint16_t)desiredValue);
+}
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+MBED_FORCEINLINE int32_t core_util_atomic_exchange_s32(volatile int32_t *valuePtr, int32_t desiredValue)
+{
+    return (int32_t)core_util_atomic_exchange_u32((volatile uint32_t *)valuePtr, (uint32_t)desiredValue);
+}
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+MBED_FORCEINLINE int64_t core_util_atomic_exchange_s64(volatile int64_t *valuePtr, int64_t desiredValue)
+{
+    return (int64_t)core_util_atomic_exchange_u64((volatile uint64_t *)valuePtr, (uint64_t)desiredValue);
+}
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
 MBED_FORCEINLINE bool core_util_atomic_exchange_bool(volatile bool *valuePtr, bool desiredValue)
 {
     return (bool)core_util_atomic_exchange_u8((volatile uint8_t *)valuePtr, desiredValue);
@@ -440,6 +599,50 @@ uint64_t core_util_atomic_incr_u64(volatile uint64_t *valuePtr, uint64_t delta);
 /**
  * Atomic increment.
  * @param  valuePtr Target memory location being incremented.
+ * @param  delta    The amount being incremented.
+ * @return          The new incremented value.
+ */
+MBED_FORCEINLINE int8_t core_util_atomic_incr_s8(volatile int8_t *valuePtr, int8_t delta)
+{
+    return (int8_t)core_util_atomic_incr_u8((volatile uint8_t *)valuePtr, (uint8_t)delta);
+}
+
+/**
+ * Atomic increment.
+ * @param  valuePtr Target memory location being incremented.
+ * @param  delta    The amount being incremented.
+ * @return          The new incremented value.
+ */
+MBED_FORCEINLINE int16_t core_util_atomic_incr_s16(volatile int16_t *valuePtr, int16_t delta)
+{
+    return (int16_t)core_util_atomic_incr_u16((volatile uint16_t *)valuePtr, (uint16_t)delta);
+}
+
+/**
+ * Atomic increment.
+ * @param  valuePtr Target memory location being incremented.
+ * @param  delta    The amount being incremented.
+ * @return          The new incremented value.
+ */
+MBED_FORCEINLINE int32_t core_util_atomic_incr_s32(volatile int32_t *valuePtr, int32_t delta)
+{
+    return (int32_t)core_util_atomic_incr_u32((volatile uint32_t *)valuePtr, (uint32_t)delta);
+}
+
+/**
+ * Atomic increment.
+ * @param  valuePtr Target memory location being incremented.
+ * @param  delta    The amount being incremented.
+ * @return          The new incremented value.
+ */
+MBED_FORCEINLINE int64_t core_util_atomic_incr_s64(volatile int64_t *valuePtr, int64_t delta)
+{
+    return (int64_t)core_util_atomic_incr_u64((volatile uint64_t *)valuePtr, (uint64_t)delta);
+}
+
+/**
+ * Atomic increment.
+ * @param  valuePtr Target memory location being incremented.
  * @param  delta    The amount being incremented in bytes.
  * @return          The new incremented value.
  *
@@ -479,6 +682,50 @@ uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta);
  * @return          The new decremented value.
  */
 uint64_t core_util_atomic_decr_u64(volatile uint64_t *valuePtr, uint64_t delta);
+
+/**
+ * Atomic decrement.
+ * @param  valuePtr Target memory location being decremented.
+ * @param  delta    The amount being decremented.
+ * @return          The new decremented value.
+ */
+MBED_FORCEINLINE int8_t core_util_atomic_decr_s8(volatile int8_t *valuePtr, int8_t delta)
+{
+    return (int8_t)core_util_atomic_decr_u8((volatile uint8_t *)valuePtr, (uint8_t)delta);
+}
+
+/**
+ * Atomic decrement.
+ * @param  valuePtr Target memory location being decremented.
+ * @param  delta    The amount being decremented.
+ * @return          The new decremented value.
+ */
+MBED_FORCEINLINE int16_t core_util_atomic_decr_s16(volatile int16_t *valuePtr, int16_t delta)
+{
+    return (int16_t)core_util_atomic_decr_u16((volatile uint16_t *)valuePtr, (uint16_t)delta);
+}
+
+/**
+ * Atomic decrement.
+ * @param  valuePtr Target memory location being decremented.
+ * @param  delta    The amount being decremented.
+ * @return          The new decremented value.
+ */
+MBED_FORCEINLINE int32_t core_util_atomic_decr_s32(volatile int32_t *valuePtr, int32_t delta)
+{
+    return (int32_t)core_util_atomic_decr_u32((volatile uint32_t *)valuePtr, (uint32_t)delta);
+}
+
+/**
+ * Atomic decrement.
+ * @param  valuePtr Target memory location being decremented.
+ * @param  delta    The amount being decremented.
+ * @return          The new decremented value.
+ */
+MBED_FORCEINLINE int64_t core_util_atomic_decr_s64(volatile int64_t *valuePtr, int64_t delta)
+{
+    return (int64_t)core_util_atomic_decr_u64((volatile uint64_t *)valuePtr, (uint64_t)delta);
+}
 
 /**
  * Atomic decrement.

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -212,6 +212,12 @@ bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentV
 bool core_util_atomic_cas_u64(volatile uint64_t *ptr, uint64_t *expectedCurrentValue, uint64_t desiredValue);
 
 /** \copydoc core_util_atomic_cas_u8 */
+MBED_FORCEINLINE bool core_util_atomic_cas_bool(volatile bool *ptr, bool *expectedCurrentValue, bool desiredValue)
+{
+    return (bool)core_util_atomic_cas_u8((volatile uint8_t *)ptr, (uint8_t *)expectedCurrentValue, desiredValue);
+}
+
+/** \copydoc core_util_atomic_cas_u8 */
 bool core_util_atomic_cas_ptr(void *volatile *ptr, void **expectedCurrentValue, void *desiredValue);
 
 /**
@@ -256,6 +262,18 @@ MBED_FORCEINLINE uint32_t core_util_atomic_load_u32(const volatile uint32_t *val
  * @return          The loaded value.
  */
 uint64_t core_util_atomic_load_u64(const volatile uint64_t *valuePtr);
+
+/**
+ * Atomic load.
+ * @param  valuePtr Target memory location.
+ * @return          The loaded value.
+ */
+MBED_FORCEINLINE bool core_util_atomic_load_bool(const volatile bool *valuePtr)
+{
+    bool value = *valuePtr;
+    MBED_BARRIER();
+    return value;
+}
 
 /**
  * Atomic load.
@@ -311,6 +329,18 @@ MBED_FORCEINLINE void core_util_atomic_store_u32(volatile uint32_t *valuePtr, ui
  * @param  desiredValue The value to store.
  */
 void core_util_atomic_store_u64(volatile uint64_t *valuePtr, uint64_t desiredValue);
+
+/**
+ * Atomic store.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ */
+MBED_FORCEINLINE void core_util_atomic_store_bool(volatile bool *valuePtr, bool desiredValue)
+{
+    MBED_BARRIER();
+    *valuePtr = desiredValue;
+    MBED_BARRIER();
+}
 
 /**
  * Atomic store.

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -202,175 +202,16 @@ MBED_FORCEINLINE void core_util_atomic_flag_clear(volatile core_util_atomic_flag
  */
 bool core_util_atomic_cas_u8(volatile uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue);
 
-/**
- * Atomic compare and set. It compares the contents of a memory location to a
- * given value and, only if they are the same, modifies the contents of that
- * memory location to a given new value. This is done as a single atomic
- * operation. The atomicity guarantees that the new value is calculated based on
- * up-to-date information; if the value had been updated by another thread in
- * the meantime, the write would fail due to a mismatched expectedCurrentValue.
- *
- * Refer to https://en.wikipedia.org/wiki/Compare-and-set [which may redirect
- * you to the article on compare-and swap].
- *
- * @param  ptr                  The target memory location.
- * @param[in,out] expectedCurrentValue A pointer to some location holding the
- *                              expected current value of the data being set atomically.
- *                              The computed 'desiredValue' should be a function of this current value.
- *                              @note: This is an in-out parameter. In the
- *                              failure case of atomic_cas (where the
- *                              destination isn't set), the pointee of expectedCurrentValue is
- *                              updated with the current value.
- * @param[in] desiredValue      The new value computed based on '*expectedCurrentValue'.
- *
- * @return                      true if the memory location was atomically
- *                              updated with the desired value (after verifying
- *                              that it contained the expectedCurrentValue),
- *                              false otherwise. In the failure case,
- *                              exepctedCurrentValue is updated with the new
- *                              value of the target memory location.
- *
- * pseudocode:
- * function cas(p : pointer to int, old : pointer to int, new : int) returns bool {
- *     if *p != *old {
- *         *old = *p
- *         return false
- *     }
- *     *p = new
- *     return true
- * }
- *
- * @note: In the failure case (where the destination isn't set), the value
- * pointed to by expectedCurrentValue is instead updated with the current value.
- * This property helps writing concise code for the following incr:
- *
- * function incr(p : pointer to int, a : int) returns int {
- *     done = false
- *     value = *p // This fetch operation need not be atomic.
- *     while not done {
- *         done = atomic_cas(p, &value, value + a) // *value gets updated automatically until success
- *     }
- *     return value + a
- * }
- *
- * @note: This corresponds to the C11 "atomic_compare_exchange_strong" - it
- * always succeeds if the current value is expected, as per the pseudocode
- * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
- */
+/** \copydoc core_util_atomic_cas_u8 */
 bool core_util_atomic_cas_u16(volatile uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue);
 
-/**
- * Atomic compare and set. It compares the contents of a memory location to a
- * given value and, only if they are the same, modifies the contents of that
- * memory location to a given new value. This is done as a single atomic
- * operation. The atomicity guarantees that the new value is calculated based on
- * up-to-date information; if the value had been updated by another thread in
- * the meantime, the write would fail due to a mismatched expectedCurrentValue.
- *
- * Refer to https://en.wikipedia.org/wiki/Compare-and-set [which may redirect
- * you to the article on compare-and swap].
- *
- * @param  ptr                  The target memory location.
- * @param[in,out] expectedCurrentValue A pointer to some location holding the
- *                              expected current value of the data being set atomically.
- *                              The computed 'desiredValue' should be a function of this current value.
- *                              @note: This is an in-out parameter. In the
- *                              failure case of atomic_cas (where the
- *                              destination isn't set), the pointee of expectedCurrentValue is
- *                              updated with the current value.
- * @param[in] desiredValue      The new value computed based on '*expectedCurrentValue'.
- *
- * @return                      true if the memory location was atomically
- *                              updated with the desired value (after verifying
- *                              that it contained the expectedCurrentValue),
- *                              false otherwise. In the failure case,
- *                              exepctedCurrentValue is updated with the new
- *                              value of the target memory location.
- *
- * pseudocode:
- * function cas(p : pointer to int, old : pointer to int, new : int) returns bool {
- *     if *p != *old {
- *         *old = *p
- *         return false
- *     }
- *     *p = new
- *     return true
- * }
- *
- * @note: In the failure case (where the destination isn't set), the value
- * pointed to by expectedCurrentValue is instead updated with the current value.
- * This property helps writing concise code for the following incr:
- *
- * function incr(p : pointer to int, a : int) returns int {
- *     done = false
- *     value = *p // This fetch operation need not be atomic.
- *     while not done {
- *         done = atomic_cas(p, &value, value + a) // *value gets updated automatically until success
- *     }
- *     return value + a
- *
- * @note: This corresponds to the C11 "atomic_compare_exchange_strong" - it
- * always succeeds if the current value is expected, as per the pseudocode
- * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
- * }
- */
+/** \copydoc core_util_atomic_cas_u8 */
 bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue);
 
-/**
- * Atomic compare and set. It compares the contents of a memory location to a
- * given value and, only if they are the same, modifies the contents of that
- * memory location to a given new value. This is done as a single atomic
- * operation. The atomicity guarantees that the new value is calculated based on
- * up-to-date information; if the value had been updated by another thread in
- * the meantime, the write would fail due to a mismatched expectedCurrentValue.
- *
- * Refer to https://en.wikipedia.org/wiki/Compare-and-set [which may redirect
- * you to the article on compare-and swap].
- *
- * @param  ptr                  The target memory location.
- * @param[in,out] expectedCurrentValue A pointer to some location holding the
- *                              expected current value of the data being set atomically.
- *                              The computed 'desiredValue' should be a function of this current value.
- *                              @note: This is an in-out parameter. In the
- *                              failure case of atomic_cas (where the
- *                              destination isn't set), the pointee of expectedCurrentValue is
- *                              updated with the current value.
- * @param[in] desiredValue      The new value computed based on '*expectedCurrentValue'.
- *
- * @return                      true if the memory location was atomically
- *                              updated with the desired value (after verifying
- *                              that it contained the expectedCurrentValue),
- *                              false otherwise. In the failure case,
- *                              exepctedCurrentValue is updated with the new
- *                              value of the target memory location.
- *
- * pseudocode:
- * function cas(p : pointer to int, old : pointer to int, new : int) returns bool {
- *     if *p != *old {
- *         *old = *p
- *         return false
- *     }
- *     *p = new
- *     return true
- * }
- *
- * @note: In the failure case (where the destination isn't set), the value
- * pointed to by expectedCurrentValue is instead updated with the current value.
- * This property helps writing concise code for the following incr:
- *
- * function incr(p : pointer to int, a : int) returns int {
- *     done = false
- *     value = *p // This fetch operation need not be atomic.
- *     while not done {
- *         done = atomic_cas(p, &value, value + a) // *value gets updated automatically until success
- *     }
- *     return value + a
- * }
- *
- * @note: This corresponds to the C11 "atomic_compare_exchange_strong" - it
- * always succeeds if the current value is expected, as per the pseudocode
- * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
- */
+/** \copydoc core_util_atomic_cas_u8 */
+bool core_util_atomic_cas_u64(volatile uint64_t *ptr, uint64_t *expectedCurrentValue, uint64_t desiredValue);
+
+/** \copydoc core_util_atomic_cas_u8 */
 bool core_util_atomic_cas_ptr(void *volatile *ptr, void **expectedCurrentValue, void *desiredValue);
 
 /**
@@ -408,6 +249,13 @@ MBED_FORCEINLINE uint32_t core_util_atomic_load_u32(const volatile uint32_t *val
     MBED_BARRIER();
     return value;
 }
+
+/**
+ * Atomic load.
+ * @param  valuePtr Target memory location.
+ * @return          The loaded value.
+ */
+uint64_t core_util_atomic_load_u64(const volatile uint64_t *valuePtr);
 
 /**
  * Atomic load.
@@ -462,6 +310,13 @@ MBED_FORCEINLINE void core_util_atomic_store_u32(volatile uint32_t *valuePtr, ui
  * @param  valuePtr     Target memory location.
  * @param  desiredValue The value to store.
  */
+void core_util_atomic_store_u64(volatile uint64_t *valuePtr, uint64_t desiredValue);
+
+/**
+ * Atomic store.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ */
 MBED_FORCEINLINE void core_util_atomic_store_ptr(void *volatile *valuePtr, void *desiredValue)
 {
     MBED_BARRIER();
@@ -492,6 +347,14 @@ uint16_t core_util_atomic_incr_u16(volatile uint16_t *valuePtr, uint16_t delta);
  * @return          The new incremented value.
  */
 uint32_t core_util_atomic_incr_u32(volatile uint32_t *valuePtr, uint32_t delta);
+
+/**
+ * Atomic increment.
+ * @param  valuePtr Target memory location being incremented.
+ * @param  delta    The amount being incremented.
+ * @return          The new incremented value.
+ */
+uint64_t core_util_atomic_incr_u64(volatile uint64_t *valuePtr, uint64_t delta);
 
 /**
  * Atomic increment.
@@ -527,6 +390,14 @@ uint16_t core_util_atomic_decr_u16(volatile uint16_t *valuePtr, uint16_t delta);
  * @return          The new decremented value.
  */
 uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta);
+
+/**
+ * Atomic decrement.
+ * @param  valuePtr Target memory location being decremented.
+ * @param  delta    The amount being decremented.
+ * @return          The new decremented value.
+ */
+uint64_t core_util_atomic_decr_u64(volatile uint64_t *valuePtr, uint64_t delta);
 
 /**
  * Atomic decrement.

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -355,6 +355,57 @@ MBED_FORCEINLINE void core_util_atomic_store_ptr(void *volatile *valuePtr, void 
 }
 
 /**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+uint8_t core_util_atomic_exchange_u8(volatile uint8_t *valuePtr, uint8_t desiredValue);
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+uint16_t core_util_atomic_exchange_u16(volatile uint16_t *valuePtr, uint16_t desiredValue);
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+uint32_t core_util_atomic_exchange_u32(volatile uint32_t *valuePtr, uint32_t desiredValue);
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+uint64_t core_util_atomic_exchange_u64(volatile uint64_t *valuePtr, uint64_t desiredValue);
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+MBED_FORCEINLINE bool core_util_atomic_exchange_bool(volatile bool *valuePtr, bool desiredValue)
+{
+    return (bool)core_util_atomic_exchange_u8((volatile uint8_t *)valuePtr, desiredValue);
+}
+
+/**
+ * Atomic exchange.
+ * @param  valuePtr     Target memory location.
+ * @param  desiredValue The value to store.
+ * @return              The previous value.
+ */
+void *core_util_atomic_exchange_ptr(void *volatile *valuePtr, void *desiredValue);
+
+/**
  * Atomic increment.
  * @param  valuePtr Target memory location being incremented.
  * @param  delta    The amount being incremented.


### PR DESCRIPTION
### Description

Three extensions to the atomic functions in mbed_critical.h:

* Exchange operations 
* Operations on `bool` (load, store, exchange, cas)
* Operations on `uint64_t` (load, store, exchange, cas, incr, decr)

Bool exchange could have been used by #9520 - slightly tidying and shrinking the code.

Exchange and 64-bit operations are anticipated to be needed as part of ARMv6-M retargetting for ARMC6 atomics, as per its library documentation.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Release notes

(Also covering #9247)

* mbed_critical.h now also offers `atomic_load`, `atomic_store` and `atomic_exchange` functions. 
* mbed_critical.h now supports atomic `bool`, `int8_t`, `int16_t`, `int32_t`, `uint64_t` and `int64_t`.

Previously code had to just do plain C loads and stores of "atomic" variables, as no atomic operations were provided by the library. Such direct accesses are indeed atomic in ARM hardware and compilers (up to 32-bit when properly aligned), but did not provide any ordering semantics. Having real atomic accesses provides a full and safe replacement for `volatile` for interthread or thread-to-interrupt synchronisation. 

Old style example (very synthetic):

    uint32_t data; 
    volatile bool ready;

    irq_handler() { // assume single-shot, so doesn't re-run while foreground processes
        data = REG;
        ready = true;  // XXX ready could be written before data!
    }

    // volatile qualifier forces reload each time
    while (!ready) {
    }
    do_something(data); // XXX data could be loaded before "wait for ready" loop.

A workaround for the ordering problems above is to also mark `data` as volatile, but this scales poorly, and can impede optimisation of work on data. Plus it would still not be safe on a multi-CPU system - the compiler wouldn't reorder, but the CPU still might, leading to a different order visible on another CPU. 

New style example:

    uint32_t data; 
    bool ready; // volatile not needed - atomic functions do the work

    irq_handler() { // assume single-shot, so doesn't re-run while foreground processes
        data = REG;
        core_util_atomic_store_bool(&ready, true); // data is written first - atomic store "releases" it
    }

    // Compiler will reload each time
    while (!core_util_atomic_load_bool(&ready) {
    }
    do_something(data); // data is loaded after seeing ready set (atomic load "acquires" the data)

Note that you don't need to mark atomic data or atomic-protected data as `volatile`, just as you don't need to mark mutexes or mutex-protected data as `volatile`. The atomics and mutexes are inherently multi-thread safe, and if they correctly synchronise the data, the data is not subject to racey accesses.

#### Migration guide
* Check for existing uses of the `volatile` type qualifier in code. It should not be used anywhere except for accessing memory-mapped I/O registers. All other uses (eg inter-thread communication or thread<->interrupt communication) can be replaced with atomic operations on non-volatile types.
* Check to see if uses of `atomic_cas` can be simplified to `atomic_exchange` - particularly for `bool`.
* Remove casting or select a better type from the new atomic types available.
* Use 64-bit atomic functions rather than rolling your own with enter/exit critical.

### Reviewers

@pan-, @VeijoPesonen 
