### PR TITLE
DOCS: fix doxygen not being generated for BLE classes

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -2106,7 +2106,21 @@ PREDEFINED             = DOXYGEN_ONLY            \
                          COMPONENT_SPM_MAILBOX   \
                          "MBED_DEPRECATED_SINCE(d, m)=" \
                          "MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=" \
-                         "MBED_DEPRECATED(s)="
+                         "MBED_DEPRECATED(s)=" \
+                         "BLE_ROLE_OBSERVER=1" \
+                         "BLE_ROLE_BROADCASTER=1" \
+                         "BLE_ROLE_PERIPHERAL=1" \
+                         "BLE_ROLE_CENTRAL=1" \
+                         "BLE_FEATURE_GATT_CLIENT=1" \
+                         "BLE_FEATURE_GATT_SERVER=1" \
+                         "BLE_FEATURE_SECURITY=1" \
+                         "BLE_FEATURE_SECURE_CONNECTIONS=1" \
+                         "BLE_FEATURE_SIGNING=1" \
+                         "BLE_FEATURE_PHY_MANAGEMENT=1" \
+                         "BLE_FEATURE_WHITELIST=1" \
+                         "BLE_FEATURE_PRIVACY=1" \
+                         "BLE_FEATURE_PERIODIC_ADVERTISING=1" \
+                         "BLE_FEATURE_EXTENDED_ADVERTISING=1"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
BLE is built conditionally based on compile time flags and doxygen needs to enable all the modules for the docs to be generated. This PR adds the macros to the doxyfile options.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@AnotherButler 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
