### PR TITLE
Skip test on Cortex M33 devices

### DIFF
--- a/TESTS/mbed_hal/spm/main.cpp
+++ b/TESTS/mbed_hal/spm/main.cpp
@@ -27,6 +27,10 @@
 #error [NOT_SUPPORTED] Disable this Test until FUTURE_SEQUANA_PSA enables Memory protection
 #endif
 
+#if defined(__CORTEX_M33)
+#error [NOT_SUPPORTED] Cannot run on M33 core as SecureFault is implemented in secure-side and cant be remapped
+#endif
+
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"


### PR DESCRIPTION
### Description

On platforms using coretx m33 accessing the secure memory will cause SecureFault instead of Hardfault.
SecureFault is implemented in the secure image and cannot be changed in runtime.
For those reasons we need to skip the test for M33 boards

This PR is required for #9908 & #9910 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@ARMmbed/mbed-os-psa @ARMmbed/mbed-os-maintainers 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
