### PR TITLE
PSOC6: correctly align hex files with split text sections

### DIFF
--- a/tools/targets/PSOC6.py
+++ b/tools/targets/PSOC6.py
@@ -96,7 +96,7 @@ def patch(message_func, ihex, hexf, align=256):
             aligned_end += align
             message_func("Aligning end from 0x%x to 0x%x" % (end, aligned_end))
             alignments.frombytes(ihex.tobinarray(end, aligned_end - 1), end)
-    ihex.merge(alignments)
+    ihex.merge(alignments, 'ignore')
 
 def merge_images(hexf0, hexf1=None):
     ihex = IntelHex()


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
When the original PSOC6 CM4 hex file contains unalinged text sections
that span through multiple intelhex segments, aligned segments (filled
with zeroes) overlap with the original data segments, resulting in
error thrown by ihex.merge(alignments, overlap='error').
Such hex file can be produced when the ELF is built with ARM MDK Compiler
with --split_sections option:
http://www.keil.com/support/man/docs/armcc/armcc_chr1359124944914.htm

Change the merge strategy to overlap='ignore', so that the overlapping
zero-filled segments are skipped.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update1
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
