### PR TITLE
ESP8266: Country code API

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1201,4 +1201,29 @@ nsapi_connection_status_t ESP8266::connection_status() const
 {
     return _conn_status;
 }
+
+bool ESP8266::set_country_code_policy(bool track_ap, const char *country_code, int channel_start, int channels)
+{
+    int t_ap = track_ap ? 0 : 1;
+
+    _smutex.lock();
+    bool done = _parser.send("AT+CWCOUNTRY_DEF=%d,\"%s\",%d,%d", t_ap, country_code, channel_start, channels)
+                && _parser.recv("OK\n");
+
+    if (!done) {
+        tr_error("\"AT+CWCOUNTRY_DEF=%d,\"%s\",%d,%d\" - FAIL", t_ap, country_code, channel_start, channels);
+    }
+
+    done &= _parser.send("AT+CWCOUNTRY_CUR=%d,\"%s\",%d,%d", t_ap, country_code, channel_start, channels)
+                    && _parser.recv("OK\n");
+
+    if (!done) {
+        tr_error("\"AT+CWCOUNTRY_CUR=%d,\"%s\",%d,%d\" - FAIL", t_ap, country_code, channel_start, channels);
+    }
+
+    _smutex.unlock();
+
+    return done;
+}
+
 #endif

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -335,6 +335,15 @@ public:
      */
     bool set_default_wifi_mode(const int8_t mode);
 
+    /**
+     * @param track_ap      if TRUE, sets the county code to be the same as the AP's that ESP is connected to,
+     *                      if FALSE the code will not change
+     * @param country_code  ISO 3166-1 Alpha-2 coded country code
+     * @param channel_start the channel number to start at
+     * @param channels      number of channels
+     */
+    bool set_country_code_policy(bool track_ap, const char *country_code, int channel_start, int channels);
+
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -68,8 +68,11 @@ ESP8266Interface::ESP8266Interface()
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
-    memset(_country_code, 0, sizeof(_country_code));
-    strncpy(_country_code, MBED_CONF_ESP8266_COUNTRY_CODE, sizeof(_country_code));
+
+    _ch_info.track_ap = true;
+    strncpy(_ch_info.country_code, MBED_CONF_ESP8266_COUNTRY_CODE, sizeof(_ch_info.country_code));
+    _ch_info.channel_start = MBED_CONF_ESP8266_CHANNEL_START;
+    _ch_info.channels = MBED_CONF_ESP8266_CHANNELS;
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -99,8 +102,11 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug, PinName r
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
-    memset(_country_code, 0, sizeof(_country_code));
-    strncpy(_country_code, MBED_CONF_ESP8266_COUNTRY_CODE, sizeof(_country_code));
+
+    _ch_info.track_ap = true;
+    strncpy(_ch_info.country_code, MBED_CONF_ESP8266_COUNTRY_CODE, sizeof(_ch_info.country_code));
+    _ch_info.channel_start = MBED_CONF_ESP8266_CHANNEL_START;
+    _ch_info.channels = MBED_CONF_ESP8266_CHANNELS;
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -411,7 +417,7 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
-        if (!_esp.set_country_code_policy(true, _country_code, MBED_CONF_ESP8266_CHANNEL_START, MBED_CONF_ESP8266_CHANNELS)) {
+        if (!_esp.set_country_code_policy(true, _ch_info.country_code, _ch_info.channel_start, _ch_info.channels)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (!_esp.cond_enable_tcp_passive_mode()) {
@@ -862,7 +868,7 @@ nsapi_error_t ESP8266Interface::set_blocking(bool blocking)
     return NSAPI_ERROR_OK;
 }
 
-nsapi_error_t ESP8266Interface::set_country_code(const char *country_code, int len)
+nsapi_error_t ESP8266Interface::set_country_code(bool track_ap, const char *country_code, int len, int channel_start, int channels)
 {
     for (int i = 0; i < len; i++) {
         // Validation done by firmware
@@ -872,9 +878,14 @@ nsapi_error_t ESP8266Interface::set_country_code(const char *country_code, int l
         }
     }
 
+    _ch_info.track_ap = track_ap;
+
     // Firmware takes only first three characters
-    strncpy(_country_code, country_code, sizeof(_country_code));
-    _country_code[sizeof(_country_code)-1] = '\0';
+    strncpy(_ch_info.country_code, country_code, sizeof(_ch_info.country_code));
+    _ch_info.country_code[sizeof(_ch_info.country_code)-1] = '\0';
+
+    _ch_info.channel_start = channel_start;
+    _ch_info.channels = channels;
 
     return NSAPI_ERROR_OK;
 }

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -69,6 +69,7 @@ ESP8266Interface::ESP8266Interface()
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
     memset(_country_code, 0, sizeof(_country_code));
+    strncpy(_country_code, MBED_CONF_ESP8266_COUNTRY_CODE, sizeof(_country_code));
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -99,6 +100,7 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug, PinName r
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
     memset(_country_code, 0, sizeof(_country_code));
+    strncpy(_country_code, MBED_CONF_ESP8266_COUNTRY_CODE, sizeof(_country_code));
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -393,15 +395,7 @@ bool ESP8266Interface::_get_firmware_ok()
 
 nsapi_error_t ESP8266Interface::_init(void)
 {
-
-
     if (!_initialized) {
-
-        if (!_country_code[0] || !_country_code[1] ) {
-            strncpy(_country_code, MBED_CONF_ESP8266_COUNTRY_CODE, 2);
-            _country_code[2] = '\0';
-        }
-
         if (_reset() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
@@ -868,5 +862,21 @@ nsapi_error_t ESP8266Interface::set_blocking(bool blocking)
     return NSAPI_ERROR_OK;
 }
 
+nsapi_error_t ESP8266Interface::set_country_code(const char *country_code, int len)
+{
+    for (int i = 0; i < len; i++) {
+        // Validation done by firmware
+        if (!country_code[i]) {
+            tr_warning("invalid country code");
+            return NSAPI_ERROR_PARAMETER;
+        }
+    }
+
+    // Firmware takes only first three characters
+    strncpy(_country_code, country_code, sizeof(_country_code));
+    _country_code[sizeof(_country_code)-1] = '\0';
+
+    return NSAPI_ERROR_OK;
+}
 
 #endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -68,6 +68,7 @@ ESP8266Interface::ESP8266Interface()
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
+    memset(_country_code, 0, sizeof(_country_code));
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -97,6 +98,7 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug, PinName r
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
+    memset(_country_code, 0, sizeof(_country_code));
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -391,7 +393,15 @@ bool ESP8266Interface::_get_firmware_ok()
 
 nsapi_error_t ESP8266Interface::_init(void)
 {
+
+
     if (!_initialized) {
+
+        if (!_country_code[0] || !_country_code[1] ) {
+            strncpy(_country_code, MBED_CONF_ESP8266_COUNTRY_CODE, 2);
+            _country_code[2] = '\0';
+        }
+
         if (_reset() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
@@ -405,6 +415,9 @@ nsapi_error_t ESP8266Interface::_init(void)
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (!_esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        if (!_esp.set_country_code_policy(true, _country_code, MBED_CONF_ESP8266_CHANNEL_START, MBED_CONF_ESP8266_CHANNELS)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (!_esp.cond_enable_tcp_passive_mode()) {

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -339,11 +339,15 @@ protected:
 
     /** Set country code
      *
-     *  @param country_code 2-3 character country code
-     *  @param len          Length of the country code
-     *  @return             NSAPI_ERROR_OK on success, negative error code on failure.
+     *  @param track_ap      if TRUE, use country code used by the AP ESP is connected to,
+     *                       otherwise uses country_code always
+     *  @param country_code  ISO 3166-1 coded, 2 character alphanumeric country code assumed
+     *  @param len           Length of the country code
+     *  @param channel_start The channel number to start at
+     *  @param channel       Number of channels
+     *  @return              NSAPI_ERROR_OK on success, negative error code on failure.
      */
-    nsapi_error_t set_country_code(const char *country_code, int len)
+    nsapi_error_t set_country_code(bool track_ap, const char *country_code, int len, int channel_start, int channels);
 
 private:
     // AT layer
@@ -371,7 +375,13 @@ private:
     nsapi_security_t _ap_sec;
 
     // Country code
-    char _country_code[4]; /* ISO 3166-1 coded country code - +1 for the '\0' - assumed. Documentation doesn't tell */
+    struct _channel_info {
+        bool track_ap; // Set country code based on the AP ESP is connected to
+        char country_code[4]; // ISO 3166-1 coded, 2-3 character alphanumeric country code - +1 for the '\0' - assumed. Documentation doesn't tell.
+        int channel_start;
+        int channels;
+    };
+    struct _channel_info _ch_info;
 
     bool _if_blocking; // NetworkInterface, blocking or not
     rtos::ConditionVariable _if_connected;

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -44,6 +44,18 @@
 #endif
 #endif /* TARGET_FF_ARDUINO */
 
+#ifndef MBED_CONF_ESP8266_COUNTRY_CODE
+#define MBED_CONF_ESP8266_COUNTRY_CODE "CN"
+#endif
+
+#ifndef MBED_CONF_ESP8266_CHANNEL_START
+#define MBED_CONF_ESP8266_CHANNEL_START 1
+#endif
+
+#ifndef MBED_CONF_ESP8266_CHANNELS
+#define MBED_CONF_ESP8266_CHANNELS 13
+#endif
+
 /** ESP8266Interface class
  *  Implementation of the NetworkStack for the ESP8266
  */
@@ -349,6 +361,9 @@ private:
     static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1]; /* The longest possible passphrase; +1 for the \0 */
     nsapi_security_t _ap_sec;
+
+    // Country code
+    char _country_code[3]; /* ISO 3166-1 Alpha-2 coded country code plus, +1 for the \0 */
 
     bool _if_blocking; // NetworkInterface, blocking or not
     rtos::ConditionVariable _if_connected;

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -337,6 +337,14 @@ protected:
      */
     virtual nsapi_error_t set_blocking(bool blocking);
 
+    /** Set country code
+     *
+     *  @param country_code 2-3 character country code
+     *  @param len          Length of the country code
+     *  @return             NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    nsapi_error_t set_country_code(const char *country_code, int len)
+
 private:
     // AT layer
     ESP8266 _esp;
@@ -363,7 +371,7 @@ private:
     nsapi_security_t _ap_sec;
 
     // Country code
-    char _country_code[3]; /* ISO 3166-1 Alpha-2 coded country code plus, +1 for the \0 */
+    char _country_code[4]; /* ISO 3166-1 coded country code - +1 for the '\0' - assumed. Documentation doesn't tell */
 
     bool _if_blocking; // NetworkInterface, blocking or not
     rtos::ConditionVariable _if_connected;

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -32,6 +32,18 @@
         "socket-bufsize": {
             "help": "Max socket data heap usage",
             "value": 8192
+        },
+        "country-code": {
+            "help": "ISO 3166-1 coded, 2 character alphanumeric country code, 'CN' by default",
+            "value": null
+        },
+        "channel-start": {
+            "help": "the channel number to start at, 1 by default",
+            "value": null
+        },
+        "channels": {
+            "help": "channel count, 13 by default",
+            "value": null
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Description
ESP8266Interface API updated with possibility to configure country code and channels to be used.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@kjbracey-arm 
@michalpasztamobica 

### Release Notes
ESP8266Interface: new API to configure country code and channels to be used.
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
