### PR TITLE
wait_us without usticker

### DIFF
--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -37,9 +37,19 @@ void wait_ms(int ms)
 
 void wait_us(int us)
 {
+#if DEVICE_USTICKER
     const ticker_data_t *const ticker = get_us_ticker_data();
     uint32_t start = ticker_read(ticker);
     while ((ticker_read(ticker) - start) < (uint32_t)us);
+#else // fallback to wait_ns for targets without usticker
+    while (us > 1000) {
+        us -= 1000;
+        wait_ns(1000000);
+    }
+    if (us > 0) {
+        wait_ns(us * 1000);
+    }
+#endif // DEVICE_USTICKER
 }
 
 #endif // #ifndef MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
### Description

Some targets (Mainly PSA secure targets running TF-M) have no usticker.
In order to support `wait_us()` in these targets (`mbed_die()` uses it for example), `wait_us()` is implemented using `wait_ns()` which does software-loop based delays.

* only last commit is relevant, other commits are from #9812.

Fixes #9853 

Depends on #9812 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

Some targets have no usticker. Fallback to use busy loop `wait_ns()` for cases like this.
