### PR TITLE
Add config header to assembly compilation

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -473,14 +473,13 @@ class ARMC6(ARM_STD):
     def get_compile_options(self, defines, includes, for_asm=False):
         opts = ['-D%s' % d for d in defines]
         opts.extend(["-I%s" % i for i in includes if i])
+        config_header = self.get_config_header()
+        if config_header:
+            opts.extend(self.get_config_option(config_header))
         if for_asm:
             return ["--cpreproc",
                     "--cpreproc_opts=%s" % ",".join(self.flags['common'] + opts)]
-        else:
-            config_header = self.get_config_header()
-            if config_header:
-                opts.extend(self.get_config_option(config_header))
-            return opts
+        return opts
 
     @hook_tool
     def assemble(self, source, object, includes):


### PR DESCRIPTION
### Description
Add missing config header for assembly file in ARMC6.
This Fixes an inconsistency between toolchains
GCC and ARMC5 are already doing this
IAR has a solution implemented as well
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy @deepikabhavnani @mikisch81 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
