### PR TITLE
Remove ITM from NRF52_DK and DELTA_DFBM_NQ620 targets

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/README.md
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/README.md
@@ -153,6 +153,16 @@ The assert handler is defined in mbed-os/features/FEATURE_BLE/targets/TARGET_NOR
  * It is not possible to do an asynchronous write from flash and receive non-asynchronously at the same time since the non-asynchronous receive buffer is being used as the temporary transmission buffer.
  * The driver will flush the DMA buffer after a configurable timeout. During this process the UART will be halted and therefor unable to receive data. Hardware flow control should be enabled to avoid missing any data during this window.
 
+#### Serial Wire Output (SWO)
+
+On the nRF52832 pin 18 (p18 or p0_18) is the SWO pin and a GPIO pin.  On the nRF52_DK and DELTA_DFBM_NQ620 targets p18 is also mapped to LED2, so the ITM has been removed from these targets to avoid contention.  If you need SWO capability instead of LED2, add the ITM through ```mbed_app.json```:
+```
+    "target_overrides": {
+        "*": {
+            "target.device_has_add": ["ITM"]
+        }
+    }
+```
 
 ## SoftDevice
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6791,7 +6791,8 @@
         "device_name": "nRF52832_xxAA",
         "macros_add": [
             "WSF_MAX_HANDLERS=10"
-        ]
+        ],
+        "device_has_remove": ["ITM"]
     },
     "SDT52832B": {
         "inherits": ["MCU_NRF52832"],
@@ -6835,7 +6836,8 @@
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52832"],
         "release_versions": ["5"],
-        "device_name": "nRF52832_xxAA"
+        "device_name": "nRF52832_xxAA",
+        "device_has_remove": ["ITM"]
     },
     "MCU_NRF52840": {
         "inherits": ["Target"],


### PR DESCRIPTION
The NRF52_DK and DELTA_DFBM_NQ620 have the SWO pin (p0_18) mapped to LED2. This means that on startup LED2 turns on after the ITM is initialized which is confusing. Since most users want LED2 usage
instead of SWO we remove the ITM for these targets.

The nRF52 readme is updated to instruct users how to get SWO support if they need it.

This addresses https://github.com/ARMmbed/mbed-os/issues/9695

### Description

By default LED2 is now off on startup and ITM/SWO functionality can be regained by bringing in ITM through mbed_app.json as documented in updated nRF52 readme:  

```
    "target_overrides": {
        "*": {
            "target.device_has_add": ["ITM"]
        }
    }
```

Tested that LED2 is now off on entry to main() and SWO capability can be brought back in through ```mbed_app.json```.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@dlfryar @pan- 

