### PR TITLE
Fix multihoming tests 

### DIFF
--- a/TESTS/network/multihoming/multihoming_asynchronous_dns.cpp
+++ b/TESTS/network/multihoming/multihoming_asynchronous_dns.cpp
@@ -55,35 +55,41 @@ void MULTIHOMING_ASYNCHRONOUS_DNS()
 
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {
 
-        for (unsigned int j = 0; j < interface_num; j++) {
-
-            nsapi_error_t err = get_interface()->gethostbyname_async(dns_test_hosts[i],
-                                                                     mbed::Callback<void(nsapi_error_t, SocketAddress *)>(hostbyname_cb, (void *) &data), NSAPI_UNSPEC, interface_name[j]);
-            TEST_ASSERT(err >= 0);
-
-            semaphore.wait();
-
-            TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
-            printf("DNS: query  interface_name %s %d \n", interface_name[j], j);
-            if (data.result == NSAPI_ERROR_OK) {
-                result_ok++;
-                printf("DNS: query OK \"%s\" => \"%s\"\n", dns_test_hosts[i], data.addr.get_ip_address());
-            } else if (data.result == NSAPI_ERROR_DNS_FAILURE) {
-                result_dns_failure++;
-                printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
-            } else if (data.result == NSAPI_ERROR_TIMEOUT) {
-                result_exp_timeout++;
-                printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
-            } else if (data.result == NSAPI_ERROR_NO_MEMORY) {
-                result_no_mem++;
-                printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
-            } else {
-                printf("DNS: query \"%s\" => %d, unexpected answer\n", dns_test_hosts[i], data.result);
-                TEST_ASSERT(data.result == NSAPI_ERROR_OK || data.result == NSAPI_ERROR_NO_MEMORY || data.result == NSAPI_ERROR_DNS_FAILURE || data.result == NSAPI_ERROR_TIMEOUT);
+        for (unsigned int interface_index = 0; interface_index < MBED_CONF_MULTIHOMING_MAX_INTERFACES_NUM; interface_index++) {
+            NetworkInterface  *interface = get_interface(interface_index);
+            if (interface == NULL) {
+                continue;
             }
 
-        }
+            for (unsigned int j = 0; j < interface_num; j++) {
 
+                nsapi_error_t err = interface->gethostbyname_async(dns_test_hosts[i],
+                                                                       mbed::Callback<void(nsapi_error_t, SocketAddress *)>(hostbyname_cb, (void *) &data), NSAPI_UNSPEC, interface_name[j]);
+                TEST_ASSERT(err >= 0);
+
+                semaphore.wait();
+
+                TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
+                printf("DNS: query  interface_name %s %d \n", interface_name[j], j);
+                if (data.result == NSAPI_ERROR_OK) {
+                    result_ok++;
+                    printf("DNS: query OK \"%s\" => \"%s\"\n", dns_test_hosts[i], data.addr.get_ip_address());
+                } else if (data.result == NSAPI_ERROR_DNS_FAILURE) {
+                    result_dns_failure++;
+                    printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
+                } else if (data.result == NSAPI_ERROR_TIMEOUT) {
+                    result_exp_timeout++;
+                    printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
+                } else if (data.result == NSAPI_ERROR_NO_MEMORY) {
+                    result_no_mem++;
+                    printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
+                } else {
+                    printf("DNS: query \"%s\" => %d, unexpected answer\n", dns_test_hosts[i], data.result);
+                    TEST_ASSERT(data.result == NSAPI_ERROR_OK || data.result == NSAPI_ERROR_NO_MEMORY || data.result == NSAPI_ERROR_DNS_FAILURE || data.result == NSAPI_ERROR_TIMEOUT);
+                }
+
+            }
+        }
 
 
 

--- a/TESTS/network/multihoming/multihoming_synchronous_dns.cpp
+++ b/TESTS/network/multihoming/multihoming_synchronous_dns.cpp
@@ -44,29 +44,35 @@ void MULTIHOMING_SYNCHRONOUS_DNS()
 
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {
         SocketAddress address;
-        for (unsigned int j = 0; j < interface_num; j++) {
 
-            nsapi_error_t err = get_interface()->gethostbyname(dns_test_hosts[i], &address, NSAPI_UNSPEC, interface_name[j]);
-            printf("DNS: query  interface_name %s %d \n", interface_name[j], j);
-
-            if (err == NSAPI_ERROR_OK) {
-                result_ok++;
-                printf("DNS: query OK \"%s\" => \"%s\"\n", dns_test_hosts[i], address.get_ip_address());
-            } else if (err == NSAPI_ERROR_DNS_FAILURE) {
-                result_dns_failure++;
-                printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
-            } else if (err == NSAPI_ERROR_TIMEOUT) {
-                result_exp_timeout++;
-                printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
-            } else if (err == NSAPI_ERROR_NO_MEMORY) {
-                result_no_mem++;
-                printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
-            } else {
-                printf("DNS: query \"%s\" => %d, unexpected answer\n", dns_test_hosts[i], err);
-                TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_NO_MEMORY || err == NSAPI_ERROR_DNS_FAILURE || err == NSAPI_ERROR_TIMEOUT);
+        for (unsigned int interface_index = 0; interface_index < MBED_CONF_MULTIHOMING_MAX_INTERFACES_NUM; interface_index++) {
+            NetworkInterface  *interface = get_interface(interface_index);
+            if (interface == NULL) {
+                continue;
             }
 
+            for (unsigned int j = 0; j < interface_num; j++) {
 
+                nsapi_error_t err = interface->gethostbyname(dns_test_hosts[i], &address, NSAPI_UNSPEC, interface_name[j]);
+                printf("DNS: query  interface_name %s %d \n", interface_name[j], j);
+
+                if (err == NSAPI_ERROR_OK) {
+                    result_ok++;
+                    printf("DNS: query OK \"%s\" => \"%s\"\n", dns_test_hosts[i], address.get_ip_address());
+                } else if (err == NSAPI_ERROR_DNS_FAILURE) {
+                    result_dns_failure++;
+                    printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
+                } else if (err == NSAPI_ERROR_TIMEOUT) {
+                    result_exp_timeout++;
+                    printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
+                } else if (err == NSAPI_ERROR_NO_MEMORY) {
+                    result_no_mem++;
+                    printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
+                } else {
+                    printf("DNS: query \"%s\" => %d, unexpected answer\n", dns_test_hosts[i], err);
+                    TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_NO_MEMORY || err == NSAPI_ERROR_DNS_FAILURE || err == NSAPI_ERROR_TIMEOUT);
+                }
+            }
         }
     }
 }

--- a/TESTS/network/multihoming/multihoming_tests.h
+++ b/TESTS/network/multihoming/multihoming_tests.h
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include "mbed.h"
+
 #ifndef MULTIHOMING_TESTS_H
 #define MULTIHOMING_TESTS_H
 
@@ -22,7 +24,7 @@
 #define INTERFACE_NAME_LEN 6
 
 #ifndef MBED_CONF_MULTIHOMING_MAX_INTERFACES_NUM
-#define MBED_CONF_MULTIHOMING_MAX_INTERFACES_NUM    3
+#define MBED_CONF_MULTIHOMING_MAX_INTERFACES_NUM    2
 #endif
 
 #ifndef MBED_CONF_APP_DNS_TEST_HOSTS_NUM
@@ -36,6 +38,8 @@
 #endif
 
 
+#define ETH_INTERFACE  0
+#define WIFI_INTERFACE 1
 
 
 struct dns_application_data {
@@ -53,7 +57,7 @@ extern int  interface_num;
 const char dns_test_hosts[MBED_CONF_APP_DNS_TEST_HOSTS_NUM][DNS_TEST_HOST_LEN] = MBED_CONF_APP_DNS_TEST_HOSTS;
 
 
-NetworkInterface *get_interface();
+NetworkInterface *get_interface(int interface_index);
 void drop_bad_packets(UDPSocket &sock, int orig_timeout);
 void fill_tx_buffer_ascii(char *buff, size_t len);
 


### PR DESCRIPTION
### Description
Fixed test cases for multihoming.
This apply proper network interface instance verify. 
It prevents crash if device doesn't have ethernet or wifi device. 
   
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@SeppoTakalo please review
@mikaleppanen please review
@kjbracey-arm please review

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
