### PR TITLE
Multi thread Block Device Tests Fix - Ensure unique block address 

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
@@ -47,6 +47,11 @@ void basic_erase_program_read_test(SPIFBlockDevice &block_device, bd_size_t bloc
 {
     int err = 0;
     _mutex->lock();
+
+    // Make sure block address per each test is unique
+    static unsigned block_seed = 1;
+    srand(block_seed++);
+
     // Find a random block
     bd_addr_t block = (rand() * block_size) % block_device.size();
 

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -187,6 +187,11 @@ void basic_erase_program_read_test(BlockDevice *block_device, bd_size_t block_si
 {
     int err = 0;
     _mutex->lock();
+
+    // Make sure block address per each test is unique
+    static unsigned block_seed = 1;
+    srand(block_seed++);
+
     // Find a random block
     bd_addr_t block = (rand() * block_size) % (block_device->size());
 


### PR DESCRIPTION
### Description

Fix multi-threaded block device tests to ensure unique block address per test

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
