### PR TITLE
Fix cordio gatts configuring write permission

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -467,7 +467,7 @@ ble_error_t GattServer::insert_descriptor(
     }
 
     // configure write permission
-    if (descriptor->isReadAllowed()) {
+    if (descriptor->isWriteAllowed()) {
         attribute_it->permissions |= ATTS_PERMIT_WRITE;
         switch (descriptor->getWriteSecurityRequirement().value()) {
             case att_security_requirement_t::NONE:


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

When configuring write permission of an inserted descriptor, should check the value of `_write_allowed`.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing   /workflow.html#pull-request-types).
-->
