### PR TITLE
Use us ticker for tickless on devs with wrapper

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -288,7 +288,7 @@ void test_sleep(void)
     TEST_ASSERT_UINT64_WITHIN(DELAY_DELTA_US, DELAY_US, timer.read_high_resolution_us());
 }
 
-#if DEVICE_LPTICKER
+#if DEVICE_LPTICKER && !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER
 /** Test wake up from deepsleep
  *
  * Given a SysTimer with a tick scheduled in the future
@@ -342,7 +342,7 @@ Case cases[] = {
     Case("Handler called once", test_handler_called_once),
 #if DEVICE_SLEEP
     Case("Wake up from sleep", test_sleep),
-#if DEVICE_LPTICKER
+#if DEVICE_LPTICKER && !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER
     Case("Wake up from deep sleep", test_deepsleep),
 #endif
 #endif

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -24,6 +24,7 @@
 #include "platform/mbed_power_mgmt.h"
 #include "TimerEvent.h"
 #include "lp_ticker_api.h"
+#include "us_ticker_api.h"
 #include "mbed_critical.h"
 #include "mbed_assert.h"
 #include <new>
@@ -35,7 +36,12 @@ extern "C" {
 
     using namespace mbed;
 
-#if (defined(MBED_TICKLESS) && DEVICE_LPTICKER)
+#ifdef MBED_TICKLESS
+
+MBED_STATIC_ASSERT(!MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_USTICKER,
+                   "Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true");
+MBED_STATIC_ASSERT(MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_LPTICKER,
+                   "Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false");
 
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
@@ -47,7 +53,11 @@ extern "C" {
     {
         // Do not use SingletonPtr since this relies on the RTOS
         if (NULL == os_timer) {
-            os_timer = new (os_timer_data) rtos::internal::SysTimer();
+#if MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER
+            os_timer = new (os_timer_data) rtos::internal::SysTimer(get_us_ticker_data());
+#else
+            os_timer = new (os_timer_data) rtos::internal::SysTimer(get_lp_ticker_data());
+#endif
             os_timer->setup_irq();
         }
 
@@ -94,7 +104,8 @@ extern "C" {
     static void default_idle_hook(void)
     {
         uint32_t ticks_to_sleep = osKernelSuspend();
-        const bool block_deep_sleep = ticks_to_sleep <= MBED_CONF_TARGET_DEEP_SLEEP_LATENCY;
+        const bool block_deep_sleep = MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER ||
+                (ticks_to_sleep <= MBED_CONF_TARGET_DEEP_SLEEP_LATENCY);
 
         if (block_deep_sleep) {
             sleep_manager_lock_deep_sleep();

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -38,10 +38,10 @@ extern "C" {
 
 #ifdef MBED_TICKLESS
 
-MBED_STATIC_ASSERT(!MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_USTICKER,
-                   "Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true");
-MBED_STATIC_ASSERT(MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_LPTICKER,
-                   "Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false");
+    MBED_STATIC_ASSERT(!MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_USTICKER,
+                       "Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true");
+    MBED_STATIC_ASSERT(MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_LPTICKER,
+                       "Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false");
 
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
@@ -105,7 +105,7 @@ MBED_STATIC_ASSERT(MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_LPTICKER,
     {
         uint32_t ticks_to_sleep = osKernelSuspend();
         const bool block_deep_sleep = MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER ||
-                (ticks_to_sleep <= MBED_CONF_TARGET_DEEP_SLEEP_LATENCY);
+                                      (ticks_to_sleep <= MBED_CONF_TARGET_DEEP_SLEEP_LATENCY);
 
         if (block_deep_sleep) {
             sleep_manager_lock_deep_sleep();

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -38,6 +38,10 @@
             "default-form-factor": {
                 "help": "Default form factor of this board taken from supported_form_factors. This must be a lowercase string such as 'arduino'",
                 "value": null
+            },
+            "tickless-from-us-ticker": {
+                "help": "Run tickless from the microsecond ticker rather than the low power ticker. Running tickless off of the microsecond ticker improves interrupt latency on targets which use lpticker_delay_ticks",
+                "value": false
             }
         }
     },
@@ -1854,7 +1858,8 @@
             }
         },
         "overrides": {
-            "deep-sleep-latency": 3
+            "deep-sleep-latency": 3,
+            "tickless-from-us-ticker": true
         },
         "device_has": [
             "USTICKER",
@@ -7002,7 +7007,8 @@
         "device_name": "NUC472HI8AE",
         "bootloader_supported": true,
         "overrides": {
-            "network-default-interface-type": "ETHERNET"
+            "network-default-interface-type": "ETHERNET",
+            "tickless-from-us-ticker": true
         }
     },
     "NCS36510": {
@@ -7125,7 +7131,10 @@
         ],
         "release_versions": ["2", "5"],
         "device_name": "M453VG6AE",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "tickless-from-us-ticker": true
+        }
     },
     "NUMAKER_PFM_NANO130": {
         "core": "Cortex-M0",
@@ -7187,7 +7196,10 @@
             "SPI_ASYNCH"
         ],
         "release_versions": ["5"],
-        "device_name": "NANO130KE3BN"
+        "device_name": "NANO130KE3BN",
+        "overrides": {
+            "tickless-from-us-ticker": true
+        }
     },
     "HI2110": {
         "inherits": ["Target"],
@@ -7508,7 +7520,8 @@
         "release_versions": ["5"],
         "bootloader_supported": true,
         "overrides": {
-            "network-default-interface-type": "ETHERNET"
+            "network-default-interface-type": "ETHERNET",
+            "tickless-from-us-ticker": true
         }
     },
     "NUMAKER_PFM_M487": {
@@ -7745,7 +7758,8 @@
         "detect_code": ["1305"],
         "release_versions": ["5"],
         "device_name": "M2351KIAAEES",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "tickless-from-us-ticker": true
     },
     "TMPM3H6": {
         "inherits": ["Target"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3127,7 +3127,7 @@
             },
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 1
+                "value": 0
             }
         },
         "macros_add": [


### PR DESCRIPTION
### Description

The low power ticker wrapper layer adds a large amount of interrupt latency. This can cause dropped bytes at a baud of 115200 on some devices. To prevent this by default use the microsecond ticker for tickless on devices which make use of the low power ticker wrapper.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant 
@ithinuel 