### PR TITLE
Fix psa_system_reset() on PSA IPC platform

### DIFF
--- a/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IPC/platform_ipc.c
+++ b/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IPC/platform_ipc.c
@@ -59,7 +59,7 @@ psa_status_t mbed_psa_reboot_and_request_new_security_state(uint32_t new_state)
 
 MBED_NORETURN void psa_system_reset(void)
 {
-    psa_handle_t conn = psa_connect(PSA_PLATFORM_LC_SET, 1);
+    psa_handle_t conn = psa_connect(PSA_PLATFORM_SYSTEM_RESET, 1);
     if (conn <= PSA_NULL_HANDLE) {
         return;
     }


### PR DESCRIPTION
### Description
On IPC platforms the wrong service was being called
Fix will actually call the right one
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@ARMmbed/mbed-os-psa 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
