### PR TITLE
STM32 GPIO: use maximum speed

### DIFF
--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -79,7 +79,13 @@ void pin_function(PinName pin, int data)
 #if defined (TARGET_STM32F1)
     if (mode == STM_PIN_OUTPUT) {
 #endif
+
+#if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
+        LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
+#else
         LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
+#endif
+
 #if defined (TARGET_STM32F1)
     }
 #endif


### PR DESCRIPTION
### Description

To avoid some restrictions, it is recommended to use the maximum GPIO speed.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@LMESTM 
