### PR TITLE
Update Wi-SUN network default name

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -112,7 +112,7 @@
         },
         "wisun-network-name": {
             "help": "default network name for wisun network",
-            "value": "\"NETWORK_NAME\""
+            "value": "\"Wi-SUN Network\""
         },
         "wisun-regulatory-domain": {
             "help": "Regulator domain.",


### PR DESCRIPTION
### Description

Update Wi-SUN network default name to be "Wi-SUN Network".
This change is needed to get unified network name to all Wi-SUN applications.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarlamsa , @mikter 