### PR TITLE
support in more types then just RSA_KEYPAIR

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -1125,17 +1125,12 @@ psa_status_t psa_generate_key(psa_key_handle_t key_handle,
     in_vec[1].base = &bits;
     in_vec[1].len = sizeof(size_t);
 
-    /* currently the parameter argument is used only for RSA keypair
-       and ignored in other cases. support for other algorithms
-       may be added later*/
-    if (PSA_KEY_TYPE_RSA_KEYPAIR == type) {
-        in_vec[2].base = parameters;
-        /* size of parameter is unsigned integer as defined in header */
-        in_vec[2].len = parameters_size;
-    } else { // currenty ignored for non RSA case
-        in_vec[2].base = NULL;
-        in_vec[2].len = 0;
+    if (((parameters == NULL) && (parameters_size != 0)) || ((parameters != NULL) && (parameters_size == 0))) {
+        return (PSA_ERROR_INVALID_ARGUMENT);
     }
+
+    in_vec[2].base = parameters;
+    in_vec[2].len = parameters_size;
 
     handle = psa_connect(PSA_KEY_MNG_ID, MINOR_VER);
     if (handle <= 0) {


### PR DESCRIPTION
remove a workaround that was saved for future use.
after this change, if the type is not supported the psa_crypto will return the error code for unsupported


### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@itayzafrir 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
