### PR TITLE
AC6 Build fixes for Nordic targets

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/softdevice/common/nrf_sdh_ble.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/softdevice/common/nrf_sdh_ble.c
@@ -65,7 +65,7 @@ NRF_SECTION_SET_DEF(sdh_ble_observers, nrf_sdh_ble_evt_observer_t, NRF_SDH_BLE_O
 
 
 //lint -save -e10 -e19 -e40 -e27 Illegal character (0x24)
-#if defined(__CC_ARM)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
     extern uint32_t  Image$$RW_IRAM1$$Base;
     uint32_t const * const m_ram_start = &Image$$RW_IRAM1$$Base;
 #elif defined(__ICCARM__)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/softdevice/common/nrf_sdh_ble.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/softdevice/common/nrf_sdh_ble.c
@@ -65,7 +65,7 @@ NRF_SECTION_SET_DEF(sdh_ble_observers, nrf_sdh_ble_evt_observer_t, NRF_SDH_BLE_O
 
 
 //lint -save -e10 -e19 -e40 -e27 Illegal character (0x24)
-#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
     extern uint32_t  Image$$RW_IRAM1$$Base;
     uint32_t const * const m_ram_start = &Image$$RW_IRAM1$$Base;
 #elif defined(__ICCARM__)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section.h
@@ -66,7 +66,7 @@ extern "C" {
  * param[in]    section_name    Name of the section.
  * @hideinitializer
  */
-#if defined(__CC_ARM)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
 #define NRF_SECTION_START_ADDR(section_name)       &CONCAT_2(section_name, $$Base)
 
 #elif defined(__GNUC__)
@@ -82,7 +82,7 @@ extern "C" {
  * @param[in]   section_name    Name of the section.
  * @hideinitializer
  */
-#if defined(__CC_ARM)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
 #define NRF_SECTION_END_ADDR(section_name)         &CONCAT_2(section_name, $$Limit)
 
 #elif defined(__GNUC__)
@@ -111,7 +111,7 @@ extern "C" {
  * @warning Data type must be word aligned to prevent padding.
  * @hideinitializer
  */
-#if defined(__CC_ARM)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
 #define NRF_SECTION_DEF(section_name, data_type)                \
     extern data_type * CONCAT_2(section_name, $$Base);          \
     extern void      * CONCAT_2(section_name, $$Limit)
@@ -140,7 +140,7 @@ extern "C" {
  * @param[in]   section_var     Variable to register in the given section.
  * @hideinitializer
  */
-#if defined(__CC_ARM)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
 #define NRF_SECTION_ITEM_REGISTER(section_name, section_var) \
     section_var __attribute__ ((section(STRINGIFY(section_name)))) __attribute__((used))
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section.h
@@ -66,7 +66,7 @@ extern "C" {
  * param[in]    section_name    Name of the section.
  * @hideinitializer
  */
-#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
 #define NRF_SECTION_START_ADDR(section_name)       &CONCAT_2(section_name, $$Base)
 
 #elif defined(__GNUC__)
@@ -82,7 +82,7 @@ extern "C" {
  * @param[in]   section_name    Name of the section.
  * @hideinitializer
  */
-#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
 #define NRF_SECTION_END_ADDR(section_name)         &CONCAT_2(section_name, $$Limit)
 
 #elif defined(__GNUC__)
@@ -111,7 +111,7 @@ extern "C" {
  * @warning Data type must be word aligned to prevent padding.
  * @hideinitializer
  */
-#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
 #define NRF_SECTION_DEF(section_name, data_type)                \
     extern data_type * CONCAT_2(section_name, $$Base);          \
     extern void      * CONCAT_2(section_name, $$Limit)
@@ -140,7 +140,7 @@ extern "C" {
  * @param[in]   section_var     Variable to register in the given section.
  * @hideinitializer
  */
-#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+#if defined(__ARMCC_VERSION)
 #define NRF_SECTION_ITEM_REGISTER(section_name, section_var) \
     section_var __attribute__ ((section(STRINGIFY(section_name)))) __attribute__((used))
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.h
@@ -87,7 +87,7 @@ typedef struct
 typedef struct
 {
     nrf_section_set_t const * p_set;        //!< Pointer to the appropriate section set.
-#if !defined(__GNUC__) || (defined(__CC_ARM) || defined(__ARMCC_VERSION))
+#if !defined(__GNUC__) || defined(__ARMCC_VERSION)
     nrf_section_t const     * p_section;    //!< Pointer to the selected section.
                                             /**<
                                              * In case of GCC all sections in the set are sorted and

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.h
@@ -87,7 +87,7 @@ typedef struct
 typedef struct
 {
     nrf_section_set_t const * p_set;        //!< Pointer to the appropriate section set.
-#if !defined(__GNUC__) || defined(__CC_ARM)
+#if !defined(__GNUC__) || (defined(__CC_ARM) || defined(__ARMCC_VERSION))
     nrf_section_t const     * p_section;    //!< Pointer to the selected section.
                                             /**<
                                              * In case of GCC all sections in the set are sorted and

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7982,7 +7982,7 @@
         "core": "Cortex-M4F",
         "public": true,
         "extra_labels": ["RDA", "UNO_91H", "FLASH_CMSIS_ALGO"],
-        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["GCC_ARM", "IAR"],
         "macros": ["TWO_RAM_REGIONS", "CMSIS_NVIC_VIRTUAL", "CMSIS_NVIC_VIRTUAL_HEADER_FILE=\"RDA5981_nvic_virtual.h\""],
         "device_has": [
             "USTICKER",
@@ -7999,7 +7999,7 @@
             "FLASH",
             "TRNG"
         ],
-        "release_versions": ["2", "5"]
+        "release_versions": []
     },
     "UNO_91H": {
         "inherits": ["RDA5981X"],


### PR DESCRIPTION
### Description
Build fixes for Nordic targets.
Nordic target code uses __CC_ARM(without checking for __ARMCC_VERSION as well) only in few places to bind the code for ARM compiler, but note that __CC_ARM is no longer defined for ARMc6. So we have to augment those with __ARMCC_VERSION as well.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@0xc0170 @kjbracey-arm @deepikabhavnani 
