### PR TITLE
Adding RHOMBIO_L476DMW1K as a new Board target

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
@@ -1,0 +1,98 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2015, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_PERIPHERALNAMES_H
+#define MBED_PERIPHERALNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ADC_1 = (int)ADC1_BASE,
+    ADC_2 = (int)ADC2_BASE,
+    ADC_3 = (int)ADC3_BASE
+} ADCName;
+
+typedef enum {
+    DAC_1 = (int)DAC_BASE
+} DACName;
+
+typedef enum {
+    UART_1 = (int)USART1_BASE,
+    UART_2 = (int)USART2_BASE,
+    UART_3 = (int)USART3_BASE,
+    UART_4 = (int)UART4_BASE,
+    UART_5 = (int)UART5_BASE,
+    LPUART_1 = (int)LPUART1_BASE
+} UARTName;
+
+//#define STDIO_UART_TX  PA_2
+//#define STDIO_UART_RX  PA_3
+//#define STDIO_UART     UART_2
+
+typedef enum {
+    SPI_1 = (int)SPI1_BASE,
+    SPI_2 = (int)SPI2_BASE,
+    SPI_3 = (int)SPI3_BASE
+} SPIName;
+
+typedef enum {
+    I2C_1 = (int)I2C1_BASE,
+    I2C_2 = (int)I2C2_BASE,
+    I2C_3 = (int)I2C3_BASE
+} I2CName;
+
+typedef enum {
+    PWM_1  = (int)TIM1_BASE,
+    PWM_2  = (int)TIM2_BASE,
+    PWM_3  = (int)TIM3_BASE,
+    PWM_4  = (int)TIM4_BASE,
+    PWM_5  = (int)TIM5_BASE,
+    PWM_8  = (int)TIM8_BASE,
+    PWM_15 = (int)TIM15_BASE,
+    PWM_16 = (int)TIM16_BASE,
+    PWM_17 = (int)TIM17_BASE
+} PWMName;
+
+typedef enum {
+    CAN_1 = (int)CAN1_BASE
+} CANName;
+
+typedef enum {
+    QSPI_1 = (int)QSPI_R_BASE,
+} QSPIName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
@@ -1,4 +1,6 @@
 /* mbed Microcontroller Library
+
+* SPDX-License-Identifier: Apache-2.0
  *******************************************************************************
  * Copyright (c) 2015, STMicroelectronics
  * All rights reserved.

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
@@ -1,7 +1,7 @@
 /* mbed Microcontroller Library
-
-* SPDX-License-Identifier: Apache-2.0
- *******************************************************************************
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ********************************************************1***********************
  * Copyright (c) 2015, STMicroelectronics
  * All rights reserved.
  *
@@ -56,10 +56,6 @@ typedef enum {
     UART_5 = (int)UART5_BASE,
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
-
-//#define STDIO_UART_TX  PA_2
-//#define STDIO_UART_RX  PA_3
-//#define STDIO_UART     UART_2
 
 typedef enum {
     SPI_1 = (int)SPI1_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralPins.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
-
-* SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *******************************************************************************
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralPins.c
@@ -1,4 +1,6 @@
 /* mbed Microcontroller Library
+
+* SPDX-License-Identifier: Apache-2.0
  *******************************************************************************
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralPins.c
@@ -1,0 +1,380 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+
+#include "PeripheralPins.h"
+#include "mbed_toolchain.h"
+
+//==============================================================================
+// Notes
+//
+// - The pins mentioned Px_y_ALTz are alternative possibilities which use other
+//   HW peripheral instances. You can use them the same way as any other "normal"
+//   pin (i.e. PwmOut pwm(PA_7_ALT0);). These pins are not displayed on the board
+//   pinout image on mbed.org.
+//
+// - The pins which are other components present on the board have
+//   the comment "Connected to xxx". The pin function may not work properly in this
+//   case. These pins may not be displayed on the board pinout image on mbed.org.
+//   Please read the board reference manual and schematic for more information.
+//
+// - Warning: pins the default STDIO_UART_TX and STDIO_UART_RX pins are commented
+//   See https://os.mbed.com/teams/ST/wiki/STDIO for more information.
+//
+//==============================================================================
+
+
+//*** ADC ***
+
+MBED_WEAK const PinMap PinMap_ADC[] = {
+    {PA_0,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 5, 0)},  // ADC1_IN5  // rhomb.io AD0
+    {PA_0_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 5, 0)},  // ADC2_IN5  // rhomb.io AD0 
+    {PA_1,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 6, 0)},  // ADC1_IN6  // rhomb.io AD1
+    {PA_1_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 6, 0)},  // ADC2_IN6  // rhomb.io AD1
+    {PA_2,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 7, 0)},  // ADC1_IN7  // rhomb.io UART-A_TXD
+    {PA_2_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 7, 0)},  // ADC2_IN7  // rhomb.io UART-A_TXD
+    {PA_3,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 8, 0)},  // ADC1_IN8  // rhomb.io UART-A_RXD
+    {PA_3_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 8, 0)},  // ADC2_IN8  // rhomb.io UART-A_RXD
+    {PA_4,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 9, 0)},  // ADC1_IN9  // rhomb.io AD2
+    {PA_4_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 9, 0)},  // ADC2_IN9  // rhomb.io AD2
+    {PA_5,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 10, 0)}, // ADC1_IN10 // rhomb.io SPIA_CLK
+    {PA_5_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 10, 0)}, // ADC2_IN10 // rhomb.io SPIA_CLK 
+    {PA_6,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 11, 0)}, // ADC1_IN11 // rhomb.io SPIA_MISO
+    {PA_6_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 11, 0)}, // ADC2_IN11 // rhomb.io SPIA_MISO
+    {PA_7,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 12, 0)}, // ADC1_IN12 // rhomb.io SPIA_MOSI
+    {PA_7_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 12, 0)}, // ADC2_IN12 // rhomb.io SPIA_MOSI 
+    {PB_0,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 15, 0)}, // ADC1_IN15 // rhomb.io AD3
+    {PB_0_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 15, 0)}, // ADC2_IN15 // rhomb.io AD3
+    {PB_1,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 16, 0)}, // ADC1_IN16 // rhomb.io NMI
+    {PB_1_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 16, 0)}, // ADC2_IN16 // rhomb.io NMI
+    {PC_0,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 1, 0)},  // ADC1_IN1  // rhomb.io AD5
+    {PC_0_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 1, 0)},  // ADC2_IN1  // rhomb.io AD5 
+    {PC_0_ALT1,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 1, 0)},  // ADC3_IN1  // rhomb.io AD5
+    {PC_1,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 2, 0)},  // ADC1_IN2  // rhomb.io AD4
+    {PC_1_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 2, 0)},  // ADC2_IN2  // rhomb.io AD4 
+    {PC_1_ALT1,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 2, 0)},  // ADC3_IN2  // rhomb.io AD4 
+    {PC_2,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 3, 0)},  // ADC1_IN3  // rhomb.io CAPT1 (R19 must be populated)
+    {PC_2_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 3, 0)},  // ADC2_IN3  // rhomb.io CAPT1 (R19 must be populated) 
+    {PC_2_ALT1,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 3, 0)},  // ADC3_IN3  // rhomb.io CAPT1 (R19 must be populated) 
+    {PC_3,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 4, 0)},  // ADC1_IN4  // rhomb.io CAPT0 (R18 must be populated)
+    {PC_3_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 4, 0)},  // ADC2_IN4  // rhomb.io CAPT0 (R18 must be populated)
+    {PC_3_ALT1,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 4, 0)},  // ADC3_IN4  // rhomb.io CAPT0 (R18 must be populated) 
+    {PC_4,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 13, 0)}, // ADC1_IN13 // rhomb.io AD8
+    {PC_4_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 13, 0)}, // ADC2_IN13 // rhomb.io AD8 
+    {PC_5,       ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 14, 0)}, // ADC1_IN14 // rhomb.io AD7
+    {PC_5_ALT0,  ADC_2, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 14, 0)}, // ADC2_IN14 // rhomb.io AD7 
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_ADC_Internal[] = {
+    {ADC_TEMP,   ADC_1,    STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)},
+    {ADC_VREF,   ADC_1,    STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,  0, 0)},
+    {ADC_VBAT,   ADC_1,    STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)},
+    {NC, NC, 0}
+};
+
+//*** DAC ***
+
+MBED_WEAK const PinMap PinMap_DAC[] = {
+    {PA_4,       DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 1, 0)}, // DAC1_OUT1 // rhomb.io AD2
+    {PA_5,       DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 2, 0)}, // DAC1_OUT2 // rhomb.io SPIA_CLK
+    {NC, NC, 0}
+};
+
+//*** I2C ***
+
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
+    {PB_7,       I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)}, // rhomb.io INT1
+    {PB_9,       I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)}, // rhomb.io I2C-A_SDA // Connected to ATECC608A
+    {PB_11,      I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C2)}, // rhomb.io QSPI_CS0 /
+    {PB_14,      I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C2)}, // rhomb.io SPI-A_CS1
+    {PC_1,       I2C_3, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C3)}, // rhomb.io AD4
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
+    {PB_6,       I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)}, // rhomb.io SPI-A_CS0
+    {PB_8,       I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)}, // rhomb.io I2C-A_SCL // Connected to ATECC608A
+    {PB_10,      I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C2)}, // rhomb.io IO2
+    {PB_13,      I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C2)}, // rhomb.io SPI-A_CS2
+    {PC_0,       I2C_3, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C3)}, // rhomb.io AD5
+    {NC, NC, 0}
+};
+
+//*** PWM ***
+
+// TIM5 cannot be used because already used by the us_ticker
+MBED_WEAK const PinMap PinMap_PWM[] = {
+    {PA_0,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 1, 0)},   // TIM2_CH1   // rhomb.io AD0
+//  {PA_0,       PWM_5,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM5, 1, 0)},   // TIM5_CH1   // rhomb.io AD0
+    {PA_1,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 2, 0)},   // TIM2_CH2   // rhomb.io AD1
+//  {PA_1,       PWM_5,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM5, 2, 0)},   // TIM5_CH2   // rhomb.io AD1
+    {PA_1_ALT0,  PWM_15, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM15, 1, 1)}, // TIM15_CH1N // rhomb.io AD1
+    {PA_2,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 3, 0)},   // TIM2_CH3   // rhomb.io UART-A_TXD
+//  {PA_2,       PWM_5,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM5, 3, 0)},   // TIM5_CH3   // rhomb.io UART-A_TXD
+    {PA_2_ALT0,  PWM_15, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM15, 1, 0)}, // TIM15_CH1  // rhomb.io UART-A_TXD
+    {PA_3,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 4, 0)},   // TIM2_CH4   // rhomb.io UART-A_RXD
+//  {PA_3,       PWM_5,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM5, 4, 0)},   // TIM5_CH4   // rhomb.io UART-A_RXD
+    {PA_3_ALT0,  PWM_15, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM15, 2, 0)}, // TIM15_CH2  // rhomb.io UART-A_RXD
+    {PA_5,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 1, 0)},   // TIM2_CH1   // rhomb.io SPI-A_CLK
+    {PA_5_ALT0,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 1, 1)},   // TIM8_CH1N  // rhomb.io SPI-A_CLK
+    {PA_6,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 1, 0)},   // TIM3_CH1   // rhomb.io SPI-A_MISO 
+    {PA_6_ALT0,  PWM_16, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM16, 1, 0)}, // TIM16_CH1  // rhomb.io SPI-A_MISO 
+    {PA_7,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 1, 1)},   // TIM1_CH1N  // rhomb.io SPI-A_MOSI 
+    {PA_7_ALT0,  PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 2, 0)},   // TIM3_CH2   // rhomb.io SPI-A_MOSI 
+    {PA_7_ALT1,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 1, 1)},   // TIM8_CH1N  // rhomb.io SPI-A_MOSI 
+    {PA_7_ALT2,  PWM_17, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM17, 1, 0)}, // TIM17_CH1  // rhomb.io SPI-A_MOSI 
+    {PA_8,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 1, 0)},   // TIM1_CH1   // rhomb.io IO3
+    {PA_9,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 2, 0)},   // TIM1_CH2   // rhomb.io IO4
+    {PA_10,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 3, 0)},   // TIM1_CH3   // rhomb.io OTG_ID
+    {PA_11,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 4, 0)},   // TIM1_CH4   // rhomb.io OTG_N 
+    {PA_15,      PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 1, 0)},   // TIM2_CH1   // rhomb.io INT2 
+    {PB_0,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 2, 1)},   // TIM1_CH2N  // rhomb.io AD3  
+    {PB_0_ALT0,  PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 3, 0)},   // TIM3_CH3   // rhomb.io AD3 
+    {PB_0_ALT1,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 2, 1)},   // TIM8_CH2N  // rhomb.io AD3 
+    {PB_1,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 3, 1)},   // TIM1_CH3N  // rhomb.io NMI
+    {PB_1_ALT0,  PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 4, 0)},   // TIM3_CH4   // rhomb.io NMI
+    {PB_1_ALT1,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 3, 1)},   // TIM8_CH3N  // rhomb.io NMI
+    {PB_3,       PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 2, 0)},   // TIM2_CH2   // rhomb.io INT0
+    {PB_4,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 1, 0)},   // TIM3_CH1   // rhomb.io IO1
+    {PB_5,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 2, 0)},   // TIM3_CH2   // rhomb.io IO0
+    {PB_6,       PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 1, 0)},   // TIM4_CH1   // rhomb.io SPI-A_CS0
+    {PB_6_ALT0,  PWM_16, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM16, 1, 1)}, // TIM16_CH1N // rhomb.io SPI-A_CS0
+    {PB_7,       PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 2, 0)},   // TIM4_CH2   // rhomb.io INT1
+    {PB_7_ALT0,  PWM_17, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM17, 1, 1)}, // TIM17_CH1N // rhomb.io INT1
+    {PB_8,       PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 3, 0)},   // TIM4_CH3   // rhomb.io I2C-A_SCL
+    {PB_8_ALT0,  PWM_16, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM16, 1, 0)}, // TIM16_CH1  // rhomb.io I2C-A_SCL
+    {PB_9,       PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 4, 0)},   // TIM4_CH4   // rhomb.io I2C-A_SDA
+    {PB_9_ALT0,  PWM_17, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM17, 1, 0)}, // TIM17_CH1  // rhomb.io I2C-A_SDA
+    {PB_10,      PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 3, 0)},   // TIM2_CH3   // rhomb.io IO2
+    {PB_11,      PWM_2,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM2, 4, 0)},   // TIM2_CH4   // rhomb.io QSPI_CS0
+    {PB_13,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 1, 1)},   // TIM1_CH1N  // rhomb.io SPI-A_CS2
+    {PB_13_ALT0, PWM_15, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM15, 1, 1)}, // TIM15_CH1N // rhomb.io SPI-A_CS2
+    {PB_14,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 2, 1)},   // TIM1_CH2N  // rhomb.io SPI-A_CS1
+    {PB_14_ALT0, PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 2, 1)},   // TIM8_CH2N  // rhomb.io SPI-A_CS1
+    {PB_14_ALT1, PWM_15, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM15, 1, 0)}, // TIM15_CH1  // rhomb.io SPI-A_CS1
+    {PB_15,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 3, 1)},   // TIM1_CH3N  // rhomb.io IO7
+    {PB_15_ALT0, PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 3, 1)},   // TIM8_CH3N  // rhomb.io IO7
+    {PB_15_ALT1, PWM_15, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM15, 2, 0)}, // TIM15_CH2  // rhomb.io IO7
+    {PC_6,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 1, 0)},   // TIM3_CH1  // rhomb.io PWM3
+    {PC_6_ALT0,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 1, 0)},   // TIM8_CH1  // rhomb.io PWM3
+    {PC_7,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 2, 0)},   // TIM3_CH2  // rhomb.io PWM0
+    {PC_7_ALT0,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 2, 0)},   // TIM8_CH2  // rhomb.io PWM0
+    {PC_8,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 3, 0)},   // TIM3_CH3  // rhomb.io SDIO_DATA0
+    {PC_8_ALT0,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 3, 0)},   // TIM8_CH3  // rhomb.io SDIO_DATA0
+    {PC_9,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 4, 0)},   // TIM3_CH4  // rhomb.io SDIO_DATA1
+    {PC_9_ALT0,  PWM_8,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF3_TIM8, 4, 0)},   // TIM8_CH4  // rhomb.io SDIO_DATA1
+    {PD_12,      PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 1, 0)},   // TIM4_CH1  // rhomb.io IO12
+    {PD_13,      PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 2, 0)},   // TIM4_CH2  // rhomb.io IO13
+    {PD_14,      PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 3, 0)},   // TIM4_CH3  // rhomb.io PWM2
+    {PD_15,      PWM_4,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM4, 4, 0)},   // TIM4_CH4  // rhomb.io SDIO_CDN
+    {PE_0,       PWM_16, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM16, 1, 0)}, // TIM16_CH1 // rhomb.io RESET_OUT
+    {PE_1,       PWM_17, STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF14_TIM17, 1, 0)}, // TIM17_CH1 // rhomb.io USB_SWITCH
+    {PE_3,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 1, 0)},   // TIM3_CH1  // rhomb.io SAI-A_SDO
+    {PE_4,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 2, 0)},   // TIM3_CH2  // rhomb.io SAI-A_LRCLK
+    {PE_5,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 3, 0)},   // TIM3_CH3  // rhomb.io SAI-A_BCLK
+    {PE_6,       PWM_3,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM3, 4, 0)},   // TIM3_CH4  // rhomb.io SAI-A_SDI
+    {PE_8,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 1, 1)},   // TIM1_CH1N // rhomb.io IO5
+    {PE_9,       PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 1, 0)},   // TIM1_CH1  // rhomb.io PWM1
+    {PE_10,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 2, 1)},   // TIM1_CH2N // rhomb.io QSPI_CLK
+    {PE_11,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 2, 0)},   // TIM1_CH2  // rhomb.io QSPI_MEM_CS
+    {PE_12,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 3, 1)},   // TIM1_CH3N // rhomb.io QSPI_IO0
+    {PE_13,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 3, 0)},   // TIM1_CH3  // rhomb.io QSPI_IO1
+    {PE_14,      PWM_1,  STM_PIN_DATA_EXT(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF1_TIM1, 4, 0)},   // TIM1_CH4  // rhomb.io QSPI_IO2
+    {NC, NC, 0}
+};
+
+//*** SERIAL ***
+
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
+    {PA_0,       UART_4,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART4)},    // rhomb.io AD0
+    {PA_2,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io UART-A_TXD
+    {PA_9,       UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io IO4
+    {PB_6,       UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io SPI-A_CS0 
+    {PB_10,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io IO2
+    {PB_11,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_LPUART1)}, // rhomb.io QSPI_CS0 
+    {PC_1,       LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_LPUART1)}, // rhomb.io AD4
+    {PC_4,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io COMP-A_N
+    {PC_10,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SDIO_DATA2
+    {PC_10_ALT0, UART_4,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART4)},    // rhomb.io SDIO_DATA2
+    {PC_12,      UART_5,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART5)},    // rhomb.io SDIO_CLK
+    {PD_5,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io UART-B_TXD
+    {PD_8,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io UART-C_TXD
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
+    {PA_1,       UART_4,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART4)},    // rhomb.io AD1
+    {PA_3,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io UART-A_RXD
+    {PA_10,      UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io OTG_ID
+    {PB_7,       UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io INT1
+    {PB_10,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_LPUART1)}, // rhomb.io IO2
+    {PB_11,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SPI_CS0
+    {PC_0,       LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_LPUART1)}, // rhomb.io AD5
+    {PC_5,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io COMP-A_P
+    {PC_11,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SDIO_DATA3
+    {PC_11_ALT0, UART_4,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART4)},    // rhomb.io SDIO_DATA3
+    {PD_2,       UART_5,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART5)},    // rhomb.io SDIO_CMD
+    {PD_6,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io UART-B_RXD
+    {PD_9,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io UART-C_RXD
+    {NC, NC, 0}
+};
+ 
+MBED_WEAK const PinMap PinMap_UART_RTS[] = {
+    {PA_1,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io AD1
+    {PA_12,      UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io OTG_P
+    {PA_15,      UART_4,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART4)},    // rhomb.io INT2
+    {PB_1,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io NMI
+    {PB_3,       UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io INT0
+    {PB_4,       UART_5,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART5)},    // rhomb.io IO1
+    {PB_12,      LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_LPUART1)}, // rhomb.io 1WIRE // Connected to DS28E05X
+    {PB_14,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SPI-A_CS1
+    {PD_2,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SDIO_CMD
+    {PD_4,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io UART-A_RTS
+    {PD_12,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io IO12
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_UART_CTS[] = {
+    {PA_0,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io AD0
+    {PA_6,       UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SPI-A_MISO
+    {PA_11,      UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io OTG_N
+    {PB_4,       UART_1,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},   // rhomb.io IO1
+    {PB_5,       UART_5,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART5)},    // rhomb.io IO0
+    {PB_7,       UART_4,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_UART4)},    // rhomb.io INT1
+    {PB_13,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io SPI-A_CS2
+    {PB_13_ALT0, LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF8_LPUART1)}, // rhomb.io SPI-A_CS2
+    {PD_3,       UART_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},   // rhomb.io UART-A_CTS
+    {PD_11,      UART_3,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART3)},   // rhomb.io IO11
+    {NC, NC, 0}
+};
+
+//*** SPI ***
+
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
+    {PA_7,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io SPI-A_MOSI
+    {PB_5,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io IO0
+    {PB_5_ALT0,  SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io IO0
+    {PB_15,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io IO7
+    {PC_3,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io IO14
+    {PC_12,      SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io SDIO_CLK
+    {PD_4,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io UART-A_RTS
+    {PE_15,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io QSPI_IO3
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
+    {PA_6,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io SPI-A_MISO
+    {PB_4,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io IO1
+    {PB_4_ALT0,  SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io IO1
+    {PB_14,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io SPI-A_CS1
+    {PC_2,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io IO15
+    {PC_11,      SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io SDIO_DATA3
+    {PD_3,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io UART-A_CTS
+    {PE_14,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io QSPI_IO2
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_SPI_SCLK[] = {
+    {PA_5,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io SPI-A_CLK
+    {PB_3,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io INT0
+    {PB_3_ALT0,  SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io INT0
+    {PB_10,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io IO2
+    {PB_13,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io SPI-A_CS2
+    {PC_10,      SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io SDIO_DATA2
+    {PD_1,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io CAN-A_TX
+    {PE_13,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io QSPI_IO1
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_SPI_SSEL[] = {
+    {PA_4,       SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io AD2
+    {PA_4_ALT0,  SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io AD2
+    {PA_15,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io INT2
+    {PA_15_ALT0, SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)}, // rhomb.io INT2
+    {PB_9,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io I2C-A_SDA
+    {PB_12,      SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io 1WIRE // Connected to DS28E05X
+    {PD_0,       SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)}, // rhomb.io CAN-A_RX
+    {PE_12,      SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)}, // rhomb.io QSPI_IO0
+    {NC, NC, 0}
+};
+
+//*** CAN ***
+
+MBED_WEAK const PinMap PinMap_CAN_RD[] = {
+    {PA_11,      CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN1)}, // rhomb.io OTG_N
+    {PB_8,       CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN1)}, // rhomb.io I2C-A_SCL
+    {PD_0,       CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN1)}, // rhomb.io CAN-A_RX
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_CAN_TD[] = {
+    {PA_12,      CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN1)}, // rhomb.io OTG_P 
+    {PB_9,       CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN1)}, // rhomb.io I2C-A_SDA
+    {PD_1,       CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN1)}, // rhomb.io CAN-A_TX
+    {NC, NC, 0}
+};
+
+//*** QUADSPI ***
+
+MBED_WEAK const PinMap PinMap_QSPI_DATA0[] = {
+    {PB_1,      QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO0 // rhomb.io NMI 
+    {PE_12,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO0 // rhomb.io QSPI_IO0 // Connected to W25Q128JVPIQ
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_QSPI_DATA1[] = {
+    {PB_0,      QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO1 // rhomb.io AD3
+    {PE_13,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO1 // rhomb.io QSPI_IO1 // Connected to W25Q128JVPIQ
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_QSPI_DATA2[] = {
+    {PA_7,      QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO2 // rhomb.io SPI_A_MOSI 
+    {PE_14,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO2 // rhomb.io QSPI_IO2 // Connected to W25Q128JVPIQ
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_QSPI_DATA3[] = {
+    {PA_6,      QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO3 // rhomb.io SPI_A_MISO  
+    {PE_15,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_BK1_IO3 // rhomb.io QSPI_IO3 // Connected to W25Q128JVPIQ
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_QSPI_SCLK[] = {
+    {PB_10,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_CLK // rhomb.io IO2
+    {PE_10,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_CLK // rhomb.io QSPI_CLK // Connected to W25Q128JVPIQ
+    {NC, NC, 0}
+};
+
+MBED_WEAK const PinMap PinMap_QSPI_SSEL[] = {
+    {PB_11,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_NCS // rhomb.io QSPI_CS0
+    {PE_11,     QSPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF10_QUADSPI)},  // QUADSPI_NCS // rhomb.io QSPI_MEM_CS // Connected to W25Q128JVPIQ
+    {NC, NC, 0}
+};

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
@@ -1,0 +1,373 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+#include "PinNamesTypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ALT0  = 0x100,
+    ALT1  = 0x200,
+    ALT2  = 0x300,
+    ALT3  = 0x400
+} ALTx;
+
+typedef enum {
+    PA_0  = 0x00, 
+    PA_0_ALT0 = PA_0 | ALT0,
+    PA_1  = 0x01, 
+    PA_1_ALT0 = PA_1 | ALT0,
+    PA_2  = 0x02, 
+    PA_2_ALT0 = PA_2 | ALT0,
+    PA_3  = 0x03, 
+    PA_3_ALT0 = PA_3 | ALT0,
+    PA_4  = 0x04,
+    PA_4_ALT0 = PA_4 | ALT0,
+    PA_5  = 0x05, 
+    PA_5_ALT0 = PA_5 | ALT0,
+    PA_6  = 0x06,
+    PA_6_ALT0 = PA_6 | ALT0,
+    PA_7  = 0x07,
+    PA_7_ALT0 = PA_7 | ALT0,
+    PA_7_ALT1 = PA_7 | ALT1,
+    PA_7_ALT2 = PA_7 | ALT2,
+    PA_8  = 0x08,
+    PA_9  = 0x09,
+    PA_10 = 0x0A,
+    PA_11 = 0x0B,
+    PA_12 = 0x0C,
+    PA_13 = 0x0D,
+    PA_14 = 0x0E,
+    PA_15 = 0x0F,
+    PA_15_ALT0 = PA_15 | ALT0,
+
+    PB_0  = 0x10,
+    PB_0_ALT0 = PB_0 | ALT0,
+    PB_0_ALT1 = PB_0 | ALT1,
+    PB_1  = 0x11,
+    PB_1_ALT0 = PB_1 | ALT0,
+    PB_1_ALT1 = PB_1 | ALT1,
+    PB_2  = 0x12, 
+    PB_3  = 0x13, 
+    PB_3_ALT0 = PB_3 | ALT0,
+    PB_4  = 0x14,
+    PB_4_ALT0 = PB_4 | ALT0,
+    PB_5  = 0x15,
+    PB_5_ALT0 = PB_5 | ALT0,
+    PB_6  = 0x16,
+    PB_6_ALT0 = PB_6 | ALT0,
+    PB_7  = 0x17,
+    PB_7_ALT0 = PB_7 | ALT0,
+    PB_8  = 0x18, 
+    PB_8_ALT0 = PB_8 | ALT0,
+    PB_9  = 0x19, 
+    PB_9_ALT0 = PB_9 | ALT0,
+    PB_10 = 0x1A,
+    PB_11 = 0x1B,
+    PB_12 = 0x1C,
+    PB_13 = 0x1D,
+    PB_13_ALT0 = PB_13 | ALT0,
+    PB_14 = 0x1E,
+    PB_14_ALT0 = PB_14 | ALT0,
+    PB_14_ALT1 = PB_14 | ALT1,
+    PB_15 = 0x1F,
+    PB_15_ALT0 = PB_15 | ALT0,
+    PB_15_ALT1 = PB_15 | ALT1,
+
+    PC_0  = 0x20,
+    PC_0_ALT0 = PC_0 | ALT0,
+    PC_0_ALT1 = PC_0 | ALT1,
+    PC_1  = 0x21,
+    PC_1_ALT0 = PC_1 | ALT0,
+    PC_1_ALT1 = PC_1 | ALT1,
+    PC_2  = 0x22,
+    PC_2_ALT0 = PC_2 | ALT0,
+    PC_2_ALT1 = PC_2 | ALT1,
+    PC_3  = 0x23,
+    PC_3_ALT0 = PC_3 | ALT0,
+    PC_3_ALT1 = PC_3 | ALT1,
+    PC_4  = 0x24,
+    PC_4_ALT0 = PC_4 | ALT0,
+    PC_5  = 0x25,
+    PC_5_ALT0 = PC_5 | ALT0,
+    PC_6  = 0x26,
+    PC_6_ALT0 = PC_6 | ALT0,
+    PC_7  = 0x27,
+    PC_7_ALT0 = PC_7 | ALT0,
+    PC_8  = 0x28,
+    PC_8_ALT0 = PC_8 | ALT0,
+    PC_9  = 0x29,
+    PC_9_ALT0 = PC_9 | ALT0,
+    PC_10 = 0x2A,
+    PC_10_ALT0 = PC_10 | ALT0,
+    PC_11 = 0x2B,
+    PC_11_ALT0 = PC_11 | ALT0,
+    PC_12 = 0x2C,
+    PC_13 = 0x2D,
+    PC_14 = 0x2E, 
+    PC_15 = 0x2F, 
+
+    PD_0  = 0x30, 
+    PD_1  = 0x31,
+    PD_2  = 0x32,
+    PD_3  = 0x33,
+    PD_4  = 0x34,
+    PD_5  = 0x35,
+    PD_6  = 0x36,
+    PD_7  = 0x37,
+    PD_8  = 0x38,
+    PD_9  = 0x39,
+    PD_10 = 0x3A,
+    PD_11 = 0x3B,
+    PD_12 = 0x3C,
+    PD_13 = 0x3D,
+    PD_14 = 0x3E,
+    PD_15 = 0x3F,
+
+    PE_0  = 0x40,
+    PE_1  = 0x41,
+    PE_2  = 0x42,
+    PE_3  = 0x43,
+    PE_4  = 0x44,
+    PE_5  = 0x45,
+    PE_6  = 0x46,
+    PE_7  = 0x47,
+    PE_8  = 0x48, 
+    PE_9  = 0x49,
+    PE_10 = 0x4A, 
+    PE_11 = 0x4B, 
+    PE_12 = 0x4C, 
+    PE_13 = 0x4D, 
+    PE_14 = 0x4E, 
+    PE_15 = 0x4F, 
+
+    PH_0  = 0x70, 
+    PH_1  = 0x71, 
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
+
+    // STDIO for console print
+/*#ifdef MBED_CONF_TARGET_STDIO_UART_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    STDIO_UART_TX = PC_4,
+#endif
+#ifdef MBED_CONF_TARGET_STDIO_UART_RX
+    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    STDIO_UART_RX = PC_5,
+#endif*/
+
+    STDIO_UART_TX = PC_4,
+    STDIO_UART_RX = PC_5,
+
+    // Generic signals namings
+    LED1 = PC_7, // LED Green
+    LED2 = PC_7, // LED Green
+	
+    USER_BUTTON = PB_1,
+    // Standardized button names
+    BUTTON1 = USER_BUTTON,
+
+    SERIAL_TX = STDIO_UART_TX,
+    SERIAL_RX = STDIO_UART_RX,
+    USBTX = STDIO_UART_TX,
+    USBRX = STDIO_UART_RX,
+
+    I2C_SCL     = PB_8,
+    I2C_SDA     = PB_9,
+    SPI_MOSI    = PA_7,
+    SPI_MISO    = PA_6,
+    SPI_SCK     = PA_5,
+    SPI_CS      = PB_6,
+    PWM_OUT     = PC_7,
+
+    /**** USB pins ****/
+    USB_OTG_FS_DM = PA_11,
+    USB_OTG_FS_DP = PA_12,
+    USB_OTG_FS_ID = PA_10,
+
+    /**** OSCILLATOR pins ****/
+    RCC_OSC32_IN = PC_14,
+    RCC_OSC32_OUT = PC_15,
+    RCC_OSC_IN = PH_0,
+    RCC_OSC_OUT = PH_1,
+
+    /**** DEBUG pins ****/
+    SYS_JTCK_SWCLK = PA_14,
+    SYS_JTDI = PA_15,
+    SYS_JTDO_SWO = PB_3,
+    SYS_JTMS_SWDIO = PA_13,
+    SYS_JTRST = PB_4,
+/*  SYS_PVD_IN = PB_7,
+    SYS_TRACECLK = PE_2,
+    SYS_TRACED0 = PE_3,
+    SYS_TRACED1 = PE_4,
+    SYS_TRACED2 = PE_5,
+    SYS_TRACED3 = PE_6,
+    SYS_WKUP1 = PA_0,
+    SYS_WKUP2 = PC_13,
+    SYS_WKUP3 = PE_6,
+    SYS_WKUP4 = PA_2,
+    SYS_WKUP5 = PC_5,*/
+
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PE_12,
+    QSPI_FLASH1_IO1 = PE_13,
+    QSPI_FLASH1_IO2 = PE_14,
+    QSPI_FLASH1_IO3 = PE_15,
+    QSPI_FLASH1_SCK = PE_10,
+    QSPI_FLASH1_CSN = PE_11,
+
+ // rhomb.io system namings //.........................
+    NMI   = PB_1,
+    INT0  = PB_3,
+    INT1  = PB_7,
+    INT2  = PA_15,
+
+    IO0   = PB_5,
+    IO1   = PB_4,
+    IO2   = PB_10,
+    IO3   = PA_8,
+    IO4   = PA_9,
+    IO5   = PE_8, 
+    IO6   = PE_7,   
+    IO7   = PB_15,
+  
+    IO8   = PC_13,
+    IO9   = PD_7,   
+    IO10  = PD_10,
+    IO11  = PD_11,
+    IO12  = PD_12,
+    IO13  = PD_13,
+    IO14  = PC_3,
+    IO15  = PC_2,
+
+    //LED0  = PC_7,
+ 
+    PWM0  = PC_7,
+    PWM1  = PE_9,
+    PWM2  = PD_14,
+    PWM3  = PC_6,
+    PWM4  = PB_2,
+ 
+    UART_A_RXD  = PA_3,
+    UART_A_TXD  = PA_2,
+    UART_A_CTS  = PD_3,
+    UART_A_RTS  = PD_4,
+
+    UART_B_RXD  = PD_6,
+    UART_B_TXD  = PD_5,
+
+    UART_C_RXD  = PD_9,
+    UART_C_TXD  = PD_8,  
+    
+    I2C_A_SDA   = PB_9,
+    I2C_A_SCL   = PB_8,
+    I2C_B_SDA   = PB_14, // R14 must be populated/closed (default is open)
+    I2C_B_SCL   = PB_13, // R15 must be populated/closed (default is open)
+
+    SPI_A_MOSI  = PA_7,  
+    SPI_A_MISO  = PA_6,  
+    SPI_A_CLK   = PA_5,
+    SPI_A_CS0   = PB_6,
+    SPI_A_CS1   = PB_14,
+    SPI_A_CS2   = PB_13,
+  
+    QSPI_IO0    = PE_12, 
+    QSPI_IO1    = PE_13,  
+    QSPI_IO2    = PE_14, 
+    QSPI_IO3    = PE_15,   
+    QSPI_CLK    = PE_10, 
+    QSPI_CS0    = PB_11,  
+    QSPI_MEM_CS = PE_11,  
+
+    _1WIRE    = PB_12,  
+    CAN_A_RX  = PD_0,  
+    CAN_A_TX  = PD_1, 
+  
+    SDIO_DATAO = PC_8,  
+    SDIO_DATA1 = PC_9, 
+    SDIO_DATA2 = PC_10,
+    SDIO_DATA3 = PC_11,
+    SDIO_CLK   = PC_12,   
+    SDIO_CMD   = PD_2,  
+    SDIO_CDN   = PD_15,  
+
+    SAI_A_BCLK  = PE_5, 
+    SAI_A_LRCLK = PE_4,  
+    SAI_A_SDI   = PE_6,  
+    SAI_A_SDO   = PE_3,  
+    SAI_A_MCLK  = PE_2,  
+
+    OTG_P  = PA_12,  
+    OTG_N  = PA_11,    
+    OTG_ID = PA_10,  
+  
+    AD0 = PA_0,
+    AD1 = PA_1, 
+    AD2 = PA_4, 
+    AD3 = PB_0,
+    AD4 = PC_1,
+    AD5 = PC_0,
+  //AD6 not used
+    AD7 = PC_5,   
+    AD8 = PC_4,
+
+	COMP_A_P = PC_5,
+    COMP_A_N = PC_4,   
+  
+    CAPT0  = PC_3,  // R18 must be populated/closed (default is open)
+    CAPT1  = PC_2,  // R19 must be populated/closed (default is open)
+
+    SWDIO  = PA_13,
+    SWCLK  = PA_14,  
+  
+    RSTOUT = PE_0, 
+ 
+    // Not connected
+    NC = (int)0xFFFFFFFF
+
+} PinName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
@@ -1,4 +1,6 @@
 /* mbed Microcontroller Library
+
+* SPDX-License-Identifier: Apache-2.0
  *******************************************************************************
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PinNames.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
-
-* SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *******************************************************************************
  * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
@@ -185,24 +185,13 @@ typedef enum {
     ADC_VBAT = 0xF2,
 
     // STDIO for console print
-/*#ifdef MBED_CONF_TARGET_STDIO_UART_TX
-    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
-#else
-    STDIO_UART_TX = PC_4,
-#endif
-#ifdef MBED_CONF_TARGET_STDIO_UART_RX
-    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
-#else
-    STDIO_UART_RX = PC_5,
-#endif*/
-
     STDIO_UART_TX = PC_4,
     STDIO_UART_RX = PC_5,
 
     // Generic signals namings
     LED1 = PC_7, // LED Green
     LED2 = PC_7, // LED Green
-	
+
     USER_BUTTON = PB_1,
     // Standardized button names
     BUTTON1 = USER_BUTTON,
@@ -237,17 +226,6 @@ typedef enum {
     SYS_JTDO_SWO = PB_3,
     SYS_JTMS_SWDIO = PA_13,
     SYS_JTRST = PB_4,
-/*  SYS_PVD_IN = PB_7,
-    SYS_TRACECLK = PE_2,
-    SYS_TRACED0 = PE_3,
-    SYS_TRACED1 = PE_4,
-    SYS_TRACED2 = PE_5,
-    SYS_TRACED3 = PE_6,
-    SYS_WKUP1 = PA_0,
-    SYS_WKUP2 = PC_13,
-    SYS_WKUP3 = PE_6,
-    SYS_WKUP4 = PA_2,
-    SYS_WKUP5 = PC_5,*/
 
     /**** QSPI FLASH pins ****/
     QSPI_FLASH1_IO0 = PE_12,
@@ -280,8 +258,6 @@ typedef enum {
     IO13  = PD_13,
     IO14  = PC_3,
     IO15  = PC_2,
-
-    //LED0  = PC_7,
  
     PWM0  = PC_7,
     PWM1  = PE_9,
@@ -348,11 +324,11 @@ typedef enum {
     AD3 = PB_0,
     AD4 = PC_1,
     AD5 = PC_0,
-  //AD6 not used
+    // AD6 not used
     AD7 = PC_5,   
     AD8 = PC_4,
 
-	COMP_A_P = PC_5,
+    COMP_A_P = PC_5,
     COMP_A_N = PC_4,   
   
     CAPT0  = PC_3,  // R18 must be populated/closed (default is open)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/system_clock.c
@@ -1,0 +1,370 @@
+/* mbed Microcontroller Library
+* Copyright (c) 2006-2017 ARM Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+  * This file configures the system clock as follows:
+  *-----------------------------------------------------------------------------
+  * System clock source | 1- USE_PLL_HSE_EXTC (external 8 MHz clock)
+  *                     | 2- USE_PLL_HSE_XTAL (external 8 MHz xtal)
+  *                     | 3- USE_PLL_HSI (internal 16 MHz)
+  *                     | 4- USE_PLL_MSI (internal 100kHz to 48 MHz)
+  *-----------------------------------------------------------------------------
+  * SYSCLK(MHz)         | 80
+  * AHBCLK (MHz)        | 80
+  * APB1CLK (MHz)       | 80
+  * APB2CLK (MHz)       | 80
+  * USB capable         | YES
+  *-----------------------------------------------------------------------------
+**/
+
+#include "stm32l4xx.h"
+#include "nvic_addr.h"
+#include "mbed_error.h"
+
+/*!< Uncomment the following line if you need to relocate your vector Table in
+     Internal SRAM. */
+/* #define VECT_TAB_SRAM */
+#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
+                                   This value must be a multiple of 0x200. */
+
+
+// clock source is selected with CLOCK_SOURCE in json config
+#define USE_PLL_HSE_EXTC 0x8 // Use external clock (ST Link MCO - not enabled by default)
+#define USE_PLL_HSE_XTAL 0x4 // Use external xtal (X3 on board - not provided by default)
+#define USE_PLL_HSI      0x2 // Use HSI internal clock
+#define USE_PLL_MSI      0x1 // Use MSI internal clock
+
+#define DEBUG_MCO        (0) // Output the MCO on PA8 for debugging (0=OFF, 1=SYSCLK, 2=HSE, 3=HSI, 4=MSI)
+
+#if ( ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL) || ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC) )
+uint8_t SetSysClock_PLL_HSE(uint8_t bypass);
+#endif /* ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL) || ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC) */
+
+#if ((CLOCK_SOURCE) & USE_PLL_HSI)
+uint8_t SetSysClock_PLL_HSI(void);
+#endif /* ((CLOCK_SOURCE) & USE_PLL_HSI) */
+
+#if ((CLOCK_SOURCE) & USE_PLL_MSI)
+uint8_t SetSysClock_PLL_MSI(void);
+#endif /* ((CLOCK_SOURCE) & USE_PLL_MSI) */
+
+
+/**
+  * @brief  Setup the microcontroller system.
+  * @param  None
+  * @retval None
+  */
+
+void SystemInit(void)
+{
+    /* FPU settings ------------------------------------------------------------*/
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2)); /* set CP10 and CP11 Full Access */
+#endif
+    /* Reset the RCC clock configuration to the default reset state ------------*/
+    /* Set MSION bit */
+    RCC->CR |= RCC_CR_MSION;
+
+    /* Reset CFGR register */
+    RCC->CFGR = 0x00000000;
+
+    /* Reset HSEON, CSSON , HSION, and PLLON bits */
+    RCC->CR &= (uint32_t)0xEAF6FFFF;
+
+    /* Reset PLLCFGR register */
+    RCC->PLLCFGR = 0x00001000;
+
+    /* Reset HSEBYP bit */
+    RCC->CR &= (uint32_t)0xFFFBFFFF;
+
+    /* Disable all interrupts */
+    RCC->CIER = 0x00000000;
+
+    /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+    SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+#else
+    SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
+#endif
+
+}
+
+
+/**
+  * @brief  Configures the System clock source, PLL Multiplier and Divider factors,
+  *               AHB/APBx prescalers and Flash settings
+  * @note   This function should be called only once the RCC clock configuration
+  *         is reset to the default reset state (done in SystemInit() function).
+  * @param  None
+  * @retval None
+  */
+
+void SetSysClock(void)
+{
+#if ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC)
+    /* 1- Try to start with HSE and external clock */
+    if (SetSysClock_PLL_HSE(1) == 0)
+#endif
+    {
+#if ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL)
+        /* 2- If fail try to start with HSE and external xtal */
+        if (SetSysClock_PLL_HSE(0) == 0)
+#endif
+        {
+#if ((CLOCK_SOURCE) & USE_PLL_HSI)
+            /* 3- If fail start with HSI clock */
+            if (SetSysClock_PLL_HSI() == 0)
+#endif
+            {
+#if ((CLOCK_SOURCE) & USE_PLL_MSI)
+                /* 4- If fail start with MSI clock */
+                if (SetSysClock_PLL_MSI() == 0)
+#endif
+                {
+                    {
+                        error("SetSysClock failed\n");
+                    }
+                }
+            }
+        }
+    }
+
+    // Output clock on MCO1 pin(PA8) for debugging purpose
+#if DEBUG_MCO == 1
+    HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
+#endif
+}
+
+#if ( ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL) || ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC) )
+/******************************************************************************/
+/*            PLL (clocked by HSE) used as System clock source                */
+/******************************************************************************/
+uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
+{
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef RCC_PeriphClkInit = {0};
+
+    // Used to gain time after DeepSleep in case HSI is used
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET) {
+        return 0;
+    }
+
+    // Select MSI as system clock source to allow modification of the PLL configuration
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_SYSCLK;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
+    HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_0);
+
+    // Enable HSE oscillator and activate PLL with HSE as source
+    RCC_OscInitStruct.OscillatorType        = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI;
+    if (bypass == 0) {
+        RCC_OscInitStruct.HSEState            = RCC_HSE_ON; // External 8 MHz xtal on OSC_IN/OSC_OUT
+    } else {
+        RCC_OscInitStruct.HSEState            = RCC_HSE_BYPASS; // External 8 MHz clock on OSC_IN
+    }
+    RCC_OscInitStruct.HSIState              = RCC_HSI_OFF;
+    RCC_OscInitStruct.PLL.PLLSource         = RCC_PLLSOURCE_HSE; // 8 MHz
+    RCC_OscInitStruct.PLL.PLLState          = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLM              = 1; // VCO input clock = 8 MHz (8 MHz / 1)
+    RCC_OscInitStruct.PLL.PLLN              = 20; // VCO output clock = 160 MHz (8 MHz * 20)
+    RCC_OscInitStruct.PLL.PLLP              = 7; // PLLSAI3 clock = 22 MHz (160 MHz / 7)
+    RCC_OscInitStruct.PLL.PLLQ              = 2;
+    RCC_OscInitStruct.PLL.PLLR              = 2; // PLL clock = 80 MHz (160 MHz / 2)
+
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    // Select PLL clock as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers
+    RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 80 MHz or 48 MHz
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 80 MHz or 48 MHz
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 80 MHz or 48 MHz
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 80 MHz or 48 MHz
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USB;
+    RCC_PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_PLLSAI1;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1Source = RCC_PLLSOURCE_HSE;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1M = 1;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1N = 12;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1P = RCC_PLLP_DIV7;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1Q = RCC_PLLQ_DIV2;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1R = RCC_PLLR_DIV2;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1ClockOut = RCC_PLLSAI1_48M2CLK;
+    if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    // Disable MSI Oscillator
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
+    RCC_OscInitStruct.MSIState       = RCC_MSI_OFF;
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
+    HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+    // Output clock on MCO1 pin(PA8) for debugging purpose
+#if DEBUG_MCO == 2
+    if (bypass == 0) {
+        HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSE, RCC_MCODIV_2);    // 4 MHz
+    } else {
+        HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSE, RCC_MCODIV_1);    // 8 MHz
+    }
+#endif
+
+    return 1; // OK
+}
+#endif /* ((CLOCK_SOURCE) & USE_PLL_HSE_XTAL) || ((CLOCK_SOURCE) & USE_PLL_HSE_EXTC) */
+
+#if ((CLOCK_SOURCE) & USE_PLL_HSI)
+/******************************************************************************/
+/*            PLL (clocked by HSI) used as System clock source                */
+/******************************************************************************/
+uint8_t SetSysClock_PLL_HSI(void)
+{
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef RCC_PeriphClkInit = {0};
+
+    // Select MSI as system clock source to allow modification of the PLL configuration
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_SYSCLK;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
+    HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_0);
+
+    // Enable HSI oscillator and activate PLL with HSI as source
+    RCC_OscInitStruct.OscillatorType       = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSEState             = RCC_HSE_OFF;
+    RCC_OscInitStruct.HSIState             = RCC_HSI_ON;
+    RCC_OscInitStruct.HSICalibrationValue  = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.PLL.PLLState         = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource        = RCC_PLLSOURCE_HSI; // 16 MHz
+    RCC_OscInitStruct.PLL.PLLM             = 2; // VCO input clock = 8 MHz (16 MHz / 2)
+    RCC_OscInitStruct.PLL.PLLN             = 20; // VCO output clock = 160 MHz (8 MHz * 20)
+    RCC_OscInitStruct.PLL.PLLP             = 7; // PLLSAI3 clock = 22 MHz (160 MHz / 7)
+    RCC_OscInitStruct.PLL.PLLQ             = 2;
+    RCC_OscInitStruct.PLL.PLLR             = 2; // PLL clock = 80 MHz (160 MHz / 2)
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    // Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers
+    RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 80 MHz
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 80 MHz
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 80 MHz
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 80 MHz
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    RCC_PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USB;
+    RCC_PeriphClkInit.UsbClockSelection = RCC_USBCLKSOURCE_PLLSAI1;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1Source = RCC_PLLSOURCE_HSI;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1M = 2;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1N = 12;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1P = RCC_PLLP_DIV7;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1Q = RCC_PLLQ_DIV2;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1R = RCC_PLLR_DIV2;
+    RCC_PeriphClkInit.PLLSAI1.PLLSAI1ClockOut = RCC_PLLSAI1_48M2CLK;
+    if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphClkInit) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    // Disable MSI Oscillator
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_MSI;
+    RCC_OscInitStruct.MSIState       = RCC_MSI_OFF;
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
+    HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+    // Output clock on MCO1 pin(PA8) for debugging purpose
+#if DEBUG_MCO == 3
+    HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI, RCC_MCODIV_1); // 16 MHz
+#endif
+
+    return 1; // OK
+}
+#endif /* ((CLOCK_SOURCE) & USE_PLL_HSI) */
+
+#if ((CLOCK_SOURCE) & USE_PLL_MSI)
+/******************************************************************************/
+/*            PLL (clocked by MSI) used as System clock source                */
+/******************************************************************************/
+uint8_t SetSysClock_PLL_MSI(void)
+{
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
+    // Enable LSE Oscillator to automatically calibrate the MSI clock
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
+    RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
+    HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
+    /* Enable MSI Oscillator and activate PLL with MSI as source */
+    RCC_OscInitStruct.OscillatorType       = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
+    RCC_OscInitStruct.HSEState             = RCC_HSE_OFF;
+    RCC_OscInitStruct.HSIState             = RCC_HSI_OFF;
+
+    RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.MSIClockRange       = RCC_MSIRANGE_11; /* 48 MHz */
+    RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_MSI;
+    RCC_OscInitStruct.PLL.PLLM            = 6;    /* 8 MHz */
+    RCC_OscInitStruct.PLL.PLLN            = 40;   /* 320 MHz */
+    RCC_OscInitStruct.PLL.PLLP            = 7;    /* 45 MHz */
+    RCC_OscInitStruct.PLL.PLLQ            = 4;    /* 80 MHz */
+    RCC_OscInitStruct.PLL.PLLR            = 4;    /* 80 MHz */
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
+    /* Enable MSI Auto-calibration through LSE */
+    HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
+    /* Select MSI output as USB clock source */
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
+    PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */
+    HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+    // Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers
+    RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; /* 80 MHz */
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         /* 80 MHz */
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+        return 0; // FAIL
+    }
+
+    // Output clock on MCO1 pin(PA8) for debugging purpose
+#if DEBUG_MCO == 4
+    HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_MSI, RCC_MCODIV_2); // 2 MHz
+#endif
+
+    return 1; // OK
+}
+#endif /* ((CLOCK_SOURCE) & USE_PLL_MSI) */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/system_clock.c
@@ -1,5 +1,7 @@
 /* mbed Microcontroller Library
-* Copyright (c) 2006-2017 ARM Limited
+* Copyright (c) 2006-2019 ARM Limited
+*
+* SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3957,6 +3957,41 @@
         "device_name": "STM32L476VG",
         "bootloader_supported": true
     },
+	"RHOMBIO_L476DMW1K": {
+        "components_add": ["FLASHIAP"],
+        "inherits": ["FAMILY_STM32"],
+        "core": "Cortex-M4F",
+        "extra_labels_add": ["STM32L4", "STM32L476xG", "STM32L476VG"],
+        "config": {
+            "clock_source": {
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
+                "value": "USE_PLL_MSI",
+                "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
+            }
+        },
+        "overrides": { "lpticker_delay_ticks": 4 },
+        "detect_code": ["1500"],
+        "macros_add": [
+            "MBED_TICKLESS",
+            "USBHOST_OTHER",
+            "TWO_RAM_REGIONS"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "CAN",
+            "SERIAL_FC",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "release_versions": ["2", "5"],
+        "device_name": "STM32L476VG",
+        "bootloader_supported": true
+    },	
     "MTS_MDOT_F405RG": {
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",


### PR DESCRIPTION
### Description

This pull request contains files necessary to the execution of Mbed-OS over RHOMBIO_L476DMW1K IoT Kit. The kit is based on STM32L476VG and the files to be added are a porting based on target DISCO_L476VG, sharing most of its pin and peripheral configuration.

The kit has been tested with ARM, GCC_ARM and IAR.

Greentea logs attached below:
[RHOMBIO_L476DMW1K-GCC_ARM-TESTS-PASS.txt](https://github.com/ARMmbed/mbed-os/files/2886419/RHOMBIO_L476DMW1K-GCC_ARM-TESTS-PASS.txt)
[RHOMBIO_L476DMW1K-ARM-TESTS-PASS.txt](https://github.com/ARMmbed/mbed-os/files/2886420/RHOMBIO_L476DMW1K-ARM-TESTS-PASS.txt)
[RHOMBIO_L476DMW1K-IAR-TESTS-PASS.txt](https://github.com/ARMmbed/mbed-os/files/2886421/RHOMBIO_L476DMW1K-IAR-TESTS-PASS.txt)

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@MarceloSalazar 

### Release Notes
