### PR TITLE
Tools changes to make ARMC6 as default ARM compiler

### DIFF
--- a/features/storage/FEATURE_STORAGE/cfstore/configuration-store/configuration_store.h
+++ b/features/storage/FEATURE_STORAGE/cfstore/configuration-store/configuration_store.h
@@ -163,7 +163,7 @@ typedef struct _ARM_CFSTORE_STATUS {
     ARM_CFSTORE_HANDLE (__name) = (ARM_CFSTORE_HANDLE) (__name##_buf_cFsToRe);  \
     memset((__name##_buf_cFsToRe), 0, CFSTORE_HANDLE_BUFSIZE)
 
-#if defined __MBED__ && (defined TOOLCHAIN_GCC_ARM || defined TOOLCHAIN_ARMC6)
+#if defined __MBED__ && (defined TOOLCHAIN_GCC_ARM || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
 /** @brief  Helper macro to swap 2 handles, which is useful for the Find() idiom. */
 #define CFSTORE_HANDLE_SWAP(__a_HaNdLe, __b_HaNdLe)         \
     do{ ARM_CFSTORE_HANDLE __temp_HaNdLe = (__a_HaNdLe);    \
@@ -174,6 +174,7 @@ typedef struct _ARM_CFSTORE_STATUS {
         __asm volatile("" ::: "memory");                    \
     }while(0)
 
+        
 #elif defined __MBED__ && defined TOOLCHAIN_ARM
 /** @brief  Helper macro to swap 2 handles, which is useful for the Find() idiom. */
 #define CFSTORE_HANDLE_SWAP(__a_HaNdLe, __b_HaNdLe)         \

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -55,7 +55,11 @@ static SingletonPtr<PlatformMutex> _mutex;
 #   define PREFIX(x)    _sys##x
 #   define OPEN_MAX     _SYS_OPEN
 #   ifdef __MICROLIB
-#       pragma import(__use_full_stdio)
+#       if __ARMCC_VERSION >= 6010050
+            asm(" .global __use_full_stdio\n");
+#       else
+#           pragma import(__use_full_stdio)
+#       endif
 #   endif
 
 #elif defined(__ICCARM__)

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -56,7 +56,7 @@ static SingletonPtr<PlatformMutex> _mutex;
 #   define OPEN_MAX     _SYS_OPEN
 #   ifdef __MICROLIB
 #       if __ARMCC_VERSION >= 6010050
-            asm(" .global __use_full_stdio\n");
+asm(" .global __use_full_stdio\n");
 #       else
 #           pragma import(__use_full_stdio)
 #       endif
@@ -1250,13 +1250,13 @@ extern "C" WEAK caddr_t _sbrk(int incr)
     if (new_heap >= (unsigned char *)__get_MSP()) {
 #endif
         errno = ENOMEM;
-        return (caddr_t) -1;
+        return (caddr_t) - 1;
     }
 
     // Additional heap checking if set
     if (mbed_heap_size && (new_heap >= mbed_heap_start + mbed_heap_size)) {
         errno = ENOMEM;
-        return (caddr_t) -1;
+        return (caddr_t) - 1;
     }
 
     heap = new_heap;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8279,5 +8279,9 @@
         "detect_code": ["1703"],
         "macros_add": ["GD32E10X"],
         "release_versions": ["5"]
+    },
+    "__build_tools_metadata__": {
+        "version": "1",
+        "public": false
     }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1325,7 +1325,7 @@
     "KW24D": {
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4",
-        "supported_toolchains": ["GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM"],
         "is_disk_virtual": true,
         "macros": ["CPU_MKW24D512VHA5", "FSL_RTOS_MBED"],
@@ -1353,6 +1353,7 @@
             "FLASH",
             "802_15_4_PHY"
         ],
+        "release_versions": ["2", "5"],
         "device_name": "MKW24D512xxx5",
         "bootloader_supported": true,
         "overrides": {
@@ -2479,6 +2480,7 @@
     "MTB_MXCHIP_EMW3166": {
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
+        "supported_toolchains": ["ARMC5", "uARM", "IAR", "GCC_ARM"],
         "extra_labels_add": [
             "STM32F4",
             "STM32F412xG",
@@ -2510,6 +2512,7 @@
     },
     "USI_WM_BN_BM_22": {
         "inherits": ["FAMILY_STM32"],
+        "supported_toolchains": ["ARMC5", "uARM", "IAR", "GCC_ARM"],
         "components_add": ["SPIF", "FLASHIAP"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -7877,7 +7880,7 @@
         "inherits": ["Target"],
         "macros": ["MBED_MPU_CUSTOM"],
         "default_toolchain": "GCC_ARM",
-        "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
+        "supported_toolchains": ["GCC_ARM", "IAR", "ARMC5"],
         "core": "Cortex-M4F",
         "OUTPUT_EXT": "hex",
         "device_has": [

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -130,7 +130,7 @@ def get_toolchain_name(target, toolchain_name):
             if toolchain_name == "ARM":
                 return "ARM" #note that returning ARM here means, use ARMC5 toolchain
             else:
-                return None #ARMC6 explicitly specified by user, but target doesnt seem to support ARMC6, so return error.    
+                return "ARMC6" #ARMC6 explicitly specified by user, try ARMC6 anyway although the target doesnt explicitly specify ARMC6, as ARMC6 is our default ARM toolchain
     elif toolchain_name == "uARM":
         if ("ARMC5" in target.supported_toolchains):
             return "uARM" #use ARM_MICRO to use AC5+microlib
@@ -343,8 +343,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                 target.name, toolchain_name))
 
     toolchain_name = get_toolchain_name(target, toolchain_name)
-    notify.debug("Selected toolchain: %s" % (toolchain_name))
-
+    
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
     except KeyError:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -135,7 +135,6 @@ def get_toolchain_name(target, toolchain_name):
             if ("ARMC5" in target.supported_toolchains):
                 return "uARM" #use ARM_MICRO to use AC5+microlib
             else:
-                target.default_toolchain = "uARM"
                 return "ARMC6" #use AC6+microlib
     else:
         if toolchain_name == "ARM":
@@ -310,7 +309,8 @@ def target_supports_toolchain(target, toolchain_name):
                 return any(tc in target.supported_toolchains for tc in ("ARMC5","ARMC6","uARM"))
             if(toolchain_name == "ARMC6"):
                 #we did not find ARMC6, but check for ARM is listed
-                return any(tc in target.supported_toolchains for tc in ("ARM",))
+                return "ARM" in target.supported_toolchains
+        #return False in other cases
         return False
     else:
         ARM_COMPILERS = ("ARM", "ARMC6", "uARM")
@@ -354,7 +354,13 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
             "Target {} is not supported by toolchain {}".format(
                 target.name, toolchain_name))
 
-    toolchain_name = get_toolchain_name(target, toolchain_name)
+    selected_toolchain_name = get_toolchain_name(target, toolchain_name)
+
+    #If a target supports ARMC6 and we want to build UARM with it, 
+    #then set the default_toolchain to uARM to link AC6 microlib.
+    if(selected_toolchain_name == "ARMC6" and toolchain_name == "uARM"):
+        target.default_toolchain = "uARM"
+    toolchain_name = selected_toolchain_name     
 
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
@@ -986,7 +992,13 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
     Return - True if target + toolchain built correctly, False if not supported
     """
 
-    toolchain_name = get_toolchain_name(target, toolchain_name)
+    selected_toolchain_name = get_toolchain_name(target, toolchain_name)
+
+    #If a target supports ARMC6 and we want to build UARM with it, 
+    #then set the default_toolchain to uARM to link AC6 microlib.
+    if(selected_toolchain_name == "ARMC6" and toolchain_name == "uARM"):
+        target.default_toolchain = "uARM"
+    toolchain_name = selected_toolchain_name
 
     if report is not None:
         start = time()

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -209,6 +209,7 @@ def is_official_target(target_name, version):
             # For version 5, ARM, GCC_ARM, and IAR toolchain support is required
             required_toolchains = [
                 set(['ARM', 'GCC_ARM', 'IAR']),
+                set(['ARMC5', 'GCC_ARM', 'IAR']),
                 set(['ARMC6'])
             ]
             supported_toolchains = set(target.supported_toolchains)

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -122,21 +122,27 @@ def add_result_to_report(report, result):
     report[target][toolchain][id_name].append(result_wrap)
 
 def get_toolchain_name(target, toolchain_name):
-
-    if toolchain_name == "ARM" or toolchain_name == "ARMC6" :
-        if("ARM" in target.supported_toolchains or "ARMC6" in target.supported_toolchains):
-            return "ARMC6"
-        elif ("ARMC5" in target.supported_toolchains):
-            if toolchain_name == "ARM":
-                return "ARM" #note that returning ARM here means, use ARMC5 toolchain
+    if int(target.build_tools_metadata["version"]) > 0:
+        if toolchain_name == "ARM" or toolchain_name == "ARMC6" :
+            if("ARM" in target.supported_toolchains or "ARMC6" in target.supported_toolchains):
+                return "ARMC6"
+            elif ("ARMC5" in target.supported_toolchains):
+                if toolchain_name == "ARM":
+                    return "ARM" #note that returning ARM here means, use ARMC5 toolchain
+                else:
+                    return "ARMC6" #ARMC6 explicitly specified by user, try ARMC6 anyway although the target doesnt explicitly specify ARMC6, as ARMC6 is our default ARM toolchain
+        elif toolchain_name == "uARM":
+            if ("ARMC5" in target.supported_toolchains):
+                return "uARM" #use ARM_MICRO to use AC5+microlib
             else:
-                return "ARMC6" #ARMC6 explicitly specified by user, try ARMC6 anyway although the target doesnt explicitly specify ARMC6, as ARMC6 is our default ARM toolchain
-    elif toolchain_name == "uARM":
-        if ("ARMC5" in target.supported_toolchains):
-            return "uARM" #use ARM_MICRO to use AC5+microlib
-        else:
-            target.default_toolchain = "uARM"
-            return "ARMC6" #use AC6+microlib
+                target.default_toolchain = "uARM"
+                return "ARMC6" #use AC6+microlib
+    else:
+        if toolchain_name == "ARM":
+            if CORE_ARCH[target.core] == 8:
+                return "ARMC6"
+            elif getattr(target, "default_toolchain", None) == "uARM":
+                return "uARM"
 
     return toolchain_name
 
@@ -295,17 +301,23 @@ def get_mbed_official_release(version):
     return mbed_official_release
 
 def target_supports_toolchain(target, toolchain_name):
-    if toolchain_name in target.supported_toolchains:
-        return True
+    if int(target.build_tools_metadata["version"]) > 0:
+        if toolchain_name in target.supported_toolchains:
+            return True
+        else:
+            if(toolchain_name == "ARM"):
+                #we cant find ARM, see if one ARMC5, ARMC6 or uARM listed
+                return any(tc in target.supported_toolchains for tc in ("ARMC5","ARMC6","uARM"))
+            if(toolchain_name == "ARMC6"):
+                #we did not find ARMC6, but check for ARM is listed
+                return any(tc in target.supported_toolchains for tc in ("ARM",))
+        return False
     else:
-        if(toolchain_name == "ARM"):
-            #we cant find ARM, see if one ARMC5, ARMC6 or uARM listed
-            return any(tc in target.supported_toolchains for tc in ("ARMC5","ARMC6","uARM"))
-        if(toolchain_name == "ARMC6"):
-            #we did not find ARMC6, but check for ARM is listed
-            return any(tc in target.supported_toolchains for tc in ("ARM",))
-            
-    return False        
+        ARM_COMPILERS = ("ARM", "ARMC6", "uARM")
+        if toolchain_name in ARM_COMPILERS:
+            return any(tc in target.supported_toolchains for tc in ARM_COMPILERS)
+        else:
+            return toolchain_name in target.supported_toolchains
 
 def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                       macros=None, clean=False, jobs=1,
@@ -336,7 +348,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     # If the configuration object was not yet created, create it now
     config = config or Config(target, src_paths, app_config=app_config)
     target = config.target
-        
+    
     if not target_supports_toolchain(target, toolchain_name):
         raise NotSupportedException(
             "Target {} is not supported by toolchain {}".format(
@@ -529,13 +541,13 @@ def build_project(src_paths, build_path, target, toolchain_name,
     if clean and exists(build_path):
         rmtree(build_path)
     mkdir(build_path)
-
+    
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, config=config,
         app_config=app_config, build_profile=build_profile, ignore=ignore)
     toolchain.version_check()
-
+    
     # The first path will give the name to the library
     name = (name or toolchain.config.name or
             basename(normpath(abspath(src_paths[0]))))

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -355,7 +355,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                 target.name, toolchain_name))
 
     toolchain_name = get_toolchain_name(target, toolchain_name)
-    
+
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
     except KeyError:
@@ -541,13 +541,13 @@ def build_project(src_paths, build_path, target, toolchain_name,
     if clean and exists(build_path):
         rmtree(build_path)
     mkdir(build_path)
-    
+
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, config=config,
         app_config=app_config, build_profile=build_profile, ignore=ignore)
     toolchain.version_check()
-    
+
     # The first path will give the name to the library
     name = (name or toolchain.config.name or
             basename(normpath(abspath(src_paths[0]))))

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -316,7 +316,7 @@ class UvisionArmc5(Uvision):
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
         if not (set(target.supported_toolchains).intersection(
-                set(["ARM", "uARM"]))):
+                set(["ARMC5", "uARM"]))):
             return False
         if not DeviceCMSIS.check_supported(target_name):
             return False
@@ -339,7 +339,7 @@ class UvisionArmc6(Uvision):
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
         if not (set(target.supported_toolchains).intersection(
-                set(["ARMC6"]))):
+                set(["ARM", "ARMC6", "uARM"]))):
             return False
         if not DeviceCMSIS.check_supported(target_name):
             return False

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -315,9 +315,15 @@ class UvisionArmc5(Uvision):
     @classmethod
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
-        if not (set(target.supported_toolchains).intersection(
-                set(["ARMC5", "uARM"]))):
-            return False
+        if int(target.build_tools_metadata["version"]) > 0:
+            if not (set(target.supported_toolchains).intersection(
+                    set(["ARMC5", "uARM"]))):
+                return False
+        else:
+            if not (set(target.supported_toolchains).intersection(
+                    set(["ARM", "uARM"]))):
+                return False        
+            
         if not DeviceCMSIS.check_supported(target_name):
             return False
         if "Cortex-A" in target.core:
@@ -338,9 +344,15 @@ class UvisionArmc6(Uvision):
     @classmethod
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
-        if not (set(target.supported_toolchains).intersection(
-                set(["ARM", "ARMC6", "uARM"]))):
-            return False
+        if int(target.build_tools_metadata["version"]) > 0:
+            if not (set(target.supported_toolchains).intersection(
+                    set(["ARM", "ARMC6", "uARM"]))):
+                return False
+        else:
+            if not (set(target.supported_toolchains).intersection(
+                    set(["ARMC6"]))):
+                return False
+                
         if not DeviceCMSIS.check_supported(target_name):
             return False
         if "Cortex-A" in target.core:

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -162,7 +162,7 @@ def generate_py_target(new_targets, name):
 
 class Target(namedtuple("Target", "name json_data resolution_order resolution_order_names build_tools_metadata")):
     """An object to represent a Target (MCU/Board)"""
-    
+
     # Default location of the 'targets.json' file
     __targets_json_location_default = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), '..', '..', 'targets', 'targets.json')

--- a/tools/test/build_api/build_api_test.py
+++ b/tools/test/build_api/build_api_test.py
@@ -30,8 +30,11 @@ import intelhex
 Tests for build_api.py
 """
 make_mock_target = namedtuple(
-    "Target", "init_hooks name features core supported_toolchains")
-
+    "Target", "init_hooks name features core supported_toolchains build_tools_metadata")
+#Add ARMC5 to the supported_toolchains list as ARMC5 actually refers ARM Compiler 5 and is needed by ARM/ARM_STD classes when it checks for supported toolchains
+TOOLCHAINS.add("ARMC5")
+#Make a mock build_tools_metadata
+mock_build_tools_metadata = {u'version':0, u'public':False}
 
 class BuildApiTests(unittest.TestCase):
     """
@@ -92,7 +95,7 @@ class BuildApiTests(unittest.TestCase):
         """
         app_config = "app_config"
         mock_target = make_mock_target(lambda _, __ : None,
-                                       "Junk", [], "Cortex-M3", TOOLCHAINS)
+                                       "Junk", [], "Cortex-M3", TOOLCHAINS, mock_build_tools_metadata)
         mock_config_init.return_value = namedtuple(
             "Config", "target has_regions name")(mock_target, False, None)
 
@@ -111,7 +114,7 @@ class BuildApiTests(unittest.TestCase):
         :return:
         """
         mock_target = make_mock_target(lambda _, __ : None,
-                                       "Junk", [], "Cortex-M3", TOOLCHAINS)
+                                       "Junk", [], "Cortex-M3", TOOLCHAINS, mock_build_tools_metadata)
         mock_config_init.return_value = namedtuple(
             "Config", "target has_regions name")(mock_target, False, None)
 

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -41,9 +41,17 @@ from tools.notifier.mock import MockNotifier
 
 ALPHABET = [char for char in printable if char not in [u'.', u'/', u'\\']]
 
+#Create a global test target
+test_target_map = TARGET_MAP["K64F"]
+#We have to add ARMC5,UARM here to supported_toolchains, otherwise the creation of ARM class would fail as it won't find ARMC5 entry in supported_toolchains
+#We also have to add uARM, cause, ARM_MICRO class would check for both uARM and ARMC5 in supported_toolchains(as ARM_MICRO represents ARMC5+Micro).
+#And do this globally here so all tests can use this
+test_target_map.supported_toolchains.append("ARMC5")
+test_target_map.supported_toolchains.append("uARM")
+
 
 @patch('tools.toolchains.arm.run_cmd')
-def test_arm_version_check(_run_cmd):
+def test_armc5_version_check(_run_cmd):
     set_targets_json_location()
     _run_cmd.return_value = ("""
     Product: ARM Compiler 5.06
@@ -51,7 +59,10 @@ def test_arm_version_check(_run_cmd):
     Tool: armcc [4d3621]
     """, "", 0)
     notifier = MockNotifier()
-    toolchain = TOOLCHAIN_CLASSES["ARM"](TARGET_MAP["K64F"], notify=notifier)
+    target_map = TARGET_MAP["K64F"]
+    #We have to add ARMC5 here to supported_toolchains, otherwise the creation of ARM class would fail as it wont find ARMC5 entry in supported_toolchains
+    target_map.supported_toolchains.append("ARMC5")
+    toolchain = TOOLCHAIN_CLASSES["ARM"](target_map, notify=notifier)
     toolchain.version_check()
     assert notifier.messages == []
     _run_cmd.return_value = ("""
@@ -69,6 +80,20 @@ def test_arm_version_check(_run_cmd):
     toolchain.version_check()
     assert len(notifier.messages) == 1
 
+@patch('tools.toolchains.arm.run_cmd')
+def test_armc6_version_check(_run_cmd):
+    set_targets_json_location()
+    notifier = MockNotifier()
+    print(TARGET_MAP["K64F"])
+    toolchain = TOOLCHAIN_CLASSES["ARMC6"](TARGET_MAP["K64F"], notify=notifier)
+    print(toolchain)
+    _run_cmd.return_value = ("""
+    Product: ARM Compiler 6.11 Professional
+    Component: ARM Compiler 6.11
+    Tool: armclang [5d3b4200]
+    """, "", 0)
+    toolchain.version_check()
+    assert notifier.messages == []   
 
 @patch('tools.toolchains.iar.run_cmd')
 def test_iar_version_check(_run_cmd):
@@ -141,7 +166,7 @@ def test_toolchain_profile_c(profile, source_file):
     set_targets_json_location()
     with patch('os.mkdir') as _mkdir:
         for _, tc_class in TOOLCHAIN_CLASSES.items():
-            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile,
+            toolchain = tc_class(test_target_map, build_profile=profile,
                                  notify=MockNotifier())
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
@@ -173,7 +198,7 @@ def test_toolchain_profile_cpp(profile, source_file):
     to_compile = os.path.join(*filename)
     with patch('os.mkdir') as _mkdir:
         for _, tc_class in TOOLCHAIN_CLASSES.items():
-            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile,
+            toolchain = tc_class(test_target_map, build_profile=profile,
                                  notify=MockNotifier())
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
@@ -205,7 +230,7 @@ def test_toolchain_profile_asm(profile, source_file):
     to_compile = os.path.join(*filename)
     with patch('os.mkdir') as _mkdir:
         for _, tc_class in TOOLCHAIN_CLASSES.items():
-            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile,
+            toolchain = tc_class(test_target_map, build_profile=profile,
                                  notify=MockNotifier())
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
@@ -225,7 +250,7 @@ def test_toolchain_profile_asm(profile, source_file):
                                                                parameter)
 
     for name, Class in  TOOLCHAIN_CLASSES.items():
-        CLS = Class(TARGET_MAP["K64F"], notify=MockNotifier())
+        CLS = Class(test_target_map, notify=MockNotifier())
         assert name == CLS.name or name ==  LEGACY_TOOLCHAIN_NAMES[CLS.name]
 
 @given(fixed_dictionaries({
@@ -245,7 +270,7 @@ def test_toolchain_profile_ld(profile, source_file):
     with patch('os.mkdir') as _mkdir,\
          patch('tools.toolchains.mbedToolchain.default_cmd') as _dflt_cmd:
         for _, tc_class in TOOLCHAIN_CLASSES.items():
-            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile,
+            toolchain = tc_class(test_target_map, build_profile=profile,
                                  notify=MockNotifier())
             toolchain.RESPONSE_FILES = False
             toolchain.inc_md5 = ""
@@ -264,7 +289,7 @@ def test_toolchain_profile_ld(profile, source_file):
                                                                parameter)
 
     for name, Class in  TOOLCHAIN_CLASSES.items():
-        CLS = Class(TARGET_MAP["K64F"], notify=MockNotifier())
+        CLS = Class(test_target_map, notify=MockNotifier())
         assert name == CLS.name or name ==  LEGACY_TOOLCHAIN_NAMES[CLS.name]
 
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -390,10 +390,14 @@ class ARMC6(ARM_STD):
                 self.flags['common'].append("-DMBED_RTOS_SINGLE_THREAD")
             if "-D__MICROLIB" not in self.flags['common']:
                 self.flags['common'].append("-D__MICROLIB")
-            if "-Wl,--library_type=microlib" not in self.flags['ld']:
-                self.flags['ld'].append("-Wl,--library_type=microlib")
-            if "-Wl,--library_type=microlib" not in self.flags['common']:
-                self.flags['common'].append("-Wl,--library_type=microlib")    
+            if "--library_type=microlib" not in self.flags['ld']:
+                self.flags['ld'].append("--library_type=microlib")
+            if "-Wl,--library_type=microlib" not in self.flags['c']:
+                self.flags['c'].append("-Wl,--library_type=microlib")    
+            if "-Wl,--library_type=microlib" not in self.flags['cxx']:
+                self.flags['cxx'].append("-Wl,--library_type=microlib")        
+            if "--library_type=microlib" not in self.flags['asm']:
+                self.flags['asm'].append("--library_type=microlib")            
 
         core = target.core
         if CORE_ARCH[target.core] == 8:
@@ -470,7 +474,10 @@ class ARMC6(ARM_STD):
         self.elf2bin = join(TOOLCHAIN_PATHS["ARMC6"], "fromelf")
 
     def _get_toolchain_labels(self):
-        return ["ARM", "ARM_STD", "ARMC6"]
+        if getattr(self.target, "default_toolchain", "ARM") == "uARM":
+            return ["ARM", "ARM_MICRO"]
+        else:
+            return ["ARM", "ARM_STD"]
 
     def parse_dependencies(self, dep_path):
         return mbedToolchain.parse_dependencies(self, dep_path)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -343,7 +343,7 @@ class ARM_STD(ARM):
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                      build_profile=build_profile)
         #check only for ARMC5 because ARM_STD means using ARMC5, and thus supported_toolchains must include ARMC5
-        if not set(("ARMC5",)).intersection(set(target.supported_toolchains)):
+        if "ARMC5" not in target.supported_toolchains:
             raise NotSupportedException("ARM compiler 5 support is required for ARM build")
 
 class ARM_MICRO(ARM):
@@ -356,7 +356,7 @@ class ARM_MICRO(ARM):
 
         #At this point we already know that we want to use ARMC5+Microlib, so check for if they are supported
         #For, AC6+Microlib we still use ARMC6 class
-        if not set(("uARM","ARMC5")).intersection(set(target.supported_toolchains)) == set(("uARM","ARMC5")):
+        if not set(("uARM","ARMC5")).issubset(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                     build_profile=build_profile)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -475,9 +475,9 @@ class ARMC6(ARM_STD):
 
     def _get_toolchain_labels(self):
         if getattr(self.target, "default_toolchain", "ARM") == "uARM":
-            return ["ARM", "ARM_MICRO"]
+            return ["ARM", "ARM_MICRO", "ARMC6"]
         else:
-            return ["ARM", "ARM_STD"]
+            return ["ARM", "ARM_STD", "ARMC6"]
 
     def parse_dependencies(self, dep_path):
         return mbedToolchain.parse_dependencies(self, dep_path)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -342,9 +342,13 @@ class ARM_STD(ARM):
                  build_profile=None, build_dir=None):
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                      build_profile=build_profile)
-        #check only for ARMC5 because ARM_STD means using ARMC5, and thus supported_toolchains must include ARMC5
-        if "ARMC5" not in target.supported_toolchains:
-            raise NotSupportedException("ARM compiler 5 support is required for ARM build")
+        if int(target.build_tools_metadata["version"]) > 0:
+            #check only for ARMC5 because ARM_STD means using ARMC5, and thus supported_toolchains must include ARMC5
+            if "ARMC5" not in target.supported_toolchains:
+                raise NotSupportedException("ARM compiler 5 support is required for ARM build")
+        else:
+            if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):
+                raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
 
 class ARM_MICRO(ARM):
     PATCHED_LIBRARY = False
@@ -354,13 +358,16 @@ class ARM_MICRO(ARM):
                  build_dir=None):
         target.default_toolchain = "uARM"
 
-        #At this point we already know that we want to use ARMC5+Microlib, so check for if they are supported
-        #For, AC6+Microlib we still use ARMC6 class
-        if not set(("uARM","ARMC5")).issubset(set(target.supported_toolchains)):
-            raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
+        if int(target.build_tools_metadata["version"]) > 0:
+            #At this point we already know that we want to use ARMC5+Microlib, so check for if they are supported
+            #For, AC6+Microlib we still use ARMC6 class
+            if not set(("ARMC5","uARM")).issubset(set(target.supported_toolchains)):
+                raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
+        else:
+            if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):
+                raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                     build_profile=build_profile)
-                        
 
 class ARMC6(ARM_STD):
     OFFICIALLY_SUPPORTED = True
@@ -382,8 +389,12 @@ class ARMC6(ARM_STD):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
-        if not set(("ARM", "ARMC6", "uARM")).intersection(set(target.supported_toolchains)):
-            raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")
+        if int(target.build_tools_metadata["version"]) > 0:
+            if not set(("ARM", "ARMC6", "uARM")).intersection(set(target.supported_toolchains)):
+                raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")
+        else:
+            if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
+                raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")
             
         if getattr(target, "default_toolchain", "ARMC6") == "uARM":
             if "-DMBED_RTOS_SINGLE_THREAD" not in self.flags['common']:


### PR DESCRIPTION
### Description
This PR implements tools changes to make ARMC6 as default ARM compiler.
For some targets, which are not ARMC6 compatible will be kept in ARMC5. 
A new supported toolchain option ARMC5 has been added to specifically use
ARMC5 for some targets.
Below are the targets currently staying with ARMC5:
1. FUTURE_SEQUANA targets(4 targets)
2. MTB_ADV_WISE_1530
3. MTB_MXCHIP_EMW3166
4. MTB_USI_WM_BN_BM_22
5. KW24D

The PR also contains other minor fixes to support ARMC6.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@cmonr @0xc0170 @theotherjimmy @bridadan

