### PR TITLE
ESP8266: connect() returns OK in non-blocking calls

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -253,7 +253,11 @@ int ESP8266Interface::connect()
 
     _cmutex.unlock();
 
-    return _connect_retval;
+    if (!_if_blocking) {
+        return NSAPI_ERROR_OK;
+    } else {
+        return _connect_retval;
+    }
 }
 
 int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)


### PR DESCRIPTION
### Description

I accidentally broke the non-blocking behavior with PR #9639. This commit brings back the previous functionality: in case of non-blocking calls, just return NSAPI_ERROR_OK. This time I ran netsocket-* and network-* to see that everything is passing (aside from what we know is not)

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
