### PR TITLE
PSOC6: fix port_write API

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/port_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/port_api.c
@@ -109,8 +109,8 @@ void port_write(port_t *obj, int value)
         for (pin = 0; pin < 8; ++pin) {
             if (obj->mask & (1 << pin)) {
                 Cy_GPIO_Write(obj->port, pin, value & 0x1);
-                value >>= 1;
             }
+            value >>= 1;
         }
     }
 }

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/port_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/port_api.c
@@ -105,8 +105,8 @@ void port_write(port_t *obj, int value)
         for (pin = 0; pin < 8; ++pin) {
             if (obj->mask & (1 << pin)) {
                 Cy_GPIO_Write(obj->port, pin, value & 0x1);
-                value >>= 1;
             }
+            value >>= 1;
         }
     }
 }


### PR DESCRIPTION
### Description

Fix port_write API to correctly shift the passed value.
This allows the reference application provided in PortOut docs
to work corectly with arbitrary LED_MASK.
https://os.mbed.com/docs/mbed-os/v5.11/apis/portout.html

The fix applies to both PSOC6 and PSOC6_FUTURE HAL implementations.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@lrusinowicz 

### Release Notes

