### PR TITLE
Revert "MIMXRT1050_EVK: Add IAR support in the exporter"

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -96,9 +96,6 @@
     "LPC54628J512ET180": {
         "OGChipSelectEditMenu": "LPC54618J512\tNXP LPC54618J512"
     },
-    "MIMXRT1052": {
-        "OGChipSelectEditMenu": "MIMXRT1052xxx6B\tNXP MIMXRT1052xxx6B"
-    },
     "STM32F072RB": {
         "OGChipSelectEditMenu": "STM32F072RB\tST STM32F072RB"
     },


### PR DESCRIPTION
### Description

Reverts ARMmbed/mbed-os#9496

Reason: MCU is only available in IAR 8.22 and higher. Please see 9610 for more details

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change