### PR TITLE
Greentea: Remove TLSSocket_simultaneous test

### DIFF
--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -195,9 +195,12 @@ Case cases[] = {
     Case("TLSSOCKET_SEND_REPEAT", TLSSOCKET_SEND_REPEAT),
     Case("TLSSOCKET_SEND_TIMEOUT", TLSSOCKET_SEND_TIMEOUT),
     Case("TLSSOCKET_NO_CERT", TLSSOCKET_NO_CERT),
-#ifndef __IAR_SYSTEMS_ICC__
-    Case("TLSSOCKET_SIMULTANEOUS", TLSSOCKET_SIMULTANEOUS)
-#endif
+//    Temporarily removing this test, as TLS library consumes too much memory
+//    and we see frequent memory allocation failures on architectures with less
+//    RAM such as DISCO_L475VG_IOT1A and NUCLEO_F207ZG (both have 128 kB RAM)
+//    This test also fails for IAR, due to wrong heap configuration in the linker
+//    script - see https://github.com/ARMmbed/mbed-os/issues/8306
+//    Case("TLSSOCKET_SIMULTANEOUS", TLSSOCKET_SIMULTANEOUS)
 };
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);


### PR DESCRIPTION
### Description

The reason is that some platforms lack memory to run it. To be brought back once TLS library memory consumption is optimized.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@mtomczykmobica 
@KariHaapalehto 
@tymoteuszblochmobica 

### Release Notes

