### PR TITLE
Bare-metal profile 

### DIFF
--- a/platform/bare_metal/mbed_lib.json
+++ b/platform/bare_metal/mbed_lib.json
@@ -1,0 +1,4 @@
+{
+  "name": "bare-metal",
+  "requires": ["platform", "drivers"]
+}


### PR DESCRIPTION
### Description
This pull request provides the "bare-metal profile" that allows for mbed OS 
to be built "bare-metal" or without an rtos. Requirinng the bare-metal 
library limits the code built into mbed OS to the hal, drivers, and 
platform.

The following table is the difference when using bare metal with release profile
on a simplified blinky example.

| Module             |        .text |      .data |        .bss |
|--------------------|--------------|------------|-------------|
| [fill]             |     111(-33) |      8(+4) |  2327(+206) |
| [lib]/c.a          |    17815(+0) |   2472(+0) |      89(+0) |
| [lib]/gcc.a        |     3112(+0) |      0(+0) |       0(+0) |
| [lib]/misc         |      204(+0) |      4(+0) |      28(+0) |
| main.o             |       56(+0) |      0(+0) |       4(+0) |
| mbed-os/cmsis      |     1033(+0) |      0(+0) |       0(+0) |
| mbed-os/components |       0(-56) |      0(+0) |       0(+0) |
| mbed-os/drivers    |      80(+18) |      0(+0) |       0(+0) |
| mbed-os/features   |       0(-42) |      0(+0) |     0(-184) |
| mbed-os/hal        |    1396(-68) |      4(-4) |     66(-64) |
| mbed-os/platform   |   1961(-550) |    260(+0) |    201(-56) |
| mbed-os/rtos       |     0(-6929) |    0(-168) |    0(-5973) |
| mbed-os/targets    |   5232(-788) |     12(+0) |     381(-1) |
| Subtotals          | 31000(-8448) | 2760(-168) | 3096(-6072) |

Total Static RAM memory (data + bss): 5856(-6240) bytes
Total Flash memory (text + data): 33760(-8616) bytes

Further, build time is reduced from 25sec to 8sec on my desktop and 
1m22s to 13s on my mid-2014 mac book pro.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

?

### Release Notes

Mbed OS may now be built without the rtos by creating an `mbed_app.json` with
the following contents:

```json
{
    "requires": ["bare-metal"]
}
```