### PR TITLE
Correct typo no_dsp - nodsp

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -404,8 +404,8 @@ class ARMC6(ARM_STD):
             "Cortex-M4F": "cortex-m4",
             "Cortex-M7F": "cortex-m7",
             "Cortex-M7FD": "cortex-m7",
-            "Cortex-M33": "cortex-m33+no_dsp+no_fp",
-            "Cortex-M33F": "cortex-m33+no_dsp",
+            "Cortex-M33": "cortex-m33+nodsp",
+            "Cortex-M33F": "cortex-m33+nodsp",
             "Cortex-M33FE": "cortex-m33"}.get(core, core)
 
         cpu = cpu.lower()


### PR DESCRIPTION
### Description

Correct typo - no dsp option for armclang is nodsp (without underscore)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

