### PR TITLE
Add missing wifi parameters to test configs

### DIFF
--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -21,7 +21,7 @@
 #error [NOT_SUPPORTED] No network configuration found for this target.
 #endif
 #ifndef MBED_CONF_APP_ECHO_SERVER_ADDR
-#error [NOT_SUPPORTED] Requires parameters from mbed_app.json
+#error [NOT_SUPPORTED] Requires echo-server-discard-port parameter from mbed_app.json
 #endif
 
 #include "mbed.h"

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -2,15 +2,42 @@
     "name": "nsapi",
     "config": {
         "present": 1,
-        "default-stack": "LWIP",
-        "default-wifi-ssid": null,
-        "default-wifi-password": null,
-        "default-wifi-security": "NONE",
-        "default-cellular-plmn": null,
-        "default-cellular-sim-pin": null,
-        "default-cellular-apn": null,
-        "default-cellular-username": null,
-        "default-cellular-password": null,
+        "default-stack": {
+            "help" : "Default stack to be used, valid values: LWIP, NANOSTACK.",
+            "value" : "LWIP"
+        },
+        "default-wifi-ssid" : {
+            "help" : "Default wifi SSID.",
+            "value": null
+        },
+        "default-wifi-password" : {
+            "help" : "Password for the default Wifi network.",
+            "value": null
+        },
+        "default-wifi-security" : {
+            "help" : "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2.",
+            "value" : "NONE"
+        },
+        "default-cellular-plmn" : {
+            "help" : "Default Public Land Mobile Network for cellular connection.",
+            "value": null
+        },
+        "default-cellular-sim-pin" : {
+            "help" : "PIN for the default SIM card.",
+            "value": null
+        },
+        "default-cellular-apn" : {
+            "help" : "Default cellular Access Point Name.",
+            "value": null
+        },
+        "default-cellular-username" : {
+            "help" : "Username for the default cellular network.",
+            "value": null
+        },
+        "default-cellular-password" : {
+            "help" : "Password for the default cellular network.",
+            "value": null
+        },
         "default-mesh-type": {
             "help": "Configuration type for MeshInterface::get_default_instance(). [LOWPAN/THREAD]",
             "value": "THREAD"

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -7,15 +7,15 @@
             "value" : "LWIP"
         },
         "default-wifi-ssid" : {
-            "help" : "Default wifi SSID.",
+            "help" : "Default Wi-Fi SSID.",
             "value": null
         },
         "default-wifi-password" : {
-            "help" : "Password for the default Wifi network.",
+            "help" : "Password for the default Wi-Fi network.",
             "value": null
         },
         "default-wifi-security" : {
-            "help" : "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2.",
+            "help" : "Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2.",
             "value" : "NONE"
         },
         "default-cellular-plmn" : {

--- a/tools/test_configs/ESP8266Interface.json
+++ b/tools/test_configs/ESP8266Interface.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "wifi-secure-ssid": {
-            "help": "WiFi SSID for WPA2 secured network",
+            "help": "Wi-Fi SSID for WPA2 secured network",
             "value": "\"WIFI_SSID_SECURED\""
         },
         "wifi-unsecure-ssid": {
-            "help": "WiFi SSID for unsecure netwrok",
+            "help": "Wi-Fi SSID for unsecure netwrok",
             "value": "\"WIFI_SSID_UNSECURE\""
         },
         "wifi-password": {
-            "help": "WiFi Password",
+            "help": "Wi-Fi Password",
             "value": "\"WIFI_PASSWORD\""
         },
         "wifi-secure-protocol": {
-            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "help": "Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
             "value": "\"WPA2\""
         },
         "wifi-ch-secure": {

--- a/tools/test_configs/ESP8266Interface.json
+++ b/tools/test_configs/ESP8266Interface.json
@@ -1,5 +1,41 @@
 {
     "config": {
+        "wifi-secure-ssid": {
+            "help": "WiFi SSID for WPA2 secured network",
+            "value": "\"WIFI_SSID_SECURED\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "WiFi SSID for unsecure netwrok",
+            "value": "\"WIFI_SSID_UNSECURE\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"WIFI_PASSWORD\""
+        },
+        "wifi-secure-protocol": {
+            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "value": "\"WPA2\""
+        },
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": null
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": null
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
+        },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
             "value" : "\"echo.mbedcloudtesting.com\""
@@ -26,7 +62,7 @@
             "target.network-default-interface-type": "WIFI",
             "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
             "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
-            "nsapi.default-wifi-security": "WIFI_SECURITY",
+            "nsapi.default-wifi-security": "WPA2",
             "esp8266.provide-default": true
         }
     }

--- a/tools/test_configs/HeapBlockDeviceAndWifiInterface.json
+++ b/tools/test_configs/HeapBlockDeviceAndWifiInterface.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "wifi-secure-ssid": {
-            "help": "WiFi SSID for WPA2 secured network",
+            "help": "Wi-Fi SSID for WPA2 secured network",
             "value": "\"WIFI_SSID_SECURED\""
         },
         "wifi-unsecure-ssid": {
-            "help": "WiFi SSID for unsecure netwrok",
+            "help": "Wi-Fi SSID for unsecure netwrok",
             "value": "\"WIFI_SSID_UNSECURE\""
         },
         "wifi-password": {
-            "help": "WiFi Password",
+            "help": "Wi-Fi Password",
             "value": "\"WIFI_PASSWORD\""
         },
         "wifi-secure-protocol": {
-            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "help": "Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
             "value": "\"WPA2\""
         },
         "wifi-ch-secure": {

--- a/tools/test_configs/HeapBlockDeviceAndWifiInterface.json
+++ b/tools/test_configs/HeapBlockDeviceAndWifiInterface.json
@@ -1,5 +1,41 @@
 {
     "config": {
+        "wifi-secure-ssid": {
+            "help": "WiFi SSID for WPA2 secured network",
+            "value": "\"WIFI_SSID_SECURED\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "WiFi SSID for unsecure netwrok",
+            "value": "\"WIFI_SSID_UNSECURE\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"WIFI_PASSWORD\""
+        },
+        "wifi-secure-protocol": {
+            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "value": "\"WPA2\""
+        },
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": null
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": null
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
+        },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
             "value" : "\"echo.mbedcloudtesting.com\""
@@ -31,7 +67,7 @@
             "target.network-default-interface-type": "WIFI",
             "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
             "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
-            "nsapi.default-wifi-security": "WIFI_SECURITY"
+            "nsapi.default-wifi-security": "WPA2"
         }
     }
 }

--- a/tools/test_configs/ISM43362Interface.json
+++ b/tools/test_configs/ISM43362Interface.json
@@ -1,5 +1,41 @@
 {
     "config": {
+        "wifi-secure-ssid": {
+            "help": "WiFi SSID for WPA2 secured network",
+            "value": "\"WIFI_SSID_SECURE\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "WiFi SSID for unsecure netwrok",
+            "value": "\"WIFI_SSID_UNSECURE\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"WIFI_PASSWORD\""
+        },
+        "wifi-secure-protocol": {
+            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "value": "\"WPA2\""
+        },
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": null
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": null
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
+        },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
             "value" : "\"echo.mbedcloudtesting.com\""
@@ -19,42 +55,6 @@
         "echo-server-discard-port-tls" : {
             "help" : "Discard port of echo server for TLS",
             "value" : "2009"
-        },
-        "wifi-secure-ssid": {
-            "help": "WiFi SSID for WPA2 secured network",
-            "value": "\"SSID-SECURE\""
-        },
-        "wifi-unsecure-ssid": {
-            "help": "WiFi SSID for unsecure network",
-            "value": "\"SSID-UNSECURE\""
-        },
-        "wifi-password": {
-            "help": "WiFi Password",
-            "value": "\"PASSWORD\""
-        },
-        "wifi-secure-protocol": {
-            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2",
-            "value": "\"WPA2\""
-        },
-        "wifi-ch-secure": {
-            "help": "Channel number of secure SSID",
-            "value": 1
-        },
-        "wifi-ch-unsecure": {
-            "help": "Channel number of unsecure SSID",
-            "value": 2
-        },
-        "ap-mac-secure": {
-            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
-            "value": "\"AA:AA:AA:AA:AA:AA\""
-        },
-        "ap-mac-unsecure": {
-            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
-            "value": "\"BB:BB:BB:BB:BB:BB\""
-        },
-        "max-scan-size": {
-            "help": "How many networks may appear in Wifi scan result",
-            "value": 10
         }
     },
     "target_overrides": {
@@ -63,7 +63,7 @@
             "target.network-default-interface-type": "WIFI",
             "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
             "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
-            "nsapi.default-wifi-security": "WIFI_SECURITY",
+            "nsapi.default-wifi-security": "WPA2",
             "ism43362.provide-default": true
         }
     }

--- a/tools/test_configs/ISM43362Interface.json
+++ b/tools/test_configs/ISM43362Interface.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "wifi-secure-ssid": {
-            "help": "WiFi SSID for WPA2 secured network",
+            "help": "Wi-Fi SSID for WPA2 secured network",
             "value": "\"WIFI_SSID_SECURE\""
         },
         "wifi-unsecure-ssid": {
-            "help": "WiFi SSID for unsecure netwrok",
+            "help": "Wi-Fi SSID for unsecure netwrok",
             "value": "\"WIFI_SSID_UNSECURE\""
         },
         "wifi-password": {
-            "help": "WiFi Password",
+            "help": "Wi-Fi Password",
             "value": "\"WIFI_PASSWORD\""
         },
         "wifi-secure-protocol": {
-            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "help": "Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
             "value": "\"WPA2\""
         },
         "wifi-ch-secure": {

--- a/tools/test_configs/SpwfSAInterface.json
+++ b/tools/test_configs/SpwfSAInterface.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "wifi-secure-ssid": {
-            "help": "WiFi SSID for WPA2 secured network",
+            "help": "Wi-Fi SSID for WPA2 secured network",
             "value": "\"WIFI_SSID_SECURE\""
         },
         "wifi-unsecure-ssid": {
-            "help": "WiFi SSID for unsecure netwrok",
+            "help": "Wi-Fi SSID for unsecure netwrok",
             "value": "\"WIFI_SSID_UNSECURE\""
         },
         "wifi-password": {
-            "help": "WiFi Password",
+            "help": "Wi-Fi Password",
             "value": "\"WIFI_PASSWORD\""
         },
         "wifi-secure-protocol": {
-            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "help": "Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
             "value": "\"WPA2\""
         },
         "wifi-ch-secure": {

--- a/tools/test_configs/SpwfSAInterface.json
+++ b/tools/test_configs/SpwfSAInterface.json
@@ -1,5 +1,41 @@
 {
     "config": {
+        "wifi-secure-ssid": {
+            "help": "WiFi SSID for WPA2 secured network",
+            "value": "\"WIFI_SSID_SECURE\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "WiFi SSID for unsecure netwrok",
+            "value": "\"WIFI_SSID_UNSECURE\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"WIFI_PASSWORD\""
+        },
+        "wifi-secure-protocol": {
+            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "value": "\"WPA2\""
+        },
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": null
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": null
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
+        },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
             "value" : "\"echo.mbedcloudtesting.com\""
@@ -34,7 +70,7 @@
             "target.network-default-interface-type": "WIFI",
             "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
             "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
-            "nsapi.default-wifi-security": "WIFI_SECURITY",
+            "nsapi.default-wifi-security": "WPA2",
             "idw0xx1.provide-default": true
         }
     }


### PR DESCRIPTION
### Description

The point is to follow the configs as described in the [documentation ](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md).

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 