### PR TITLE
Lock sleep when USB is initialized

### DIFF
--- a/usb/device/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
+++ b/usb/device/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
@@ -106,7 +106,7 @@ USBPhy *get_usb_phy()
     return &usbphy;
 }
 
-USBPhyHw::USBPhyHw()
+USBPhyHw::USBPhyHw(): events(NULL)
 {
 
 }
@@ -117,6 +117,9 @@ USBPhyHw::~USBPhyHw()
 
 void USBPhyHw::init(USBPhyEvents *events)
 {
+    if (this->events == NULL) {
+        sleep_manager_lock_deep_sleep();
+    }
     this->events = events;
 
     // Disable IRQ
@@ -183,6 +186,11 @@ void USBPhyHw::deinit()
     disconnect();
     NVIC_DisableIRQ(USB0_IRQn);
     USB0->INTEN = 0;
+
+    if (events != NULL) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    events = NULL;
 }
 
 bool USBPhyHw::powered()

--- a/usb/device/targets/TARGET_NXP/USBHAL_LPC17.cpp
+++ b/usb/device/targets/TARGET_NXP/USBHAL_LPC17.cpp
@@ -369,7 +369,7 @@ USBPhy *get_usb_phy()
     return &usbphy;
 }
 
-USBPhyHw::USBPhyHw(void)
+USBPhyHw::USBPhyHw(void): events(NULL)
 {
 
 }
@@ -381,6 +381,9 @@ USBPhyHw::~USBPhyHw(void)
 
 void USBPhyHw::init(USBPhyEvents *events)
 {
+    if (this->events == NULL) {
+        sleep_manager_lock_deep_sleep();
+    }
     this->events = events;
 
     // Disable IRQ
@@ -440,6 +443,11 @@ void USBPhyHw::deinit()
     NVIC_DisableIRQ(USB_IRQn);
     events = NULL;
     opStarted = 0;
+
+    if (events != NULL) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    events = NULL;
 }
 
 bool USBPhyHw::powered()

--- a/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhy_RZ_A1.cpp
+++ b/usb/device/targets/TARGET_RENESAS/TARGET_RZ_A1XX/USBPhy_RZ_A1.cpp
@@ -128,6 +128,9 @@ void USBPhyHw::init(USBPhyEvents *events)
 {
     volatile uint8_t dummy_read;
 
+    if (this->events == NULL) {
+        sleep_manager_lock_deep_sleep();
+    }
     this->events = events;
 
     /* registers me */
@@ -174,6 +177,11 @@ void USBPhyHw::deinit()
 #endif
     dummy_read = CPG.STBCR7;
     (void)dummy_read;
+
+    if (events != NULL) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    events = NULL;
 }
 
 bool USBPhyHw::powered()

--- a/usb/device/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/usb/device/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -168,6 +168,9 @@ void USBPhyHw::init(USBPhyEvents *events)
 {
     NVIC_DisableIRQ(USBHAL_IRQn);
 
+    if (this->events == NULL) {
+        sleep_manager_lock_deep_sleep();
+    }
     this->events = events;
     sof_enabled = false;
     memset(epComplete, 0, sizeof(epComplete));
@@ -333,6 +336,11 @@ void USBPhyHw::deinit()
 {
     HAL_PCD_DeInit(&hpcd);
     NVIC_DisableIRQ(USBHAL_IRQn);
+
+    if (events != NULL) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    events = NULL;
 }
 
 bool USBPhyHw::powered()


### PR DESCRIPTION
### Description

Lock sleep when USB is initialized to ensure USB always has a clock lock deep sleep while it is in use. Thanks @rajkan01 for finding this.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@rajkan01 
