### PR TITLE
Correct the device name for NUC472 / M453 - IAR 8

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -253,7 +253,7 @@
         "OGChipSelectEditMenu": "NCS36510\tONSemiconductor NCS36510"
     },
     "NUC472HI8AE": {
-        "OGChipSelectEditMenu": "NUC400AE series\tNuvoton NUC400AE series (NUC442AE,NUC472AE)"
+        "OGChipSelectEditMenu": "NUC472HI8AE\tNuvoton NUC472HI8AE"
     },
     "M453VG6AE": {
         "OGChipSelectEditMenu": "M451AE series\tNuvoton M451AE series (M451AE,M452AE,M453AE,M451MAE)"

--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -256,7 +256,7 @@
         "OGChipSelectEditMenu": "NUC472HI8AE\tNuvoton NUC472HI8AE"
     },
     "M453VG6AE": {
-        "OGChipSelectEditMenu": "M451AE series\tNuvoton M451AE series (M451AE,M452AE,M453AE,M451MAE)"
+        "OGChipSelectEditMenu": "M453VG6AE\tNuvoton M453VG6AE"
     },
     "nRF52840_xxAA":{
         "OGChipSelectEditMenu": "nRF52840_xxAA\tNordicSemi nRF52840_xxAA",


### PR DESCRIPTION
### Description
Correct the device name for NUC472 / M453 for IAR8

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@0xc0170 
