### PR TITLE
ESP8266: graceful disconnect on network state timeout

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1137,8 +1137,13 @@ void ESP8266::_oob_connection_status()
                        "ESP8266::_oob_connection_status: invalid AT cmd\n");
         }
     } else {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_ENOMSG), \
-                   "ESP8266::_oob_connection_status: network status timed out\n");
+        tr_error("_oob_connection_status(): network status timeout, disconnecting");
+        if (!disconnect()) {
+            tr_warning("_oob_connection_status(): driver initiated disconnect failed");
+        } else {
+            tr_debug("_oob_connection_status(): disconnected");
+        }
+        _conn_status = NSAPI_STATUS_ERROR_UNSUPPORTED;
     }
 
     MBED_ASSERT(_conn_stat_cb);


### PR DESCRIPTION
### Description
On Wi-Fi connection state change if timeout occurs we have called MBED_ERROR. This seems to happen more often than expected so controlled disconnect works better. Re-establishing the connection is left on application's responsibility.

Fixes internal issue: ONME-4198 (CRITICAL)

### Pull request type


    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@Timjun01 
@michalpasztamobica 
@SeppoTakalo 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
