### PR TITLE
return the new values for key type & size even if function fails

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -1076,13 +1076,11 @@ static void psa_key_management_operation(void)
                     size_t bits;
                     status = psa_get_key_information(psa_key_mng.handle,
                                                      &type, &bits);
-                    if (status == PSA_SUCCESS) {
-                        if (msg.out_size[0] >= sizeof(psa_key_type_t))
-                            psa_write(msg.handle, 0,
-                                      &type, sizeof(psa_key_type_t));
-                        if (msg.out_size[1] >= sizeof(size_t)) {
-                            psa_write(msg.handle, 1, &bits, sizeof(size_t));
-                        }
+                    if (msg.out_size[0] >= sizeof(psa_key_type_t))
+                        psa_write(msg.handle, 0,
+                                  &type, sizeof(psa_key_type_t));
+                    if (msg.out_size[1] >= sizeof(size_t)) {
+                        psa_write(msg.handle, 1, &bits, sizeof(size_t));
                     }
 
                     break;


### PR DESCRIPTION
### Description

update the value if the key bytes and size even if the function fails.
those parameters are passed as in\out parameters but the new value is discarded if the function fails,
removing the if statement and always update the values 



<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@itayzafrir 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
