### PR TITLE
Handle oversized packets in tcp and udp socket tests.

### DIFF
--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -69,13 +69,15 @@ void TCPSOCKET_ECHOTEST()
     int x = 0;
     for (int pkt_s = pkt_sizes[x]; x < PKTS; pkt_s = pkt_sizes[x++]) {
         fill_tx_buffer_ascii(tcp_global::tx_buffer, BUFF_SIZE);
-
         sent = sock.send(tcp_global::tx_buffer, pkt_s);
         if (sent < 0) {
             printf("[Round#%02d] network error %d\n", x, sent);
             TEST_FAIL();
-            TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
-            return;
+            break;
+        } else if (sent != pkt_s) {
+            printf("[%02d] sock.send return size %d does not match the expectation %d\n", x, sent, pkt_s);
+            TEST_FAIL();
+            break;
         }
 
         int bytes2recv = sent;

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -77,9 +77,11 @@ void TLSSOCKET_ECHOTEST()
         if (sent < 0) {
             printf("[Round#%02d] network error %d\n", x, sent);
             TEST_FAIL();
-            TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
-            delete sock;
-            return;
+            break;
+        } else if (sent != pkt_s) {
+            printf("[%02d] sock.send return size %d does not match the expectation %d\n", x, sent, pkt_s);
+            TEST_FAIL();
+            break;
         }
 
         int bytes2recv = sent;
@@ -89,7 +91,6 @@ void TLSSOCKET_ECHOTEST()
                 printf("[Round#%02d] network error %d\n", x, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
-                delete sock;
                 return;
             }  else if (recvd > bytes2recv) {
                 TEST_FAIL_MESSAGE("sock.recv returned more bytes than requested");

--- a/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
@@ -49,46 +49,33 @@ void TLSSOCKET_ECHOTEST_BURST()
     fill_tx_buffer_ascii(tls_global::tx_buffer, BURST_SIZE);
 
     int recvd;
-    int bt_left;
     int sent;
     for (int i = 0; i < BURST_CNT; i++) {
-        bt_left = BURST_SIZE;
-        while (bt_left > 0) {
-            sent = sock->send(&(tls_global::tx_buffer[BURST_SIZE - bt_left]), bt_left);
-            if (sent == NSAPI_ERROR_WOULD_BLOCK) {
-                if (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
-                    TEST_FAIL();
-                    goto END;
-                }
-                continue;
-            } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
-                TEST_FAIL();
-                goto END;
-            }
-            bt_left -= sent;
+        sent = sock->send(tls_global::tx_buffer, BURST_SIZE);
+        if (sent < 0) {
+            printf("[%02d] network error %d\n", i, sent);
+            TEST_FAIL();
+            break;
+        } else if (sent != BURST_SIZE) {
+            printf("[%02d] sock.send return size %d does not match the expectation %d\n", i, sent, BURST_SIZE);
+            TEST_FAIL();
+            break;
         }
 
-        bt_left = BURST_SIZE;
-        while (bt_left > 0) {
-            recvd = sock->recv(&(tls_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
+        int bytes2recv = sent;
+        while (bytes2recv) {
+            recvd = sock->recv(&(tls_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
-                break;
-            } else if (recvd > bt_left) {
-                TEST_FAIL_MESSAGE("sock.recv returned more bytes than requested");
+                printf("[Round#%02d] network error %d\n", i, recvd);
+                TEST_FAIL();
+                TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
+                return;
             }
-            bt_left -= recvd;
-        }
-
-        if (bt_left != 0) {
-            TEST_FAIL_MESSAGE("bt_left != 0");
-            goto END;
+            bytes2recv -= recvd;
         }
 
         TEST_ASSERT_EQUAL(0, memcmp(tls_global::tx_buffer, tls_global::rx_buffer, BURST_SIZE));
     }
-END:
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
     delete sock;
 }

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -77,6 +77,24 @@ nsapi_version_t get_ip_version()
     return test.get_ip_version();
 }
 
+bool check_oversized_packets(nsapi_error_t error, int &size)
+{
+    if (error == NSAPI_ERROR_PARAMETER) {
+        if (get_ip_version() == NSAPI_IPv4) {
+            if (size > udp_global::MAX_SEND_SIZE_IPV4) {
+                size = udp_global::MAX_SEND_SIZE_IPV4;
+                return true;
+            }
+        } else if (get_ip_version() == NSAPI_IPv6) {
+            if (size > udp_global::MAX_SEND_SIZE_IPV6) {
+                size = udp_global::MAX_SEND_SIZE_IPV6;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void fill_tx_buffer_ascii(char *buff, size_t len)
 {
     for (size_t i = 0; i < len; ++i) {

--- a/TESTS/netsocket/udp/udp_tests.h
+++ b/TESTS/netsocket/udp/udp_tests.h
@@ -21,6 +21,7 @@
 NetworkInterface *get_interface();
 void drop_bad_packets(UDPSocket &sock, int orig_timeout);
 nsapi_version_t get_ip_version();
+bool check_oversized_packets(nsapi_error_t error, int &size);
 void fill_tx_buffer_ascii(char *buff, size_t len);
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
@@ -39,6 +40,9 @@ static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_UDPSOCKET_TIMEOUT_S;
 #else
 static const int TESTS_TIMEOUT = 480;
 #endif
+
+static const int MAX_SEND_SIZE_IPV4 = 536;
+static const int MAX_SEND_SIZE_IPV6 = 1220;
 }
 
 /*

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -79,7 +79,9 @@ void UDPSOCKET_ECHOTEST()
         for (int retry_cnt = 0; retry_cnt <= 2; retry_cnt++) {
             memset(rx_buffer, 0, BUFF_SIZE);
             sent = sock.sendto(udp_addr, tx_buffer, pkt_s);
-            if (sent > 0) {
+            if (check_oversized_packets(sent, pkt_s)) {
+                TEST_IGNORE_MESSAGE("This device does not handle oversized packets");
+            } else if (sent > 0) {
                 packets_sent++;
             }
             if (sent != pkt_s) {

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -91,7 +91,11 @@ void UDPSOCKET_ECHOTEST_BURST()
     SocketAddress temp_addr;
     for (int i = 0; i < BURST_CNT; i++) {
         for (int x = 0; x < BURST_PKTS; x++) {
-            TEST_ASSERT_EQUAL(tx_buffers[x].len, sock.sendto(udp_addr, tx_buffers[x].payload, tx_buffers[x].len));
+            int sent = sock.sendto(udp_addr, tx_buffers[x].payload, tx_buffers[x].len);
+            if (check_oversized_packets(sent, tx_buffers[x].len)) {
+                TEST_IGNORE_MESSAGE("This device does not handle oversized packets");
+            }
+            TEST_ASSERT_EQUAL(tx_buffers[x].len, sent);
         }
 
         bt_total = 0;


### PR DESCRIPTION
### Description

Some modems will not be able to handle IPv4 packets larger than 536 B and we need to cope with this in our tests.
My proposal is to provide a generic function for handling the situation, in order not to obfuscate the test code too much. The function will limit the size of the packets in TCP_ECHOTEST_BURST(), where the test is able to continue. We could rewrite the other tests to do the same, but I thought that perhaps it is not their purpose to do so - they will simply 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@VeijoPesonen 
@SeppoTakalo 
@mtomczykmobica 
@KariHaapalehto 
@tymoteuszblochmobica 

### Release Notes

Not applicable.
