### PR TITLE
FUTURE_SEQUANA_M0_PSA - fix CM4 starting address

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/TARGET_FUTURE_SEQUANA_M0_PSA/spm_hal_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/TARGET_FUTURE_SEQUANA_M0_PSA/spm_hal_api.c
@@ -32,7 +32,7 @@
 
 void spm_hal_start_nspe(void)
 {
-    Cy_SysEnableCM4(CY_CORTEX_M4_APPL_ADDR);
+    Cy_SysEnableCM4(PSA_NON_SECURE_ROM_START);
 }
 
 void spm_hal_memory_protection_init(void)


### PR DESCRIPTION
### Description

Use PSA_NON_SECURE_ROM_START configuration value instead of hardcoded CY_CORTEX_M4_APPL_ADDR.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@orenc17 @jenia81 

