### PR TITLE
SPI::write: fix number of transmitted symbols.

### DIFF
--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -156,7 +156,7 @@ int SPI::write(int value)
     lock();
     _acquire();
     uint32_t ret = 0;
-    spi_transfer(&_peripheral->spi, &value, (_bits+7)/8, &ret, (_bits+7)/8, NULL);
+    spi_transfer(&_peripheral->spi, &value, 1, &ret, 1, NULL);
     unlock();
     return ret;
 }

--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -27,7 +27,8 @@ namespace mbed {
 
 SPI::spi_peripheral_s SPI::_peripherals[DEVICE_SPI_COUNT];
 
-SPI::spi_peripheral_s::spi_peripheral_s() : owner(NULL) {
+SPI::spi_peripheral_s::spi_peripheral_s() : owner(NULL)
+{
 
 }
 
@@ -80,7 +81,8 @@ SPI::~SPI()
     unlock();
 }
 
-struct SPI::spi_peripheral_s *SPI::_lookup(SPIName name, bool or_last) {
+struct SPI::spi_peripheral_s *SPI::_lookup(SPIName name, bool or_last)
+{
     struct SPI::spi_peripheral_s *result = NULL;
     core_util_critical_section_enter();
     for (uint32_t idx = 0; idx < DEVICE_SPI_COUNT; idx++) {


### PR DESCRIPTION
### Description

This is a fix to issue reported by @jeromecoutant : spi communication problem with `ism43362` module on spi feature branch.

It looks like there is a bug in `SPI::write`. Independently on symbol size number of transferred symbols should be always 1. This PR should fix this problem.

`mbed test -t GCC_ARM -m DISCO_F413ZH -n tests-netsocket-dns -v`

```
| target               | platform_name | test suite          | result | elapsed_time (sec) | copy_method |
|----------------------|---------------|---------------------|--------|--------------------|-------------|
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | OK     | 140.31             | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target               | platform_name | test suite          | test case                             | passed | failed | result | elapsed_time (sec) |
|----------------------|---------------|---------------------|---------------------------------------|--------|--------|--------|--------------------|
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS                      | 1      | 0      | OK     | 0.27               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_CACHE                | 1      | 0      | OK     | 0.69               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_CANCEL               | 1      | 0      | OK     | 5.35               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_EXTERNAL_EVENT_QUEUE | 1      | 0      | OK     | 3.49               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_INVALID_HOST         | 1      | 0      | OK     | 1.66               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC  | 1      | 0      | OK     | 0.79               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_SIMULTANEOUS         | 1      | 0      | OK     | 1.2                |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_SIMULTANEOUS_CACHE   | 1      | 0      | OK     | 0.86               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_SIMULTANEOUS_REPEAT  | 1      | 0      | OK     | 65.63              |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | ASYNCHRONOUS_DNS_TIMEOUTS             | 1      | 0      | OK     | 3.04               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | SYNCHRONOUS_DNS                       | 1      | 0      | OK     | 0.12               |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | SYNCHRONOUS_DNS_INVALID               | 1      | 0      | OK     | 31.99              |
| DISCO_F413ZH-GCC_ARM | DISCO_F413ZH  | tests-netsocket-dns | SYNCHRONOUS_DNS_MULTIPLE              | 1      | 0      | OK     | 0.5                |
mbedgt: test case results: 13 OK

```

Please note that to run the test spi support for `DISCO_F413ZH` needs to be enabled.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant @ithinuel 

