### PR TITLE
Fix of Buffered Serial RX/TX crash problem on REALTEK_RTL8195am

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/serial_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/serial_api.c
@@ -292,7 +292,6 @@ static void SerialRxDoneCallBack(VOID *pAdapter)
 #ifdef CONFIG_MBED_ENABLED
 static void serial_loguart_irq_handler(uint32_t id, LOG_UART_INT_ID event)
 {
-    log_uart_irq_set(&stdio_uart_log, event, 0);
     if (log_irq_handler) {
         if (event == IIR_RX_RDY || event == IIR_CHAR_TIMEOUT) {
             log_irq_handler(serial_log_irq_ids, RxIrq);


### PR DESCRIPTION
This PR addresses the issue of [#8081](https://github.com/ARMmbed/mbed-os/issues/8081).
It removes 'interrupt disable' in 'serial_loguart_irq_handler' function in "serial_api.c".

### Description

1. Remove 'log_uart_irq_set' to avoid interrupt being untimely disabled in buffered serial mode.   


### Pull request type


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
