### PR TITLE
Increase events.share-eventsize to 768B because of ESP8266 AT driver and asynchronous DNS

### DIFF
--- a/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
@@ -21,6 +21,7 @@ set(unittest-test-sources
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
+  stubs/mbed_error.c
   stubs/mbed_shared_queues_stub.cpp
   stubs/nsapi_dns_stub.cpp
   stubs/EventFlags_stub.cpp

--- a/UNITTESTS/features/netsocket/NetworkStack/unittest.cmake
+++ b/UNITTESTS/features/netsocket/NetworkStack/unittest.cmake
@@ -24,6 +24,7 @@ set(unittest-test-sources
   stubs/mbed_assert_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
+  stubs/mbed_error.c
   stubs/mbed_shared_queues_stub.cpp
   stubs/nsapi_dns_stub.cpp
   stubs/EventFlags_stub.cpp

--- a/UNITTESTS/features/netsocket/TCPServer/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPServer/unittest.cmake
@@ -25,6 +25,7 @@ set(unittest-test-sources
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
+  stubs/mbed_error.c
   stubs/mbed_shared_queues_stub.cpp
   stubs/nsapi_dns_stub.cpp
   stubs/EventFlags_stub.cpp

--- a/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
@@ -22,6 +22,7 @@ set(unittest-test-sources
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
+  stubs/mbed_error.c
   stubs/mbed_shared_queues_stub.cpp
   stubs/nsapi_dns_stub.cpp
   stubs/EventFlags_stub.cpp

--- a/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
@@ -22,6 +22,7 @@ set(unittest-test-sources
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
+  stubs/mbed_error.c
   stubs/mbed_shared_queues_stub.cpp
   stubs/EventFlags_stub.cpp
   stubs/nsapi_dns_stub.cpp

--- a/events/mbed_lib.json
+++ b/events/mbed_lib.json
@@ -8,7 +8,7 @@
         },
         "shared-eventsize": {
             "help": "Event buffer size (bytes) for shared event queue",
-            "value": 256
+            "value": 768
         },
         "shared-dispatch-from-application": {
             "help": "No thread created for shared event queue - application will call dispatch from another thread (eg dispatch_forever at end of main)",


### PR DESCRIPTION
### Description
events.shared-eventsize: increased from 256B to 768B
    
Original value was too small once both ESP8266 driver and
asynchronous DNS started to use shared event queue. An assumption is
made that once shared event queue is taken into use there are going to
be multiple users instead of one, for which the original value would
have been sufficient.
### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
@SeppoTakalo 
@geky 
@michalpasztamobica 

### Release Notes

"events.shared-eventsize" increased from 256B to 768B
    
Original value was too small once both ESP8266 driver and
asynchronous DNS started to use shared event queue. An assumption is
made that once shared event queue is taken into use there are going to
be multiple users instead of one, for which the original value would
have been sufficient.