### PR TITLE
allow hash or mac on large buffers with less memory use

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -18,6 +18,11 @@
 #define mbedtls_free   free
 #endif
 
+// ---------------------------------- Macros -----------------------------------
+#if !defined(MIN)
+#define MIN( a, b ) ( ( ( a ) < ( b ) ) ? ( a ) : ( b ) )
+#endif
+
 // -------------------------------- Structures ---------------------------------
 typedef struct psa_spm_hash_clone_s {
     int32_t partition_id;
@@ -27,6 +32,12 @@ typedef struct psa_spm_hash_clone_s {
 
 // ---------------------------------- Globals ----------------------------------
 static int psa_spm_init_refence_counter = 0;
+
+/* maximal memoty allocation for reading large hash ort mac input buffers.
+the data will be read in chunks of size */
+#if !defined (MAX_DATA_CHUNK_SIZE_IN_BYTES)
+    #define MAX_DATA_CHUNK_SIZE_IN_BYTES 400
+#endif
 
 #ifndef MAX_CONCURRENT_HASH_CLONES
 #define MAX_CONCURRENT_HASH_CLONES 2
@@ -216,24 +227,42 @@ static void psa_mac_operation(void)
                 }
 
                 case PSA_MAC_UPDATE: {
-                    uint8_t *input_ptr = mbedtls_calloc(1, msg.in_size[1]);
-                    if (input_ptr == NULL) {
+
+                    uint8_t * input_buffer = NULL;
+                    size_t data_remaining = msg.in_size[1];
+                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
+                    size_t size_to_read = 0;
+
+                    input_buffer = mbedtls_calloc(1, allocation_size);
+                    if (input_buffer == NULL) {
                         status = PSA_ERROR_INSUFFICIENT_MEMORY;
                         break;
                     }
 
-                    bytes_read = psa_read(msg.handle, 1, input_ptr,
-                                          msg.in_size[1]);
+                    while (data_remaining > 0)
+                    {
+                        size_to_read = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
+                        bytes_read = psa_read(msg.handle, 1, input_buffer,
+                                              size_to_read);
 
-                    if (bytes_read != msg.in_size[1]) {
-                        SPM_PANIC("SPM read length mismatch");
+                        if (bytes_read != size_to_read) {
+                            SPM_PANIC("SPM read length mismatch");
+                        }
+
+                        status = psa_mac_update(msg.rhandle,
+                                                input_buffer,
+                                                bytes_read);
+                        
+                        // stop on error 
+                        if (status != PSA_SUCCESS)
+                        {
+                            break;
+                        }
+                        data_remaining = data_remaining - bytes_read;
                     }
+                    
+                    mbedtls_free(input_buffer);
 
-                    status = psa_mac_update(msg.rhandle,
-                                            input_ptr,
-                                            msg.in_size[1]);
-
-                    mbedtls_free(input_ptr);
                     break;
                 }
 
@@ -363,23 +392,41 @@ static void psa_hash_operation(void)
                 }
 
                 case PSA_HASH_UPDATE: {
-                    uint8_t *input_ptr = mbedtls_calloc(1, msg.in_size[1]);
-                    if (input_ptr == NULL) {
+                    uint8_t * input_buffer = NULL;
+                    size_t data_remaining = msg.in_size[1];
+                    size_t size_to_read = 0;
+                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
+
+                    input_buffer = mbedtls_calloc(1, allocation_size);
+                    if (input_buffer == NULL) {
                         status = PSA_ERROR_INSUFFICIENT_MEMORY;
                         break;
                     }
 
-                    bytes_read = psa_read(msg.handle, 1, input_ptr,
-                                          msg.in_size[1]);
+                    while (data_remaining > 0)
+                    {
+                        size_to_read = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
+                        bytes_read = psa_read(msg.handle, 1, input_buffer,
+                                              size_to_read);
 
-                    if (bytes_read != msg.in_size[1]) {
-                        SPM_PANIC("SPM read length mismatch");
+                        if (bytes_read != size_to_read) {
+                            SPM_PANIC("SPM read length mismatch");
+                        }
+
+                        status = psa_hash_update(msg.rhandle,
+                                                input_buffer,
+                                                bytes_read);
+
+                        // stop on error 
+                        if (status != PSA_SUCCESS)
+                        {
+                            break;
+                        }
+                        data_remaining = data_remaining - bytes_read;
                     }
 
-                    status = psa_hash_update(msg.rhandle,
-                                             input_ptr,
-                                             msg.in_size[1]);
-                    mbedtls_free(input_ptr);
+                    mbedtls_free(input_buffer);
+
                     break;
                 }
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -33,7 +33,7 @@ typedef struct psa_spm_hash_clone_s {
 // ---------------------------------- Globals ----------------------------------
 static int psa_spm_init_refence_counter = 0;
 
-/* maximal memoty allocation for reading large hash ort mac input buffers.
+/* maximal memory allocation for reading large hash or mac input buffers.
 the data will be read in chunks of size */
 #if !defined (MAX_DATA_CHUNK_SIZE_IN_BYTES)
 #define MAX_DATA_CHUNK_SIZE_IN_BYTES 400

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -96,7 +96,7 @@ static void destroy_hash_clone(void *source_operation)
 }
 
 static inline psa_status_t get_hash_clone(size_t index, int32_t partition_id,
-        psa_spm_hash_clone_t **hash_clone)
+                                          psa_spm_hash_clone_t **hash_clone)
 {
     if (index >= MAX_CONCURRENT_HASH_CLONES ||
             psa_spm_hash_clones[index].partition_id != partition_id ||

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -36,7 +36,7 @@ static int psa_spm_init_refence_counter = 0;
 /* maximal memoty allocation for reading large hash ort mac input buffers.
 the data will be read in chunks of size */
 #if !defined (MAX_DATA_CHUNK_SIZE_IN_BYTES)
-    #define MAX_DATA_CHUNK_SIZE_IN_BYTES 400
+#define MAX_DATA_CHUNK_SIZE_IN_BYTES 400
 #endif
 
 #ifndef MAX_CONCURRENT_HASH_CLONES
@@ -96,7 +96,7 @@ static void destroy_hash_clone(void *source_operation)
 }
 
 static inline psa_status_t get_hash_clone(size_t index, int32_t partition_id,
-                                          psa_spm_hash_clone_t **hash_clone)
+        psa_spm_hash_clone_t **hash_clone)
 {
     if (index >= MAX_CONCURRENT_HASH_CLONES ||
             psa_spm_hash_clones[index].partition_id != partition_id ||
@@ -228,7 +228,7 @@ static void psa_mac_operation(void)
 
                 case PSA_MAC_UPDATE: {
 
-                    uint8_t * input_buffer = NULL;
+                    uint8_t *input_buffer = NULL;
                     size_t data_remaining = msg.in_size[1];
                     size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
                     size_t size_to_read = 0;
@@ -239,8 +239,7 @@ static void psa_mac_operation(void)
                         break;
                     }
 
-                    while (data_remaining > 0)
-                    {
+                    while (data_remaining > 0) {
                         size_to_read = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
                         bytes_read = psa_read(msg.handle, 1, input_buffer,
                                               size_to_read);
@@ -252,15 +251,14 @@ static void psa_mac_operation(void)
                         status = psa_mac_update(msg.rhandle,
                                                 input_buffer,
                                                 bytes_read);
-                        
-                        // stop on error 
-                        if (status != PSA_SUCCESS)
-                        {
+
+                        // stop on error
+                        if (status != PSA_SUCCESS) {
                             break;
                         }
                         data_remaining = data_remaining - bytes_read;
                     }
-                    
+
                     mbedtls_free(input_buffer);
 
                     break;
@@ -392,7 +390,7 @@ static void psa_hash_operation(void)
                 }
 
                 case PSA_HASH_UPDATE: {
-                    uint8_t * input_buffer = NULL;
+                    uint8_t *input_buffer = NULL;
                     size_t data_remaining = msg.in_size[1];
                     size_t size_to_read = 0;
                     size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
@@ -403,8 +401,7 @@ static void psa_hash_operation(void)
                         break;
                     }
 
-                    while (data_remaining > 0)
-                    {
+                    while (data_remaining > 0) {
                         size_to_read = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
                         bytes_read = psa_read(msg.handle, 1, input_buffer,
                                               size_to_read);
@@ -414,12 +411,11 @@ static void psa_hash_operation(void)
                         }
 
                         status = psa_hash_update(msg.rhandle,
-                                                input_buffer,
-                                                bytes_read);
+                                                 input_buffer,
+                                                 bytes_read);
 
-                        // stop on error 
-                        if (status != PSA_SUCCESS)
-                        {
+                        // stop on error
+                        if (status != PSA_SUCCESS) {
                             break;
                         }
                         data_remaining = data_remaining - bytes_read;


### PR DESCRIPTION

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Previously a buffer the size of whole input was allocated for hash or MAC operations which is inefficient. This change allows the use of a fixed size buffer for large inputs to process the input
in multiple smaller pieces.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@avolinski  @itayzafrir 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
description: Hash and mac operations are now processed in secure partition in multiple chunks internally leading to decrease in memory use for large buffers. 
effect analysis: This change has no impact on API and should not alter behavior from the user perspective. 
Migration: not action should be required from the user side.

