### PR TITLE
Remove assertion of MDMRST in case of SARA-R4

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.c
@@ -24,11 +24,18 @@ void ublox_board_init(void) {
     // Enable power to 3V3
     gpio_init_inout(&gpio, PWR3V3, PIN_OUTPUT, OpenDrain, 1);
     
-    // start with modem disabled 
-    gpio_init_out_ex(&gpio, MDMRST,    0);
 #if defined(TARGET_UBLOX_C030_R41XM)
+    /* In case of SARA-R4, MDMRST needs to be asserted for 10 seconds before modem actually powers down.
+     * This means that modem is initially responsive to AT commands but powers down
+     * after 10 seconds unless MDMRST is de-asserted (onboard_modem_init()).
+     *
+     * This will cause confusion for application as CellularDevice::is_ready()
+     * will return TRUE initially and later modem will power off without any indication to application.
+     */
+    gpio_init_out_ex(&gpio, MDMRST,    1);
     gpio_init_inout(&gpio, MDMPWRON, PIN_OUTPUT, OpenDrain, 1);
 #else
+    gpio_init_out_ex(&gpio, MDMRST,    0);
     gpio_init_out_ex(&gpio, MDMPWRON,  0);
 #endif
     gpio_init_out_ex(&gpio, MDMRTS,    0);


### PR DESCRIPTION
### Description
In case of SARA-R4, MDMRST needs to be asserted for 10 seconds before modem actually powers down. This means that modem is initially responsive to AT commands but powers down after 10 seconds unless MDMRST is de-asserted (a call to `onboard_modem_init()` ). This can create confusion for application as `CellularDevice::is_ready()` will return `TRUE` initially and ten seconds later modem will power off without any indication to the application.

This can also cause test cases to fail that rely on `system_reset()` for MCU reboot. In such case, Cellular state machine will get an OK response from `CellularDevice::is_ready()` so it will not call the `power_on()` methods and resume its states however after 10 seconds, modem will power down possibly leaving state machine in an undesired state or leading to failure of test case.

We have evaluated others options to fix this problem and have decided not to assert MDMRST in our start-up code. Other options require us to wait 10 seconds at each reset which is not reasonable.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
