### PR TITLE
Enhance targets.json with components

### DIFF
--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -183,7 +183,7 @@ static BlockDevice *get_bd_instance(uint8_t bd_type)
 // Mutex is also protecting printouts for clear logs.
 // Mutex is NOT protecting Block Device actions: erase/program/read - which is the purpose of the multithreaded test!
 void basic_erase_program_read_test(BlockDevice *block_device, bd_size_t block_size, uint8_t *write_block,
-                                   uint8_t *read_block, unsigned addrwidth)
+                                   uint8_t *read_block, unsigned addrwidth, int thread_num)
 {
     int err = 0;
     _mutex->lock();
@@ -193,7 +193,13 @@ void basic_erase_program_read_test(BlockDevice *block_device, bd_size_t block_si
     srand(block_seed++);
 
     // Find a random block
-    bd_addr_t block = (rand() * block_size) % (block_device->size());
+    int threaded_rand_number = (rand() * TEST_NUM_OF_THREADS) + thread_num;
+    bd_addr_t block = (threaded_rand_number * block_size) % block_device->size();
+
+    // Flashiap boards with inconsistent sector size will not align with random start addresses
+    if (bd_arr[test_iteration] == flashiap) {
+        block = 0;
+    }
 
     // Use next random number as temporary seed to keep
     // the address progressing in the pseudorandom sequence
@@ -206,7 +212,11 @@ void basic_erase_program_read_test(BlockDevice *block_device, bd_size_t block_si
     }
     // Write, sync, and read the block
     utest_printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
-    _mutex->unlock();
+
+    // Thread test for flashiap write to the same sector, so all write/read/erase actions should be locked
+    if (bd_arr[test_iteration] != flashiap) {
+        _mutex->unlock();
+    }
 
     err = block_device->erase(block, block_size);
     TEST_ASSERT_EQUAL(0, err);
@@ -217,7 +227,10 @@ void basic_erase_program_read_test(BlockDevice *block_device, bd_size_t block_si
     err = block_device->read(read_block, block, block_size);
     TEST_ASSERT_EQUAL(0, err);
 
-    _mutex->lock();
+    if (bd_arr[test_iteration] != flashiap) {
+        _mutex->lock();
+    }
+
     // Check that the data was unmodified
     srand(seed);
     int val_rand;
@@ -276,7 +289,7 @@ void test_random_program_read_erase()
     }
 
     for (int b = 0; b < TEST_BLOCK_COUNT; b++) {
-        basic_erase_program_read_test(block_device, block_size, write_block, read_block, addrwidth);
+        basic_erase_program_read_test(block_device, block_size, write_block, read_block, addrwidth, 0);
     }
 
 end:
@@ -287,7 +300,9 @@ end:
 static void test_thread_job(void *block_device_ptr)
 {
     static int thread_num = 0;
-    thread_num++;
+    _mutex->lock();
+    int block_num = thread_num++;
+    _mutex->unlock();
     BlockDevice *block_device = (BlockDevice *)block_device_ptr;
 
     bd_size_t block_size = block_device->get_erase_size();
@@ -302,7 +317,7 @@ static void test_thread_job(void *block_device_ptr)
     }
 
     for (int b = 0; b < TEST_BLOCK_COUNT; b++) {
-        basic_erase_program_read_test(block_device, block_size, write_block, read_block, addrwidth);
+        basic_erase_program_read_test(block_device, block_size, write_block, read_block, addrwidth, block_num);
     }
 
 end:
@@ -384,6 +399,11 @@ void test_erase_functionality()
     start_address -= start_address % erase_size; // align with erase_block
     utest_printf("start_address=0x%016" PRIx64 "\n", start_address);
 
+    // Flashiap boards with inconsistent sector size will not align with random start addresses
+    if (bd_arr[test_iteration] == flashiap) {
+        start_address = 0;
+    }
+
     // Allocate buffer for write test data
     uint8_t *data_buf = (uint8_t *)malloc(data_buf_size);
     TEST_SKIP_UNLESS_MESSAGE(data_buf, "Not enough memory for test.\n");
@@ -445,6 +465,11 @@ void test_contiguous_erase_write_read()
     utest_printf("\nTest Contiguous Erase/Program/Read Starts..\n");
 
     TEST_SKIP_UNLESS_MESSAGE(block_device != NULL, "no block device found.");
+
+    // Flashiap boards with inconsistent sector size will not align with random start addresses
+    if (bd_arr[test_iteration] == flashiap) {
+        return;
+    }
 
     // Test flow:
     //  1. Erase whole test area

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1499,6 +1499,7 @@
     },
     "SDT64B": {
         "inherits": ["K64F"],
+        "components_add": ["FLASHIAP"],
         "extra_labels_add": ["K64F"],
         "extra_labels_remove": ["FRDM"],
         "components_remove": ["SD"],
@@ -2197,6 +2198,7 @@
     },
     "NUCLEO_F207ZG": {
         "inherits": ["FAMILY_STM32"],
+        "components_add": ["FLASHIAP"],
         "supported_form_factors": ["ARDUINO", "MORPHO"],
         "core": "Cortex-M3",
         "extra_labels_add": ["STM32F2", "STM32F207ZG", "STM_EMAC"],
@@ -2560,7 +2562,7 @@
         }
     },
     "DISCO_F413ZH": {
-        "components_add": ["QSPIF"],
+        "components_add": ["QSPIF", "FLASHIAP"],
         "inherits": ["FAMILY_STM32"],
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
@@ -2926,6 +2928,7 @@
     },
     "NUCLEO_F767ZI": {
         "inherits": ["FAMILY_STM32"],
+        "components_add": ["FLASHIAP"],
         "core": "Cortex-M7FD",
         "extra_labels_add": [
             "STM32F7",
@@ -3791,7 +3794,7 @@
             "STM32F746NG",
             "STM_EMAC"
         ],
-        "components_add": ["QSPIF"],
+        "components_add": ["QSPIF", "FLASHIAP"],
         "supported_form_factors": ["ARDUINO"],
         "config": {
             "clock_source": {
@@ -4235,7 +4238,7 @@
         "release_versions": ["5"],
         "device_has_remove": [],
         "extra_labels_add": ["PSA"],
-        "components_add": ["FLASHIAP"],
+        "components_add": ["SD", "FLASHIAP"],
         "macros_add": [
             "MBEDTLS_PSA_CRYPTO_C"
         ],
@@ -4321,6 +4324,7 @@
     },
     "UBLOX_C030_U201": {
         "inherits": ["UBLOX_C030"],
+        "components_add": ["SD", "FLASHIAP"],
         "release_versions": ["5"]
     },
     "UBLOX_C030_N211": {
@@ -5180,6 +5184,7 @@
     },
     "GR_LYCHEE": {
         "inherits": ["RZ_A1XX"],
+        "components_add": ["SD", "FLASHIAP"],
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["RZA1UL", "MBRZA1LU"],
         "components_add": ["SD"],
@@ -6941,6 +6946,7 @@
     },
     "NUMAKER_PFM_NUC472": {
         "core": "Cortex-M4F",
+        "components_add": ["SD", "FLASHIAP"],
         "default_toolchain": "ARM",
         "extra_labels": [
             "NUVOTON",
@@ -7513,10 +7519,12 @@
     },
     "NUMAKER_PFM_M487": {
         "inherits": ["MCU_M480"],
+        "components_add": ["SD", "FLASHIAP"],
         "device_name": "M487JIDAE"
     },
     "NUMAKER_IOT_M487": {
         "inherits": ["MCU_M480"],
+        "components_add": ["FLASHIAP"],
         "device_name": "M487JIDAE"
     },
     "TMPM066": {


### PR DESCRIPTION
### Description
The enhancement is further specified [here](https://jira.arm.com/browse/IOTSTOR-777).
Due to the enhancement some boards failed the general block device tests for flashiap component,
The fails were due to boards containing inconsistent sector sizes.
The tests were modified but should be improved to address the problem.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-storage 

