### PR TITLE
Crypto Service - keys access control

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
@@ -28,16 +28,19 @@ typedef struct psa_crypto_access_control_s {
 
 static psa_crypto_access_control_t crypto_access_control_arr[PSA_KEY_SLOT_COUNT];
 
-#define PSA_CRYPTO_ACCESS_CONTROL_RESET() (memset(crypto_access_control_arr, 0, sizeof(crypto_access_control_arr)))
+static inline void psa_crypto_access_control_reset()
+{
+    memset(crypto_access_control_arr, 0, sizeof(crypto_access_control_arr));
+}
 
 void psa_crypto_access_control_init(void)
 {
-    PSA_CRYPTO_ACCESS_CONTROL_RESET();
+    psa_crypto_access_control_reset();
 }
 
 void psa_crypto_access_control_destroy(void)
 {
-    PSA_CRYPTO_ACCESS_CONTROL_RESET();
+    psa_crypto_access_control_reset();
 }
 
 void psa_crypto_access_control_register_handle(psa_key_handle_t key_handle, int32_t partition_id)

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+
+#include "psa_crypto_access_control.h"
+#include "psa_crypto_slot_management.h"
+#include "spm_panic.h"
+
+typedef struct psa_crypto_access_control_s {
+    psa_key_handle_t key_handle;
+    int32_t partition_id;
+} psa_crypto_access_control_t;
+
+static psa_crypto_access_control_t crypto_access_control_arr[PSA_KEY_SLOT_COUNT];
+
+#define PSA_CRYPTO_ACCESS_CONTROL_RESET() (memset(crypto_access_control_arr, 0, sizeof(crypto_access_control_arr)))
+
+void psa_crypto_access_control_init(void)
+{
+    PSA_CRYPTO_ACCESS_CONTROL_RESET();
+}
+
+void psa_crypto_access_control_destroy(void)
+{
+    PSA_CRYPTO_ACCESS_CONTROL_RESET();
+}
+
+void psa_crypto_access_control_register_handle(psa_key_handle_t key_handle, int32_t partition_id)
+{
+    for (size_t i = 0; i < PSA_KEY_SLOT_COUNT; i++) {
+        if (crypto_access_control_arr[i].key_handle == 0 &&
+                crypto_access_control_arr[i].partition_id == 0) {
+            crypto_access_control_arr[i].key_handle = key_handle;
+            crypto_access_control_arr[i].partition_id = partition_id;
+            return;
+        }
+    }
+
+    SPM_PANIC("psa_crypto_access_control_register_handle failed");
+}
+
+void psa_crypto_access_control_unregister_handle(psa_key_handle_t key_handle)
+{
+    for (size_t i = 0; i < PSA_KEY_SLOT_COUNT; i++) {
+        if (crypto_access_control_arr[i].key_handle == key_handle) {
+            crypto_access_control_arr[i].key_handle = 0;
+            crypto_access_control_arr[i].partition_id = 0;
+            return;
+        }
+    }
+
+    SPM_PANIC("psa_crypto_access_control_unregister_handle failed");
+}
+
+uint8_t psa_crypto_access_control_is_handle_permitted(psa_key_handle_t key_handle, int32_t partition_id)
+{
+    for (size_t i = 0; i < PSA_KEY_SLOT_COUNT; i++) {
+        if (crypto_access_control_arr[i].key_handle == key_handle &&
+                crypto_access_control_arr[i].partition_id == partition_id) {
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "psa_crypto_access_control.h"
+#include "psa_crypto_core.h"
 #include "psa_crypto_slot_management.h"
 
 #if defined(TARGET_TFM)

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.c
@@ -19,7 +19,15 @@
 
 #include "psa_crypto_access_control.h"
 #include "psa_crypto_slot_management.h"
+
+#if defined(TARGET_TFM)
+#define SPM_PANIC(format, ...) \
+{ \
+    while(1){}; \
+}
+#else
 #include "spm_panic.h"
+#endif
 
 typedef struct psa_crypto_access_control_s {
     psa_key_handle_t key_handle;

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.h
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.h
@@ -22,14 +22,19 @@
 
 #include "crypto_platform.h"
 
+/* initialize the module, resets all tracked information */
 void psa_crypto_access_control_init(void);
 
+/* deinitialize the module, resets all tracked information */
 void psa_crypto_access_control_destroy(void);
 
+/* tracks and associates the key_handle with partition_id */
 void psa_crypto_access_control_register_handle(psa_key_handle_t key_handle, int32_t partition_id);
 
+/* removes tracking of the key_handle */
 void psa_crypto_access_control_unregister_handle(psa_key_handle_t key_handle);
 
+/* checks if the key_handle is associated with the partition_id, returns 0 is false otherwise 1 */
 uint8_t psa_crypto_access_control_is_handle_permitted(psa_key_handle_t key_handle, int32_t partition_id);
 
 #endif /* PSA_CRYPTO_ACCESS_CONTROL_H */

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.h
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PSA_CRYPTO_ACCESS_CONTROL_H
+#define PSA_CRYPTO_ACCESS_CONTROL_H
+
+#include <stdint.h>
+
+#include "psa_crypto_core.h"
+#include "crypto_platform.h"
+
+void psa_crypto_access_control_init(void);
+
+void psa_crypto_access_control_destroy(void);
+
+void psa_crypto_access_control_register_handle(psa_key_handle_t key_handle, int32_t partition_id);
+
+void psa_crypto_access_control_unregister_handle(psa_key_handle_t key_handle);
+
+uint8_t psa_crypto_access_control_is_handle_permitted(psa_key_handle_t key_handle, int32_t partition_id);
+
+#endif /* PSA_CRYPTO_ACCESS_CONTROL_H */

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.h
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_access_control.h
@@ -20,7 +20,6 @@
 
 #include <stdint.h>
 
-#include "psa_crypto_core.h"
 #include "crypto_platform.h"
 
 void psa_crypto_access_control_init(void);


### PR DESCRIPTION
### Description
Access control for crypto keys in crypto service.

This is in continuation of PR #9575 which ensured that only the key creator is allowed to _open_ a key & obtain a handle to it.

This PR, validates that the `psa_key_handle_t` argument (passed in as an input argument to the crypto APIs) is associated with the calling partition, i.e. that the API caller is also the key owner/creator.

~~Please do not merge or run CI - needs preceding PR https://github.com/ARMmbed/mbed-os/pull/9575~~

~~**Reviewers**, reviews should start from c9130428951d60d865826e431eb400d92223b163, previous commits are from #9575 and are being reviewed there.~~


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@avolinski 

<!-- 
    Optional
    Request additional reviewers with @username
-->

