### PR TITLE
Add missing copyright header to STM32 driver

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2017 ARM Limited. All rights reserved.
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef KINETIS_EMAC_H_

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.h
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2017 ARM Limited. All rights reserved.
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef NUMAKER_EMAC_H_

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_IMX/imx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_IMX/imx_emac.h
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2017 ARM Limited. All rights reserved.
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef KINETIS_EMAC_H_

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_MCU_LPC546XX/lpc546xx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_MCU_LPC546XX/lpc546xx_emac.h
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2017 ARM Limited. All rights reserved.
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef LPC546XX_EMAC_H_

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/wifi_emac/wifi_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F4/TARGET_MODULE_UBLOX_ODIN_W2/wifi_emac/wifi_emac.h
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2017 ARM Limited. All rights reserved.
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef WIFI_EMAC_H_

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.cpp
@@ -1,3 +1,19 @@
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <stdlib.h>
 
 #include "cmsis_os.h"

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac_config.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

This driver was done by Arm, so adding a Copyright header to it.
Remaining issues reported in https://github.com/ARMmbed/mbed-os/issues/9490

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@0xc0170 

### Release Notes

