### PR TITLE
Migrate SecureStore & DeviceKey from mbedtls APIs to PSA Crypto ones

### DIFF
--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -20,10 +20,8 @@
 
 #if SECURESTORE_ENABLED
 
-#include "aes.h"
-#include "cmac.h"
 #include "mbedtls/platform.h"
-#include "entropy.h"
+#include "psa/crypto.h"
 #include "DeviceKey.h"
 #include "mbed_assert.h"
 #include "mbed_wait_api.h"
@@ -64,9 +62,12 @@ typedef struct {
     record_metadata_t metadata;
     char *key;
     uint32_t offset_in_data;
-    uint8_t ctr_buf[enc_block_size];
-    mbedtls_aes_context enc_ctx;
-    mbedtls_cipher_context_t auth_ctx;
+    psa_key_handle_t enc_handle;
+    psa_cipher_operation_t enc_operation;
+    uint32_t backlog_size;
+    uint8_t backlog_buf[enc_block_size];
+    psa_key_handle_t auth_handle;
+    psa_mac_operation_t auth_operation;
     KVStore::set_handle_t underlying_handle;
 } inc_set_handle_t;
 
@@ -82,40 +83,123 @@ typedef struct {
 
 // -------------------------------------------------- Functions Implementation ----------------------------------------------------
 
-int encrypt_decrypt_start(mbedtls_aes_context &enc_aes_ctx, uint8_t *iv, const char *key,
-                          uint8_t *ctr_buf, uint8_t *salt_buf, int salt_buf_size)
+static inline uint32_t align_down(uint32_t val, uint32_t size)
+{
+    return (val / size) * size;
+}
+
+int encrypt_decrypt_start(psa_key_handle_t &enc_handle, psa_cipher_operation_t &operation, uint8_t *iv,
+                          const char *key, uint8_t *salt_buf, int salt_buf_size, bool encrypt)
 {
     DeviceKey &devkey = DeviceKey::get_instance();
     char *salt = reinterpret_cast<char *>(salt_buf);
     uint8_t encrypt_key[derived_key_size];
+    uint8_t ctr_buf[enc_block_size];
     strcpy(salt, enc_prefix);
     int pos = strlen(enc_prefix);
     strncpy(salt + pos, key, salt_buf_size - pos - 1);
     salt_buf[salt_buf_size - 1] = 0;
-    int os_ret = devkey.generate_derived_key(salt_buf, strlen(salt), encrypt_key,  DEVICE_KEY_16BYTE);
-    if (os_ret) {
-        return os_ret;
+    int devkey_ret = devkey.generate_derived_key(salt_buf, strlen(salt), encrypt_key,  DEVICE_KEY_16BYTE);
+    if (devkey_ret) {
+        return MBED_ERROR_FAILED_OPERATION;
     }
 
-    mbedtls_aes_init(&enc_aes_ctx);
-    mbedtls_aes_setkey_enc(&enc_aes_ctx, encrypt_key, enc_block_size * 8);
+    psa_status_t psa_ret = psa_allocate_key(&enc_handle);
+    if (psa_ret != PSA_SUCCESS) {
+        return MBED_ERROR_FAILED_OPERATION;
+    }
+
+    psa_key_policy_t policy = PSA_KEY_POLICY_INIT;
+    psa_key_policy_set_usage(&policy, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT, PSA_ALG_CTR);
+    psa_ret = psa_set_key_policy(enc_handle, &policy);
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
+    }
+
+    psa_ret = psa_import_key(enc_handle, PSA_KEY_TYPE_AES, encrypt_key, enc_block_size);
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
+    }
+
+    memset(&operation, 0, sizeof(operation));
+    if (encrypt) {
+        psa_ret = psa_cipher_encrypt_setup(&operation, enc_handle, PSA_ALG_CTR);
+    } else {
+        psa_ret = psa_cipher_decrypt_setup(&operation, enc_handle, PSA_ALG_CTR);
+    }
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
+    }
 
     memcpy(ctr_buf, iv, iv_size);
     memset(ctr_buf + iv_size, 0, iv_size);
 
-    return 0;
+    psa_ret = psa_cipher_set_iv(&operation, ctr_buf, enc_block_size);
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
+    }
+
+    return MBED_SUCCESS;
+
+fail:
+    psa_destroy_key(enc_handle);
+    return MBED_ERROR_FAILED_OPERATION;
 }
 
-int encrypt_decrypt_data(mbedtls_aes_context &enc_aes_ctx, const uint8_t *in_buf,
-                         uint8_t *out_buf, uint32_t chunk_size, uint8_t *ctr_buf, size_t &aes_offs)
+int encrypt_decrypt_data(psa_cipher_operation_t &operation, const uint8_t *in_buf,
+                         uint8_t *out_buf, uint32_t data_size)
 {
-    uint8_t stream_block[enc_block_size];
-
-    return mbedtls_aes_crypt_ctr(&enc_aes_ctx, chunk_size, &aes_offs, ctr_buf,
-                                 stream_block, in_buf, out_buf);
+    // This code works around a problem in mbed-crypto encryption APIs, not
+    // allowing the in place encryption/decryption of data whose size is not a
+    // multiple of the encryption block size
+    while (data_size) {
+        uint32_t chunk_size, enc_size;
+        uint8_t tail_buf[enc_block_size];
+        const uint8_t *src_buf;
+        uint8_t *dst_buf;
+        size_t out_len;
+        bool use_tail_buf = false;
+        if ((data_size < enc_block_size) && (in_buf == out_buf)) {
+            chunk_size = data_size;
+            memcpy(tail_buf, in_buf, chunk_size);
+            enc_size = enc_block_size;
+            src_buf = tail_buf;
+            dst_buf = tail_buf;
+            use_tail_buf = true;
+        } else {
+            if ((in_buf == out_buf) && (data_size % enc_block_size)) {
+                chunk_size = align_down(data_size, enc_block_size);
+            } else {
+                chunk_size = data_size;
+            }
+            enc_size = chunk_size;
+            src_buf = in_buf;
+            dst_buf = out_buf;
+        }
+        psa_status_t psa_ret = psa_cipher_update(&operation, src_buf, enc_size, dst_buf, enc_size, &out_len);
+        if (psa_ret != PSA_SUCCESS) {
+            return MBED_ERROR_FAILED_OPERATION;
+        }
+        if (use_tail_buf) {
+            memcpy(out_buf, tail_buf, chunk_size);
+        }
+        data_size -= chunk_size;
+        in_buf += chunk_size;
+        out_buf += chunk_size;
+    }
+    return MBED_SUCCESS;
 }
 
-int cmac_calc_start(mbedtls_cipher_context_t &auth_ctx, const char *key, uint8_t *salt_buf, int salt_buf_size)
+int encrypt_decrypt_finish(psa_key_handle_t &enc_handle, psa_cipher_operation_t &operation)
+{
+    psa_cipher_abort(&operation);
+    memset(&operation, 0, sizeof(operation));
+    psa_destroy_key(enc_handle);
+    return MBED_SUCCESS;
+}
+
+int cmac_calc_start(psa_key_handle_t &auth_handle, psa_mac_operation_t &operation, const char *key,
+                    uint8_t *salt_buf, int salt_buf_size)
 {
     DeviceKey &devkey = DeviceKey::get_instance();
     char *salt = reinterpret_cast<char *>(salt_buf);
@@ -124,51 +208,76 @@ int cmac_calc_start(mbedtls_cipher_context_t &auth_ctx, const char *key, uint8_t
     int pos = strlen(auth_prefix);
     strncpy(salt + pos, key, salt_buf_size - pos - 1);
     salt_buf[salt_buf_size - 1] = 0;
-    int os_ret = devkey.generate_derived_key(salt_buf, strlen(salt), auth_key, DEVICE_KEY_16BYTE);
-    if (os_ret) {
-        return os_ret;
+    int devkey_ret = devkey.generate_derived_key(salt_buf, strlen(salt), auth_key, DEVICE_KEY_16BYTE);
+    if (devkey_ret) {
+        return MBED_ERROR_FAILED_OPERATION;
     }
 
-    const mbedtls_cipher_info_t *cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
-
-    mbedtls_cipher_init(&auth_ctx);
-
-    if ((os_ret = mbedtls_cipher_setup(&auth_ctx, cipher_info)) != 0) {
-        return os_ret;
+    psa_status_t psa_ret = psa_allocate_key(&auth_handle);
+    if (psa_ret != PSA_SUCCESS) {
+        return MBED_ERROR_FAILED_OPERATION;
     }
 
-    os_ret = mbedtls_cipher_cmac_starts(&auth_ctx, auth_key, cmac_size * 8);
-    if (os_ret != 0) {
-        return os_ret;
+    psa_key_policy_t policy = PSA_KEY_POLICY_INIT;
+    psa_key_policy_set_usage(&policy, PSA_KEY_USAGE_SIGN, PSA_ALG_CMAC);
+    psa_ret = psa_set_key_policy(auth_handle, &policy);
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
     }
 
-    return 0;
+    psa_ret = psa_import_key(auth_handle, PSA_KEY_TYPE_AES, auth_key, enc_block_size);
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
+    }
+
+    psa_ret = psa_mac_sign_setup(&operation, auth_handle, PSA_ALG_CMAC);
+    if (psa_ret != PSA_SUCCESS) {
+        goto fail;
+    }
+
+    return MBED_SUCCESS;
+
+fail:
+    psa_destroy_key(auth_handle);
+    return MBED_ERROR_FAILED_OPERATION;
+
 }
 
-int cmac_calc_data(mbedtls_cipher_context_t &auth_ctx, const void *input, size_t ilen)
+int cmac_calc_data(psa_mac_operation_t &operation, const void *input, size_t ilen)
 {
-    int os_ret;
+    psa_status_t psa_ret = psa_mac_update(&operation, (const unsigned char *) input, ilen);
+    if (psa_ret != PSA_SUCCESS) {
+        return MBED_ERROR_FAILED_OPERATION;
+    }
 
-    os_ret = mbedtls_cipher_cmac_update(&auth_ctx, static_cast<const uint8_t *>(input), ilen);
-
-    return os_ret;
+    return MBED_SUCCESS;
 }
 
-int cmac_calc_finish(mbedtls_cipher_context_t &auth_ctx, uint8_t *output)
+int cmac_calc_finish(psa_key_handle_t &auth_handle, psa_mac_operation_t &operation, uint8_t *output)
 {
-    int os_ret;
+    size_t mac_length;
 
-    os_ret = mbedtls_cipher_cmac_finish(&auth_ctx, output);
+    if (output) {
+        psa_status_t psa_ret = psa_mac_sign_finish(&operation, output, cmac_size, &mac_length);
+        if (psa_ret != PSA_SUCCESS) {
+            return MBED_ERROR_FAILED_OPERATION;
+        }
+    }
 
-    return os_ret;
+    psa_mac_abort(&operation);
+    memset(&operation, 0, sizeof(operation));
+    psa_destroy_key(auth_handle);
+
+    return MBED_SUCCESS;
 }
+
 
 
 
 // Class member functions
 
 SecureStore::SecureStore(KVStore *underlying_kv, KVStore *rbp_kv) :
-    _is_initialized(false), _underlying_kv(underlying_kv), _rbp_kv(rbp_kv), _entropy(0),
+    _is_initialized(false), _underlying_kv(underlying_kv), _rbp_kv(rbp_kv),
     _inc_set_handle(0), _scratch_buf(0)
 {
 }
@@ -182,7 +291,7 @@ SecureStore::~SecureStore()
 int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_data_size,
                            uint32_t create_flags)
 {
-    int ret, os_ret;
+    int ret;
     inc_set_handle_t *ih;
     info_t info;
     bool enc_started = false, auth_started = false;
@@ -238,15 +347,14 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
 
     if (create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
         // generate a new random iv
-        os_ret = mbedtls_entropy_func(_entropy, ih->metadata.iv, iv_size);
-        if (os_ret) {
+        psa_status_t psa_ret = psa_generate_random(ih->metadata.iv, iv_size);
+        if (psa_ret != PSA_SUCCESS) {
             ret = MBED_ERROR_FAILED_OPERATION;
             goto fail;
         }
-        os_ret = encrypt_decrypt_start(ih->enc_ctx, ih->metadata.iv, key, ih->ctr_buf, _scratch_buf,
-                                       scratch_buf_size);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
+        ret = encrypt_decrypt_start(ih->enc_handle, ih->enc_operation, ih->metadata.iv, key, _scratch_buf,
+                                    scratch_buf_size, true);
+        if (ret) {
             goto fail;
         }
         enc_started = true;
@@ -254,25 +362,23 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
         memset(ih->metadata.iv, 0, iv_size);
     }
 
-    os_ret = cmac_calc_start(ih->auth_ctx, key, _scratch_buf, scratch_buf_size);
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_start(ih->auth_handle, ih->auth_operation, key, _scratch_buf, scratch_buf_size);
+    if (ret) {
         goto fail;
     }
     auth_started = true;
     // Although name is not part of the data, we calculate CMAC on it as well
-    os_ret = cmac_calc_data(ih->auth_ctx, key, strlen(key));
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_data(ih->auth_operation, key, strlen(key));
+    if (ret) {
         goto fail;
     }
-    os_ret = cmac_calc_data(ih->auth_ctx, &ih->metadata, sizeof(record_metadata_t));
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_data(ih->auth_operation, &ih->metadata, sizeof(record_metadata_t));
+    if (ret) {
         goto fail;
     }
 
     ih->offset_in_data = 0;
+    ih->backlog_size = 0;
     ih->key = 0;
 
     // Should strip security flags from underlying storage
@@ -298,11 +404,11 @@ int SecureStore::set_start(set_handle_t *handle, const char *key, size_t final_d
 
 fail:
     if (enc_started) {
-        mbedtls_aes_free(&ih->enc_ctx);
+        encrypt_decrypt_finish(ih->enc_handle, ih->enc_operation);
     }
 
     if (auth_started) {
-        mbedtls_cipher_free(&ih->auth_ctx);
+        cmac_calc_finish(ih->auth_handle, ih->auth_operation, 0);
     }
 
     // mark handle as invalid by clearing metadata size field in header
@@ -315,8 +421,7 @@ end:
 
 int SecureStore::set_add_data(set_handle_t handle, const void *value_data, size_t data_size)
 {
-    size_t aes_offs = 0;
-    int os_ret, ret = MBED_SUCCESS;
+    int ret = MBED_SUCCESS;
     inc_set_handle_t *ih;
     const uint8_t *src_ptr;
 
@@ -333,7 +438,7 @@ int SecureStore::set_add_data(set_handle_t handle, const void *value_data, size_
         return MBED_ERROR_INVALID_ARGUMENT;
     }
 
-    if (ih->offset_in_data + data_size > ih->metadata.data_size) {
+    if (ih->offset_in_data + ih->backlog_size + data_size > ih->metadata.data_size) {
         ret = MBED_ERROR_INVALID_SIZE;
         goto end;
     }
@@ -343,14 +448,38 @@ int SecureStore::set_add_data(set_handle_t handle, const void *value_data, size_
         uint32_t chunk_size;
         const uint8_t *dst_ptr;
         if (ih->metadata.create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
+            // In encryption mode, we have a problem with fragments of encryption block sizes -
+            // we don't want to encrypt them twice, which may happen if further input is added.
+            // So unless they are at the very end of our input, keep them in the backlog buffer.
+
+            if (ih->backlog_size) {
+                memcpy(_scratch_buf, ih->backlog_buf, ih->backlog_size);
+                memcpy(_scratch_buf + ih->backlog_size, src_ptr,
+                       std::min((uint32_t)data_size, scratch_buf_size - ih->backlog_size));
+                src_ptr = _scratch_buf;
+                data_size += ih->backlog_size;
+                ih->backlog_size = 0;
+            }
+
             // In encrypt mode we don't want to allocate a buffer in the size given by the user -
-            // Encrypt the data chunk by chunk
+            // Encrypt the data chunk by chunk using our scratch buffer
             chunk_size = std::min((uint32_t) data_size, scratch_buf_size);
+
+            // Now take care of dangling encryption fragments
+            uint32_t enc_block_frag = chunk_size % enc_block_size;
+            if (enc_block_frag && (ih->offset_in_data + chunk_size < ih->metadata.data_size)) {
+                chunk_size -= enc_block_frag;
+                ih->backlog_size = enc_block_frag;
+                memcpy(ih->backlog_buf, src_ptr + chunk_size, enc_block_frag);
+            }
+
+            if (!chunk_size) {
+                break;
+            }
+
             dst_ptr = _scratch_buf;
-            os_ret = encrypt_decrypt_data(ih->enc_ctx, src_ptr, _scratch_buf,
-                                          chunk_size, ih->ctr_buf, aes_offs);
-            if (os_ret) {
-                ret = MBED_ERROR_FAILED_OPERATION;
+            ret = encrypt_decrypt_data(ih->enc_operation, src_ptr, _scratch_buf, chunk_size);
+            if (ret) {
                 goto fail;
             }
         } else {
@@ -358,9 +487,8 @@ int SecureStore::set_add_data(set_handle_t handle, const void *value_data, size_
             dst_ptr = static_cast <const uint8_t *>(value_data);
         }
 
-        os_ret = cmac_calc_data(ih->auth_ctx, dst_ptr, chunk_size);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
+        ret = cmac_calc_data(ih->auth_operation, dst_ptr, chunk_size);
+        if (ret) {
             goto fail;
         }
 
@@ -380,10 +508,10 @@ fail:
         delete[] ih->key;
     }
     if (ih->metadata.create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
-        mbedtls_aes_free(&ih->enc_ctx);
+        encrypt_decrypt_finish(ih->enc_handle, ih->enc_operation);
     }
 
-    mbedtls_cipher_free(&ih->auth_ctx);
+    cmac_calc_finish(ih->auth_handle, ih->auth_operation, 0);
 
     // mark handle as invalid by clearing metadata size field in header
     ih->metadata.metadata_size = 0;
@@ -395,7 +523,7 @@ end:
 
 int SecureStore::set_finalize(set_handle_t handle)
 {
-    int os_ret, ret = MBED_SUCCESS;
+    int ret = MBED_SUCCESS;
     inc_set_handle_t *ih;
     uint8_t cmac[cmac_size] = {0};
 
@@ -414,9 +542,8 @@ int SecureStore::set_finalize(set_handle_t handle)
         goto end;
     }
 
-    os_ret = cmac_calc_finish(ih->auth_ctx, cmac);
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_finish(ih->auth_handle, ih->auth_operation, cmac);
+    if (ret) {
         goto end;
     }
 
@@ -446,10 +573,8 @@ end:
     // mark handle as invalid by clearing metadata size field in header
     ih->metadata.metadata_size = 0;
     if (ih->metadata.create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
-        mbedtls_aes_free(&ih->enc_ctx);
+        encrypt_decrypt_finish(ih->enc_handle, ih->enc_operation);
     }
-
-    mbedtls_cipher_free(&ih->auth_ctx);
 
     _mutex.unlock();
     return ret;
@@ -518,10 +643,9 @@ end:
 int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_t *actual_size,
                         size_t offset, info_t *info)
 {
-    int os_ret, ret;
+    int ret;
     bool rbp_key_exists = false;
     uint8_t rbp_cmac[cmac_size];
-    size_t aes_offs = 0;
     uint32_t data_size;
     uint32_t actual_data_size;
     uint32_t current_offset;
@@ -569,30 +693,26 @@ int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_
         goto end;
     }
 
-    os_ret = cmac_calc_start(ih->auth_ctx, key, _scratch_buf, scratch_buf_size);
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_start(ih->auth_handle, ih->auth_operation, key, _scratch_buf, scratch_buf_size);
+    if (ret) {
         goto end;
     }
     auth_started = true;
 
     // Although name is not part of the data, we calculate CMAC on it as well
-    os_ret = cmac_calc_data(ih->auth_ctx, key, strlen(key));
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_data(ih->auth_operation, key, strlen(key));
+    if (ret) {
         goto end;
     }
-    os_ret = cmac_calc_data(ih->auth_ctx, &ih->metadata, sizeof(record_metadata_t));
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_data(ih->auth_operation, &ih->metadata, sizeof(record_metadata_t));
+    if (ret) {
         goto end;
     }
 
     if (create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
-        os_ret = encrypt_decrypt_start(ih->enc_ctx, ih->metadata.iv, key, ih->ctr_buf, _scratch_buf,
-                                       scratch_buf_size);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
+        ret = encrypt_decrypt_start(ih->enc_handle, ih->enc_operation, ih->metadata.iv, key,
+                                    _scratch_buf, scratch_buf_size, false);
+        if (ret) {
             goto end;
         }
         enc_started = true;
@@ -633,18 +753,15 @@ int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_
             goto end;
         }
 
-        os_ret = cmac_calc_data(ih->auth_ctx, dest_buf, chunk_size);
-        if (os_ret) {
-            ret = MBED_ERROR_FAILED_OPERATION;
+        ret = cmac_calc_data(ih->auth_operation, dest_buf, chunk_size);
+        if (ret) {
             goto end;
         }
 
         if (create_flags & REQUIRE_CONFIDENTIALITY_FLAG) {
             // Decrypt data in place
-            os_ret = encrypt_decrypt_data(ih->enc_ctx, dest_buf, dest_buf, chunk_size, ih->ctr_buf,
-                                          aes_offs);
-            if (os_ret) {
-                ret = MBED_ERROR_FAILED_OPERATION;
+            ret = encrypt_decrypt_data(ih->enc_operation, dest_buf, dest_buf, chunk_size);
+            if (ret) {
                 goto end;
             }
 
@@ -663,9 +780,8 @@ int SecureStore::do_get(const char *key, void *buffer, size_t buffer_size, size_
     }
 
     uint8_t calc_cmac[cmac_size], read_cmac[cmac_size];
-    os_ret = cmac_calc_finish(ih->auth_ctx, calc_cmac);
-    if (os_ret) {
-        ret = MBED_ERROR_FAILED_OPERATION;
+    ret = cmac_calc_finish(ih->auth_handle, ih->auth_operation, calc_cmac);
+    if (ret) {
         goto end;
     }
 
@@ -701,11 +817,11 @@ end:
     ih->metadata.metadata_size = 0;
 
     if (enc_started) {
-        mbedtls_aes_free(&ih->enc_ctx);
+        encrypt_decrypt_finish(ih->enc_handle, ih->enc_operation);
     }
 
     if (auth_started) {
-        mbedtls_cipher_free(&ih->auth_ctx);
+        cmac_calc_finish(ih->auth_handle, ih->auth_operation, 0);
     }
 
     return ret;
@@ -734,8 +850,12 @@ int SecureStore::get_info(const char *key, info_t *info)
 int SecureStore::init()
 {
     int ret = MBED_SUCCESS;
+    psa_status_t psa_ret;
 
     MBED_ASSERT(!(scratch_buf_size % enc_block_size));
+
+    // Failing this will break backward compatibility
+    MBED_ASSERT(PSA_BLOCK_CIPHER_BLOCK_SIZE(PSA_KEY_TYPE_AES) >= enc_block_size);
 
     _mutex.lock();
 #if defined(MBEDTLS_PLATFORM_C)
@@ -745,8 +865,10 @@ int SecureStore::init()
     }
 #endif /* MBEDTLS_PLATFORM_C */
 
-    _entropy = new mbedtls_entropy_context;
-    mbedtls_entropy_init(static_cast<mbedtls_entropy_context *>(_entropy));
+    psa_ret = psa_crypto_init();
+    if (psa_ret != PSA_SUCCESS) {
+        MBED_ERROR(MBED_ERROR_INITIALIZATION_FAILED, "Unable to initialize crypto framework");
+    }
 
     _scratch_buf = new uint8_t[scratch_buf_size];
     _inc_set_handle = new inc_set_handle_t;
@@ -767,24 +889,30 @@ int SecureStore::init()
 
 fail:
     _mutex.unlock();
+
+    if (!_is_initialized) {
+        // deallocate all already allocated resources
+        deinit();
+    }
     return ret;
 }
 
 int SecureStore::deinit()
 {
     _mutex.lock();
-    if (_is_initialized) {
-        mbedtls_entropy_free(static_cast<mbedtls_entropy_context *>(_entropy));
-        delete static_cast<mbedtls_entropy_context *>(_entropy);
-        delete static_cast<inc_set_handle_t *>(_inc_set_handle);
-        delete _scratch_buf;
-        // TODO: Deinit member KVs?
-    }
+    delete static_cast<inc_set_handle_t *>(_inc_set_handle);
+    _inc_set_handle = 0;
 
-    _is_initialized = false;
+    delete _scratch_buf;
+    _scratch_buf = 0;
+    // TODO: Deinit member KVs?
+
 #if defined(MBEDTLS_PLATFORM_C)
     mbedtls_platform_teardown(NULL);
 #endif /* MBEDTLS_PLATFORM_C */
+
+    _is_initialized = false;
+
     _mutex.unlock();
 
     return MBED_SUCCESS;

--- a/features/storage/kvstore/securestore/SecureStore.h
+++ b/features/storage/kvstore/securestore/SecureStore.h
@@ -273,7 +273,6 @@ private:
     PlatformMutex _mutex;
     bool _is_initialized;
     KVStore *_underlying_kv, *_rbp_kv;
-    void *_entropy;
     void *_inc_set_handle;
     uint8_t *_scratch_buf;
 


### PR DESCRIPTION
### Description
This PR migrates SecureStore & DeviceKey features from the (soon to be deprecated) mbedtls APIs to the PSA Crypto ones.
It covers the following functionality: 
- Random generation
- CMAC signing
- AES CTR Encryption & Decryption 

Leftovers (depending on future changes in mbed-crypto):
- Code still uses mbedtls defines (still not changed to the PSA Crypto form).
- Code still uses the `mbedtls_ssl_safer_memcmp` API, as there's no PSA crypto alternative for it (covered by [this issue in the psa-crypto repo](https://github.com/ARMmbed/psa-crypto/issues/143)).
- Code needed to work around a PSA Crypto limitation, not allowing an in place encryption if input is not encryption block aligned (covered by [this issue in the mbed-crypto repo](https://github.com/ARMmbed/mbed-crypto/issues/63)).
- Code still uses the (newly added) mbedtls platform APIs. Not sure whether this will change.

Also resolves #9725, as the changes messed with the same parts in the code.
Tested all KVStore & DeviceKey tests on K64F & K66F.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-crypto 

### Release Notes
- Migrated SecureStore & DeviceKey from mbedtls APIs to PSA Crypto ones