### PR TITLE
Fix for RDA targets failing AC6 builds

### DIFF
--- a/targets/TARGET_RDA/mbed_rtx.h
+++ b/targets/TARGET_RDA/mbed_rtx.h
@@ -29,7 +29,7 @@
 #define OS_CLOCK                160000000
 #endif
 
-#if defined(__CC_ARM)
+#if defined(__ARMCC_VERSION)
 extern uint32_t                 Image$$ARM_LIB_HEAP$$ZI$$Base[];
 extern uint32_t                 Image$$ARM_LIB_HEAP$$ZI$$Length[];
 extern uint32_t                 Image$$ARM_LIB_STACK$$ZI$$Base[];

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1318,7 +1318,7 @@
     "KW24D": {
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4",
-        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM"],
         "is_disk_virtual": true,
         "macros": ["CPU_MKW24D512VHA5", "FSL_RTOS_MBED"],
@@ -1346,7 +1346,6 @@
             "FLASH",
             "802_15_4_PHY"
         ],
-        "release_versions": ["2", "5"],
         "device_name": "MKW24D512xxx5",
         "bootloader_supported": true,
         "overrides": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7982,7 +7982,7 @@
         "core": "Cortex-M4F",
         "public": true,
         "extra_labels": ["RDA", "UNO_91H", "FLASH_CMSIS_ALGO"],
-        "supported_toolchains": ["GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "macros": ["TWO_RAM_REGIONS", "CMSIS_NVIC_VIRTUAL", "CMSIS_NVIC_VIRTUAL_HEADER_FILE=\"RDA5981_nvic_virtual.h\""],
         "device_has": [
             "USTICKER",
@@ -7999,7 +7999,7 @@
             "FLASH",
             "TRNG"
         ],
-        "release_versions": []
+        "release_versions": ["2", "5"]
     },
     "UNO_91H": {
         "inherits": ["RDA5981X"],


### PR DESCRIPTION
### Description

Fix for RDA targets failing AC6 builds.
RDA target code uses __CC_ARM in mbed_rtx.h. Note that __CC_ARM is no longer defined for ARMc6. So modified with __ARMCC_VERSION macro which works for both AC5 and AC6.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

