### PR TITLE
Default psa headers implementation

### DIFF
--- a/components/TARGET_PSA/inc/psa/client.h
+++ b/components/TARGET_PSA/inc/psa/client.h
@@ -17,7 +17,43 @@
 
 #if defined(TARGET_TFM)
 #include "interface/include/psa_client.h"
-#else
+#elif defined(TARGET_MBED_SPM)
 #include "TARGET_MBED_SPM/psa_defs.h"
 #include "TARGET_MBED_SPM/spm_client.h"
+#else
+
+#ifndef __MBED_OS_DEFAULT_PSA_CLIENT_API_H__
+#define __MBED_OS_DEFAULT_PSA_CLIENT_API_H__
+
+#if !defined(UINT32_MAX)
+#define UINT32_MAX ((uint32_t)-1)
+#endif
+
+#if !defined(INT32_MIN)
+#define INT32_MIN   (-0x7fffffff - 1)
+#endif
+
+#define PSA_FRAMEWORK_VERSION   (0x0100) /**< Version of the PSA Framework API. */
+#define PSA_VERSION_NONE        (0L)     /**< Identifier for an unimplemented Root of Trust (RoT) Service. */
+#define PSA_SUCCESS             (0L) /**< A general result code for calls to psa_call()  indicating success.*/
+#define PSA_CONNECTION_REFUSED  (INT32_MIN + 1)   /**< The return value from psa_connect() if the RoT Service or SPM was unable to establish a connection.*/
+#define PSA_CONNECTION_BUSY     (INT32_MIN + 2)   /**< The return value from psa_connect() if the RoT Service rejects the connection for a transient reason.*/
+#define PSA_DROP_CONNECTION     (INT32_MIN)       /**< The result code in a call to psa_reply() to indicate a nonrecoverable error in the client.*/
+#define PSA_NULL_HANDLE         ((psa_handle_t)0)   /**< Denotes an invalid handle.*/
+
+typedef int32_t psa_status_t;
+typedef int32_t psa_handle_t;
+
+typedef struct psa_invec {
+    const void *base;   /**< Starting address of the buffer.*/
+    size_t len;         /**< Length in bytes of the buffer.*/
+} psa_invec;
+
+
+typedef struct psa_outvec {
+    void *base;      /**< Starting address of the buffer.*/
+    size_t len;      /**< Length in bytes of the buffer.*/
+} psa_outvec;
+
+#endif // __MBED_OS_DEFAULT_PSA_CLIENT_API_H__
 #endif

--- a/components/TARGET_PSA/inc/psa/service.h
+++ b/components/TARGET_PSA/inc/psa/service.h
@@ -17,8 +17,10 @@
 
 #if defined(TARGET_TFM)
 #include "interface/include/psa_service.h"
-#else
+#elif defined(TARGET_MBED_SPM)
 #include "TARGET_MBED_SPM/psa_defs.h"
 #include "TARGET_MBED_SPM/COMPONENT_SPE/spm_server.h"
 #include "TARGET_MBED_SPM/COMPONENT_SPE/spm_panic.h"
+#else
+#error "Compiling psa service header on non-secure target is not allowed"
 #endif


### PR DESCRIPTION
### Description
On single core targets a default `psa/client.h` should be specified
`psa/service.h` should only be included in secure builds

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

@ARMmbed/mbed-os-psa 