### PR TITLE
Update mbed_stats.c to use __ARMCC_VERSION flag for compatibility with AC6

### DIFF
--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -170,7 +170,7 @@ void mbed_stats_sys_get(mbed_stats_sys_t *stats)
 #if defined(__IAR_SYSTEMS_ICC__)
     stats->compiler_id = IAR;
     stats->compiler_version = __VER__;
-#elif defined(__CC_ARM)
+#elif defined(__ARMCC_VERSION)
     stats->compiler_id = ARM;
     stats->compiler_version = __ARMCC_VERSION;
 #elif defined(__GNUC__)


### PR DESCRIPTION
### Description
Update mbed_stats.c to use __ARMCC_VERSION for compatibility with AC6

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@deepikabhavnani 
