### PR TITLE
tests-net*: enables Mbed Trace, level - ERROR

### DIFF
--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -28,6 +28,7 @@
 #include "nsapi_dns.h"
 #include "EventQueue.h"
 #include "dns_tests.h"
+#include "mbed_trace.h"
 
 using namespace utest::v1;
 
@@ -197,5 +198,8 @@ Specification specification(test_setup, cases, greentea_teardown, greentea_conti
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -30,6 +30,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "tcp_tests.h"
+#include "mbed_trace.h"
 
 using namespace utest::v1;
 
@@ -182,5 +183,8 @@ Specification specification(greentea_setup, cases, greentea_teardown, greentea_c
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -30,6 +30,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "tls_tests.h"
+#include "mbed_trace.h"
 
 #if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 
@@ -214,6 +215,9 @@ void run_test(void)
 static unsigned char stack_mem[8192];
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     Thread *th = new Thread(osPriorityNormal, 8192, stack_mem, "tls_gt_thread");
     th->start(callback(run_test));
     th->join();

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -30,6 +30,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "udp_tests.h"
+#include "mbed_trace.h"
 
 using namespace utest::v1;
 
@@ -139,5 +140,8 @@ Specification specification(greentea_setup, cases, greentea_teardown, greentea_c
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }

--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -47,6 +47,8 @@
 
 #include "emac_tests.h"
 #include "emac_util.h"
+#include "mbed_trace.h"
+
 
 using namespace utest::v1;
 
@@ -79,6 +81,9 @@ Specification specification(test_setup, cases);
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }
 

--- a/TESTS/network/interface/main.cpp
+++ b/TESTS/network/interface/main.cpp
@@ -27,6 +27,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "networkinterface_tests.h"
+#include "mbed_trace.h"
 
 using namespace utest::v1;
 
@@ -52,5 +53,7 @@ Specification specification(test_setup, cases);
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/TESTS/network/l3ip/main.cpp
+++ b/TESTS/network/l3ip/main.cpp
@@ -22,6 +22,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "L3IPInterface.h"
+#include "mbed_trace.h"
 
 using namespace utest::v1;
 
@@ -80,5 +81,8 @@ Specification specification(greentea_setup, cases, greentea_teardown, greentea_c
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }

--- a/TESTS/network/multihoming/main.cpp
+++ b/TESTS/network/multihoming/main.cpp
@@ -30,6 +30,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "multihoming_tests.h"
+#include "mbed_trace.h"
 
 using namespace utest::v1;
 
@@ -152,5 +153,8 @@ Specification specification(greentea_setup, cases, greentea_teardown, greentea_c
 
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -26,6 +26,7 @@
 #include "unity.h"
 #include "utest.h"
 #include "wifi_tests.h"
+#include "mbed_trace.h"
 
 // Test for parameters
 #if defined(MBED_CONF_APP_WIFI_SECURE_SSID)
@@ -91,5 +92,8 @@ Specification specification(test_setup, cases, greentea_continue_handlers);
 // Entry point into the tests
 int main()
 {
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ERROR);
+    mbed_trace_init();
+
     return !Harness::run(specification);
 }


### PR DESCRIPTION
### Description
Adds Mbed Trace initialization. People need to remember to add following app config flag to enable traces.

`"mbed-trace.enable": 1`

Treshold is set to ERROR traces.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers
@AriParkkila 
@kjbracey-arm 
@kimlep01 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
