### PR TITLE
Remove #ifndef NO_GREENTEA from tests

### DIFF
--- a/TESTS/mbed-crypto/sanity/main.cpp
+++ b/TESTS/mbed-crypto/sanity/main.cpp
@@ -438,9 +438,7 @@ utest::v1::status_t case_teardown_handler(const Case *const source, const size_t
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(120, "default_auto");
-#endif
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/mbed_hal/spm/main.cpp
+++ b/TESTS/mbed_hal/spm/main.cpp
@@ -150,9 +150,7 @@ Case cases[] = {
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(20, "default_auto");
-#endif
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -44,9 +44,7 @@ using namespace utest::v1;
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(60, "default_auto");
-#endif
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
@@ -468,9 +468,7 @@ utest::v1::status_t case_teardown_handler(const Case *const source, const size_t
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(120, "default_auto");
-#endif
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/crypto_init/main.cpp
+++ b/TESTS/psa/crypto_init/main.cpp
@@ -41,9 +41,7 @@ using namespace utest::v1;
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(60, "default_auto");
-#endif
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/entropy_inject/main.cpp
+++ b/TESTS/psa/entropy_inject/main.cpp
@@ -92,9 +92,7 @@ void run_entropy_inject_with_crypto_init()
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(60, "default_auto");
-#endif
 
     /* fill seed in some data */
     for (size_t i = 0; i < sizeof(seed); ++i) {

--- a/TESTS/psa/its_ps/main.cpp
+++ b/TESTS/psa/its_ps/main.cpp
@@ -184,9 +184,7 @@ Case cases[] = {
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(60, "default_auto");
-#endif
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/spm_client/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_client/COMPONENT_NSPE/main.cpp
@@ -475,9 +475,7 @@ Case cases[] = {
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
     // Setup Greentea using a reasonable timeout in seconds
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(60, "default_auto");
-#endif
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/spm_server/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_server/COMPONENT_NSPE/main.cpp
@@ -213,9 +213,7 @@ utest::v1::status_t spm_setup(const size_t number_of_cases)
         error("Could not open a connection with SERVER_TESTS_PART1_CONTROL ROT_SRV");
     }
 
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(60, "default_auto");
-#endif
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/psa/spm_smoke/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_smoke/COMPONENT_NSPE/main.cpp
@@ -74,10 +74,7 @@ void example_main(void)
 
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(20, "default_auto");
-#endif
-    // Call the default reporting function
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/features/frameworks/TARGET_PSA/val_greentea.cpp
+++ b/features/frameworks/TARGET_PSA/val_greentea.cpp
@@ -20,9 +20,7 @@ void mbed_val_test_init(uint32_t test_num, char8_t *desc, uint32_t test_bitfield
 
     mbed_val_print(PRINT_ALWAYS, "\nTEST: %d | DESCRIPTION: ", test_num);
     mbed_val_print(PRINT_ALWAYS, desc, 0);
-#ifndef NO_GREENTEA
     GREENTEA_SETUP(100, "default_auto");
-#endif
     mbed_val_set_status(RESULT_START(VAL_STATUS_SUCCESS));
     pal_mbed_os_compliance_test_initialize();
     return;


### PR DESCRIPTION
### Description

Remove #ifndef NO_GREENTEA from PSA tests as #9835 was merged

wait for #9823

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@ARMmbed/mbed-os-psa @ARMmbed/mbed-os-maintainers 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
