### PR TITLE
Cellular: fix connect-disconnect sequence called many times

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
@@ -653,20 +653,6 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_attach)
     cn.attach(&network_cb);
 }
 
-TEST_F(TestAT_CellularNetwork, test_get_connection_status)
-{
-    EventQueue que;
-    FileHandle_stub fh1;
-    ATHandler at(&fh1, que, 0, ",");
-
-    AT_CellularNetwork cn(at);
-
-    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
-    network_cb_count = 0;
-    cn.attach(&network_cb);
-    EXPECT_TRUE(NSAPI_STATUS_DISCONNECTED == cn.get_connection_status());
-}
-
 TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_set_receive_period)
 {
     EventQueue que;

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -44,11 +44,6 @@ void AT_CellularNetwork::attach(Callback<void(nsapi_event_t, intptr_t)> status_c
 {
 }
 
-nsapi_connection_status_t AT_CellularNetwork::get_connection_status() const
-{
-    return NSAPI_STATUS_LOCAL_UP;
-}
-
 nsapi_error_t AT_CellularNetwork::set_registration_urc(RegistrationType type, bool urc_on)
 {
     if (AT_CellularNetwork_stub::set_registration_urc_fail_counter) {

--- a/UNITTESTS/stubs/CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/CellularDevice_stub.cpp
@@ -103,6 +103,6 @@ nsapi_error_t CellularDevice::shutdown()
     return NSAPI_ERROR_OK;
 }
 
-void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr)
+void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx)
 {
 }

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -133,6 +133,8 @@ public: // from NetworkInterface
      *  The parameters on the callback are the event type and event type dependent reason parameter.
      *
      *  @remark  deleting CellularDevice/CellularContext in callback is not allowed.
+     *  @remark  Allocating/adding lots of traces not recommended as callback is called mostly from State machines thread which
+     *           is now 2048. You can change to main thread for example via EventQueue.
      *
      *  @param status_cb The callback for status changes.
      */

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -283,8 +283,8 @@ public:
      *  The parameters on the callback are the event type and event-type dependent reason parameter.
      *
      *  @remark  deleting CellularDevice/CellularContext in callback not allowed.
-     *  @remark  application should not attach to this function if using CellularContext::attach as it will contain the
-     *           same information.
+     *  @remark  Allocating/adding lots of traces not recommended as callback is called mostly from State machines thread which
+     *           is now 2048. You can change to main thread for example via EventQueue.
      *
      *  @param status_cb The callback for status changes.
      */
@@ -420,8 +420,8 @@ protected:
      *  This method will broadcast to every interested classes:
      *  CellularContext (might be many) and CellularStateMachine if available.
      */
-    void cellular_callback(nsapi_event_t ev, intptr_t ptr);
-
+    void cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx = NULL);
+    void stm_callback(nsapi_event_t ev, intptr_t ptr);
     int _network_ref_count;
     int _sms_ref_count;
     int _info_ref_count;

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -319,6 +319,10 @@ public:
      *  on the network. The parameters on the callback are the event type and
      *  event-type dependent reason parameter.
      *
+     *  @remark Application should not call attach if using CellularContext class. Call instead CellularContext::attach
+     *          as CellularDevice is dependent of this attach if CellularContext/CellularDevice is used to get
+     *          device/sim ready, registered, attached, connected.
+     *
      *  @param status_cb The callback for status changes
      */
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb) = 0;

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -327,12 +327,6 @@ public:
      */
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb) = 0;
 
-    /** Get the connection status
-     *
-     *  @return         The connection status according to ConnectionStatusType
-     */
-    virtual nsapi_connection_status_t get_connection_status() const = 0;
-
     /** Read operator names
      *
      *  @param op_names      on successful return contains linked list of operator names.

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -171,7 +171,7 @@ void AT_CellularNetwork::read_reg_params_and_compare(RegistrationType type)
                     reg_params._status == RegisteredRoaming)) {
                 if (previous_registration_status == RegisteredHomeNetwork ||
                         previous_registration_status == RegisteredRoaming) {
-                    _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);
+                    call_network_cb(NSAPI_STATUS_DISCONNECTED);
                 }
             }
         }
@@ -200,11 +200,8 @@ void AT_CellularNetwork::urc_cgreg()
 
 void AT_CellularNetwork::call_network_cb(nsapi_connection_status_t status)
 {
-    if (_connect_status != status) {
-        _connect_status = status;
-        if (_connection_status_cb) {
-            _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connect_status);
-        }
+    if (_connection_status_cb) {
+        _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connect_status);
     }
 }
 

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -210,11 +210,6 @@ void AT_CellularNetwork::attach(Callback<void(nsapi_event_t, intptr_t)> status_c
     _connection_status_cb = status_cb;
 }
 
-nsapi_connection_status_t AT_CellularNetwork::get_connection_status() const
-{
-    return _connect_status;
-}
-
 nsapi_error_t AT_CellularNetwork::set_registration_urc(RegistrationType type, bool urc_on)
 {
     int index = (int)type;

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -63,8 +63,6 @@ public: // CellularNetwork
 
     virtual void attach(Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
-    virtual nsapi_connection_status_t get_connection_status() const;
-
     virtual nsapi_error_t set_access_technology(RadioAccessTechnology rat);
 
     virtual nsapi_error_t scan_plmn(operList_t &operators, int &ops_count);

--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -320,6 +320,7 @@ void CellularStateMachine::retry_state_or_fail()
         tr_debug("%s: retry %d/%d", get_state_string(_state), _retry_count, RETRY_ARRAY_SIZE);
         _event_timeout = _retry_timeout_array[_retry_count];
         _is_retry = true;
+        _cb_data.error = NSAPI_ERROR_OK;
     } else {
         report_failure(get_state_string(_state));
         return;


### PR DESCRIPTION
### Description
Fix connect-disconnect sequence called many times

- Fixes #9760 
- Fix syncing back to at mode after ppp disconnect.
- Fix AT_CellularContext flags and states to allow new connect after disconnect.
- Fix that state machine is not reseted in disconnect is it's running (might be
  running because of another context or new connect already started).
- Removed API get_connection_status() from CellularNetwork. This was left accidentally
  after refactoring. It wasn't giving correct states after refactoring.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [X] Breaking change

### Reviewers

@mirelachirica @AriParkkila 

### Release Notes

Removed API get_connection_status() from CellularNetwork. This was left accidentally
after refactoring. It wasn't giving correct states after refactoring. Application should use CellularContext::get_connection_status instead.
