### PR TITLE
Update mbed-coap to version 4.7.4

### DIFF
--- a/features/frameworks/mbed-coap/.yotta_ignore
+++ b/features/frameworks/mbed-coap/.yotta_ignore
@@ -1,5 +1,0 @@
-# need unity.h:
-unittest/*
-test/*
-doxygen/*
-

--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v4.7.4](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.4) 
+
+- Remove dependency to yotta tool
+- Do not remove stored (GET) blockwise message when EMPTY ACK received
+    When non piggybacked response mode is used original GET request must not be removed from the stored message list.
+    Message is needed for building the next (GET) blockwise message.
+- Move definitions to sn_config.h
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.7.3...v4.7.4)
+
 ## [v4.7.3](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.3) 
 
 - Do not store EMPTY response to blockwise list

--- a/features/frameworks/mbed-coap/Makefile.test
+++ b/features/frameworks/mbed-coap/Makefile.test
@@ -11,6 +11,28 @@ TESTDIRS := $(UNITTESTS:%=build-%)
 CLEANTESTDIRS := $(UNITTESTS:%=clean-%)
 COVERAGEFILE := ./lcov/coverage.info
 
+TEST_MODULES = ./test_modules
+TEST_MODULE_MBED_TRACE = $(TEST_MODULES)/mbed-trace
+TEST_MODULE_NANOSTACK = $(TEST_MODULES)/nanostack-libservice
+TEST_MODULE_RANDLIB = $(TEST_MODULES)/mbed-client-randlib
+
+.PHONY: clone
+clone:
+	if [ ! -d $(TEST_MODULES) ]; \
+		then mkdir $(TEST_MODULES); \
+	fi;
+
+	if [ ! -d $(TEST_MODULE_MBED_TRACE) ]; \
+		then git clone --depth 1 git@github.com:ARMmbed/mbed-trace.git $(TEST_MODULE_MBED_TRACE); \
+	fi;
+
+	if [ ! -d $(TEST_MODULE_NANOSTACK) ]; \
+		then git clone --depth 1 git@github.com:ARMmbed/nanostack-libservice.git $(TEST_MODULE_NANOSTACK); \
+	fi;
+
+	if [ ! -d $(TEST_MODULE_RANDLIB) ]; \
+		then git clone --depth 1 git@github.com:ARMmbed/mbed-client-randlib.git $(TEST_MODULE_RANDLIB); \
+	fi;
 .PHONY: test
 test: $(TESTDIRS)
 	@rm -rf ./lcov
@@ -27,7 +49,7 @@ test: $(TESTDIRS)
 	@rm -f lcov/index.xml
 	@find ./ -name '*.gcno' | xargs cp --backup=numbered -t ./coverage/
 	@find ./ -name '*.gcda' | xargs cp --backup=numbered -t ./coverage/
-	@gcovr --object-directory ./coverage  --exclude-unreachable-branches -e '.*/builds/.*' -e '.*/test/.*' -e '.*/yotta_modules/.*' -e '.*/stubs/.*' -e '.*/mbed-coap/.*' -x -o ./lcov/gcovr.xml
+	@gcovr --object-directory ./coverage  --exclude-unreachable-branches -e '.*/builds/.*' -e '.*/test/.*' -e '.*/stubs/.*' -e '.*/mbed-coap/.*' -x -o ./lcov/gcovr.xml
 	@lcov -d test/. -c -o $(COVERAGEFILE)
 	@lcov -q -r $(COVERAGEFILE) "/usr*" -o $(COVERAGEFILE)
 	@lcov -q -r $(COVERAGEFILE) "/test*" -o $(COVERAGEFILE)

--- a/features/frameworks/mbed-coap/mbed-coap/sn_config.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_config.h
@@ -17,6 +17,10 @@
 #ifndef SN_CONFIG_H
 #define SN_CONFIG_H
 
+#ifdef MBED_CLIENT_USER_CONFIG_FILE
+#include MBED_CLIENT_USER_CONFIG_FILE
+#endif
+
 /**
 * \brief Configuration options (set of defines and values)
 *
@@ -30,9 +34,15 @@
  * \brief For Message duplication detection
  * Init value for the maximum count of messages to be stored for duplication detection
  * Setting of this value to 0 will disable duplication check, also reduce use of ROM memory
- * Default is set to 1.
+ * Default is set to 0.
  */
-#undef SN_COAP_DUPLICATION_MAX_MSGS_COUNT   /* 1 */
+#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+#endif
+
+#ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
+#endif
 
 /**
  * \def SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
@@ -42,7 +52,13 @@
  * also reduce use of ROM memory.
  * Note: This define is common for both received and sent Blockwise messages
  */
-#undef SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE   /* 0 */ // < Must be 2^x and x is at least 4. Suitable values: 0, 16, 32, 64, 128, 256, 512 and 1024
+#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE MBED_CONF_MBED_CLIENT_SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+#endif
+
+#ifndef SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE              0  /**< Must be 2^x and x is at least 4. Suitable values: 0, 16, 32, 64, 128, 256, 512 and 1024 */
+#endif
 
 /**
  * \def SN_COAP_DISABLE_RESENDINGS
@@ -50,21 +66,33 @@
  * when using CoAP with TCP transport for example. By default resendings are
  * enabled. Set to 1 to disable.
  */
-#undef SN_COAP_DISABLE_RESENDINGS          /* 0 */ // < Default re-sending are not disabled. Set to 1 to disable re-sendings
+#ifdef SN_COAP_DISABLE_RESENDINGS
+#define ENABLE_RESENDINGS                               0   /** Disable resendings **/
+#else
+#define ENABLE_RESENDINGS                               1   /**< Enable / Disable resending from library in building */
+#endif
 
 /**
  * \def SN_COAP_RESENDING_QUEUE_SIZE_MSGS
  * \brief Sets the number of messages stored
  * in the resending queue. Default is 2
  */
-#undef SN_COAP_RESENDING_QUEUE_SIZE_MSGS    /* 2  */ // < Default re-sending queue size - defines how many messages can be stored. Setting this to 0 disables feature
+#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_MSGS
+#define SN_COAP_RESENDING_QUEUE_SIZE_MSGS MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_MSGS
+#endif
+
+#ifndef SN_COAP_RESENDING_QUEUE_SIZE_MSGS
+#define SN_COAP_RESENDING_QUEUE_SIZE_MSGS               2   /**< Default re-sending queue size - defines how many messages can be stored. Setting this to 0 disables feature */
+#endif
 
 /**
  * \def DEFAULT_RESPONSE_TIMEOUT
  * \brief Sets the CoAP re-send interval in seconds.
  * By default is 10 seconds.
  */
-#undef DEFAULT_RESPONSE_TIMEOUT
+#ifndef DEFAULT_RESPONSE_TIMEOUT
+#define DEFAULT_RESPONSE_TIMEOUT                        10  /**< Default re-sending timeout as seconds */
+#endif
 
 /**
  * \def SN_COAP_RESENDING_QUEUE_SIZE_BYTES
@@ -72,7 +100,13 @@
  * Setting this to 0 disables this feature.
  * By default, this feature is disabled.
  */
-#undef SN_COAP_RESENDING_QUEUE_SIZE_BYTES   /* 0  */ // Default re-sending queue size - defines size of the re-sending buffer. Setting this to 0 disables feature
+#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_BYTES
+#define SN_COAP_RESENDING_QUEUE_SIZE_BYTES MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_BYTES
+#endif
+
+#ifndef SN_COAP_RESENDING_QUEUE_SIZE_BYTES
+#define SN_COAP_RESENDING_QUEUE_SIZE_BYTES              0   /**< Default re-sending queue size - defines size of the re-sending buffer. Setting this to 0 disables feature */
+#endif
 
 /**
  * \def SN_COAP_MAX_INCOMING_MESSAGE_SIZE
@@ -83,7 +117,9 @@
  * available storage capability.
  * By default, maximum size is UINT16_MAX, 65535 bytes.
  */
-#undef SN_COAP_MAX_INCOMING_MESSAGE_SIZE    /* UINT16_MAX */
+#ifndef SN_COAP_MAX_INCOMING_MESSAGE_SIZE
+#define SN_COAP_MAX_INCOMING_MESSAGE_SIZE               UINT16_MAX
+#endif
 
 /**
  * \def SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE
@@ -98,21 +134,27 @@
  * Note that value should be less than transport layer maximum fragment size.
  * Note that value has no effect if blockwise transfer is disabled.
  */
-#undef SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE        /* 0 */
+#ifndef SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE
+#define SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE           0
+#endif
 
 /**
  * \def SN_COAP_BLOCKWISE_ENABLED
  * \brief Enables the blockwise functionality in CoAP library also when blockwise payload
  * size is set to '0' in  SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE.
  */
-#undef SN_COAP_BLOCKWISE_ENABLED                    /* 0 */
+#ifndef SN_COAP_BLOCKWISE_ENABLED
+#define SN_COAP_BLOCKWISE_ENABLED                       0  /**< Enable blockwise */
+#endif
 
 /**
  * \def SN_COAP_RESENDING_MAX_COUNT
  * \brief Defines how many times CoAP library tries to re-send the CoAP packet.
  * By default value is 3.
  */
-#undef SN_COAP_RESENDING_MAX_COUNT                    /* 3 */
+#ifndef SN_COAP_RESENDING_MAX_COUNT
+#define SN_COAP_RESENDING_MAX_COUNT                     3
+#endif
 
 /**
  * \def SN_COAP_MAX_ALLOWED_RESENDING_COUNT
@@ -120,7 +162,9 @@
  * 'sn_coap_protocol_set_retransmission_parameters()' API.
  * By default value is 6.
  */
-#undef SN_COAP_MAX_ALLOWED_RESENDING_COUNT            /* 6 */
+#ifndef SN_COAP_MAX_ALLOWED_RESENDING_COUNT
+#define SN_COAP_MAX_ALLOWED_RESENDING_COUNT             6   /**< Maximum allowed count of re-sending */
+#endif
 
 /**
  * \def SN_COAP_MAX_ALLOWED_RESPONSE_TIMEOUT
@@ -128,7 +172,9 @@
  * 'sn_coap_protocol_set_retransmission_parameters()' API.
  * By default value is 40.
  */
-#undef SN_COAP_MAX_ALLOWED_RESPONSE_TIMEOUT           /* 40 */
+#ifndef SN_COAP_MAX_ALLOWED_RESPONSE_TIMEOUT
+#define SN_COAP_MAX_ALLOWED_RESPONSE_TIMEOUT            40  /**< Maximum allowed re-sending timeout */
+#endif
 
 /**
  * \def SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS
@@ -136,7 +182,9 @@
  * 'sn_coap_protocol_set_retransmission_buffer()' API.
  * By default value is 6.
  */
-#undef SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS   /* 6 */
+#ifndef SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS
+#define SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS    6   /**< Maximum allowed number of saved re-sending messages */
+#endif
 
 /**
  * \def SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_BYTES
@@ -144,7 +192,9 @@
  * 'sn_coap_protocol_set_retransmission_buffer()' API.
  * By default value is 512.
  */
-#undef SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_BYTES   /* 512 */
+#ifndef SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_BYTES
+#define SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_BYTES   512 /**< Maximum allowed size of re-sending buffer */
+#endif
 
 /**
  * \def SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT
@@ -152,14 +202,18 @@
  * that can be set via 'sn_coap_protocol_set_duplicate_buffer_size' API.
  * By default value is 6.
  */
-#undef SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT
+#ifndef SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT
+#define SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT   6
+#endif
 
 /**
  * \def SN_COAP_DUPLICATION_MAX_TIME_MSGS_STORED
  * \brief Maximum time in seconds howe long message is kept for duplicate detection.
  * By default 60 seconds.
  */
-#undef SN_COAP_DUPLICATION_MAX_TIME_MSGS_STORED
+#ifndef SN_COAP_DUPLICATION_MAX_TIME_MSGS_STORED
+#define SN_COAP_DUPLICATION_MAX_TIME_MSGS_STORED    60 /** RESPONSE_TIMEOUT * RESPONSE_RANDOM_FACTOR * (2 ^ MAX_RETRANSMIT - 1) + the expected maximum round trip time **/
+#endif
 
 /**
  * \def SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
@@ -167,17 +221,25 @@
  * Longer time will increase the memory consumption in lossy networks.
  * By default 60 seconds.
  */
-#undef SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
+#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
+#define SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED MBED_CONF_MBED_CLIENT_SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
+#endif
+
+#ifndef SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
+#define SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED      60 /**< Maximum time in seconds of data (messages and payload) to be stored for blockwising */
+#endif
 
 /**
  * \def SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE
  * \brief Maximum size of blockwise message that can be received.
  * By default 65535 bytes.
  */
-#undef SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE
+#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_MAX_INCOMING_MESSAGE_SIZE
+#define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE MBED_CONF_MBED_CLIENT_SN_COAP_MAX_INCOMING_MESSAGE_SIZE
+#endif
 
-#ifdef MBED_CLIENT_USER_CONFIG_FILE
-#include MBED_CLIENT_USER_CONFIG_FILE
+#ifndef SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE
+#define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE     UINT16_MAX
 #endif
 
 #endif // SN_CONFIG_H

--- a/features/frameworks/mbed-coap/run_unit_tests.sh
+++ b/features/frameworks/mbed-coap/run_unit_tests.sh
@@ -17,7 +17,6 @@ echo
 echo "Build mbed-coap C unit tests"
 echo
 
-yt target x86-linux-native
-yt up
+make -f Makefile.test clone
 make -f Makefile.test test
 #make -f Makefile.test test clean

--- a/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
+++ b/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
@@ -34,117 +34,12 @@ extern "C" {
 
 struct sn_coap_hdr_;
 
-/* * * * * * * * * * * */
-/* * * * DEFINES * * * */
-/* * * * * * * * * * * */
-
-/* * For Message resending * */
-#ifdef SN_COAP_DISABLE_RESENDINGS
-#define ENABLE_RESENDINGS                               0 /* Disable resendings */
-#else
-#define ENABLE_RESENDINGS                               1   /**< Enable / Disable resending from library in building */
-#endif
-
-#define SN_COAP_RESENDING_MAX_COUNT                     3   /**< Default number of re-sendings  */
-
-#ifdef YOTTA_CFG_COAP_RESENDING_QUEUE_SIZE_MSGS
-#define SN_COAP_RESENDING_QUEUE_SIZE_MSGS YOTTA_CFG_COAP_RESENDING_QUEUE_SIZE_MSGS
-#elif defined MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_MSGS
-#define SN_COAP_RESENDING_QUEUE_SIZE_MSGS MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_MSGS
-#endif
-
-#ifndef SN_COAP_RESENDING_QUEUE_SIZE_MSGS
-#define SN_COAP_RESENDING_QUEUE_SIZE_MSGS               2   /**< Default re-sending queue size - defines how many messages can be stored. Setting this to 0 disables feature */
-#endif
-
-#ifdef YOTTA_CFG_COAP_RESENDING_QUEUE_SIZE_BYTES
-#define SN_COAP_RESENDING_QUEUE_SIZE_BYTES YOTTA_CFG_COAP_RESENDING_QUEUE_SIZE_BYTES
-#elif defined MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_BYTES
-#define SN_COAP_RESENDING_QUEUE_SIZE_BYTES MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_BYTES
-#endif
-
-#ifndef SN_COAP_RESENDING_QUEUE_SIZE_BYTES
-#define SN_COAP_RESENDING_QUEUE_SIZE_BYTES              0   /**< Default re-sending queue size - defines size of the re-sending buffer. Setting this to 0 disables feature */
-#endif
-
-#define DEFAULT_RESPONSE_TIMEOUT                        10  /**< Default re-sending timeout as seconds */
-
-/* These parameters sets maximum values application can set with API */
-#define SN_COAP_MAX_ALLOWED_RESENDING_COUNT             6   /**< Maximum allowed count of re-sending */
-#define SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_MSGS    6   /**< Maximum allowed number of saved re-sending messages */
-#define SN_COAP_MAX_ALLOWED_RESENDING_BUFF_SIZE_BYTES   512 /**< Maximum allowed size of re-sending buffer */
-#define SN_COAP_MAX_ALLOWED_RESPONSE_TIMEOUT            40  /**< Maximum allowed re-sending timeout */
-
-#define RESPONSE_RANDOM_FACTOR                          1.5   /**< Resending random factor, value is specified in IETF CoAP specification */
-
-/* * For Message duplication detecting * */
-
-/* Init value for the maximum count of messages to be stored for duplication detection          */
-/* Setting of this value to 0 will disable duplication check, also reduce use of ROM memory     */
-#ifdef YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT
-#elif defined MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#endif
-
-// Keep the old flag to maintain backward compatibility
-#ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
-#endif
-
-/* Maximum allowed number of saved messages for duplicate searching */
-#define SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT   6
-
-/* Maximum time in seconds of messages to be stored for duplication detection */
-#define SN_COAP_DUPLICATION_MAX_TIME_MSGS_STORED    60 /* RESPONSE_TIMEOUT * RESPONSE_RANDOM_FACTOR * (2 ^ MAX_RETRANSMIT - 1) + the expected maximum round trip time */
-
-/* * For Message blockwising * */
-
-/* Init value for the maximum payload size to be sent and received at one blockwise message                         */
-/* Setting of this value to 0 will disable this feature, and also reduce use of ROM memory                          */
-/* Note: This define is common for both received and sent Blockwise messages                                        */
-
-#ifdef YOTTA_CFG_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE YOTTA_CFG_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-#elif defined MBED_CONF_MBED_CLIENT_SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE MBED_CONF_MBED_CLIENT_SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-#endif
-
-#ifndef SN_COAP_BLOCKWISE_ENABLED
-#define SN_COAP_BLOCKWISE_ENABLED                   0  /**< Enable blockwise */
-#endif
-
-#ifndef SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE          0  /**< Must be 2^x and x is at least 4. Suitable values: 0, 16, 32, 64, 128, 256, 512 and 1024 */
-#endif
-
-#ifndef SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE
-#define SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE       0
-#endif
-
-#ifdef MBED_CONF_MBED_CLIENT_SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
-#define SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED MBED_CONF_MBED_CLIENT_SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
-#endif
-
-#ifndef SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED
-#define SN_COAP_BLOCKWISE_MAX_TIME_DATA_STORED      60 /**< Maximum time in seconds of data (messages and payload) to be stored for blockwising */
-#endif
-
-#ifdef YOTTA_CFG_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE
-#define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE YOTTA_CFG_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE
-#elif defined MBED_CONF_MBED_CLIENT_SN_COAP_MAX_INCOMING_MESSAGE_SIZE
-#define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE MBED_CONF_MBED_CLIENT_SN_COAP_MAX_INCOMING_MESSAGE_SIZE
-#endif
-
-#ifndef SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE
-#define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE UINT16_MAX
-#endif
+#define RESPONSE_RANDOM_FACTOR                      1.5   /**< Resending random factor, value is specified in IETF CoAP specification */
 
 /* * For Option handling * */
 #define COAP_OPTION_MAX_AGE_DEFAULT                 60 /**< Default value of Max-Age if option not present */
 #define COAP_OPTION_URI_PORT_NONE                   (-1) /**< Internal value to represent no Uri-Port option */
 #define COAP_OPTION_BLOCK_NONE                      (-1) /**< Internal value to represent no Block1/2 option */
-
 
 int8_t prepare_blockwise_message(struct coap_s *handle, struct sn_coap_hdr_ *coap_hdr_ptr);
 

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -738,7 +738,10 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
             (returned_dst_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE ||
              returned_dst_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE)) {
         returned_dst_coap_msg_ptr = sn_coap_handle_blockwise_message(handle, src_addr_ptr, returned_dst_coap_msg_ptr, param);
-    } else {
+    } else if (returned_dst_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY) {
+        // Do not clean stored blockwise message when empty ack is received.
+        // Stored message is mandatory when building a next (GET) blockwise message.
+        // This will happen when non piggybacked response mode is selected.
         /* Get ... */
         coap_blockwise_msg_s *stored_blockwise_msg_temp_ptr = NULL;
 


### PR DESCRIPTION
### Description

- Remove dependency to yotta tool
- Do not remove stored (GET) blockwise message when EMPTY ACK received. When non piggybacked response mode is used original GET request must not be removed from the stored message list.Message is needed for building the next (GET) blockwise message.
- Move definitions to sn_config.h

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@yogpan01 

