### PR TITLE
BLE:Cordio: ATTS setting for write cback should use bitwise or

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -294,7 +294,7 @@ ble_error_t GattServer::insert_characteristic_value_attribute(
         attribute_it->settings = ATTS_SET_READ_CBACK;
     }
     if (properties & WRITABLE_PROPERTIES) {
-        attribute_it->settings = ATTS_SET_WRITE_CBACK;
+        attribute_it->settings |= ATTS_SET_WRITE_CBACK;
     }
     if (value_attribute.getUUID().shortOrLong() == UUID::UUID_TYPE_LONG) {
         attribute_it->settings |= ATTS_SET_UUID_128;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

The attribute settings for ATTS_SET_WRITE_CBACK overwrites the setting for ATTS_SET_READ_CBACK because the assignment operator, it should use bitwise or operator.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
