### PR TITLE
nanostack: icmpv6: fix build warning

### DIFF
--- a/features/nanostack/sal-stack-nanostack/source/Common_Protocols/icmpv6.c
+++ b/features/nanostack/sal-stack-nanostack/source/Common_Protocols/icmpv6.c
@@ -1084,7 +1084,7 @@ buffer_t *icmpv6_up(buffer_t *buf)
 
         case ICMPV6_TYPE_INFO_ECHO_REPLY:
             ipv6_neighbour_reachability_confirmation(buf->src_sa.address, buf->interface->id);
-        /* fall through */
+            /* fall through */
 
         case ICMPV6_TYPE_ERROR_DESTINATION_UNREACH:
 #ifdef HAVE_RPL_ROOT
@@ -1092,7 +1092,7 @@ buffer_t *icmpv6_up(buffer_t *buf)
                 buf = rpl_control_source_route_error_handler(buf, cur);
             }
 #endif
-        /* no break */
+            /* fall through */
 
         default:
             if (buf) {


### PR DESCRIPTION
### Description
Fix the following build warning seen when building with GCC
```
Compile [ 54.2%]: icmpv6.c
[Warning] icmpv6.c@1091,16: this statement may fall through [-Wimplicit-fallthrough=]
```
### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change


