### PR TITLE
get_mbed_official_release() mbed5 fix

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -244,10 +244,7 @@ def transform_release_toolchains(toolchains, version):
     version - The release version string. Should be a string contained within
               RELEASE_VERSIONS
     """
-    if version == '5':
-        return ['ARM', 'GCC_ARM', 'IAR']
-    else:
-        return toolchains
+    return toolchains
 
 
 def get_mbed_official_release(version):


### PR DESCRIPTION
### Description

IOTCORE-1057

https://github.com/ARMmbed/mbed-os/blob/7656891179a8a5b53b6bc450d2dd4bcd652284d0/tools/build_api.py#L238

Returns always ['ARM', 'GCC_ARM', 'IAR'] for mbed5.


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes

