### PR TITLE
Enable ODIN target in Feature IAR 8 branch

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4229,8 +4229,7 @@
     "UBLOX_EVK_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "supported_form_factors": ["ARDUINO"],
-        "release_versions": [],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "release_versions": ["5"],
         "device_has_remove": [],
         "extra_labels_add": ["PSA"],
         "components_add": ["FLASHIAP"],
@@ -4249,8 +4248,7 @@
     },
     "MBED_CONNECT_ODIN": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
-        "release_versions": [],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "release_versions": ["5"],
         "config": {
             "stdio_uart_tx_help": {
                 "help": "Value: PA_9(default) or PD_8"
@@ -4266,10 +4264,9 @@
     },
     "MTB_UBLOX_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "device_has_add": [],
         "overrides": {"lse_available": 0},
-        "release_versions": []
+        "release_versions": ["5"]
     },
     "UBLOX_C030": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
### Description
ODIN library was added in https://github.com/ARMmbed/mbed-os/pull/9682, can enable it now

Partial revert of https://github.com/ARMmbed/mbed-os/commit/358d93976e486fc87690a4213a7e01b805369323 - ODIN only

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes

