### PR TITLE
Fix IntelliSense in VSCode export

### DIFF
--- a/tools/export/vscode/__init__.py
+++ b/tools/export/vscode/__init__.py
@@ -67,16 +67,29 @@ class VSCode(Makefile):
             "configurations": [
                 {
                     "name": "Windows",
+                    "forcedInclude": [
+                        "${workspaceRoot}\\mbed_config.h"
+                    ],
+                    "compilerPath": self.toolchain.cppc[0],
+                    "intelliSenseMode": "gcc-x64",
                     "includePath": [x.replace("/", "\\") for x in all_directories],
                     "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 },
                 {
                     "name": "Mac",
+                    "forcedInclude": [
+                        "${workspaceRoot}\\mbed_config.h"
+                    ],
+                    "compilerPath": self.toolchain.cppc[0],
                     "includePath": all_directories,
                     "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 },
                 {
                     "name": "Linux",
+                    "forcedInclude": [
+                        "${workspaceRoot}\\mbed_config.h"
+                    ],
+                    "compilerPath": self.toolchain.cppc[0],
                     "includePath": all_directories,
                     "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 }

--- a/tools/export/vscode/__init__.py
+++ b/tools/export/vscode/__init__.py
@@ -68,17 +68,17 @@ class VSCode(Makefile):
                 {
                     "name": "Windows",
                     "forcedInclude": [
-                        "${workspaceRoot}\\mbed_config.h"
+                        "${workspaceRoot}/mbed_config.h"
                     ],
                     "compilerPath": self.toolchain.cppc[0],
                     "intelliSenseMode": "gcc-x64",
-                    "includePath": [x.replace("/", "\\") for x in all_directories],
+                    "includePath": all_directories,
                     "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 },
                 {
                     "name": "Mac",
                     "forcedInclude": [
-                        "${workspaceRoot}\\mbed_config.h"
+                        "${workspaceRoot}/mbed_config.h"
                     ],
                     "compilerPath": self.toolchain.cppc[0],
                     "includePath": all_directories,
@@ -87,7 +87,7 @@ class VSCode(Makefile):
                 {
                     "name": "Linux",
                     "forcedInclude": [
-                        "${workspaceRoot}\\mbed_config.h"
+                        "${workspaceRoot}/mbed_config.h"
                     ],
                     "compilerPath": self.toolchain.cppc[0],
                     "includePath": all_directories,

--- a/tools/export/vscode/__init__.py
+++ b/tools/export/vscode/__init__.py
@@ -59,16 +59,16 @@ class VSCode(Makefile):
                 continue
 
             if directory == ".":
-                all_directories.append("${workspaceRoot}/*")
+                all_directories.append("${workspaceFolder}/*")
             else:
-                all_directories.append(directory.replace("./", "${workspaceRoot}/") + "/*")
+                all_directories.append(directory.replace("./", "${workspaceFolder}/") + "/*")
 
         cpp_props = {
             "configurations": [
                 {
                     "name": "Windows",
                     "forcedInclude": [
-                        "${workspaceRoot}/mbed_config.h"
+                        "${workspaceFolder}/mbed_config.h"
                     ],
                     "compilerPath": self.toolchain.cppc[0],
                     "intelliSenseMode": "gcc-x64",
@@ -78,7 +78,7 @@ class VSCode(Makefile):
                 {
                     "name": "Mac",
                     "forcedInclude": [
-                        "${workspaceRoot}/mbed_config.h"
+                        "${workspaceFolder}/mbed_config.h"
                     ],
                     "compilerPath": self.toolchain.cppc[0],
                     "includePath": all_directories,
@@ -87,7 +87,7 @@ class VSCode(Makefile):
                 {
                     "name": "Linux",
                     "forcedInclude": [
-                        "${workspaceRoot}/mbed_config.h"
+                        "${workspaceFolder}/mbed_config.h"
                     ],
                     "compilerPath": self.toolchain.cppc[0],
                     "includePath": all_directories,


### PR DESCRIPTION
Allow to use default intelliSenseEngine in visual studio code.
Add of compilerPath and forcedInclude of mbed_config header in the
created c_cpp_properties.json file.

### Description

Allow to use default intelliSenseEngine in visual studio code.
Add of compilerPath and forcedInclude of mbed_config header in the
created c_cpp_properties.json file.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change



