### PR TITLE
Cellular: clean sensitive information from trace

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -495,7 +495,29 @@ TEST_F(TestAT_CellularContext, connect_disconnect_sync)
     ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
     EXPECT_TRUE(ctx1.is_connected() == false);
 
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
     ASSERT_EQ(ctx1.connect("1234", "internet", "usern", "pwd"), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+    EXPECT_TRUE(ctx1.is_connected() == true);
+    ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ctx1.is_connected() == false);
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
+    ASSERT_EQ(ctx1.connect("1234", "internet", "usern", "pwd"), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
+    EXPECT_TRUE(ctx1.is_connected() == true);
+    ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
+    EXPECT_TRUE(ctx1.is_connected() == false);
 
     // More connect test after we are re-writted getting of PDP context...
 }

--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/at_cellulardevicetest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/at_cellulardevicetest.cpp
@@ -315,6 +315,35 @@ TEST_F(TestAT_CellularDevice, test_AT_CellularDevice_create_delete_context)
     delete dev;
 }
 
+TEST_F(TestAT_CellularDevice, TestAT_CellularDevice_set_pin_verify_debug)
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+    AT_CellularDevice *dev = new AT_CellularDevice(&fh1);
+
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(true);
+    EXPECT_TRUE(NSAPI_ERROR_OK == dev->set_pin("12"));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_TRUE(at.get_debug());
+
+    ATHandler_stub::get_debug_clear();
+    EXPECT_FALSE(ATHandler_stub::is_get_debug_run());
+    ATHandler_stub::debug_call_count_clear();
+    at.set_debug(false);
+    EXPECT_TRUE(NSAPI_ERROR_OK == dev->set_pin("11"));
+    EXPECT_TRUE(ATHandler_stub::is_get_debug_run());
+    EXPECT_TRUE(ATHandler_stub::set_debug_call_count_get() == 3);
+    EXPECT_FALSE(at.get_debug());
+
+    delete dev;
+}
+
 TEST_F(TestAT_CellularDevice, TestAT_CellularDevice_set_pin)
 {
     FileHandle_stub fh1;

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -57,6 +57,29 @@ int ATHandler_stub::urc_amount = 0;
 mbed::Callback<void()> ATHandler_stub::callback[kATHandler_urc_table_max_size];
 char *ATHandler_stub::urc_string_table[kATHandler_urc_table_max_size] = {'\0'};
 
+bool ATHandler_stub::get_debug_flag = false;
+uint8_t ATHandler_stub::set_debug_call_count = 0;
+
+bool ATHandler_stub::is_get_debug_run()
+{
+    return ATHandler_stub::get_debug_flag;
+}
+
+void ATHandler_stub::get_debug_clear()
+{
+    ATHandler_stub::get_debug_flag = false;
+}
+
+uint8_t ATHandler_stub::set_debug_call_count_get()
+{
+    return ATHandler_stub::set_debug_call_count;
+}
+
+void ATHandler_stub::debug_call_count_clear()
+{
+    ATHandler_stub::set_debug_call_count = 0;
+}
+
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const char *output_delimiter, uint16_t send_delay) :
     _nextATHandler(0),
     _fileHandle(fh),
@@ -76,7 +99,15 @@ ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const 
 
 void ATHandler::set_debug(bool debug_on)
 {
+    ++ATHandler_stub::set_debug_call_count;
     ATHandler_stub::debug_on = debug_on;
+}
+
+bool ATHandler::get_debug() const
+{
+    ATHandler_stub::get_debug_flag = true;
+
+    return ATHandler_stub::debug_on;
 }
 
 ATHandler::~ATHandler()

--- a/UNITTESTS/stubs/ATHandler_stub.h
+++ b/UNITTESTS/stubs/ATHandler_stub.h
@@ -64,6 +64,13 @@ extern int resp_stop_success_count;
 extern bool process_oob_urc;
 extern int urc_amount;
 extern char *urc_string_table[kATHandler_urc_table_max_size];
+
+extern bool get_debug_flag;
+bool is_get_debug_run();
+void get_debug_clear();
+extern uint8_t set_debug_call_count;
+uint8_t set_debug_call_count_get();
+void debug_call_count_clear();
 }
 
 #endif

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -112,6 +112,11 @@ void ATHandler::set_debug(bool debug_on)
     _debug_on = debug_on;
 }
 
+bool ATHandler::get_debug() const
+{
+    return _debug_on;
+}
+
 ATHandler::~ATHandler()
 {
     while (_oobs) {

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -431,6 +431,13 @@ public: // just for debugging
      */
     void set_debug(bool debug_on);
 
+    /**
+     * Get degug state set by @ref set_debug
+     *
+     *  @return current state of debug
+     */
+    bool get_debug() const;
+
     /** Set debug_on for all ATHandlers in the _atHandlers list
      *
      *  @param debug_on Set true to enable debug traces

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -315,8 +315,15 @@ nsapi_error_t AT_CellularContext::do_user_authentication()
         _at.cmd_start("AT+CGAUTH=");
         _at.write_int(_cid);
         _at.write_int(_authentication_type);
+
+        const bool stored_debug_state = _at.get_debug();
+        _at.set_debug(false);
+
         _at.write_string(_uname);
         _at.write_string(_pwd);
+
+        _at.set_debug(stored_debug_state);
+
         _at.cmd_stop_read_resp();
         if (_at.get_last_error() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_AUTH_FAILURE;

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -176,7 +176,14 @@ nsapi_error_t AT_CellularDevice::set_pin(const char *sim_pin)
 
     _at->lock();
     _at->cmd_start("AT+CPIN=");
+
+    const bool stored_debug_state = _at->get_debug();
+    _at->set_debug(false);
+
     _at->write_string(sim_pin);
+
+    _at->set_debug(stored_debug_state);
+
     _at->cmd_stop_read_resp();
     return _at->unlock_return_error();
 }


### PR DESCRIPTION
### Description

Remove sensitive information from cellular subsystem trace logs.
- SIM pin
- APN username and password
Test coverage: 
- unit tests. All pass
- MTB_ADV_WISE_1570 ontarget gt tests, no regression.

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarvte 