### PR TITLE
STM32 LPTICKER (LPTIM): correct init execution after bootloader

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -59,16 +59,19 @@ const ticker_info_t *lp_ticker_get_info()
 
 volatile uint8_t  lp_Fired = 0;
 
+static int LPTICKER_inited = 0;
+
 static void LPTIM1_IRQHandler(void);
 static void (*irq_handler)(void);
 
 void lp_ticker_init(void)
 {
     /* Check if LPTIM is already configured */
-    if (__HAL_RCC_LPTIM1_IS_CLK_ENABLED()) {
+    if (LPTICKER_inited) {
         lp_ticker_disable_interrupt();
         return;
     }
+    LPTICKER_inited = 1;
 
     RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct = {0};
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};


### PR DESCRIPTION
### Description

When the bootloader jumps into the application, the lp ticker initialization exit prematurely, preventing the interrupt handler from being set correctly in the vector table leading to the default handler to be triggered.

This PR needs to be merged before #9792 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@sarahmarshy @LMESTM @c1728p9 
