### PR TITLE
Multiple memory handling fixes

### DIFF
--- a/UNITTESTS/features/netsocket/DTLSSocketWrapper/test_DTLSSocketWrapper.cpp
+++ b/UNITTESTS/features/netsocket/DTLSSocketWrapper/test_DTLSSocketWrapper.cpp
@@ -58,6 +58,7 @@ protected:
         stack.return_socketAddress = SocketAddress();
         eventFlagsStubNextRetval.clear();
         delete wrapper;
+        delete transport;
     }
 
     char *cert = "-----BEGIN CERTIFICATE-----\
@@ -103,6 +104,7 @@ TEST_F(TestDTLSSocketWrapper, constructor)
 TEST_F(TestDTLSSocketWrapper, constructor_hostname)
 {
     DTLSSocketWrapper *wrapper2 = new DTLSSocketWrapper(transport, "localhost");
+    delete wrapper2;
 }
 
 /* connect */
@@ -323,6 +325,8 @@ TEST_F(TestDTLSSocketWrapper, set_root_ca_cert_invalid)
     mbedtls_stub.counter = 0;
     mbedtls_stub.retArray[0] = 1; // mbedtls_x509_crt_parse error
     EXPECT_EQ(wrapper->set_root_ca_cert(cert, strlen(cert)), NSAPI_ERROR_PARAMETER);
+    // We need to deallocate the crt pointer ourselves.
+    delete (wrapper->get_ca_chain());
 }
 
 TEST_F(TestDTLSSocketWrapper, set_client_cert_key)

--- a/UNITTESTS/features/netsocket/NetworkInterface/test_NetworkInterface.cpp
+++ b/UNITTESTS/features/netsocket/NetworkInterface/test_NetworkInterface.cpp
@@ -216,4 +216,6 @@ TEST_F(TestNetworkInterface, correct_event_listener_per_interface)
 
     iface->remove_event_listener(my_iface_callback);
     iface2->remove_event_listener(my_iface_callback2);
+
+    delete iface2;
 }

--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -272,8 +272,12 @@ TEST_F(TestTCPSocket, accept)
     nsapi_error_t error;
     stack.return_value = NSAPI_ERROR_OK;
     socket->open((NetworkStack *)&stack);
-    EXPECT_NE(socket->accept(&error), static_cast<TCPSocket *>(NULL));
+    TCPSocket *sock = socket->accept(&error);
+    EXPECT_NE(sock, static_cast<TCPSocket *>(NULL));
     EXPECT_EQ(error, NSAPI_ERROR_OK);
+    if (sock) {
+        sock->close();
+    }
 }
 
 TEST_F(TestTCPSocket, accept_would_block)

--- a/UNITTESTS/features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
+++ b/UNITTESTS/features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
@@ -56,6 +56,7 @@ protected:
         stack.return_values.clear();
         eventFlagsStubNextRetval.clear();
         delete wrapper;
+        delete transport;
     }
 
     char *cert = "-----BEGIN CERTIFICATE-----\
@@ -101,6 +102,7 @@ TEST_F(TestTLSSocketWrapper, constructor)
 TEST_F(TestTLSSocketWrapper, constructor_hostname)
 {
     TLSSocketWrapper *wrapper2 = new TLSSocketWrapper(transport, "localhost");
+    delete wrapper2;
 }
 
 /* connect */

--- a/UNITTESTS/features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
+++ b/UNITTESTS/features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
@@ -62,5 +62,6 @@ TEST_F(TestWiFiAccessPoint, set_data)
     EXPECT_EQ(testAp.channel, ap1->get_channel());
     EXPECT_EQ(testAp.rssi, ap1->get_rssi());
     EXPECT_EQ(testAp.security, ap1->get_security());
+    delete ap1;
 }
 

--- a/UNITTESTS/stubs/NetworkStack_stub.h
+++ b/UNITTESTS/stubs/NetworkStack_stub.h
@@ -27,9 +27,10 @@ public:
     nsapi_error_t return_value;
     SocketAddress return_socketAddress;
 
-    NetworkStackstub()
+    NetworkStackstub() :
+        return_value(0),
+        return_socketAddress()
     {
-        return_value = 0;
     }
 
     virtual const char *get_ip_address()
@@ -57,6 +58,8 @@ protected:
         if (return_value == NSAPI_ERROR_OK && return_values.front() == NSAPI_ERROR_OK) {
             // Make sure a non-NULL value is returned if error is not expected
             *handle = reinterpret_cast<nsapi_socket_t *>(1234);
+        } else {
+            *handle = NULL;
         }
         return return_value;
     };
@@ -84,6 +87,12 @@ protected:
     virtual nsapi_error_t socket_accept(nsapi_socket_t server,
                                         nsapi_socket_t *handle, SocketAddress *address = 0)
     {
+        if (return_value == NSAPI_ERROR_OK && return_values.front() == NSAPI_ERROR_OK) {
+            // Make sure a non-NULL value is returned if error is not expected
+            *handle = reinterpret_cast<nsapi_socket_t *>(1234);
+        } else {
+            *handle = NULL;
+        }
         return return_value;
     };
     virtual nsapi_size_or_error_t socket_send(nsapi_socket_t handle,

--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -21,6 +21,7 @@ using namespace mbed;
 
 InternetSocket::InternetSocket()
     : _stack(0), _socket(0), _timeout(osWaitForever),
+      _remote_peer(),
       _readers(0), _writers(0),
       _factory_allocated(false)
 {

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -26,6 +26,7 @@
 
 SocketAddress::SocketAddress(nsapi_addr_t addr, uint16_t port)
 {
+    mem_init();
     _ip_address = NULL;
     set_addr(addr);
     set_port(port);
@@ -33,6 +34,7 @@ SocketAddress::SocketAddress(nsapi_addr_t addr, uint16_t port)
 
 SocketAddress::SocketAddress(const char *addr, uint16_t port)
 {
+    mem_init();
     _ip_address = NULL;
     set_ip_address(addr);
     set_port(port);
@@ -40,6 +42,7 @@ SocketAddress::SocketAddress(const char *addr, uint16_t port)
 
 SocketAddress::SocketAddress(const void *bytes, nsapi_version_t version, uint16_t port)
 {
+    mem_init();
     _ip_address = NULL;
     set_ip_bytes(bytes, version);
     set_port(port);
@@ -47,9 +50,17 @@ SocketAddress::SocketAddress(const void *bytes, nsapi_version_t version, uint16_
 
 SocketAddress::SocketAddress(const SocketAddress &addr)
 {
+    mem_init();
     _ip_address = NULL;
     set_addr(addr.get_addr());
     set_port(addr.get_port());
+}
+
+void SocketAddress::mem_init(void)
+{
+    _addr.version = NSAPI_UNSPEC;
+    memset(_addr.bytes, 0, NSAPI_IP_BYTES);
+    _port = 0;
 }
 
 bool SocketAddress::set_ip_address(const char *addr)

--- a/features/netsocket/SocketAddress.h
+++ b/features/netsocket/SocketAddress.h
@@ -178,6 +178,9 @@ public:
 private:
     void _SocketAddress(NetworkStack *iface, const char *host, uint16_t port);
 
+    /** Initialize memory */
+    void mem_init(void);
+
     mutable char *_ip_address;
     nsapi_addr_t _addr;
     uint16_t _port;

--- a/features/netsocket/TLSSocketWrapper.cpp
+++ b/features/netsocket/TLSSocketWrapper.cpp
@@ -99,6 +99,8 @@ nsapi_error_t TLSSocketWrapper::set_root_ca_cert(const void *root_ca, size_t len
     if ((ret = mbedtls_x509_crt_parse(crt, static_cast<const unsigned char *>(root_ca),
                                       len)) != 0) {
         print_mbedtls_error("mbedtls_x509_crt_parse", ret);
+        mbedtls_x509_crt_free(crt);
+        delete crt;
         return NSAPI_ERROR_PARAMETER;
     }
     set_ca_chain(crt);
@@ -130,12 +132,16 @@ nsapi_error_t TLSSocketWrapper::set_client_cert_key(const void *client_cert, siz
     if ((ret = mbedtls_x509_crt_parse(crt, static_cast<const unsigned char *>(client_cert),
                                       client_cert_len)) != 0) {
         print_mbedtls_error("mbedtls_x509_crt_parse", ret);
+        mbedtls_x509_crt_free(crt);
+        delete crt;
         return NSAPI_ERROR_PARAMETER;
     }
     mbedtls_pk_init(&_pkctx);
     if ((ret = mbedtls_pk_parse_key(&_pkctx, static_cast<const unsigned char *>(client_private_key_pem),
                                     client_private_key_len, NULL, 0)) != 0) {
         print_mbedtls_error("mbedtls_pk_parse_key", ret);
+        mbedtls_x509_crt_free(crt);
+        delete crt;
         return NSAPI_ERROR_PARAMETER;
     }
     set_own_cert(crt);


### PR DESCRIPTION
### Description

Based on valgrind reports running on unit tests a couple of changes were introduced.
Some unit tests and stubs were not deleting allocated objects.
Production code:
* TLSSocketWrapper frees allocated cert buffer in case of error from mbedtls,
* nsapi_addr has a mem_init() function, initializing all of its memory.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@JuhPuur 
@VeijoPesonen 
@mtomczykmobica 
@tymoteuszblochmobica 