### PR TITLE
Apply artifact_name configuration parameter to exported projects

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -276,7 +276,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     if linker_script is not None:
         resources.linker_script = linker_script
 
-    if toolchain.config.name is not None:
+    if toolchain.config.name:
         name = toolchain.config.name
 
     files, exporter = generate_project_files(resources, export_path,

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -276,7 +276,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     if linker_script is not None:
         resources.linker_script = linker_script
 
-    if toolchain.config.app_config_data['artifact_name'] is not None:
+    if toolchain.config.name is not None:
         name = toolchain.config.app_config_data['artifact_name']
 
     files, exporter = generate_project_files(resources, export_path,

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -276,6 +276,9 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     if linker_script is not None:
         resources.linker_script = linker_script
 
+    if toolchain.config.app_config_data['artifact_name'] is not None:
+        name = toolchain.config.app_config_data['artifact_name']
+
     files, exporter = generate_project_files(resources, export_path,
                                              target, name, toolchain, ide,
                                              macros=macros)

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -277,7 +277,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
         resources.linker_script = linker_script
 
     if toolchain.config.name is not None:
-        name = toolchain.config.app_config_data['artifact_name']
+        name = toolchain.config.name
 
     files, exporter = generate_project_files(resources, export_path,
                                              target, name, toolchain, ide,


### PR DESCRIPTION
### Description

https://github.com/ARMmbed/mbed-os/issues/8428

Previously the `artifact_name` parameter was not used when exporting projects. I just slipped this little guy in as it should cover all use cases, let me know if I missed something though as I'm a bit less familiar with this section of the tools!

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@theotherjimmy 
@bridadan 

### Release Notes

