### PR TITLE
Linker files for LPC11U68 and LPC1549 updated

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC11U6X/device/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/device/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld
@@ -8,6 +8,13 @@
  * By LPCXpresso v7.2.0 [Build 153] [2014-05-19]  on Sat Jun 14 15:26:54 JST 2014
  */
 
+ 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
+STACK_SIZE = MBED_BOOT_STACK_SIZE;
+
 MEMORY
 {
   /* Define each memory region */
@@ -229,7 +236,32 @@ SECTIONS
          . = ALIGN(8) ;
         _end_noinit = .;
     } > Ram0_32
-    
+
     PROVIDE(_pvHeapStart = .);
-    PROVIDE(_vStackTop = __top_Ram0_32 - 0);
+    .heap :
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        . = ORIGIN(Ram0_32) + LENGTH(Ram0_32) - STACK_SIZE;
+        __HeapLimit = .;
+    } > Ram0_32
+
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy :
+    {
+        *(.stack)
+    } > Ram0_32
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(Ram0_32) + LENGTH(Ram0_32);
+    __StackLimit = __StackTop - STACK_SIZE;
+    PROVIDE(__stack = __StackTop);
+    
+    PROVIDE(__stack = __StackTop);
+    PROVIDE(_vStackTop = __StackTop);
 }

--- a/targets/TARGET_NXP/TARGET_LPC15XX/device/TOOLCHAIN_GCC_ARM/LPC1549.ld
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/device/TOOLCHAIN_GCC_ARM/LPC1549.ld
@@ -138,8 +138,10 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*)
+        . = ORIGIN(Ram1_16) + LENGTH(Ram1_16);
         __HeapLimit = .;
-    } > Ram0_16
+    } > Ram1_16
+
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -147,11 +149,11 @@ SECTIONS
     .stack_dummy :
     {
         *(.stack)
-    } > Ram0_16
+    } > Ram2_4
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(Ram0_16) + LENGTH(Ram0_16) + LENGTH(Ram1_16) + LENGTH(Ram2_4);
+    __StackTop = ORIGIN(Ram2_4) + LENGTH(Ram2_4);
     __StackLimit = __StackTop - STACK_SIZE;
     PROVIDE(__stack = __StackTop);
     

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -511,6 +511,9 @@
             "SLEEP",
             "SPI"
         ],
+        "macros": [
+            "MBED_FAULT_HANDLER_DISABLED"
+        ],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "LPC11U68JBD100"


### PR DESCRIPTION
### Description
Update linker files and resolve build issue
Linker files for LPC11U68 and LPC1549 updated as Mbed OS memory model

1.  LPC1549 - Has multiple memory banks, 4K bank used for stack exclusively and 16K for Heap. Its is mbed 2 only target hence 4K for stack.
2. LPC11U68 - Added Heap and Stack sections in linker files. **Resolved build issues.**

Dependent on : https://github.com/ARMmbed/mbed-os/pull/9571

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@mmahadevan108 @mprse 

Targeted for Minor release - As dependent on #9571 
