### PR TITLE
Fix minor bugs in secure targets file filtering

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -43,6 +43,7 @@ from tools.settings import CPPCHECK_CMD, CPPCHECK_MSG_FORMAT, CLI_COLOR_MAP
 from tools.notifier.term import TerminalNotifier
 from tools.utils import argparse_filestring_type, args_error, argparse_many
 from tools.utils import argparse_filestring_type, argparse_dir_not_parent
+from tools.paths import is_relative_to_root
 
 if __name__ == '__main__':
     start = time()
@@ -188,19 +189,11 @@ if __name__ == '__main__':
                     mcu = TARGET_MAP[target]
                     profile = extract_profile(parser, options, toolchain)
 
-                    if mcu.is_PSA_secure_target:
-                        lib_build_res = build_library(
-                            ROOT, options.build_dir, mcu, toolchain,
-                            jobs=options.jobs,
-                            clean=options.clean,
-                            archive=(not options.no_archive),
-                            macros=options.macros,
-                            name=options.artifact_name,
-                            build_profile=profile,
-                            ignore=options.ignore,
-                            notify=notifier,
-                        )
-                    elif options.source_dir:
+                    if mcu.is_PSA_secure_target and \
+                            not is_relative_to_root(options.source_dir):
+                        options.source_dir = ROOT
+
+                    if options.source_dir:
                         lib_build_res = build_library(
                             options.source_dir, options.build_dir, mcu, toolchain,
                             jobs=options.jobs,

--- a/tools/make.py
+++ b/tools/make.py
@@ -34,6 +34,7 @@ from tools.paths import MBED_LIBRARIES
 from tools.paths import RPC_LIBRARY
 from tools.paths import USB_LIBRARIES
 from tools.paths import DSP_LIBRARIES
+from tools.paths import is_relative_to_root
 from tools.tests import TESTS, Test, TEST_MAP
 from tools.tests import TEST_MBED_LIB
 from tools.tests import test_known, test_name_known
@@ -307,8 +308,9 @@ if __name__ == '__main__':
             args_error(parser, "argument -t/--tool is required")
         toolchain = options.tool[0]
 
-        if Target.get_target(mcu).is_PSA_secure_target:
-            options.source_dir = ROOT
+        if Target.get_target(mcu).is_PSA_secure_target and \
+                not is_relative_to_root(options.source_dir):
+                options.source_dir = ROOT
 
         if (options.program is None) and (not options.source_dir):
             args_error(parser, "one of -p, -n, or --source is required")

--- a/tools/paths.py
+++ b/tools/paths.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from os.path import join
+from os.path import join, commonprefix, realpath
 from os import getenv
 
 # Conventions about the directory structure
@@ -85,3 +85,11 @@ CPPUTEST_TESTRUNNER_SCR = join(TEST_DIR, "utest", "testrunner")
 CPPUTEST_TESTRUNNER_INC = join(TEST_DIR, "utest", "testrunner")
 
 CPPUTEST_LIBRARY = join(BUILD_DIR, "cpputest")
+
+
+def is_relative_to_root(dirs):
+    if not isinstance(dirs, list):
+        dirs = [dirs]
+    dirs = [realpath(d) for d in dirs]
+    out = commonprefix(dirs + [ROOT])
+    return out == ROOT

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -38,7 +38,7 @@ from collections import namedtuple, defaultdict
 from copy import copy
 from itertools import chain
 from os import walk, sep
-from os.path import (join, splitext, dirname, relpath, basename, split, normcase,
+from os.path import (join, splitext, dirname, relpath, basename, split, normpath,
                      abspath, exists)
 
 from .ignore import MbedIgnoreSet, IGNORE_FILENAME
@@ -147,6 +147,11 @@ class Resources(object):
         self._sep = sep
 
         self._ignoreset = MbedIgnoreSet()
+
+        # make sure mbed-os root is added as include directory
+        script_dir = dirname(abspath(__file__))
+        mbed_os_root_dir = normpath(join(script_dir, '..', '..'))
+        self.add_file_ref(FileType.INC_DIR, mbed_os_root_dir, mbed_os_root_dir)
 
     def ignore_dir(self, directory):
         if self._collect_ignores:

--- a/tools/test.py
+++ b/tools/test.py
@@ -45,6 +45,8 @@ from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS, TOOLCHAIN_CLASSES
 from tools.settings import CLI_COLOR_MAP
 from tools.settings import ROOT
 from tools.targets import Target
+from tools.paths import is_relative_to_root
+
 if __name__ == '__main__':
     try:
         # Parse Options
@@ -211,8 +213,8 @@ if __name__ == '__main__':
             if not options.build_dir:
                 args_error(parser, "argument --build is required")
 
-            if mcu_secured:
-                base_source_paths = ROOT
+            if mcu_secured and not is_relative_to_root(options.source_dir):
+                options.source_dir = ROOT
             else:
                 base_source_paths = options.source_dir
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -214,7 +214,7 @@ if __name__ == '__main__':
                 args_error(parser, "argument --build is required")
 
             if mcu_secured and not is_relative_to_root(options.source_dir):
-                options.source_dir = ROOT
+                base_source_paths = ROOT
             else:
                 base_source_paths = options.source_dir
 


### PR DESCRIPTION
### Description
During the TF-m bring-up we found issues with the scanning rules

This PR fixes those by:
* Force adding mbed-os root to include dirs 
* Check source relative to ROOT on secure targets 

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy @mikisch81 

