### PR TITLE
Greentea tests: user-configurable timeouts

### DIFF
--- a/TESTS/netsocket/dns/dns_tests.h
+++ b/TESTS/netsocket/dns/dns_tests.h
@@ -61,6 +61,14 @@ void hostbyname_cb(void *data, nsapi_error_t result, SocketAddress *address);
 void do_asynchronous_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_count, int *exp_ok, int *exp_no_mem, int *exp_dns_failure, int *exp_timeout);
 void do_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_count, int *exp_ok, int *exp_no_mem, int *exp_dns_failure, int *exp_timeout);
 
+namespace dns_global {
+#ifdef MBED_GREENTEA_TEST_DNSSOCKET_TIMEOUT_S
+static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_DNSSOCKET_TIMEOUT_S;
+#else
+static const int TESTS_TIMEOUT = 10 * 60;
+#endif
+}
+
 /*
  * Test cases
  */

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -166,7 +166,7 @@ static void net_bringdown()
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(10 * 60, "default_auto");
+    GREENTEA_SETUP(dns_global::TESTS_TIMEOUT, "default_auto");
     net_bringup();
     return verbose_test_setup_handler(number_of_cases);
 }

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -36,7 +36,11 @@ int fetch_stats(void);
 int split2half_rmng_tcp_test_time(); // [s]
 
 namespace tcp_global {
+#ifdef MBED_GREENTEA_TEST_TCPSOCKET_TIMEOUT_S
+static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_TCPSOCKET_TIMEOUT_S;
+#else
 static const int TESTS_TIMEOUT = (10 * 60);
+#endif
 static const int TCP_OS_STACK_SIZE = 2048;
 
 static const int RX_BUFF_SIZE = 1220;

--- a/TESTS/netsocket/tls/tls_tests.h
+++ b/TESTS/netsocket/tls/tls_tests.h
@@ -39,7 +39,11 @@ int fetch_stats(void);
 int split2half_rmng_tls_test_time(); // [s]
 
 namespace tls_global {
+#ifdef MBED_GREENTEA_TEST_TLSSOCKET_TIMEOUT_S
+static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_TLSSOCKET_TIMEOUT_S;
+#else
 static const int TESTS_TIMEOUT = (10 * 60);
+#endif
 static const int TLS_OS_STACK_SIZE = 2048;
 
 static const int RX_BUFF_SIZE = 1220;

--- a/TESTS/netsocket/udp/udp_tests.h
+++ b/TESTS/netsocket/udp/udp_tests.h
@@ -34,7 +34,11 @@ int fetch_stats(void);
 int split2half_rmng_udp_test_time(); // [s]
 
 namespace udp_global {
+#ifdef MBED_GREENTEA_TEST_UDPSOCKET_TIMEOUT_S
+static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_UDPSOCKET_TIMEOUT_S;
+#else
 static const int TESTS_TIMEOUT = 480;
+#endif
 }
 
 /*

--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -54,8 +54,13 @@ using namespace utest::v1;
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
 #if !MBED_CONF_APP_ECHO_SERVER
+#ifdef MBED_GREENTEA_TEST_EMAC_TIMEOUT_S
+    GREENTEA_SETUP(MBED_GREENTEA_TEST_EMAC_TIMEOUT_S, "default_auto");
+#else
     GREENTEA_SETUP(1400, "default_auto");
-#endif
+#endif // #ifdef MBED_GREENTEA_TEST_EMAC_TIMEOUT_S
+#endif // #if !MBED_CONF_APP_ECHO_SERVER
+
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/network/interface/main.cpp
+++ b/TESTS/network/interface/main.cpp
@@ -33,7 +33,11 @@ using namespace utest::v1;
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
+#ifdef MBED_GREENTEA_TEST_INTERFACE_TIMEOUT_S
+    GREENTEA_SETUP(MBED_GREENTEA_TEST_INTERFACE_TIMEOUT_S, "default_auto");
+#else
     GREENTEA_SETUP(480, "default_auto");
+#endif
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -52,7 +52,11 @@ using namespace utest::v1;
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
+#ifdef MBED_GREENTEA_TEST_WIFI_TIMEOUT_S
+    GREENTEA_SETUP(MBED_GREENTEA_TEST_WIFI_TIMEOUT_S, "default_auto");
+#else
     GREENTEA_SETUP(360, "default_auto");
+#endif
     return verbose_test_setup_handler(number_of_cases);
 }
 


### PR DESCRIPTION
### Description

Now it is enough to add:
    "macros": [
        "MBED_GREENTEA_TEST_XXXSOCKET_TIMEOUT_S=20"
    ],
to mbed_app.json, where XXX is on of {DNS, TLS, UDP, TCP}.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@AriParkkila 
@pekkapesu 

