### PR TITLE
Remove Wifi config form echo server template json 

### DIFF
--- a/TESTS/network/emac/template_mbed_app_echo_server.txt
+++ b/TESTS/network/emac/template_mbed_app_echo_server.txt
@@ -15,9 +15,6 @@
     },
     "target_overrides": {
         "*": {
-            "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
-            "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
-            "nsapi.default-wifi-security": "WIFI_SECURITY",
             "nsapi.default-stack": "TEST"
         }
     }


### PR DESCRIPTION
### Description

Echo server is meant to run on Ethernet, so it doesn't need the WIFI config parameters.
When unconfigured, they also break the build process.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@KariHaapalehto 
@VeijoPesonen 
@SeppoTakalo 
