### PR TITLE
ARMC6: Don't force Thumb compilation for all CPUs

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -16,7 +16,7 @@
                "-Wl,-n"]
     },
     "ARMC6": {
-        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
+        "common": ["-c", "--target=arm-arm-none-eabi", "-g", "-O1",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -15,7 +15,7 @@
                "-Wl,-n"]
     },
     "ARMC6": {
-        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",
+        "common": ["-c", "--target=arm-arm-none-eabi", "-Os",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -15,7 +15,7 @@
                "-Wl,-n"]
     },
     "ARMC6": {
-        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",
+        "common": ["-c", "--target=arm-arm-none-eabi", "-Oz",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",


### PR DESCRIPTION
### Description

ARMC6 was out-of-line with ARMC5 and GCC, because it had an explicit `-mthumb` in its JSON profiles (develop.json etc).

This meant it compiled Thumb code for Cortex-A type devices, when ARMC5 and GCC are compiling ARM code.

This is out-of-line, and breaks current CMSIS-RTOS, whose `rtx_core_ca.h` has some assembler that assumes the compiler is in ARM mode. (See #9609).

However, IAR does remain different here - it is set to compile Thumb always, but CMSIS-RTOS's `rtx_core_ca.h` does cope with that for IAR (only). Arguably IAR could be brought in line by removing its
`--thumb`.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

