### PR TITLE
Fix Py3.7 mdot target build

### DIFF
--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -427,7 +427,7 @@ class LPC4088Code(object):
         # Pad the fist part (internal flash) with 0xFF to 512k
         data = partf.read()
         outbin.write(data)
-        outbin.write('\xFF' * (512*1024 - len(data)))
+        outbin.write(b'\xFF' * (512*1024 - len(data)))
         partf.close()
         # Read and append the second part (external flash) in chunks of fixed
         # size
@@ -470,7 +470,7 @@ class MTSCode(object):
         part = open(loader, 'rb')
         data = part.read()
         outbin.write(data)
-        outbin.write('\xFF' * (64*1024 - len(data)))
+        outbin.write(b'\xFF' * (64*1024 - len(data)))
         part.close()
         part = open(binf, 'rb')
         data = part.read()

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -573,7 +573,7 @@ class mbedToolchain:
 
     def compile_output(self, output=[]):
         _rc = output[0]
-        _stderr = output[1].decode("utf-8")
+        _stderr = output[1]
         command = output[2]
 
         # Parse output for Warnings and Errors


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixes https://github.com/ARMmbed/mbed-os/issues/8618

In addition to the byte/string issue, there was an additional decode that is no longer needed.

Tested with `mbed test --compile -m GCC_ARM -t MTS_MDOT_F411RE` and `pytest` (reference `.travis.yml` for command)
- Succeeds with both 2.7.15 and 3.7.2

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

