### PR TITLE
Add MBEDTLS_ENTROPY_NV_SEED to NUCLEO_F411RE to fix the build

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2439,7 +2439,7 @@
                 "macro_name": "CLOCK_SOURCE_USB"
             }
         },
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "MBEDTLS_PSA_CRYPTO_C"],
+        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "MBEDTLS_PSA_CRYPTO_C", "MBEDTLS_ENTROPY_NV_SEED"],
         "device_has_add": [
             "SERIAL_ASYNCH",
             "FLASH",


### PR DESCRIPTION
### Description
Add MBEDTLS_ENTROPY_NV_SEED  to support psa_crypto on NUCLEO_F411RE 

The platform does not have TRNG and must have a source of entropy to use psa-crypto
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

