### PR TITLE
Cellular: Fix cellular stack and drivers for netsocket tests

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -473,7 +473,7 @@ TEST_F(TestAT_CellularContext, connect_disconnect_sync)
     network_cb_count = 0;
     // connect in sync mode, semaphore will return 0 so timeout is returned
     ASSERT_EQ(ctx.connect(), NSAPI_ERROR_TIMEOUT);
-    ASSERT_EQ(network_cb_count, 0);
+    ASSERT_EQ(network_cb_count, 1);
 
     my_AT_CTX ctx1(at, &dev);
     ctx1.attach(&network_cb);
@@ -486,7 +486,7 @@ TEST_F(TestAT_CellularContext, connect_disconnect_sync)
 
     ASSERT_EQ(ctx1.connect(),  NSAPI_ERROR_OK);
 
-    ASSERT_EQ(network_cb_count, 4);
+    ASSERT_EQ(network_cb_count, 5);
 
     ASSERT_EQ(ctx1.connect(), NSAPI_ERROR_IS_CONNECTED);
 

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -253,6 +253,19 @@ nsapi_size_or_error_t AT_CellularStack::socket_sendto(nsapi_socket_t handle, con
         return NSAPI_ERROR_DEVICE_ERROR;
     }
 
+    if (socket->closed && !socket->rx_avail) {
+        tr_info("sendto socket %d closed", socket->id);
+        return NSAPI_ERROR_NO_CONNECTION;
+    }
+
+    if (size == 0) {
+        if (socket->proto == NSAPI_UDP) {
+            return NSAPI_ERROR_UNSUPPORTED;
+        } else if (socket->proto == NSAPI_TCP) {
+            return 0;
+        }
+    }
+
     nsapi_size_or_error_t ret_val = NSAPI_ERROR_OK;
 
     if (!socket->created) {
@@ -299,6 +312,11 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
         return NSAPI_ERROR_DEVICE_ERROR;
     }
 
+    if (socket->closed) {
+        tr_info("recvfrom socket %d closed", socket->id);
+        return 0;
+    }
+
     nsapi_size_or_error_t ret_val = NSAPI_ERROR_OK;
 
     if (!socket->created) {
@@ -318,6 +336,11 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
     ret_val = socket_recvfrom_impl(socket, addr, buffer, size);
 
     _at.unlock();
+
+    if (socket->closed) {
+        tr_info("recvfrom socket %d closed", socket->id);
+        return 0;
+    }
 
     if (ret_val >= 0) {
         if (addr) {
@@ -351,4 +374,19 @@ int AT_CellularStack::get_socket_index_by_port(uint16_t port)
         }
     }
     return -1;
+}
+
+AT_CellularStack::CellularSocket *AT_CellularStack::find_socket(int sock_id)
+{
+    CellularSocket *sock = NULL;
+    for (int i = 0; i < _socket_count; i++) {
+        if (_socket[i] && _socket[i]->id == sock_id) {
+            sock = _socket[i];
+            break;
+        }
+    }
+    if (!sock) {
+        tr_error("Socket not found %d", sock_id);
+    }
+    return sock;
 }

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -92,6 +92,7 @@ protected:
             _cb(NULL),
             _data(NULL),
             created(false),
+            closed(false),
             started(false),
             tx_ready(false),
             rx_avail(false),
@@ -108,6 +109,7 @@ protected:
         void (*_cb)(void *);
         void *_data;
         bool created; // socket has been created on modem stack
+        bool closed; // socket has been closed by a peer
         bool started; // socket has been opened on modem stack
         bool tx_ready; // socket is ready for sending on modem stack
         bool rx_avail; // socket has data for reading on modem stack
@@ -165,6 +167,14 @@ protected:
      */
     virtual nsapi_size_or_error_t socket_recvfrom_impl(CellularSocket *socket, SocketAddress *address,
                                                        void *buffer, nsapi_size_t size) = 0;
+
+    /**
+     *  Find the socket handle based on socket identifier
+     *
+     *  @param sock_id  Socket identifier
+     *  @return         Socket handle, NULL on error
+     */
+    CellularSocket *find_socket(int sock_id);
 
     // socket container
     CellularSocket **_socket;

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -129,6 +129,7 @@ nsapi_error_t CellularDevice::start_state_machine(CellularStateMachine::Cellular
     _mutex.lock();
     nsapi_error_t err = create_state_machine();
     if (err) {
+        _mutex.unlock();
         return err;
     }
 

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -44,21 +44,6 @@ GEMALTO_CINTERION_CellularStack::~GEMALTO_CINTERION_CellularStack()
     _at.set_urc_handler("^SISR:", 0);
 }
 
-GEMALTO_CINTERION_CellularStack::CellularSocket *GEMALTO_CINTERION_CellularStack::find_socket(int sock_id)
-{
-    CellularSocket *sock = NULL;
-    for (int i = 0; i < SOCKET_MAX; i++) {
-        if (_socket[i] && _socket[i]->id == sock_id) {
-            sock = _socket[i];
-            break;
-        }
-    }
-    if (!sock) {
-        tr_error("Socket not found %d", sock_id);
-    }
-    return sock;
-}
-
 void GEMALTO_CINTERION_CellularStack::urc_sis()
 {
     int sock_id = _at.read_int();
@@ -176,55 +161,10 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::socket_close_impl(int sock_id)
 
 nsapi_error_t GEMALTO_CINTERION_CellularStack::socket_open_defer(CellularSocket *socket, const SocketAddress *address)
 {
-    // host address (IPv4) and local+remote port is needed only for BGS2 which does not support UDP server socket
-    char sock_addr[sizeof("sockudp://") - 1 + NSAPI_IPv6_SIZE + sizeof("[]:12345;port=12345") - 1 + 1];
-
-    if (socket->proto == NSAPI_UDP) {
-        if (GEMALTO_CINTERION::get_module() != GEMALTO_CINTERION::ModuleBGS2) {
-            std::sprintf(sock_addr, "sockudp://%s:%u", address ? address->get_ip_address() : "", socket->localAddress.get_port());
-        } else {
-            std::sprintf(sock_addr, "sockudp://%s:%u;port=%u", address->get_ip_address(), address->get_port(), socket->localAddress.get_port());
-        }
-    } else {
-        if (address->get_ip_version() == NSAPI_IPv4) {
-            std::sprintf(sock_addr, "socktcp://%s:%u", address->get_ip_address(), address->get_port());
-        } else {
-            std::sprintf(sock_addr, "socktcp://[%s]:%u", address->get_ip_address(), address->get_port());
-        }
-    }
-
-    _at.cmd_start("AT^SISS=");
-    _at.write_int(socket->id);
-    _at.write_string("address", false);
-    _at.write_string(sock_addr);
-    _at.cmd_stop_read_resp();
-
-    _at.cmd_start("AT^SISO=");
-    _at.write_int(socket->id);
-    _at.cmd_stop_read_resp();
-
-    if (_at.get_last_error()) {
-        tr_error("Socket %d open failed!", socket->id);
-        _at.clear_error();
-        socket_close_impl(socket->id); // socket may already be open on modem if app and modem are not in sync, as a recovery, try to close the socket so open succeeds the next time
-        return NSAPI_ERROR_NO_SOCKET;
-    }
-
-    socket->created = true;
-    tr_debug("Cinterion open %d (err %d)", socket->id, _at.get_last_error());
-
-    return _at.get_last_error();
-}
-
-// To open socket:
-// 1. Select URC mode or polling mode with AT^SCFG
-// 2. create a GPRS connection profile with AT^SICS (must have PDP)
-// 3. create service profile with AT^SISS and map connectionID to serviceID
-// 4. open internet session with AT^SISO (ELS61 tries to attach to a packet domain)
-nsapi_error_t GEMALTO_CINTERION_CellularStack::create_socket_impl(CellularSocket *socket)
-{
     int connection_profile_id = CONNECTION_PROFILE_ID;
 
+    int retry_open = 1;
+retry_open:
     // setup internet session profile
     int internet_service_id = socket->id;
     bool foundSrvType = false;
@@ -285,6 +225,56 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::create_socket_impl(CellularSocket
         _at.cmd_stop_read_resp();
     }
 
+    // host address (IPv4) and local+remote port is needed only for BGS2 which does not support UDP server socket
+    char sock_addr[sizeof("sockudp://") - 1 + NSAPI_IPv6_SIZE + sizeof("[]:12345;port=12345") - 1 + 1];
+
+    if (socket->proto == NSAPI_UDP) {
+        if (GEMALTO_CINTERION::get_module() != GEMALTO_CINTERION::ModuleBGS2) {
+            std::sprintf(sock_addr, "sockudp://%s:%u", address ? address->get_ip_address() : "", socket->localAddress.get_port());
+        } else {
+            std::sprintf(sock_addr, "sockudp://%s:%u;port=%u", address->get_ip_address(), address->get_port(), socket->localAddress.get_port());
+        }
+    } else {
+        if (address->get_ip_version() == NSAPI_IPv4) {
+            std::sprintf(sock_addr, "socktcp://%s:%u", address->get_ip_address(), address->get_port());
+        } else {
+            std::sprintf(sock_addr, "socktcp://[%s]:%u", address->get_ip_address(), address->get_port());
+        }
+    }
+
+    _at.cmd_start("AT^SISS=");
+    _at.write_int(socket->id);
+    _at.write_string("address", false);
+    _at.write_string(sock_addr);
+    _at.cmd_stop_read_resp();
+
+    _at.cmd_start("AT^SISO=");
+    _at.write_int(socket->id);
+    _at.cmd_stop_read_resp();
+
+    if (_at.get_last_error()) {
+        tr_error("Socket %d open failed!", socket->id);
+        _at.clear_error();
+        socket_close_impl(socket->id); // socket may already be open on modem if app and modem are not in sync, as a recovery, try to close the socket so open succeeds the next time
+        if (retry_open--) {
+            goto retry_open;
+        }
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    socket->created = true;
+    tr_debug("Cinterion open %d (err %d)", socket->id, _at.get_last_error());
+
+    return _at.get_last_error();
+}
+
+// To open socket:
+// 1. Select URC mode or polling mode with AT^SCFG
+// 2. create a GPRS connection profile with AT^SICS (must have PDP)
+// 3. create service profile with AT^SISS and map connectionID to serviceID
+// 4. open internet session with AT^SISO (ELS61 tries to attach to a packet domain)
+nsapi_error_t GEMALTO_CINTERION_CellularStack::create_socket_impl(CellularSocket *socket)
+{
     if (socket->proto == NSAPI_UDP) {
         if (GEMALTO_CINTERION::get_module() != GEMALTO_CINTERION::ModuleBGS2) {
             return socket_open_defer(socket);
@@ -335,13 +325,13 @@ nsapi_size_or_error_t GEMALTO_CINTERION_CellularStack::socket_sendto_impl(Cellul
         }
     }
     if (!socket->started || !socket->tx_ready) {
-        tr_debug("Socket %d would block (started %d, tx %d)", socket->id, socket->started, socket->tx_ready);
+        tr_debug("Socket %d send would block (started %d, tx %d)", socket->id, socket->started, socket->tx_ready);
         return NSAPI_ERROR_WOULD_BLOCK;
     }
 
     if (size > UDP_PACKET_SIZE) {
-        tr_warn("Sending UDP packet size %d (max %d)", size, UDP_PACKET_SIZE);
-        size = UDP_PACKET_SIZE;
+        tr_error("sendto size %d (max %d)", size, UDP_PACKET_SIZE);
+        return NSAPI_ERROR_PARAMETER;
     }
 
     _at.set_at_timeout(FAILURE_TIMEOUT);
@@ -413,13 +403,12 @@ nsapi_size_or_error_t GEMALTO_CINTERION_CellularStack::socket_recvfrom_impl(Cell
     if (!socket->rx_avail) {
         _at.process_oob(); // check for ^SISR URC
         if (!socket->rx_avail) {
-            tr_debug("Socket %d would block", socket->id);
+            tr_debug("Socekt %d recv would block", socket->id);
             return NSAPI_ERROR_WOULD_BLOCK;
         }
     }
 
     if (size > UDP_PACKET_SIZE) {
-        tr_debug("Socket recvfrom size %d > %d", size, UDP_PACKET_SIZE);
         size = UDP_PACKET_SIZE;
     }
 
@@ -459,6 +448,7 @@ sisr_retry:
     }
     socket->rx_avail = false;
     if (len >= (nsapi_size_or_error_t)size) {
+        len = (nsapi_size_or_error_t)size;
         int remain_len = _at.read_int();
         if (remain_len > 0) {
             socket->rx_avail = true;
@@ -470,7 +460,7 @@ sisr_retry:
         char ip_address[NSAPI_IPv6_SIZE + sizeof("[]:12345") - 1 + 1];
         int ip_len = _at.read_string(ip_address, sizeof(ip_address));
         if (ip_len <= 0) {
-            tr_error("Socket %d recvfrom addr!", socket->id);
+            tr_error("Socket %d recvfrom addr (len %d)", socket->id, ip_len);
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (address) {

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.h
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.h
@@ -48,9 +48,6 @@ protected:
     virtual nsapi_error_t socket_connect(nsapi_socket_t handle, const SocketAddress &address);
 
 private:
-    // find the socket handle based on socket identifier
-    CellularSocket *find_socket(int sock_id);
-
     // socket URC handlers as per Cinterion AT manuals
     void urc_sis();
     void urc_sisw();

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -73,7 +73,7 @@ void QUECTEL_BG96::set_ready_cb(Callback<void()> callback)
 CellularDevice *CellularDevice::get_default_instance()
 {
     static UARTSerial serial(MBED_CONF_QUECTEL_BG96_TX, MBED_CONF_QUECTEL_BG96_RX, MBED_CONF_QUECTEL_BG96_BAUDRATE);
-#if defined (MBED_CONF_UBLOX_AT_RTS) && defined(MBED_CONF_UBLOX_AT_CTS)
+#if defined (MBED_CONF_QUECTEL_BG96_RTS) && defined(MBED_CONF_QUECTEL_BG96_CTS)
     tr_debug("QUECTEL_BG96 flow control: RTS %d CTS %d", MBED_CONF_QUECTEL_BG96_RTS, MBED_CONF_QUECTEL_BG96_CTS);
     serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_QUECTEL_BG96_RTS, MBED_CONF_QUECTEL_BG96_CTS);
 #endif

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -255,10 +255,6 @@ nsapi_size_or_error_t QUECTEL_BG96_CellularStack::socket_sendto_impl(CellularSoc
         return NSAPI_ERROR_PARAMETER;
     }
 
-    if (!size && socket->proto == NSAPI_UDP) {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
     int sent_len = 0;
     int sent_len_before = 0;
     int sent_len_after = 0;

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
@@ -81,17 +81,6 @@ AT_CellularContext *QUECTEL_M26::create_context_impl(ATHandler &at, const char *
     return new QUECTEL_M26_CellularContext(at, this, apn, cp_req, nonip_req);
 }
 
-nsapi_error_t QUECTEL_M26::init()
-{
-    _at->lock();
-    _at->cmd_start("AT");
-    _at->cmd_stop_read_resp();
-    _at->cmd_start("AT+CMEE="); // verbose responses
-    _at->write_int(1);
-    _at->cmd_stop_read_resp();
-    return _at->unlock_return_error();
-}
-
 nsapi_error_t QUECTEL_M26::shutdown()
 {
     _at->lock();
@@ -102,3 +91,18 @@ nsapi_error_t QUECTEL_M26::shutdown()
 
     return _at->unlock_return_error();;
 }
+
+
+#if MBED_CONF_QUECTEL_M26_PROVIDE_DEFAULT
+#include "UARTSerial.h"
+CellularDevice *CellularDevice::get_default_instance()
+{
+    static UARTSerial serial(MBED_CONF_QUECTEL_M26_TX, MBED_CONF_QUECTEL_M26_RX, MBED_CONF_QUECTEL_M26_BAUDRATE);
+#if defined (MBED_CONF_QUECTEL_M26_RTS) && defined(MBED_CONF_QUECTEL_M26_CTS)
+    tr_debug("QUECTEL_M26 flow control: RTS %d CTS %d", MBED_CONF_QUECTEL_M26_RTS, MBED_CONF_QUECTEL_M26_CTS);
+    serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_QUECTEL_M26_RTS, MBED_CONF_QUECTEL_M26_CTS);
+#endif
+    static QUECTEL_M26 device(&serial);
+    return &device;
+}
+#endif

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.h
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.h
@@ -38,7 +38,6 @@ public:
 protected: // AT_CellularDevice
     virtual nsapi_error_t get_sim_state(SimState &state);
     virtual AT_CellularContext *create_context_impl(ATHandler &at, const char *apn, bool cp_req = false, bool nonip_req = false);
-    virtual nsapi_error_t init();
     virtual nsapi_error_t shutdown();
 
 public: // NetworkInterface

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -15,18 +15,37 @@
  * limitations under the License.
  */
 
+#include "rtos/Kernel.h"
 #include "QUECTEL/M26/QUECTEL_M26_CellularStack.h"
 #include "CellularLog.h"
+
+#define SOCKET_SEND_READY_TIMEOUT (30*1000)
+#define SOCKET_READ_TIMEOUT 1000
 
 using namespace mbed;
 
 QUECTEL_M26_CellularStack::QUECTEL_M26_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type) : AT_CellularStack(atHandler, cid, stack_type)
 {
-    _at.set_urc_handler("+QIRDI:", mbed::Callback<void()>(this, &QUECTEL_M26_CellularStack::urc_qiurc));
+    _at.set_urc_handler("+QIRDI:", Callback<void()>(this, &QUECTEL_M26_CellularStack::urc_qiurc));
+
+    _at.set_urc_handler("0, CLOSED", Callback<void()>(this, &QUECTEL_M26_CellularStack::socket_closed_0));
+    _at.set_urc_handler("1, CLOSED", Callback<void()>(this, &QUECTEL_M26_CellularStack::socket_closed_1));
+    _at.set_urc_handler("2, CLOSED", Callback<void()>(this, &QUECTEL_M26_CellularStack::socket_closed_2));
+    _at.set_urc_handler("3, CLOSED", Callback<void()>(this, &QUECTEL_M26_CellularStack::socket_closed_3));
+    _at.set_urc_handler("4, CLOSED", Callback<void()>(this, &QUECTEL_M26_CellularStack::socket_closed_4));
+    _at.set_urc_handler("5, CLOSED", Callback<void()>(this, &QUECTEL_M26_CellularStack::socket_closed_5));
 }
 
 QUECTEL_M26_CellularStack::~QUECTEL_M26_CellularStack()
 {
+    _at.set_urc_handler("5, CLOSED", NULL);
+    _at.set_urc_handler("4, CLOSED", NULL);
+    _at.set_urc_handler("3, CLOSED", NULL);
+    _at.set_urc_handler("2, CLOSED", NULL);
+    _at.set_urc_handler("1, CLOSED", NULL);
+    _at.set_urc_handler("0, CLOSED", NULL);
+
+    _at.set_urc_handler("+QIRDI:", NULL);
 }
 
 nsapi_error_t QUECTEL_M26_CellularStack::socket_listen(nsapi_socket_t handle, int backlog)
@@ -42,6 +61,45 @@ nsapi_error_t QUECTEL_M26_CellularStack::socket_accept(void *server, void **sock
 nsapi_error_t QUECTEL_M26_CellularStack::socket_bind(nsapi_socket_t handle, const SocketAddress &addr)
 {
     return NSAPI_ERROR_UNSUPPORTED;
+}
+
+void QUECTEL_M26_CellularStack::socket_closed(int sock_id)
+{
+    CellularSocket *sock = find_socket(sock_id);
+    if (sock) {
+        tr_info("Socket closed %d", sock_id);
+        sock->closed = true;
+    }
+}
+
+void QUECTEL_M26_CellularStack::socket_closed_0()
+{
+    socket_closed(0);
+}
+
+void QUECTEL_M26_CellularStack::socket_closed_1()
+{
+    socket_closed(1);
+}
+
+void QUECTEL_M26_CellularStack::socket_closed_2()
+{
+    socket_closed(2);
+}
+
+void QUECTEL_M26_CellularStack::socket_closed_3()
+{
+    socket_closed(3);
+}
+
+void QUECTEL_M26_CellularStack::socket_closed_4()
+{
+    socket_closed(4);
+}
+
+void QUECTEL_M26_CellularStack::socket_closed_5()
+{
+    socket_closed(5);
 }
 
 void QUECTEL_M26_CellularStack::urc_qiurc()
@@ -348,7 +406,6 @@ nsapi_error_t QUECTEL_M26_CellularStack::create_socket_impl(CellularSocket *sock
         socket->created = ((ret_val == NSAPI_ERROR_OK) && (modem_connect_id == request_connect_id));
         return ret_val;
     } else {
-        tr_warn("QUECTEL_M26_CellularStack:%s:%u: Do not support TCP Listner/UDP Service Mode [%d,%d]", __FUNCTION__, __LINE__, socket->created, ret_val);
         ret_val = NSAPI_ERROR_OK;
     }
 
@@ -360,16 +417,16 @@ nsapi_error_t QUECTEL_M26_CellularStack::create_socket_impl(CellularSocket *sock
 nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSocket *socket, const SocketAddress &address,
                                                                     const void *data, nsapi_size_t size)
 {
-    int sent_len = (size > M26_SENT_BYTE_MAX) ? M26_SENT_BYTE_MAX : size;
+    int sent_len = size;
+    int sent_acked = 0;
     int sent_nacked = 0;
     int sent_len_before = 0;
     int sent_len_after = 0;
-    int sent_acked;
     nsapi_error_t error;
 
     tr_debug("QUECTEL_M26_CellularStack:%s:%u:[%d-%d]", __FUNCTION__, __LINE__, sent_len, size);
 
-    if (sent_len == 0) {
+    if (sent_len == 0 || size > M26_SENT_BYTE_MAX) {
         tr_error("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_PARAMETER]", __FUNCTION__, __LINE__);
         return NSAPI_ERROR_PARAMETER;
     }
@@ -385,23 +442,28 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
     }
 
     if (socket->proto == NSAPI_TCP) {
-        _at.cmd_start("AT+QISACK=");
-        _at.write_int(socket->id);
-        _at.cmd_stop();
-        _at.resp_start("+QISACK:");
-        sent_len_before = _at.read_int();
-        sent_acked = _at.read_int();
-        sent_nacked = _at.read_int();
-        _at.resp_stop();
+        bool ready_to_send = false;
+        uint64_t start_time = rtos::Kernel::get_ms_count();
+        while (!ready_to_send && start_time < rtos::Kernel::get_ms_count() + SOCKET_SEND_READY_TIMEOUT) {
+            _at.cmd_start("AT+QISACK=");
+            _at.write_int(socket->id);
+            _at.cmd_stop();
+            _at.resp_start("+QISACK:");
+            sent_len_before = _at.read_int();
+            sent_acked = _at.read_int();
+            sent_nacked = _at.read_int();
+            _at.resp_stop();
 
-        if (_at.get_last_error() != NSAPI_ERROR_OK) {
-            tr_error("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_DEVICE_ERROR]", __FUNCTION__, __LINE__);
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
+            if (_at.get_last_error() != NSAPI_ERROR_OK) {
+                tr_error("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_DEVICE_ERROR]", __FUNCTION__, __LINE__);
+                return NSAPI_ERROR_DEVICE_ERROR;
+            }
 
-        if (sent_nacked != 0) {
-            tr_debug("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_WOULD_BLOCK]", __FUNCTION__, __LINE__);
-            return NSAPI_ERROR_WOULD_BLOCK;
+            if (sent_nacked == 0) {
+                ready_to_send = true;
+            } else {
+                tr_debug("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_WOULD_BLOCK]", __FUNCTION__, __LINE__);
+            }
         }
     }
 
@@ -455,35 +517,53 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
 nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_recvfrom_impl(CellularSocket *socket, SocketAddress *address,
                                                                       void *buffer, nsapi_size_t size)
 {
-    nsapi_size_or_error_t recv_len = (size > M26_RECV_BYTE_MAX) ? M26_RECV_BYTE_MAX : size;
-    int recv_len_after = 0;
     int port;
     char type[8];
     char ip_address[NSAPI_IP_SIZE + 1];
 
     tr_debug("QUECTEL_M26_CellularStack:%s:%u:[%d]", __FUNCTION__, __LINE__, size);
-    _at.cmd_start("AT+QIRD=");
-    _at.write_int(0); /* at+qifgcnt 0-1 */
-    _at.write_int(1); /* 1-Client, 2-Server */
-    _at.write_int(socket->id);
-    _at.write_int(recv_len);
-    _at.cmd_stop();
 
-    _at.resp_start("+QIRD:");
-    if (_at.info_resp()) {
-        _at.set_delimiter(':');
-        _at.read_string(ip_address, sizeof(ip_address));
-        _at.set_default_delimiter();
-        port = _at.read_int();
-        _at.read_string(type, sizeof(type));
-        recv_len_after = _at.read_int();
-        if (recv_len_after > 0) {
-            _at.read_bytes((uint8_t *)buffer, recv_len_after);
+    uint64_t start_time = rtos::Kernel::get_ms_count();
+    nsapi_size_t len = 0;
+    for (; len < size;) {
+        int read_len = (size - len > M26_RECV_BYTE_MAX) ? M26_RECV_BYTE_MAX : size - len;
+        _at.cmd_start("AT+QIRD=");
+        _at.write_int(0); /* at+qifgcnt 0-1 */
+        _at.write_int(1); /* 1-Client, 2-Server */
+        _at.write_int(socket->id);
+        _at.write_int(read_len);
+        _at.cmd_stop();
+
+        nsapi_size_t recv_len = 0;
+        _at.resp_start("+QIRD:");
+        if (_at.info_resp()) {
+            _at.set_delimiter(':');
+            _at.read_string(ip_address, sizeof(ip_address));
+            _at.set_default_delimiter();
+            port = _at.read_int();
+            _at.read_string(type, sizeof(type));
+            recv_len = _at.read_int();
+            _at.read_bytes((uint8_t *)buffer + len, recv_len);
+            len += recv_len;
+        }
+        _at.resp_stop();
+
+        if (_at.get_last_error() != NSAPI_ERROR_OK) {
+            tr_warn("QUECTEL_M26_CellularStack:%s:%u:[ERROR NSAPI_ERROR_OK]", __FUNCTION__, __LINE__);
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+
+        if (rtos::Kernel::get_ms_count() > start_time + SOCKET_READ_TIMEOUT) {
+            tr_warn("QUECTEL_M26_CellularStack:%s:%u:[ERROR NSAPI_ERROR_TIMEOUT]", __FUNCTION__, __LINE__);
+            return NSAPI_ERROR_TIMEOUT;
+        }
+
+        if (recv_len == 0 || recv_len < read_len) {
+            break;
         }
     }
-    _at.resp_stop();
 
-    if (!recv_len_after || (_at.get_last_error() != NSAPI_ERROR_OK)) {
+    if (len == 0) {
         tr_debug("QUECTEL_M26_CellularStack:%s:%u:[ERROR NSAPI_ERROR_WOULD_BLOCK]", __FUNCTION__, __LINE__);
         return NSAPI_ERROR_WOULD_BLOCK;
     }
@@ -493,6 +573,6 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_recvfrom_impl(CellularSo
         address->set_port(port);
     }
 
-    tr_debug("QUECTEL_M26_CellularStack:%s:%u:[%d]", __FUNCTION__, __LINE__, recv_len_after);
-    return recv_len_after;
+    tr_debug("QUECTEL_M26_CellularStack:%s:%u:[%d]", __FUNCTION__, __LINE__, len);
+    return len;
 }

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.h
@@ -25,7 +25,7 @@ namespace mbed {
 #define M26_SOCKET_MAX 6
 #define M26_CREATE_SOCKET_TIMEOUT 75000 //75 seconds
 #define M26_SENT_BYTE_MAX 1460
-#define M26_RECV_BYTE_MAX 1000
+#define M26_RECV_BYTE_MAX 1024
 
 class QUECTEL_M26_CellularStack : public AT_CellularStack {
 public:
@@ -63,8 +63,14 @@ protected: // AT_CellularStack
 
 private:
     // URC handlers
-    // URC handlers
     void urc_qiurc();
+    void socket_closed(int sock_id);
+    void socket_closed_0();
+    void socket_closed_1();
+    void socket_closed_2();
+    void socket_closed_3();
+    void socket_closed_4();
+    void socket_closed_5();
 
     void handle_open_socket_response(int &modem_connect_id, int &err);
 };


### PR DESCRIPTION
### Description

Fix cellular stack and drivers:
- Handling of TCP endpoint closed
- AT debugging relieved
- Cinterion drivers to retry on socket open failure
- Various fixes for Quectel BG96 and M26 drivers

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica