### PR TITLE
LoRaWAN: Proper size checks for link ADR cmds & correct include path in Unittests framework 

### DIFF
--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -59,7 +59,7 @@ target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
 # TESTING
 ####################
 
-enable_testing()
+include(CTest)
 
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
   "${CMAKE_BINARY_DIR}/Testing"

--- a/UNITTESTS/features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
+++ b/UNITTESTS/features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
@@ -181,6 +181,10 @@ TEST_F(Test_LoRaPHYAU915, link_ADR_request)
     uint8_t nb_rep_out = 0;
     uint8_t nb_bytes_parsed = 0;
 
+    uint8_t payload [] = {SRV_MAC_LINK_ADR_REQ, 1, 2, 3, 4};
+    params.payload = payload;
+    params.payload_size = 5;
+
     LoRaPHY_stub::uint8_value = 1;
     LoRaPHY_stub::ch_mask_value = 6;
     LoRaPHY_stub::adr_parse_count = 2;

--- a/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
+++ b/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
@@ -206,6 +206,10 @@ TEST_F(Test_LoRaPHYCN470, link_ADR_request)
     uint8_t nb_rep_out = 0;
     uint8_t nb_bytes_parsed = 0;
 
+    uint8_t payload [] = {SRV_MAC_LINK_ADR_REQ, 1, 2, 3, 4};
+    params.payload = payload;
+    params.payload_size = 5;
+
     LoRaPHY_stub::uint8_value = 1;
     LoRaPHY_stub::ch_mask_value = 6;
     LoRaPHY_stub::adr_parse_count = 2;

--- a/UNITTESTS/features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
+++ b/UNITTESTS/features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
@@ -177,6 +177,7 @@ TEST_F(Test_LoRaPHYUS915, tx_config)
 
 TEST_F(Test_LoRaPHYUS915, link_ADR_request)
 {
+    uint8_t payload [] = {SRV_MAC_LINK_ADR_REQ, 1, 2, 3, 4};
     adr_req_params_t params;
     memset(&params, 0, sizeof(params));
     int8_t dr_out = 0;
@@ -184,8 +185,14 @@ TEST_F(Test_LoRaPHYUS915, link_ADR_request)
     uint8_t nb_rep_out = 0;
     uint8_t nb_bytes_parsed = 0;
 
-    EXPECT_TRUE(0 == object->link_ADR_request(&params, &dr_out, &tx_power_out, &nb_rep_out, &nb_bytes_parsed));
+    params.payload = payload;
+    params.payload_size = 4;
 
+    uint8_t status = object->link_ADR_request(&params, &dr_out, &tx_power_out, &nb_rep_out, &nb_bytes_parsed);
+
+    EXPECT_TRUE(0 == nb_bytes_parsed);
+
+    params.payload_size = 5;
     LoRaPHY_stub::uint8_value = 1;
     LoRaPHY_stub::ch_mask_value = 6;
     LoRaPHY_stub::adr_parse_count = 2;

--- a/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
+++ b/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
@@ -494,6 +494,10 @@ TEST_F(Test_LoRaWANStack, handle_rx)
     ind.buffer = ind_buf;
     ind.buffer_size = 150;
     ind.type = MCPS_UNCONFIRMED;
+    ind.port = 15;
+    ind.is_data_recvd = true;
+    ind.fpending_status = false;
+    LoRaMac_stub::dev_class_value = CLASS_A;
     radio._ev->rx_done(NULL, 0, 0, 0);
 
     //data == NULL || LENGTH == 0 (2 cases)

--- a/UNITTESTS/stubs/LoRaPHY_stub.cpp
+++ b/UNITTESTS/stubs/LoRaPHY_stub.cpp
@@ -151,9 +151,12 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
 }
 
 uint8_t LoRaPHY::parse_link_ADR_req(const uint8_t *payload,
+                                    uint8_t payload_size,
                                     link_adr_params_t *params)
 {
     params->ch_mask_ctrl = LoRaPHY_stub::ch_mask_value;
+    params->channel_mask = 0;
+    params->datarate = 0;
 
     if (LoRaPHY_stub::adr_parse_count) {
         return --LoRaPHY_stub::adr_parse_count;

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -608,7 +608,8 @@ protected:
     /**
      * Parses the parameter of an LinkAdrRequest.
      */
-    uint8_t parse_link_ADR_req(const uint8_t *payload, link_adr_params_t *adr_params);
+    uint8_t parse_link_ADR_req(const uint8_t *payload, uint8_t payload_size,
+                               link_adr_params_t *adr_params);
 
     /**
      * Verifies and updates the datarate, the TX power and the number of repetitions

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -460,13 +460,18 @@ uint8_t LoRaPHYCN470::link_ADR_request(adr_req_params_t *params,
     // Initialize local copy of channels mask
     copy_channel_mask(temp_channel_masks, channel_mask, CN470_CHANNEL_MASK_SIZE);
 
-    while (bytes_processed < params->payload_size) {
+    while (bytes_processed < params->payload_size &&
+            params->payload[bytes_processed] == SRV_MAC_LINK_ADR_REQ) {
 
         // Get ADR request parameters
-        next_index = parse_link_ADR_req(&(params->payload[bytes_processed]), &adr_settings);
+        next_index = parse_link_ADR_req(&(params->payload[bytes_processed]),
+                                        params->payload_size,
+                                        &adr_settings);
 
         if (next_index == 0) {
-            break; // break loop, since no more request has been found
+            bytes_processed = 0;
+            // break loop, malformed packet
+            break;
         }
 
         // Update bytes processed
@@ -499,6 +504,11 @@ uint8_t LoRaPHYCN470::link_ADR_request(adr_req_params_t *params,
 
             temp_channel_masks[adr_settings.ch_mask_ctrl] = adr_settings.channel_mask;
         }
+    }
+
+    if (bytes_processed == 0) {
+        *nb_bytes_parsed = 0;
+        return status;
     }
 
     verify_params.status = status;

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -460,12 +460,16 @@ uint8_t LoRaPHYUS915::link_ADR_request(adr_req_params_t *params,
     // Initialize local copy of channels mask
     copy_channel_mask(temp_channel_masks, channel_mask, US915_CHANNEL_MASK_SIZE);
 
-    while (bytes_processed < params->payload_size) {
+    while (bytes_processed < params->payload_size &&
+            params->payload[bytes_processed] == SRV_MAC_LINK_ADR_REQ) {
         next_idx = parse_link_ADR_req(&(params->payload[bytes_processed]),
+                                      params->payload_size - bytes_processed,
                                       &adr_settings);
 
         if (next_idx == 0) {
-            break; // break loop, since no more request has been found
+            bytes_processed = 0;
+            // break loop, malformed packet
+            break;
         }
 
         // Update bytes processed
@@ -499,6 +503,11 @@ uint8_t LoRaPHYUS915::link_ADR_request(adr_req_params_t *params,
         } else {
             temp_channel_masks[adr_settings.ch_mask_ctrl] = adr_settings.channel_mask;
         }
+    }
+
+    if (bytes_processed == 0) {
+        *nb_bytes_parsed = 0;
+        return status;
     }
 
     // FCC 15.247 paragraph F mandates to hop on at least 2 125 kHz channels


### PR DESCRIPTION
### Description

This PR addresses two issues:

i) adr_settings construct of type link_adr_params_t in link_adr_request() API in the LoRaPHYUS915 class would be render uninitialized if the program takes a specific branch path. We have fixed that by zero initializing the construct. In addition to that we are now checking for the proper payload size anticipating contiguous link ADR command blocks. 

ii) Currently, mbed Unittests will fail to run memcheck tool or other tools as the DartConfiguration.Tcl file would not be found. The problem is the inclusion of Ctest framework at the wrong place. We need explicit inclusion in the CmakeLists.txt which fixes the issue, 


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 
@kjbracey-arm 
@cmonr 


