### PR TITLE
Restore MBEDTLS_PSA_CRYPTO_C for PSA targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1743,7 +1743,7 @@
             "PSA"
         ],
         "is_disk_virtual": true,
-        "macros": ["CPU_MK66FN2M0VMD18", "FSL_RTOS_MBED"],
+        "macros": ["CPU_MK66FN2M0VMD18", "FSL_RTOS_MBED", "MBEDTLS_PSA_CRYPTO_C"],
         "inherits": ["Target"],
         "detect_code": ["0311"],
         "device_has": [
@@ -2435,7 +2435,7 @@
                 "macro_name": "CLOCK_SOURCE_USB"
             }
         },
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "MBEDTLS_PSA_CRYPTO_C"],
         "device_has_add": [
             "SERIAL_ASYNCH",
             "FLASH",
@@ -2684,7 +2684,8 @@
         "components_add": ["FLASHIAP"],
         "macros_add": [
             "USB_STM_HAL",
-            "USBHOST_OTHER"
+            "USBHOST_OTHER",
+            "MBEDTLS_PSA_CRYPTO_C"
         ],
         "device_has_add": [
             "ANALOGOUT",
@@ -4231,6 +4232,9 @@
         "device_has_remove": [],
         "extra_labels_add": ["PSA"],
         "components_add": ["FLASHIAP"],
+        "macros_add": [
+            "MBEDTLS_PSA_CRYPTO_C"
+        ],
         "config": {
             "stdio_uart_tx_help": {
                 "help": "Value: D8(default) or D1"


### PR DESCRIPTION
### Description
Enable PSA Crypto APIs on boards used by Pelion.
Removed by mistake in 763cb4c157f2c99babae932f88315ad67d2bc173 as part of #9195

Note: PSA Crypto APIs on other boards can still be enabled via `mbed_app.json`
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jenia81 @Patater 
