### PR TITLE
BLE: fixed initialisation order in GattServer

### DIFF
--- a/features/FEATURE_BLE/ble/GattServer.h
+++ b/features/FEATURE_BLE/ble/GattServer.h
@@ -196,9 +196,9 @@ protected:
      * Construct a GattServer instance.
      */
     GattServer() :
+        eventHandler(NULL),
         serviceCount(0),
         characteristicCount(0),
-        eventHandler(NULL),
         dataSentCallChain(),
         dataWrittenCallChain(),
         dataReadCallChain(),


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixed member initialisation order which will result in a warning or even error depending on compiler.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@donatieng 

<!--
    Optional
    Request additional reviewers with @username
-->