### PR TITLE
SPE: Fix up atomic usage

### DIFF
--- a/components/TARGET_PSA/TARGET_MBED_SPM/COMPONENT_SPE/handles_manager.h
+++ b/components/TARGET_PSA/TARGET_MBED_SPM/COMPONENT_SPE/handles_manager.h
@@ -55,7 +55,7 @@ extern "C" {
 
 /* ------------------------------------ Definitions ---------------------------------- */
 
-#define PSA_HANDLE_MGR_INVALID_HANDLE           ((uint32_t)PSA_NULL_HANDLE)
+#define PSA_HANDLE_MGR_INVALID_HANDLE           ((uint16_t)PSA_NULL_HANDLE)
 
 #define PSA_HANDLE_MGR_INVALID_FRIEND_OWNER     0       // Denoting invalid friend or invalid owner
 
@@ -80,8 +80,10 @@ typedef struct psa_handle_item_t {
 
 typedef struct psa_handle_manager_t {
 
-    uint32_t           handle_generator;    /* A counter supplying handle numbers.  */
-    uint32_t           pool_size;           /* The maximum number of handles that pool can contain. */
+    // Handle generator uses only 16 bits, and wraps.
+    // The reason for this is that we use the 16 upper bits to store the handle's index in the handles pool (for performance reasons)
+    uint16_t           handle_generator;    /* A counter supplying handle numbers.  */
+    uint16_t           pool_size;           /* The maximum number of handles that pool can contain. */
     psa_handle_item_t *handles_pool;        /* Holds couples of handles and their memory "blocks". */
 
 } psa_handle_manager_t;

--- a/components/TARGET_PSA/TARGET_MBED_SPM/COMPONENT_SPE/spm_internal.h
+++ b/components/TARGET_PSA/TARGET_MBED_SPM/COMPONENT_SPE/spm_internal.h
@@ -242,7 +242,7 @@ void channel_state_switch(uint8_t *current_state, uint8_t expected_state, uint8_
  * @param[in] current_state - current state
  * @param[in] expected_state - expected state
 */
-void channel_state_assert(uint8_t *current_state, uint8_t expected_state);
+void channel_state_assert(const uint8_t *current_state, uint8_t expected_state);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

PSA SPE code was using atomics, but not consistently. On the assumption
that the atomics are needed, correct the code to be properly atomic.

* Tighten up table full case - new_handle was left with a bogus value,
  and surrounding code (as a result?) used loop index to assert success.
  Make handle the sole output of the loop, and correct and use it.
* Ensure handle in table is cleared last, with atomic store to release.
* Make skipping of the invalid handle in handle generator loop atomic.
* Use atomic load on state assert, and don't re-read on failure.
* Tighten up types, and avoid casts by using new signed atomics.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
