### PR TITLE
SAML21J18A: #endif without #if in analogout_api.c

### DIFF
--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/TARGET_SAML21J18A/analogout_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/TARGET_SAML21J18A/analogout_api.c
@@ -21,6 +21,8 @@
 #include "PeripheralPins.h"
 #include "dac.h"
 
+#if DEVICE_ANALOGOUT
+
 extern uint8_t g_sys_init;
 
 #define MAX_VAL_12BIT 0x0FFF  /*12 Bit DAC for SAML21*/
@@ -119,4 +121,5 @@ const PinMap *analogout_pinmap()
 {
     return PinMap_DAC;
 }
-#endif
+
+#endif // DEVICE_ANALOGOUT


### PR DESCRIPTION
This PR: https://github.com/ARMmbed/mbed-os/commit/3bd3aca6db0a5cacd7e46ae7ed47507f83ad1aa3#diff-995cd6fe18f4fabfb549266dde0a3784 broke the SAML21J18A target, as there was no `#if DEVICE_ANALOGOUT` call, and this PR added an `#endif` there that's not matched now.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
