### PR TITLE
Revert "Update params in calls to LDREXW/STREXW to uint32_t"

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_def.h
@@ -130,9 +130,9 @@ static inline  void atomic_set_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) | mask;
+		newValue = (uint32_t)__LDREXW(ptr) | mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 
@@ -140,9 +140,9 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) &~mask;
+		newValue = (uint32_t)__LDREXW(ptr) &~mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 #if  defined ( __GNUC__ ) && !defined ( __CC_ARM )

--- a/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_def.h
@@ -133,9 +133,9 @@ static inline  void atomic_set_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) | mask;
+		newValue = (uint32_t)__LDREXW(ptr) | mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 // MBED patch
@@ -143,9 +143,9 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) &~mask;
+		newValue = (uint32_t)__LDREXW(ptr) &~mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 // MBED patch

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_def.h
@@ -131,9 +131,9 @@ static inline  void atomic_set_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) | mask;
+		newValue = (uint32_t)__LDREXW(ptr) | mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 
@@ -141,9 +141,9 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) &~mask;
+		newValue = (uint32_t)__LDREXW(ptr) &~mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 /* MBED */
 

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_def.h
@@ -130,9 +130,9 @@ static inline  void atomic_set_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) | mask;
+		newValue = (uint32_t)__LDREXW(ptr) | mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 
@@ -140,9 +140,9 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) &~mask;
+		newValue = (uint32_t)__LDREXW(ptr) &~mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 #if  defined ( __GNUC__ ) && !defined ( __CC_ARM )

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_def.h
@@ -133,9 +133,9 @@ static inline  void atomic_set_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) | mask;
+		newValue = (uint32_t)__LDREXW(ptr) | mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 // Added for MBED PR #3062
@@ -143,9 +143,9 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 {
 	uint32_t newValue;
 	do {
-		newValue = (uint32_t)__LDREXW((volatile uint32_t *)ptr) &~mask;
+		newValue = (uint32_t)__LDREXW(ptr) &~mask;
 
-	} while (__STREXW(newValue,(volatile uint32_t *) ptr));
+	} while (__STREXW(newValue, ptr));
 }
 
 #if defined ( __GNUC__ ) && !defined (__CC_ARM) /* GNU Compiler */


### PR DESCRIPTION

### Description

This reverts commit 334b2d64b01724a467ea99210c752de39cc23b6e.

This commit is not required any more as changes for this are already part of master branch


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

