### PR TITLE
Fix bug in crypto_acl test

### DIFF
--- a/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
@@ -364,7 +364,7 @@ void test_use_other_partition_key_asymmetric_sign_verify(void)
 
     /* try to asymmetric verify using the key that was created by the test partition */
     TEST_ASSERT_EQUAL(PSA_ERROR_INVALID_HANDLE, psa_asymmetric_verify(key_handle, key_alg, input, sizeof(input),
-                                                                      signature, len));
+                                                                      signature, sizeof(signature)));
 
     /* via test partition - close the key created by the test partition */
     TEST_ASSERT_EQUAL(PSA_SUCCESS, test_partition_crypto_close_key(key_handle));


### PR DESCRIPTION
### Description

Send correct signature buffer size to psa_asymmetric_verify() in test

This PR is required for #9908 & #9910 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@itayzafrir 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
