### PR TITLE
ESP8266: connect() checks errors from ESP chip

### DIFF
--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -52,7 +52,7 @@ using namespace utest::v1;
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(240, "default_auto");
+    GREENTEA_SETUP(360, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -368,6 +368,7 @@ private:
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
     void _hw_reset();
+    nsapi_error_t _connect_retval;
 
     //sigio
     struct {


### PR DESCRIPTION
### Description

ESP8266Interface::connect() checks ESP8266::connect() return values and returns if unrecoverable errors are returned.
Increased timeout for network-wifi greentea tests.
Fixes failing network-wifi-WIFI-CONNECT-SECURE-FAIL tests for ESP8266.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 

