### PR TITLE
Reverting to original doxy configuration

### DIFF
--- a/features/nfc/nfc/NFCController.h
+++ b/features/nfc/nfc/NFCController.h
@@ -1,6 +1,4 @@
-/** @file NFCController.h
- *
- * mbed Microcontroller Library
+/* mbed Microcontroller Library
  * Copyright (c) 2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/features/nfc/nfc/NFCEEPROM.h
+++ b/features/nfc/nfc/NFCEEPROM.h
@@ -1,6 +1,4 @@
-/** @file NFCEEPROM.h
- *
- * mbed Microcontroller Library
+/* mbed Microcontroller Library
  * Copyright (c) 2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/features/nfc/nfc/ndef/MessageBuilder.h
+++ b/features/nfc/nfc/ndef/MessageBuilder.h
@@ -1,6 +1,4 @@
-/** @file MessageBuilder.h
- *
- * mbed Microcontroller Library
+/* mbed Microcontroller Library
  * Copyright (c) 2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/features/nfc/nfc/ndef/MessageParser.h
+++ b/features/nfc/nfc/ndef/MessageParser.h
@@ -1,6 +1,4 @@
-/** @file MessageParser.h
- *
- * mbed Microcontroller Library
+/* mbed Microcontroller Library
  * Copyright (c) 2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/features/nfc/nfc/ndef/common/SimpleMessageParser.h
+++ b/features/nfc/nfc/ndef/common/SimpleMessageParser.h
@@ -1,6 +1,4 @@
-/** @file SimpleMessageParser.h
- *
- * mbed Microcontroller Library
+/* mbed Microcontroller Library
  * Copyright (c) 2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Attempts to restore original style maintained and intended by the nfc developers.

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
In a previous PR, doxy file specifier was wrongly used over license text. It needs its own block.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@pan- @0xc0170 
