### PR TITLE
Add define to skip greentea sync

### DIFF
--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -94,8 +94,10 @@ void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char 
  *           This function is blocking.
  */
 extern "C" void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
+#if defined(NO_GREENTEA)
     char _value[GREENTEA_UUID_LENGTH] = {0};
     _GREENTEA_SETUP_COMMON(timeout, host_test_name, _value, GREENTEA_UUID_LENGTH);
+#endif
 }
 
 /** \brief Handshake with host and send setup data (timeout and host test name). Allows you to preserve sync UUID.

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -94,7 +94,7 @@ void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char 
  *           This function is blocking.
  */
 extern "C" void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
-#if defined(NO_GREENTEA)
+#if ! defined(NO_GREENTEA)
     char _value[GREENTEA_UUID_LENGTH] = {0};
     _GREENTEA_SETUP_COMMON(timeout, host_test_name, _value, GREENTEA_UUID_LENGTH);
 #endif


### PR DESCRIPTION
### Description

Add a define to allow debuging greentea tests that do not require input from host without host-tests

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
