### PR TITLE
stm32l475: lwip symbols in sram1

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_STD/stm32l475xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_STD/stm32l475xx.sct
@@ -61,6 +61,7 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   }
   RW_IRAM1 MBED_RAM0_START MBED_RAM0_SIZE-Stack_Size  { ; RW data 96k L4-SRAM1
    .ANY (+RW, +Last)
+   lwip* (+ZI)
   }
  ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
   RW_IRAM2 (0x10000000+0x188) (0x08000-0x188)  {  ; ZI data 32k L4-ECC-SRAM2

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
@@ -106,6 +106,16 @@ SECTIONS
         __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
     } > SRAM1
 
+    .lwip :
+    {
+        . = ALIGN(8);
+        __lwip_bss_start__ = .;
+        *mbed-os/features/lwipstack*.o(.bss*)
+        *mbed-os/features/lwipstack*.o(COMMON)
+        . = ALIGN(8);
+        __lwip_bss_end__ = .;
+    } > SRAM1
+
     .data : AT (__etext)
     {
         __data_start__ = .;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/startup_stm32l475xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/startup_stm32l475xx.S
@@ -93,6 +93,18 @@ LoopCopyDataInit:
 	cmp	r2, r3
 	bcc	CopyDataInit
 
+/* Zero LWIP .bss section in second RAM region */
+	ldr     r1, =__lwip_bss_start__
+	ldr     r2, =__lwip_bss_end__
+
+	movs    r0, 0
+
+LWIPBssInit:
+	cmp     r1, r2
+	itt     lt
+	strlt   r0, [r1], #4
+	blt     LWIPBssInit
+
 /* Call the clock system intitialization function.*/
     bl  SystemInit
 /* Call static constructors */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -33,7 +33,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 }
 
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __size_heap__   = 0x17000;
+define symbol __size_heap__   = 0x13C00;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 
@@ -43,5 +43,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region { readwrite, block HEAP };
+place in SRAM1_region { readwrite, zeroinit object *lwip*.o, block HEAP };
 place in SRAM2_region { first block CSTACK, zeroinit };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -35,7 +35,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x13C00;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };


### PR DESCRIPTION
### Description

Move LWIP symbols to SRAM1 region, as they do not fit in the SRAM2 (32kB) with all the other symbols. This is done for purpose of using PDMC on this target with PPP modems. PPP requires LWIP which takes up additional RAM.

Tested to work with and without PPP on GCC_ARM, ARM, IAR. The only caveat is that HEAP size for IAR is reduced from 0x17000 to 0x13C00 even when PPP is not used. This is because heap is fixed size in IAR.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@linlingao 

### Release Notes

Fit LWIP into RAM regions
Heap size reduced for IAR from 0x17000 to 0x13C00