### PR TITLE
Greentea tests: set correct port to test against google.com

### DIFF
--- a/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
+++ b/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
@@ -31,8 +31,8 @@ void TLSSOCKET_HANDSHAKE_INVALID()
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_CONNECTION,
-                      sock.connect("google.com", MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE,
+                      sock.connect("google.com", 443)); // 443 is https port.
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }
 


### PR DESCRIPTION
### Description

Port 2009 (discard port) is not available on google.com. For the purpose of the TLSSOCKET_HANDSHAKE_INVALID it is best to use the https port 443. This also makes the return value different (authorisation failure) and fulfills the original purpose of this test.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 