### PR TITLE
Corrected timeout for +UDNSRN command

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -481,8 +481,11 @@ nsapi_error_t UBLOX_AT_CellularStack::gethostbyname(const char *host, SocketAddr
         _at.cmd_start("AT+UDNSRN=0,");
         _at.write_string(host);
         _at.cmd_stop();
-
-        _at.set_at_timeout(60000);
+#ifdef TARGET_UBLOX_C030_R41XM
+        _at.set_at_timeout(70000);
+#else
+        _at.set_at_timeout(120000);
+#endif
         _at.resp_start("+UDNSRN:");
         if (_at.info_resp()) {
             _at.read_string(ipAddress, sizeof(ipAddress));


### PR DESCRIPTION
### Description
The AT timeout for AT+UDNSRN command is not correct. It needs to be 70 seconds for R41XM and 120seconds for U201.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
