### PR TITLE
Make ARMC6 as the default ARM toolchain for MTB targets

### DIFF
--- a/TESTS/mbed_platform/stats_sys/main.cpp
+++ b/TESTS/mbed_platform/stats_sys/main.cpp
@@ -39,7 +39,7 @@ void test_sys_info()
 
 #if defined(__IAR_SYSTEMS_ICC__)
     TEST_ASSERT_EQUAL(IAR, stats.compiler_id);
-#elif defined(__CC_ARM)
+#elif defined(__ARMCC_VERSION)
     TEST_ASSERT_EQUAL(ARM, stats.compiler_id);
 #elif defined(__GNUC__)
     TEST_ASSERT_EQUAL(GCC_ARM, stats.compiler_id);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7694,7 +7694,7 @@
     "FVP_MPS2": {
         "inherits": ["ARM_FM"],
         "public": false,
-        "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
+        "supported_toolchains": ["GCC_ARM", "ARMC5", "IAR"],
         "OUTPUT_EXT": "elf",
         "device_has": [
             "AACI",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2480,7 +2480,7 @@
     "MTB_MXCHIP_EMW3166": {
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
-        "supported_toolchains": ["ARMC5", "uARM", "IAR", "GCC_ARM"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
         "extra_labels_add": [
             "STM32F4",
             "STM32F412xG",
@@ -2512,7 +2512,7 @@
     },
     "USI_WM_BN_BM_22": {
         "inherits": ["FAMILY_STM32"],
-        "supported_toolchains": ["ARMC5", "uARM", "IAR", "GCC_ARM"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
         "components_add": ["SPIF", "FLASHIAP"],
         "core": "Cortex-M4F",
         "extra_labels_add": [

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -191,8 +191,8 @@ def is_official_target(target_name, version):
     if hasattr(target, 'release_versions') \
        and version in target.release_versions:
         if version == '2':
-            # For version 2, either ARM or uARM toolchain support is required
-            required_toolchains = set(['ARM', 'uARM'])
+            # For version 2, one of the ARM toolchains(ARM, ARMC6, ARMC5 or uARM) support is required
+            required_toolchains = set(['ARM', 'ARMC5', 'ARMC6', 'uARM'])
 
             if not len(required_toolchains.intersection(
                     set(target.supported_toolchains))) > 0:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -251,8 +251,8 @@ def is_official_target(target_name, version):
 
     return result, reason
 
-def transform_release_toolchains(toolchains, version):
-    """ Given a list of toolchains and a release version, return a list of
+def transform_release_toolchains(toolchains, version, target):
+    """ Given a list of toolchains, release version and target(needed for checking build tools version), return a list of
     only the supported toolchains for that release
 
     Positional arguments:
@@ -260,11 +260,19 @@ def transform_release_toolchains(toolchains, version):
     version - The release version string. Should be a string contained within
               RELEASE_VERSIONS
     """
-    if version == '5':
-        return ['ARM', 'GCC_ARM', 'IAR']
+    if int(target.build_tools_metadata["version"]) > 0:
+        if version == '5':
+            if 'ARMC5' in toolchains:
+                return ['ARMC5', 'GCC_ARM', 'IAR']
+            else:    
+                return ['ARM', 'GCC_ARM', 'IAR']
+        else:
+            return toolchains
     else:
-        return toolchains
-
+        if version == '5':
+            return ['ARM', 'GCC_ARM', 'IAR']
+        else:
+            return toolchains
 
 def get_mbed_official_release(version):
     """ Given a release version string, return a tuple that contains a target
@@ -283,7 +291,7 @@ def get_mbed_official_release(version):
                 [
                     TARGET_MAP[target].name,
                     tuple(transform_release_toolchains(
-                        TARGET_MAP[target].supported_toolchains, version))
+                        TARGET_MAP[target].supported_toolchains, version, target))
                 ]
             ) for target in TARGET_NAMES \
             if (hasattr(TARGET_MAP[target], 'release_versions')

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -251,8 +251,8 @@ def is_official_target(target_name, version):
 
     return result, reason
 
-def transform_release_toolchains(toolchains, version, target):
-    """ Given a list of toolchains, release version and target(needed for checking build tools version), return a list of
+def transform_release_toolchains(target, version):
+    """ Given a release version and target, return a list of
     only the supported toolchains for that release
 
     Positional arguments:
@@ -262,17 +262,17 @@ def transform_release_toolchains(toolchains, version, target):
     """
     if int(target.build_tools_metadata["version"]) > 0:
         if version == '5':
-            if 'ARMC5' in toolchains:
+            if 'ARMC5' in target.supported_toolchains:
                 return ['ARMC5', 'GCC_ARM', 'IAR']
             else:    
-                return ['ARM', 'GCC_ARM', 'IAR']
+                return ['ARM', 'ARMC6', 'GCC_ARM', 'IAR']
         else:
-            return toolchains
+            return target.supported_toolchains
     else:
         if version == '5':
             return ['ARM', 'GCC_ARM', 'IAR']
         else:
-            return toolchains
+            return target.supported_toolchains
 
 def get_mbed_official_release(version):
     """ Given a release version string, return a tuple that contains a target
@@ -291,7 +291,7 @@ def get_mbed_official_release(version):
                 [
                     TARGET_MAP[target].name,
                     tuple(transform_release_toolchains(
-                        TARGET_MAP[target].supported_toolchains, version, target))
+                        TARGET_MAP[target], version))
                 ]
             ) for target in TARGET_NAMES \
             if (hasattr(TARGET_MAP[target], 'release_versions')
@@ -1249,6 +1249,11 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
 
     unique_supported_toolchains = get_unique_supported_toolchains(
         release_targets)
+    #Add ARMC5 column as well to the matrix to help with showing which targets are in ARMC5
+    #ARMC5 is not a toolchain class but yet we use that as a toolchain id in supported_toolchains in targets.json 
+    #capture that info in a separate column
+    unique_supported_toolchains.append('ARMC5')
+    
     prepend_columns = ["Target"] + ["mbed OS %s" % x for x in RELEASE_VERSIONS]
 
     # All tests status table print
@@ -1291,8 +1296,7 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
                 (unique_toolchain == "ARMC6" and
                  "ARM" in tgt_obj.supported_toolchains) or
                 (unique_toolchain == "ARM" and
-                 "ARMC6" in tgt_obj.supported_toolchains and
-                 CORE_ARCH[tgt_obj.core] == 8)):
+                 "ARMC6" in tgt_obj.supported_toolchains)):
                 text = "Supported"
                 perm_counter += 1
             else:

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -503,8 +503,13 @@ class ARMC6(ARM_STD):
         return ["-include", config_header]
 
     def get_compile_options(self, defines, includes, for_asm=False):
+        
         opts = ['-D%s' % d for d in defines]
-        opts.extend(["-I%s" % i for i in includes if i])
+        if self.RESPONSE_FILES:
+            opts += ['@{}'.format(self.get_inc_file(includes))]
+        else:
+            opts += ["-I%s" % i for i in includes if i]
+        
         config_header = self.get_config_header()
         if config_header:
             opts.extend(self.get_config_option(config_header))


### PR DESCRIPTION
### Description
This PR is to make ARMC6 as the default ARM toolchain for MTB targets below:
MTB_ADV_WISE_1530
MTB_MXCHIP_EMW3166
MTB_USI_WM_BN_BM_22

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@cmonr @0xc0170 @SeppoTakalo 

