### PR TITLE
REALTEK_RTL8195AM binary timestamp

### DIFF
--- a/tools/targets/REALTEK_RTL8195AM.py
+++ b/tools/targets/REALTEK_RTL8195AM.py
@@ -147,7 +147,7 @@ def create_daplink(image_bin, ram1_bin, ram2_bin):
 
     RAM2_HEADER['tag'] = format_number(TAG, 8)
     RAM2_HEADER['ver'] = format_number(VER, 8)
-    RAM2_HEADER['timestamp'] = format_number(epoch_timestamp(), 16)
+    RAM2_HEADER['timestamp'] = format_number(int(os.environ.get('DAPLINK_TIMESTAMP', epoch_timestamp())), 16)
     RAM2_HEADER['size'] = format_number(os.stat(ram2_bin).st_size + 72, 8)
     RAM2_HEADER['hash'] = format_string(sha256_checksum(ram2_bin))
     RAM2_HEADER['campaign'] = format_string(CAMPAIGN)


### PR DESCRIPTION
MBEDOSTEST-458

### Description
**what:** REALTEK_RTL8195AM test binary hash depends on build timestamp.
**reason:** https://github.com/ARMmbed/mbed-os/blob/master/tools/targets/REALTEK_RTL8195AM.py#L150
**why does this matter:** CI greentea-test skips binaries which have already passed. REALTEK_RTL8195AM test binary hashes are always different, which means CI cannot identify which binaries have already passed and which have not, thus all binaries for REALTEK_RTL8195AM are tested for (almost) every pull request for no reason.
**solution:** Keep binary hashes the same if dependencies have not been modified. Either remove the timestamp or enable timestamp redefining.
```
    build 1: •IZ\    ( Jmž !’ÑÊä¡…„	´q¿¦sÃ*uÿMµ«U~LIÀFFFFFFFFFFFFFFFFøµ5*ÿÿÿ
    build 2: •\\    ( Jmž !’ÑÊä¡…„	´q¿¦sÃ*uÿMµ«U~LIÀFFFFFFFFFFFFFFFFG.0øÿ
````


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

@ARMmbed/team-realtek 

