### PR TITLE
Add .inc as a header file type.

### DIFF
--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -467,6 +467,7 @@ class Resources(object):
         ".h": FileType.HEADER,
         ".hh": FileType.HEADER,
         ".hpp": FileType.HEADER,
+        ".inc": FileType.HEADER,
         ".o": FileType.OBJECT,
         ".hex": FileType.HEX,
         ".bin": FileType.BIN,


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This was brought up by [a thread on one of the TF-M prs](https://github.com/ARMmbed/mbed-os/pull/9653#discussion_r256165711). They are integrating an existing project into Mbed OS, and the existing project uses `.inc` files for some generated headers.

Currently, if you were to add a directory that only contained `.inc` files, this file would not be passed as an include path to the compiler. This ensures that `.inc` files are also considered header files.

Their build just so happens to work because the `.inc` files are generated in a directory that also contains a `.h` file. So the directory is marked as an include path.

I think this qualifies as a "fix" but let me know if I should change it.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy 
