### PR TITLE
Ensure header CRC is written as unsigned int

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -398,8 +398,9 @@ def _fill_header(region_list, current_region):
             else:
                 ih = intelhex_offset(region_dict[data].filename, offset=region_dict[data].start)
             if subtype.startswith("CRCITT32"):
-                fmt = {"CRCITT32be": ">l", "CRCITT32le": "<l"}[subtype]
-                header.puts(start, struct.pack(fmt, zlib.crc32(ih.tobinarray())))
+                fmt = {"CRCITT32be": ">L", "CRCITT32le": "<L"}[subtype]
+                crc_val = zlib.crc32(ih.tobinarray()) & 0xffffffff
+                header.puts(start, struct.pack(fmt, crc_val))
             elif subtype.startswith("SHA"):
                 if subtype == "SHA256":
                     hash = hashlib.sha256()


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixes #9750. The bootloader merge would fail since the CRC produces an [unsigned 32 bit integer](https://docs.python.org/3/library/zlib.html#zlib.crc32), however we specified it as a [signed 32 bit integer](https://docs.python.org/2/library/struct.html#format-characters).

I've tested this on a K64F and ran an update over Pelion, seems to work ok!

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy - tools team review

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
