### PR TITLE
Add comment fix warning

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -52,6 +52,12 @@ protected: // NetworkStack
      */
     virtual nsapi_error_t socket_stack_init();
 
+    /**
+      * Note: Socket_open does not actually open socket on all drivers, but that's deferred until calling `sendto`.
+      * The reason is that IP stack implementations are very much modem specific and it's quite common that when a
+      * socket is created (via AT commands) it must also be given remote IP address, and that is usually known
+      * only when calling `sendto`.
+      */
     virtual nsapi_error_t socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto);
 
     virtual nsapi_error_t socket_close(nsapi_socket_t handle);

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -329,7 +329,7 @@ nsapi_size_or_error_t QUECTEL_BG96_CellularStack::socket_recvfrom_impl(CellularS
     port = _at.read_int();
     if (recv_len > 0) {
         // do not read more than buffer size
-        recv_len = recv_len > size ? size : recv_len;
+        recv_len = recv_len > (nsapi_size_or_error_t)size ? size : recv_len;
         _at.read_bytes((uint8_t *)buffer, recv_len);
     }
     _at.resp_stop();


### PR DESCRIPTION
### Description
- added explanatory comment for AT cellular stack's socket_open routine
- remove compiling warning for BG96 cellular stack

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [x ] Docs update
    [ ] Test update
    [ ] Breaking change