### PR TITLE
STM32F429 ARM MICRO startup file update

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_ARM_MICRO/startup_stm32f429xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_ARM_MICRO/startup_stm32f429xx.S
@@ -195,15 +195,9 @@ __Vectors_Size  EQU  __Vectors_End - __Vectors
 ; Reset handler
 Reset_Handler    PROC
                  EXPORT  Reset_Handler             [WEAK]
-        IMPORT  SystemInitPre
-        IMPORT  HAL_InitPre
         IMPORT  SystemInit
         IMPORT  __main
 
-                 LDR     R0, =SystemInitPre
-                 BLX     R0
-                 LDR     R0, =HAL_InitPre
-                 BLX     R0
                  LDR     R0, =SystemInit
                  BLX     R0
                  LDR     R0, =__main


### PR DESCRIPTION
### Description

Missing patch from #8916 (HAL_InitPre doesn't exist any more)

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
