### PR TITLE
adv builder helper now returns an object

### DIFF
--- a/features/FEATURE_BLE/ble/gap/AdvertisingDataSimpleBuilder.h
+++ b/features/FEATURE_BLE/ble/gap/AdvertisingDataSimpleBuilder.h
@@ -158,6 +158,7 @@ public:
     AdvertisingDataSimpleBuilder &setAdvertisingInterval(adv_interval_t interval)
     {
         MBED_ASSERT(_builder.setAdvertisingInterval(interval) == BLE_ERROR_NONE);
+        return *this;
     }
 
     /**


### PR DESCRIPTION
### Description

Fix the setAdvertisingInterval helper function (Advertising example was not compiling.) This fixes a method that was not used/referenced elsewhere and was brought in via a not used header file.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@pan- 


### Release Notes

