### PR TITLE
STM32 InterruptIn protection

### DIFF
--- a/targets/TARGET_STM/gpio_irq_api.c
+++ b/targets/TARGET_STM/gpio_irq_api.c
@@ -27,6 +27,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
+
+#if DEVICE_INTERRUPTIN
+
 #include <stdbool.h>
 #include "cmsis.h"
 #include "gpio_irq_api.h"
@@ -342,3 +345,5 @@ void gpio_irq_disable(gpio_irq_t *obj)
         NVIC_ClearPendingIRQ(obj->irq_n);
     }
 }
+
+#endif /* DEVICE_INTERRUPTIN */


### PR DESCRIPTION
### Description

Hi

TARGET_STM/gpio_irq_api.c file has to be protected for compilation if DEVICE_INTERRUPTIN is not enabled.

Thx

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
