### PR TITLE
Fix compiler warnings

### DIFF
--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -63,8 +63,8 @@ void TLSSOCKET_ECHOTEST()
     if (tlssocket_connect_to_echo_srv(*sock) != NSAPI_ERROR_OK) {
         printf("Error from tlssocket_connect_to_echo_srv\n");
         TEST_FAIL();
-        return;
         delete sock;
+        return;
     }
 
     int recvd;

--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -137,8 +137,6 @@ void NETWORKINTERFACE_STATUS_NONBLOCK()
 
 void NETWORKINTERFACE_STATUS_GET()
 {
-    nsapi_connection_status_t status;
-
     net = NetworkInterface::get_default_instance();
     net->set_blocking(true);
 

--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include <stdio.h>
+#include <string.h>
 #include "hal/gpio_api.h"
 #include "platform/mbed_wait_api.h"
 #include "platform/mbed_toolchain.h"


### PR DESCRIPTION
### Description
Fixes compiler warnings

```
[Warning] mbed_board.c@67,0:  #223-D: function "memcpy" declared implicitly
[Warning] mbed_board.c@88,0:  #223-D: function "strlen" declared implicitly
[Warning] networkinterface_status.cpp@140,0:  #177-D: variable "status"  was declared but never referenced
[Warning] tlssocket_echotest.cpp@67,0:  #111-D: statement is unreachable

```
### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


