### PR TITLE
Remove pyocd requirement and update icetea.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,4 @@ beautifulsoup4>=4,<=4.6.3
 fuzzywuzzy>=0.11,<=0.17
 pyelftools>=0.24,<=0.25
 git+https://github.com/armmbed/manifest-tool.git@v1.4.6
-pyocd>=0.14,<0.15
-icetea>=1.0.2,<1.1
+icetea>=1.2.1,<1.3


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This change was prompted by the concerns raised here: https://github.com/ARMmbed/mbed-os/pull/9481#issuecomment-461118156. This removes pyocd from Mbed OS's tools requirements.

Icetea depends on mbed-flasher. mbed-flasher recently released a version
that drops the dependency on pyocd. Icetea released a version that uses
this latest version of mbed-flasher. So now that pyocd is no longer in
our dependency tree, we can drop it here.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
