### PR TITLE
BLE:Cordio:Fix insert characteristic not handle error

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -196,22 +196,32 @@ ble_error_t GattServer::insert_characteristic(
 
     // Create Characteristic Declaration Attribute
     insert_characteristic_declaration_attribute(characteristic, attribute_it);
-    insert_characteristic_value_attribute(characteristic, attribute_it);
+    ble_error_t err = insert_characteristic_value_attribute(characteristic, attribute_it);
+    if (err) {
+        return err;
+    }
+
 
     // insert descriptors
     bool cccd_created = false;
     for (size_t i = 0; i < characteristic->getDescriptorCount(); i++) {
-        insert_descriptor(
+        err = insert_descriptor(
             characteristic,
             characteristic->getDescriptor(i),
             attribute_it,
             cccd_created
         );
+        if (err) {
+            return err;
+        }
     }
 
     // insert implicit CCCD
     if ((properties & UPDATE_PROPERTIES) && (cccd_created == false)) {
-        insert_cccd(characteristic, attribute_it);
+        err = insert_cccd(characteristic, attribute_it);
+        if (err) {
+            return err;
+        }
     }
 
     return BLE_ERROR_NONE;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
The API `GattServer::insert_characteristic_value_attribute()` throws `BLE_ERROR_NO_MEM` but the caller `GattServer::insert_characteristic()` doesn't handle this, and that causes attributes be added wrongly and users aren't aware of this.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
