### PR TITLE
Fix cortex-m33-S gcc compilation error

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -54,6 +54,7 @@ class GCC(mbedToolchain):
             self.flags["ld"].append("--specs=nano.specs")
 
         core = target.core
+        self.cpu = []
         if CORE_ARCH[target.core] == 8:
             # Add linking time preprocessor macro DOMAIN_NS
             if target.core.endswith("-NS"):
@@ -75,9 +76,9 @@ class GCC(mbedToolchain):
             "Cortex-M33FE": "cortex-m33"}.get(core, core)
 
         if core == "Cortex-M33":
-            self.cpu = ["-march=armv8-m.main"]
+            self.cpu.append("-march=armv8-m.main")
         else:
-            self.cpu = ["-mcpu={}".format(cpu.lower())]
+            self.cpu.append("-mcpu={}".format(cpu.lower()))
 
         if target.core.startswith("Cortex-M"):
             self.cpu.append("-mthumb")


### PR DESCRIPTION
### Description

Fixes cortex-m33-S gcc compilation error due to a bug in `gcc.py` (Issue #9608).

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

@deepikabhavnani @ARMmbed/mbed-os-tools 
