### PR TITLE
Correctly include EventQueue.h

### DIFF
--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -26,7 +26,7 @@
 #include "unity.h"
 #include "utest.h"
 #include "nsapi_dns.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "dns_tests.h"
 
 using namespace utest::v1;

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularbase/at_cellularbasetest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularbase/at_cellularbasetest.cpp
@@ -17,7 +17,7 @@
 
 #include "gtest/gtest.h"
 #include "AT_CellularBase.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "AT_CellularNetwork.h"
 #include "ATHandler_stub.h"
 #include "FileHandle_stub.h"

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include <string.h>
 #include "AT_CellularContext.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "ATHandler.h"
 #include "AT_CellularDevice.h"
 #include "FileHandle_stub.h"

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularinformation/at_cellularinformationtest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularinformation/at_cellularinformationtest.cpp
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include <string.h>
 #include "ATHandler_stub.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "FileHandle_stub.h"
 #include "AT_CellularBase_stub.h"
 #include "ATHandler.h"

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include <string.h>
 #include "AT_CellularNetwork.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "ATHandler.h"
 #include "AT_CellularDevice.h"
 #include "FileHandle_stub.h"

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsms/at_cellularsmstest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsms/at_cellularsmstest.cpp
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include <string.h>
 #include "AT_CellularNetwork.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "ATHandler.h"
 #include "ATHandler_stub.h"
 #include "AT_CellularSMS.h"

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
@@ -18,7 +18,7 @@
 #include "AT_CellularStack.h"
 #include <string.h>
 #include "AT_CellularNetwork.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "ATHandler.h"
 #include "AT_CellularStack.h"
 #include "FileHandle_stub.h"

--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include <string.h>
 #include "AT_CellularNetwork.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "ATHandler.h"
 #include "AT_CellularStack.h"
 #include "FileHandle_stub.h"

--- a/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
+++ b/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
@@ -17,7 +17,7 @@
 
 #include "gtest/gtest.h"
 #include "LoRaWANStack.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 
 #include "LoRaPHY_stub.h"
 #include "LoRaMac_stub.h"

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -18,7 +18,7 @@
 #include <ctype.h>
 #include "nsapi_types.h"
 #include "ATHandler.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "ATHandler_stub.h"
 
 using namespace mbed;

--- a/UNITTESTS/stubs/CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/CellularDevice_stub.cpp
@@ -17,7 +17,7 @@
 
 #include "CellularDevice.h"
 #include "CellularDevice_stub.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "CellularUtil.h"
 
 using namespace mbed;

--- a/UNITTESTS/stubs/EventQueue_stub.cpp
+++ b/UNITTESTS/stubs/EventQueue_stub.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "Callback.h"
 #include "EventQueue_stub.h"
 

--- a/UNITTESTS/target_h/events/mbed_events.h
+++ b/UNITTESTS/target_h/events/mbed_events.h
@@ -18,7 +18,7 @@
 #ifndef MBED_EVENTS_H
 #define MBED_EVENTS_H
 
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 
 #include "events/mbed_shared_queues.h"
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/SimpleEventQueue.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/SimpleEventQueue.h
@@ -18,7 +18,7 @@
 #define BLE_PAL_SIMPLE_EVENT_QUEUE_H_
 
 #include <new>
-#include "EventQueue.h"
+#include "ble/pal/EventQueue.h"
 #include "ble/BLEInstanceBase.h"
 #include "ble/BLE.h"
 

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -20,13 +20,12 @@
 
 #include "platform/mbed_retarget.h"
 
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "PlatformMutex.h"
 #include "nsapi_types.h"
 
 #include "PlatformMutex.h"
 #include "Callback.h"
-#include "EventQueue.h"
 
 namespace mbed {
 

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -20,7 +20,7 @@
 #include "CellularUtil.h"
 #include "CellularLog.h"
 #include "CellularTargets.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 
 namespace mbed {
 

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -17,7 +17,7 @@
 #ifndef _CELLULAR_STATEMACHINE_H_
 #define _CELLULAR_STATEMACHINE_H_
 
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "CellularNetwork.h"
 #include "CellularCommon.h"
 #include "PlatformMutex.h"

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -22,7 +22,7 @@
 #include "platform/arm_hal_interrupt.h"
 #include <Timer.h>
 #include "equeue.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "mbed_shared_queues.h"
 #include "Timeout.h"
 

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -18,7 +18,7 @@
 #include "nsapi_dns.h"
 #include "stddef.h"
 #include <new>
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "mbed_shared_queues.h"
 
 // Default NetworkStack operations

--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "mbed_shared_queues.h"
-#include "EventQueue.h"
+#include "events/EventQueue.h"
 #include "OnboardNetworkStack.h"
 #include "Kernel.h"
 #include "PlatformMutex.h"


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

There are two EventQueue.h in mbed-os codebase:
[events/EventQueue.h](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.11.4/events/EventQueue.h)
[features/FEATURE_BLE/ble/pal/EventQueue.h](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.11.4/features/FEATURE_BLE/ble/pal/EventQueue.h)

By accident, `mbed compile` generates includes.txt with the correct
order of include search paths. This is not the case for the CMake
exporter: targets with FEATURE_BLE enables fail to compile with errors:

    mbed-os/features/cellular/framework/AT/ATHandler.h:99:60: error: 'events' has not been declared

Update all places to always include either "events/EventQueue.h"
or "ble/pal/EventQueue.h": to always find the correct header.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
