### PR TITLE
rand() and srand() are made sparse to not have same block.

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
@@ -49,8 +49,9 @@ void basic_erase_program_read_test(SPIFBlockDevice &block_device, bd_size_t bloc
     _mutex->lock();
 
     // Make sure block address per each test is unique
-    static unsigned block_seed = 1;
-    srand(block_seed++);
+    static unsigned block_seed = SPIF_TEST_NUM_OF_THREADS;
+    srand(block_seed);
+    block_seed += 2;
 
     // Find a random block
     bd_addr_t block = (rand() * block_size) % block_device.size();

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -189,8 +189,9 @@ void basic_erase_program_read_test(BlockDevice *block_device, bd_size_t block_si
     _mutex->lock();
 
     // Make sure block address per each test is unique
-    static unsigned block_seed = 1;
-    srand(block_seed++);
+    static unsigned block_seed = TEST_NUM_OF_THREADS;
+    srand(block_seed);
+    block_seed += 2;
 
     // Find a random block
     bd_addr_t block = (rand() * block_size) % (block_device->size());


### PR DESCRIPTION
### Description

Random number generation API's - rand() and srand() are made sparse to not have same block.

Failure was noted when 2 threads getting same random number were trying to write to same block and rechecking resulted in error (since block was over-written by another thread).
Random number generation in case of IAR 8, requires TLS support and without TLS it may result into same random number since same main thread space is used for all threads.

This may happen in other cases as well when rand() gives same values for for 2-threads.
Future solution recommendation will be:
Instead of checking the same random data written, checksum logic can be used in future. Threads are allowed to overwrite the data (block commands are not in mutex) in test, so instead of verifying the exact data some checksum of data should be checked to make sure data was not jumbled up 2-threads accessing it.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-storage 

@ARMmbed/mbed-os-maintainers  - Commit in applied to https://github.com/ARMmbed/mbed-os/pull/9818 PR to test with IAR 8 and here to test with IAR 7 as well.

Please consider merging this when approved. 

