### PR TITLE
PSOC6: enable export to CMake

### DIFF
--- a/tools/export/cmake/__init__.py
+++ b/tools/export/cmake/__init__.py
@@ -44,7 +44,8 @@ class CMake(Exporter):
         "MCU_NRF51Code.binary_hook",
         "TEENSY3_1Code.binary_hook",
         "LPCTargetCode.lpc_patch",
-        "LPC4088Code.binary_hook"
+        "LPC4088Code.binary_hook",
+        "PSOC6Code.complete"
     ])
 
     @classmethod
@@ -74,6 +75,12 @@ class CMake(Exporter):
         # sort includes reverse, so the deepest dir comes first (ensures short includes)
         includes = sorted([re.sub(r'^[.]/', '', l) for l in self.resources.inc_dirs], reverse=True)
 
+        # select dependant hex files to merge into compiled hex image
+        hex_files = self.resources.hex_files
+        if hasattr(self.toolchain.target, 'hex_filename'):
+            hex_filename = self.toolchain.target.hex_filename
+            hex_files = list(f for f in hex_files if basename(f) == hex_filename)
+
         ctx = {
             'name': self.project_name,
             'target': self.target,
@@ -83,7 +90,7 @@ class CMake(Exporter):
             'include_paths': includes,
             'library_paths': sorted([re.sub(r'^[.]/', '', l) for l in self.resources.lib_dirs]),
             'linker_script': self.resources.linker_script,
-            'hex_files': self.resources.hex_files,
+            'hex_files': hex_files,
             'ar': basename(self.toolchain.ar),
             'cc': basename(self.toolchain.cc[0]),
             'cc_flags': " ".join(flag for flag in self.toolchain.cc[1:] if not flag == "-c"),

--- a/tools/export/cmake/__init__.py
+++ b/tools/export/cmake/__init__.py
@@ -75,12 +75,6 @@ class CMake(Exporter):
         # sort includes reverse, so the deepest dir comes first (ensures short includes)
         includes = sorted([re.sub(r'^[.]/', '', l) for l in self.resources.inc_dirs], reverse=True)
 
-        # select dependant hex files to merge into compiled hex image
-        hex_files = self.resources.hex_files
-        if hasattr(self.toolchain.target, 'hex_filename'):
-            hex_filename = self.toolchain.target.hex_filename
-            hex_files = list(f for f in hex_files if basename(f) == hex_filename)
-
         ctx = {
             'name': self.project_name,
             'target': self.target,
@@ -90,7 +84,7 @@ class CMake(Exporter):
             'include_paths': includes,
             'library_paths': sorted([re.sub(r'^[.]/', '', l) for l in self.resources.lib_dirs]),
             'linker_script': self.resources.linker_script,
-            'hex_files': hex_files,
+            'hex_files': self.hex_files,
             'ar': basename(self.toolchain.ar),
             'cc': basename(self.toolchain.cc[0]),
             'cc_flags': " ".join(flag for flag in self.toolchain.cc[1:] if not flag == "-c"),

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -123,6 +123,15 @@ class Exporter(object):
         return [l for l in self.resources.get_file_names(FileType.LIB)
                 if l.endswith(self.toolchain.LIBRARY_EXT)]
 
+    @property
+    def hex_files(self):
+        """Returns a list of hex files to include in the exported project"""
+        hex_files = self.resources.hex_files
+        if hasattr(self.toolchain.target, 'hex_filename'):
+            hex_filename = self.toolchain.target.hex_filename
+            hex_files = [f for f in hex_files if basename(f) == hex_filename]
+        return hex_files
+
     def toolchain_flags(self, toolchain):
         """Returns a dictionary of toolchain flags.
         Keys of the dictionary are:

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -84,11 +84,6 @@ class Makefile(Exporter):
         sys_libs = [self.prepare_sys_lib(lib) for lib
                     in self.toolchain.sys_libs]
 
-        hex_files = self.resources.hex_files
-        if hasattr(self.toolchain.target, 'hex_filename'):
-            hex_filename = self.toolchain.target.hex_filename
-            hex_files = list(f for f in hex_files if basename(f) == hex_filename)
-
         ctx = {
             'name': self.project_name,
             'to_be_compiled': to_be_compiled,
@@ -98,7 +93,7 @@ class Makefile(Exporter):
             'linker_script': self.resources.linker_script,
             'libraries': libraries,
             'ld_sys_libs': sys_libs,
-            'hex_files': hex_files,
+            'hex_files': self.hex_files,
             'vpath': (["../../.."]
                       if (basename(dirname(dirname(self.export_dir)))
                           == "projectfiles")


### PR DESCRIPTION
### Description

CMake exporter needs to select a single hex file with CM0+ prebuilt image from resources.
The approach for the hex_files subset selection is identical to makefile exporter: https://github.com/ARMmbed/mbed-os/pull/9466

Single hex file should be passed to srec_cat when "hex_filename" is set in targets.json or mbed_app.json.

There is no impact on non-PSoC6 targets (without "hex_filename" attribute in targets.json).

### Pull request type

    [ ] Fix
    [X] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@theotherjimmy 

### Release Notes