### PR TITLE
PSA tools: Find secure image at post-build 

### DIFF
--- a/tools/psa/__init__.py
+++ b/tools/psa/__init__.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os.path import basename
+from os.path import basename, splitext
 from tools.resources import FileType
 
 
@@ -29,7 +29,10 @@ def find_secure_image(notify, resources, ns_image_path, configured_s_image_filen
     assert image_files, 'No image files found for this target'
 
     secure_image = next((f for f in image_files if basename(f) == configured_s_image_filename), None)
-    secure_image = next((f for f in image_files if basename(f) == basename(ns_image_path)), secure_image)
+    secure_image = next(
+        (f for f in image_files if splitext(basename(f))[0] == splitext(basename(ns_image_path))[0]),
+        secure_image
+    )
 
     if secure_image:
         notify.debug("Secure image file found: %s." % secure_image)

--- a/tools/psa/__init__.py
+++ b/tools/psa/__init__.py
@@ -1,16 +1,23 @@
 from os.path import basename
+from tools.resources import FileType
 
 
-def find_secure_image(notify, resources, ns_image_path, configured_s_image_path, image_type):
+def find_secure_image(notify, resources, ns_image_path, configured_s_image_filename, image_type):
     """ Find secure image. """
+
+    assert ns_image_path and configured_s_image_filename, 'ns_image_path and configured_s_image_path are mandatory'
+    assert image_type in [FileType.BIN, FileType.HEX], 'image_type must be of type BIN or HEX'
+
     image_files = resources.get_file_paths(image_type)
-    secure_image = next((f for f in image_files if basename(f) == configured_s_image_path), None)
+    assert image_files, 'No image files found for this target'
+
+    secure_image = next((f for f in image_files if basename(f) == configured_s_image_filename), None)
     secure_image = next((f for f in image_files if basename(f) == basename(ns_image_path)), secure_image)
 
     if secure_image:
         notify.debug("Secure image file found: %s." % secure_image)
     else:
-        notify.debug("Secure image file %s not found. Aborting." % configured_s_image_path)
+        notify.debug("Secure image file %s not found. Aborting." % configured_s_image_filename)
         raise Exception("Required secure image not found.")
 
     return secure_image

--- a/tools/psa/__init__.py
+++ b/tools/psa/__init__.py
@@ -1,0 +1,16 @@
+from os.path import basename
+
+
+def find_secure_image(notify, resources, ns_image_path, configured_s_image_path, image_type):
+    """ Find secure image. """
+    image_files = resources.get_file_paths(image_type)
+    secure_image = next((f for f in image_files if basename(f) == configured_s_image_path), None)
+    secure_image = next((f for f in image_files if basename(f) == basename(ns_image_path)), secure_image)
+
+    if secure_image:
+        notify.debug("Secure image file found: %s." % secure_image)
+    else:
+        notify.debug("Secure image file %s not found. Aborting." % configured_s_image_path)
+        raise Exception("Required secure image not found.")
+
+    return secure_image

--- a/tools/psa/__init__.py
+++ b/tools/psa/__init__.py
@@ -1,3 +1,20 @@
+#!/usr/bin/python
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from os.path import basename
 from tools.resources import FileType
 

--- a/tools/test/spm/test_find_secure_image.py
+++ b/tools/test/spm/test_find_secure_image.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import os
+from tools.notifier.mock import MockNotifier
+from tools.resources import Resources, FileType
+from tools.psa import find_secure_image
+
+
+def test_find_secure_image():
+    mock_notifier = MockNotifier()
+    mock_resources = Resources(mock_notifier)
+    ns_image_path = os.path.join('BUILD', 'TARGET_NS', 'app.bin')
+    ns_test_path = os.path.join('BUILD', 'TARGET_NS', 'test.bin')
+    config_s_image_name = 'target_config.bin'
+    default_bin = os.path.join('prebuilt', config_s_image_name)
+    test_bin = os.path.join('prebuilt', 'test.bin')
+
+    with pytest.raises(Exception, match='ns_image_path and configured_s_image_path are mandatory'):
+        find_secure_image(mock_notifier, mock_resources, None, None, FileType.BIN)
+        find_secure_image(mock_notifier, mock_resources, ns_image_path, None, FileType.BIN)
+        find_secure_image(mock_notifier, mock_resources, None, config_s_image_name, FileType.BIN)
+
+    with pytest.raises(Exception, match='image_type must be of type BIN or HEX'):
+        find_secure_image(mock_notifier, mock_resources, ns_image_path, config_s_image_name, None)
+        find_secure_image(mock_notifier, mock_resources, ns_image_path, config_s_image_name, FileType.C_SRC)
+
+    with pytest.raises(Exception, match='No image files found for this target'):
+        find_secure_image(mock_notifier, mock_resources, ns_image_path, config_s_image_name, FileType.BIN)
+
+    dummy_bin = os.path.join('path', 'to', 'dummy.bin')
+    mock_resources.add_file_ref(FileType.BIN, dummy_bin, dummy_bin)
+
+    with pytest.raises(Exception, match='Required secure image not found'):
+        find_secure_image(mock_notifier, mock_resources, ns_image_path, config_s_image_name, FileType.BIN)
+
+    mock_resources.add_file_ref(FileType.BIN, default_bin, default_bin)
+    mock_resources.add_file_ref(FileType.BIN, test_bin, test_bin)
+    secure_image = find_secure_image(mock_notifier, mock_resources, ns_image_path, config_s_image_name, FileType.BIN)
+    assert secure_image == default_bin
+
+    secure_image = find_secure_image(mock_notifier, mock_resources, ns_test_path, config_s_image_name, FileType.BIN)
+    assert secure_image == test_bin


### PR DESCRIPTION
### Description

Add a common function which finds the relevant secure image of a non-secure target.
This function will be called during the post-build hook which merges the secure and non-secure images together.

The logic was taken from the [PSOC6 post-build hook](https://github.com/ARMmbed/mbed-os/blob/master/tools/targets/PSOC6.py#L118-L132)

Tested with Musca_a1.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@theotherjimmy @orenc17 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
