### PR TITLE
Cellular: Fix sigio to be released in ATHandler destructor

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -328,15 +328,6 @@ TEST_F(TestATHandler, test_ATHandler_process_oob)
     filehandle_stub_table = NULL;
 }
 
-TEST_F(TestATHandler, test_ATHandler_set_filehandle_sigio)
-{
-    EventQueue que;
-    FileHandle_stub fh1;
-
-    ATHandler at(&fh1, que, 0, ",");
-    at.set_filehandle_sigio();
-}
-
 TEST_F(TestATHandler, test_ATHandler_flush)
 {
     EventQueue que;

--- a/UNITTESTS/stubs/FileHandle_stub.h
+++ b/UNITTESTS/stubs/FileHandle_stub.h
@@ -80,7 +80,9 @@ public:
 
     virtual void sigio(Callback<void()> func)
     {
-        func();
+        if (func) {
+            func();
+        }
     }
 
     short short_value;

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -62,7 +62,7 @@ static const uint8_t map_3gpp_errors[][2] =  {
 
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const char *output_delimiter, uint16_t send_delay) :
     _nextATHandler(0),
-    _fileHandle(fh),
+    _fileHandle(NULL), // filehandle is set by set_file_handle()
     _queue(queue),
     _last_err(NSAPI_ERROR_OK),
     _last_3gpp_error(0),
@@ -74,7 +74,7 @@ ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, uint32_t timeout, const 
     _last_response_stop(0),
     _oob_queued(false),
     _ref_count(1),
-    _is_fh_usable(true),
+    _is_fh_usable(false),
     _stop_tag(NULL),
     _delimiter(DEFAULT_DELIMITER),
     _prefix_matched(false),
@@ -114,6 +114,8 @@ void ATHandler::set_debug(bool debug_on)
 
 ATHandler::~ATHandler()
 {
+    set_file_handle(NULL);
+
     while (_oobs) {
         struct oob_t *oob = _oobs;
         _oobs = oob->next;
@@ -146,17 +148,26 @@ FileHandle *ATHandler::get_file_handle()
 
 void ATHandler::set_file_handle(FileHandle *fh)
 {
+    if (_fileHandle) {
+        set_is_filehandle_usable(false);
+    }
     _fileHandle = fh;
-    _fileHandle->set_blocking(false);
-    set_filehandle_sigio();
+    if (_fileHandle) {
+        set_is_filehandle_usable(true);
+    }
 }
 
 void ATHandler::set_is_filehandle_usable(bool usable)
 {
-    _is_fh_usable = usable;
-    if (usable) {
-        // set file handle sigio and blocking mode back
-        set_file_handle(_fileHandle);
+    if (_fileHandle) {
+        if (usable) {
+            _fileHandle->set_blocking(false);
+            _fileHandle->sigio(Callback<void()>(this, &ATHandler::event));
+        } else {
+            _fileHandle->set_blocking(true); // set back to default state
+            _fileHandle->sigio(NULL);
+        }
+        _is_fh_usable = usable;
     }
 }
 
@@ -306,11 +317,6 @@ void ATHandler::process_oob()
         tr_debug("AT OoB done");
     }
     unlock();
-}
-
-void ATHandler::set_filehandle_sigio()
-{
-    _fileHandle->sigio(Callback<void()>(this, &ATHandler::event));
 }
 
 void ATHandler::reset_buffer()

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -190,10 +190,6 @@ public:
      */
     void process_oob();
 
-    /** Set sigio for the current file handle. Sigio event goes through eventqueue so that it's handled in current thread.
-     */
-    void set_filehandle_sigio();
-
     /** Set file handle, which is used for reading AT responses and writing AT commands
      *
      *  @param fh file handle used for reading AT responses and writing AT commands


### PR DESCRIPTION
### Description

ATHandler destructor must release sigio callbacks from filehandle.

Fixes issue  #9723.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica 

### Release Notes
