### PR TITLE
Optimize tickless tick computation

### DIFF
--- a/rtos/TARGET_CORTEX/SysTimer.h
+++ b/rtos/TARGET_CORTEX/SysTimer.h
@@ -117,7 +117,7 @@ protected:
     virtual void handler();
     void _increment_tick();
     static void _set_irq_pending();
-    us_timestamp_t _start_time;
+    us_timestamp_t _time_us;
     uint64_t _tick;
     bool _suspend_time_passed;
     bool _suspended;


### PR DESCRIPTION
### Description

Optimize the tick computation by computing the elapsed ticks based on relative time rather than absolute time. On the NUCLEO_L073RZ this reduces the execution time of SysTimer::resume from >35us to less than ~15us~ 20us.

~Also, to ensure the relative time calculations do not overflow set the max time the OS can suspend to 1 hour.~

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan- 
