### PR TITLE
Fix incorrect return value in psa_security_lifecycle_state (emul)

### DIFF
--- a/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_EMUL/platform_emul.c
+++ b/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_EMUL/platform_emul.c
@@ -21,7 +21,12 @@
 uint32_t psa_security_lifecycle_state(void)
 {
     uint32_t lc_state = 0;
-    return psa_platfrom_lifecycle_get_impl(&lc_state);
+    psa_status_t status = PSA_LIFECYCLE_SUCCESS;
+    status = psa_platfrom_lifecycle_get_impl(&lc_state);
+    if (status != PSA_LIFECYCLE_SUCCESS) {
+        lc_state = PSA_LIFECYCLE_UNKNOWN;
+    }
+    return lc_state;
 }
 
 psa_status_t mbed_psa_reboot_and_request_new_security_state(uint32_t new_state)


### PR DESCRIPTION
### Description

psa_security_lifecycle_state should return uint32_t of the security
lifecycle state.

bug: psa_platfrom_lifecycle_get_impl return value is psa_status_t.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@alzix 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
