### PR TITLE
target: UBLOX: Fix build warning in UBLOX_AT_CellularNetwork.cpp

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
@@ -33,6 +33,8 @@ UBLOX_AT_CellularNetwork::~UBLOX_AT_CellularNetwork()
 
 nsapi_error_t UBLOX_AT_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)
 {
+    nsapi_error_t ret = NSAPI_ERROR_OK;
+
     switch (opRat) {
 #if defined(TARGET_UBLOX_C030_U201) || defined(TARGET_UBLOX_C027)
         case RAT_GSM:
@@ -58,9 +60,9 @@ nsapi_error_t UBLOX_AT_CellularNetwork::set_access_technology_impl(RadioAccessTe
 #endif
         default: {
             _op_act = RAT_UNKNOWN;
-            return NSAPI_ERROR_UNSUPPORTED;
+            ret = NSAPI_ERROR_UNSUPPORTED;
         }
     }
 
-    return NSAPI_ERROR_OK;
+    return(ret);
 }


### PR DESCRIPTION
### Description

Fix this build warning seen when building with ARMCC
```
Compile [ 13.7%]: UBLOX_AT_CellularNetwork.cpp
[Warning] UBLOX_AT_CellularNetwork.cpp@65,0:  #111-D: statement is unreachable
```

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

