### PR TITLE
tools/utils: ensure default build profiles are processed first

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -495,10 +495,12 @@ def argparse_profile_filestring_type(string):
     absolute path or a file name (expanded to
     mbed-os/tools/profiles/<fname>.json) of a existing file"""
     fpath = join(dirname(__file__), "profiles/{}.json".format(string))
-    if exists(string):
-        return string
-    elif exists(fpath):
+
+    # default profiles are searched first, local ones next.
+    if exists(fpath):
         return fpath
+    elif exists(string):
+        return string
     else:
         raise argparse.ArgumentTypeError(
             "{0} does not exist in the filesystem.".format(string))


### PR DESCRIPTION
### Description

The command-line argument --profile looks for build profiles provided in mbed-os/tools/profiles/. If a
directory exists in the root folder with the same name as one of the profile names provided by default [e.g debug/develop/release], that directory is processed instead, resulting in an error. Fix this behavior by processing the default profiles first.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@theotherjimmy @bridadan 