### PR TITLE
Improvement to artifact delivery method

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -37,7 +37,7 @@ from ..utils import (json_file_to_dict, intelhex_offset, integer,
 from ..arm_pack_manager import Cache
 from ..targets import (CUMULATIVE_ATTRIBUTES, TARGET_MAP, generate_py_target,
                        get_resolution_order, Target)
-from ..settings import DELIVERY_DIR, ROOT
+from ..settings import DELIVERY_DIR
 
 try:
     unicode

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -37,7 +37,7 @@ from ..utils import (json_file_to_dict, intelhex_offset, integer,
 from ..arm_pack_manager import Cache
 from ..targets import (CUMULATIVE_ATTRIBUTES, TARGET_MAP, generate_py_target,
                        get_resolution_order, Target)
-from ..settings import DELIVERY_DIR
+from ..settings import DELIVERY_DIR, ROOT
 
 try:
     unicode
@@ -603,7 +603,7 @@ class Config(object):
         if self.target.deliver_to_target:
             delivery_target = Target.get_target(self.target.deliver_to_target)
             if hasattr(delivery_target, "delivery_dir"):
-                target_delivery_dir = delivery_target.delivery_dir
+                target_delivery_dir = join(ROOT, delivery_target.delivery_dir)
             else:
                 label_dir = "TARGET_{}".format(self.target.deliver_to_target)
                 target_delivery_dir = join(DELIVERY_DIR, label_dir)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -44,7 +44,8 @@ try:
 except NameError:
     unicode = str
 PATH_OVERRIDES = set([
-    "target.bootloader_img"
+    "target.bootloader_img",
+    "target.delivery_dir"
 ])
 DELIVERY_OVERRIDES = set([
     "target.deliver_to_target",
@@ -601,9 +602,8 @@ class Config(object):
 
     def deliver_into(self):
         if self.target.deliver_to_target:
-            delivery_target = Target.get_target(self.target.deliver_to_target)
-            if hasattr(delivery_target, "delivery_dir"):
-                target_delivery_dir = join(ROOT, delivery_target.delivery_dir)
+            if self.target.delivery_dir:
+                target_delivery_dir = self.target.delivery_dir
             else:
                 label_dir = "TARGET_{}".format(self.target.deliver_to_target)
                 target_delivery_dir = join(DELIVERY_DIR, label_dir)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -49,6 +49,7 @@ PATH_OVERRIDES = set([
 DELIVERY_OVERRIDES = set([
     "target.deliver_to_target",
     "target.deliver_artifacts",
+    "target.delivery_dir"
 ])
 ROM_OVERRIDES = set([
     # managed BL
@@ -600,8 +601,13 @@ class Config(object):
 
     def deliver_into(self):
         if self.target.deliver_to_target:
-            label_dir = "TARGET_{}".format(self.target.deliver_to_target)
-            target_delivery_dir = join(DELIVERY_DIR, label_dir)
+            delivery_target = Target.get_target(self.target.deliver_to_target)
+            if hasattr(delivery_target, "delivery_dir"):
+                target_delivery_dir = delivery_target.delivery_dir
+            else:
+                label_dir = "TARGET_{}".format(self.target.deliver_to_target)
+                target_delivery_dir = join(DELIVERY_DIR, label_dir)
+
             if not exists(target_delivery_dir):
                 os.makedirs(target_delivery_dir)
 


### PR DESCRIPTION
### Description
A target can define a delivery directory instead of the default option

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy 

### Release notes

When a target declares a `deliver_to_target` in `targets.json` the output binary will be copied to `DELIVERY` directory in the root of mbed-os.
We now allow to declare a path to where the deliverables will be delivered to by declaring `delivery_dir` in the the target in `targets.json`
delivery_dir is a relative to where it was last changed.
so we have the  following scenarios:
1. delivery_dir not specified -> {mbed-os root}/DELIVERY/TARGET_{REQUESTED_TARGET}
2. delivery_dir specified in targets.json -> the path will be relative to targets folder inside mbed-os.
3. delivery_dir specified in mbed_app.json -> the path will be relative to that file's base folder.

