### PR TITLE
Cellular: fix onboard modems powering failure.

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -415,7 +415,7 @@ bool AT_CellularContext::set_new_context(int cid)
         strncpy(pdp_type_str, "IPV6", sizeof(pdp_type_str));
         pdp_type = IPV6_PDP_TYPE;
     } else if (modem_supports_ipv4) {
-        strncpy(pdp_type_str, "IP", sizeof(pdp_type));
+        strncpy(pdp_type_str, "IP", sizeof(pdp_type_str));
         pdp_type = IPV4_PDP_TYPE;
     } else {
         return false;

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -183,7 +183,7 @@ private:
     bool _is_retry;
     cell_callback_data_t _cb_data;
     nsapi_event_t _current_event;
-    int _network_status; // Is there any active context or is modem attached to a network?
+    int _status;
     PlatformMutex _mutex;
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/ONBOARD_TELIT_HE910.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/ONBOARD_TELIT_HE910.cpp
@@ -19,6 +19,8 @@
 #include "cellular/onboard_modem_api.h"
 #include "UARTSerial.h"
 #include "ONBOARD_TELIT_HE910.h"
+#include "ThisThread.h"
+#include "CellularLog.h"
 
 using namespace mbed;
 
@@ -41,6 +43,8 @@ nsapi_error_t ONBOARD_TELIT_HE910::hard_power_off()
 nsapi_error_t ONBOARD_TELIT_HE910::soft_power_on()
 {
     ::onboard_modem_power_up();
+    // From Telit_xE910 Global form factor App note: It is mandatory to avoid sending data to the serial ports during the first 200ms of the module start-up.
+    rtos::ThisThread::sleep_for(200);
     return NSAPI_ERROR_OK;
 }
 
@@ -53,6 +57,12 @@ nsapi_error_t ONBOARD_TELIT_HE910::soft_power_off()
 CellularDevice *CellularDevice::get_target_default_instance()
 {
     static UARTSerial serial(MDMTXD, MDMRXD, 115200);
+#if DEVICE_SERIAL_FC
+    if (MDMRTS != NC && MDMCTS != NC) {
+        tr_debug("Modem flow control: RTS %d CTS %d", MDMRTS, MDMCTS);
+        serial.set_flow_control(SerialBase::RTSCTS, MDMRTS, MDMCTS);
+    }
+#endif
     static ONBOARD_TELIT_HE910 device(&serial);
     return &device;
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/ONBOARD_TELIT_HE910.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/ONBOARD_TELIT_HE910.cpp
@@ -19,6 +19,7 @@
 #include "cellular/onboard_modem_api.h"
 #include "UARTSerial.h"
 #include "ONBOARD_TELIT_HE910.h"
+#include "ThisThread.h"
 #include "CellularLog.h"
 
 using namespace mbed;
@@ -42,6 +43,8 @@ nsapi_error_t ONBOARD_TELIT_HE910::hard_power_off()
 nsapi_error_t ONBOARD_TELIT_HE910::soft_power_on()
 {
     ::onboard_modem_power_up();
+    // From Telit_xE910 Global form factor App note: It is mandatory to avoid sending data to the serial ports during the first 200ms of the module start-up.
+    rtos::ThisThread::sleep_for(200);
     return NSAPI_ERROR_OK;
 }
 


### PR DESCRIPTION
### Description
 Fix onboard modem power up failures. 
- don't call soft power on if device was already powered
- some modems need to wait before sending anything to modem after soft powering

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AriParkkila 

