### PR TITLE
Reduce number of threads in block device test

### DIFF
--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -349,7 +349,7 @@ void test_multi_threads()
     char *dummy;
 
     rtos::Thread **bd_thread = new (std::nothrow) rtos::Thread*[TEST_NUM_OF_THREADS];
-    TEST_SKIP_UNLESS_MESSAGE((*bd_thread) != NULL, "no block device found.");
+    TEST_SKIP_UNLESS_MESSAGE((*bd_thread) != NULL, "not enough heap to run test.");
     memset(bd_thread, 0, TEST_NUM_OF_THREADS * sizeof(rtos::Thread *));
 
     for (i_ind = 0; i_ind < TEST_NUM_OF_THREADS; i_ind++) {

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -52,6 +52,7 @@ using namespace utest::v1;
 #define TEST_BLOCK_COUNT 10
 #define TEST_ERROR_MASK 16
 #define TEST_NUM_OF_THREADS 4
+#define TEST_THREAD_STACK_SIZE 1024
 
 const struct {
     const char *name;
@@ -331,10 +332,6 @@ void test_multi_threads()
 
     TEST_SKIP_UNLESS_MESSAGE(block_device != NULL, "no block device found.");
 
-    char *dummy = new (std::nothrow) char[TEST_NUM_OF_THREADS * OS_STACK_SIZE];
-    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test.\n");
-    delete[] dummy;
-
     for (unsigned atr = 0; atr < sizeof(ATTRS) / sizeof(ATTRS[0]); atr++) {
         static const char *prefixes[] = {"", "k", "M", "G"};
         for (int i_ind = 3; i_ind >= 0; i_ind--) {
@@ -347,21 +344,44 @@ void test_multi_threads()
         }
     }
 
-    rtos::Thread bd_thread[TEST_NUM_OF_THREADS];
-
     osStatus threadStatus;
-    int i_ind;
+    int i_ind, j_ind;
+    char *dummy;
+
+    rtos::Thread **bd_thread = new (std::nothrow) rtos::Thread*[TEST_NUM_OF_THREADS];
+    TEST_SKIP_UNLESS_MESSAGE((*bd_thread) != NULL, "no block device found.");
+    memset(bd_thread, 0, TEST_NUM_OF_THREADS * sizeof(rtos::Thread *));
 
     for (i_ind = 0; i_ind < TEST_NUM_OF_THREADS; i_ind++) {
-        threadStatus = bd_thread[i_ind].start(callback(test_thread_job, (void *)block_device));
+
+        bd_thread[i_ind] = new (std::nothrow) rtos::Thread((osPriority_t)((int)osPriorityNormal), TEST_THREAD_STACK_SIZE);
+        dummy = new (std::nothrow) char[TEST_THREAD_STACK_SIZE];
+
+        if (!bd_thread[i_ind] || !dummy) {
+            utest_printf("Not enough heap to run Thread  %d !\n", i_ind + 1);
+            break;
+        }
+        delete[] dummy;
+
+        threadStatus = bd_thread[i_ind]->start(callback(test_thread_job, (void *)block_device));
         if (threadStatus != 0) {
             utest_printf("Thread %d Start Failed!\n", i_ind + 1);
+            break;
         }
     }
 
-    for (i_ind = 0; i_ind < TEST_NUM_OF_THREADS; i_ind++) {
-        bd_thread[i_ind].join();
+    for (j_ind = 0; j_ind < i_ind; j_ind++) {
+        bd_thread[j_ind]->join();
     }
+
+    if (bd_thread) {
+        for (j_ind = 0; j_ind < i_ind; j_ind++) {
+            delete bd_thread[j_ind];
+        }
+
+        delete[] bd_thread;
+    }
+
 }
 
 void test_erase_functionality()

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -51,7 +51,7 @@ using namespace utest::v1;
 
 #define TEST_BLOCK_COUNT 10
 #define TEST_ERROR_MASK 16
-#define TEST_NUM_OF_THREADS 5
+#define TEST_NUM_OF_THREADS 4
 
 const struct {
     const char *name;

--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -45,6 +45,7 @@ FILE *fd[test_files];
 
 BlockDevice *bd = BlockDevice::get_default_instance();
 FileSystem  *fs = FileSystem::get_default_instance();
+const char *bd_type;
 
 /*----------------help functions------------------*/
 
@@ -74,12 +75,15 @@ static void deinit()
 //init the blockdevice and reformat the filesystem
 static void bd_init_fs_reformat()
 {
+    bd_type = bd->get_type();
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     init();
 }
 
 //fopen path without fs prefix
 static void FS_fopen_path_not_valid()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(1, res);
 
@@ -88,6 +92,7 @@ static void FS_fopen_path_not_valid()
 //fopen empty file name with r mode
 static void FS_fopen_empty_path_r_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "", "rb")) != NULL);
     TEST_ASSERT_EQUAL(1, res);
 }
@@ -95,6 +100,7 @@ static void FS_fopen_empty_path_r_mode()
 //fopen empty file name with w mode
 static void FS_fopen_empty_path_w_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "", "wb")) != NULL);
     TEST_ASSERT_EQUAL(1, res);
 }
@@ -102,6 +108,7 @@ static void FS_fopen_empty_path_w_mode()
 //fopen empty mode
 static void FS_fopen_invalid_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "Invalid_mode", "")) != NULL);
     TEST_ASSERT_EQUAL(1, res);
 }
@@ -109,6 +116,7 @@ static void FS_fopen_invalid_mode()
 //fopen with valid flowSystemStorage
 static void FS_fopen_supported_wb_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -122,6 +130,7 @@ static void FS_fopen_supported_wb_mode()
 //fopen with append mode
 static void FS_fopen_supported_a_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "a")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -135,6 +144,7 @@ static void FS_fopen_supported_a_mode()
 //fopen with read mode
 static void FS_fopen_supported_r_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "r")) != NULL);
     TEST_ASSERT_EQUAL(1, res);
 }
@@ -142,6 +152,7 @@ static void FS_fopen_supported_r_mode()
 //fopen with append update mode
 static void FS_fopen_supported_a_update_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "a+")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -155,6 +166,7 @@ static void FS_fopen_supported_a_update_mode()
 //fopen with read update mode
 static void FS_fopen_supported_r_update_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "r+")) != NULL);
     TEST_ASSERT_EQUAL(1, res);
 }
@@ -162,6 +174,7 @@ static void FS_fopen_supported_r_update_mode()
 //fopen with write update mode
 static void FS_fopen_supported_w_update_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "w+")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -175,6 +188,7 @@ static void FS_fopen_supported_w_update_mode()
 //fopen with read update create, check contents exist
 static void FS_fopen_read_update_create()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = "";
 
@@ -204,6 +218,7 @@ static void FS_fopen_read_update_create()
 //fopen with write update create, check contents doesnt exist
 static void FS_fopen_write_update_create()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = "";
 
@@ -233,6 +248,7 @@ static void FS_fopen_write_update_create()
 //fclose valid flow
 static void FS_fclose_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -248,6 +264,7 @@ static void FS_fclose_valid_flow()
 //fwrite with nmemb zero
 static void FS_fwrite_nmemb_zero()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -266,6 +283,7 @@ static void FS_fwrite_nmemb_zero()
 //fwrite valid flow
 static void FS_fwrite_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "good_day";
     char read_buf[small_buf_size] = {};
 
@@ -295,6 +313,7 @@ static void FS_fwrite_valid_flow()
 //fwrite to fopen mode r
 static void FS_fwrite_with_fopen_r_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -321,6 +340,7 @@ static void FS_fwrite_with_fopen_r_mode()
 //fread with size zero
 static void FS_fread_size_zero()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -348,6 +368,7 @@ static void FS_fread_size_zero()
 //fread with nmemb zero
 static void FS_fread_nmemb_zero()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -375,6 +396,7 @@ static void FS_fread_nmemb_zero()
 //fread to fopen mode w
 static void FS_fread_with_fopen_w_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = {};
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -399,6 +421,7 @@ static void FS_fread_with_fopen_w_mode()
 //fread to fwrite file
 static void FS_fread_to_fwrite_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = {};
     char write_buf[small_buf_size] = "123456789";
 
@@ -421,6 +444,7 @@ static void FS_fread_to_fwrite_file()
 //fread empty file
 static void FS_fread_empty_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = {};
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -445,6 +469,7 @@ static void FS_fread_empty_file()
 //fread valid flow small file
 static void FS_fread_valid_flow_small_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "good_day";
     char read_buf[small_buf_size] = {};
 
@@ -475,6 +500,7 @@ static void FS_fread_valid_flow_small_file()
 //fread valid flow medium file
 static void FS_fread_valid_flow_medium_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[medium_buf_size] = { 1 };
     char read_buf[medium_buf_size] = {};
 
@@ -504,6 +530,7 @@ static void FS_fread_valid_flow_medium_file()
 //fread valid flow large file
 static void FS_fread_valid_flow_large_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[large_buf_size] = { 1 };
     char read_buf[large_buf_size] = {};
 
@@ -533,6 +560,7 @@ static void FS_fread_valid_flow_large_file()
 //fread valid flow small file read more than write
 static void FS_fread_valid_flow_small_file_read_more_than_write()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "good_day";
     char read_buf[small_buf_size + 10] = {};
 
@@ -564,6 +592,7 @@ static void FS_fread_valid_flow_small_file_read_more_than_write()
 //fgetc to an empty file
 static void FS_fgetc_empty_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -586,6 +615,7 @@ static void FS_fgetc_empty_file()
 //fgetc valid flow
 static void FS_fgetc_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "good_day";
     char read_buf[small_buf_size] = {};
     int ch = 0;
@@ -620,6 +650,7 @@ static void FS_fgetc_valid_flow()
 //fgetc to fopen mode w
 static void FS_fgetc_with_fopen_w_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -644,6 +675,7 @@ static void FS_fgetc_with_fopen_w_mode()
 //fgets to an empty file
 static void FS_fgets_empty_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = {};
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -667,6 +699,7 @@ static void FS_fgets_empty_file()
 //fgets with buffer null with zero len of buffer string
 static void FS_fgets_null_buffer_zero_len()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -688,6 +721,7 @@ static void FS_fgets_null_buffer_zero_len()
 //fgets with buffer null
 static void FS_fgets_null_buffer()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -709,6 +743,7 @@ static void FS_fgets_null_buffer()
 //fgets valid flow
 static void FS_fgets_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "good_day";
     char read_buf[small_buf_size] = {};
 
@@ -737,6 +772,7 @@ static void FS_fgets_valid_flow()
 //fgets up to new line character
 static void FS_fgets_new_line()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "good_day";
     char read_buf[small_buf_size] = {};
 
@@ -767,6 +803,7 @@ static void FS_fgets_new_line()
 //fgets to fopen mode w
 static void FS_fgets_with_fopen_w_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = {};
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -792,6 +829,7 @@ static void FS_fgets_with_fopen_w_mode()
 //fflush with null
 static void FS_fflush_null_stream()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = fflush(NULL);
     TEST_ASSERT_EQUAL(0, res);
 }
@@ -800,6 +838,7 @@ static void FS_fflush_null_stream()
 //fflush valid flow
 static void FS_fflush_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -822,6 +861,7 @@ static void FS_fflush_valid_flow()
 //fflush twice
 static void FS_fflush_twice()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -848,6 +888,7 @@ static void FS_fflush_twice()
 //fputc valid flow
 static void FS_fputc_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int write_ch = 10, read_ch = 0;
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -875,6 +916,7 @@ static void FS_fputc_valid_flow()
 //fputc with file open for read mode
 static void FS_fputc_in_read_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int write_ch = 10;
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -901,6 +943,7 @@ static void FS_fputc_in_read_mode()
 //fputs valid flow
 static void FS_fputs_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = {};
 
@@ -930,6 +973,7 @@ static void FS_fputs_valid_flow()
 //fputs with file open for read mode
 static void FS_fputs_in_read_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char buffer[small_buf_size] = "good_day";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -956,6 +1000,7 @@ static void FS_fputs_in_read_mode()
 //fseek empty file, SEEK_SET, offset 0
 static void FS_fseek_empty_file_seek_set()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -981,6 +1026,7 @@ static void FS_fseek_empty_file_seek_set()
 //fseek non empty file, SEEK_SET, offset 0
 static void FS_fseek_non_empty_file_seek_set()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1011,6 +1057,7 @@ static void FS_fseek_non_empty_file_seek_set()
 //fseek empty file, SEEK_SET, offset 1 - beyond end of file
 static void FS_fseek_beyond_empty_file_seek_set()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = "";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1041,6 +1088,7 @@ static void FS_fseek_beyond_empty_file_seek_set()
 //fseek non empty file, SEEK_SET, offset data_size + 1 - beyond end of file
 static void FS_fseek_beyond_non_empty_file_seek_set()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = "";
 
@@ -1075,6 +1123,7 @@ static void FS_fseek_beyond_non_empty_file_seek_set()
 //fseek empty file, SEEK_CUR, offset 0
 static void FS_fseek_empty_file_seek_cur()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -1100,6 +1149,7 @@ static void FS_fseek_empty_file_seek_cur()
 //fseek non empty file, SEEK_CUR, offset 0
 static void FS_fseek_non_empty_file_seek_cur()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1130,6 +1180,7 @@ static void FS_fseek_non_empty_file_seek_cur()
 //fseek empty file, SEEK_CUR, offset 1 - beyond end of file
 static void FS_fseek_beyond_empty_file_seek_cur()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = {};
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1160,6 +1211,7 @@ static void FS_fseek_beyond_empty_file_seek_cur()
 //fseek non empty file, SEEK_CUR, offset data_size + 1 - beyond end of file
 static void FS_fseek_beyond_non_empty_file_seek_cur()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = {};
     char write_buf[small_buf_size] = "123456789";
 
@@ -1194,6 +1246,7 @@ static void FS_fseek_beyond_non_empty_file_seek_cur()
 //fseek empty file, SEEK_END, offset 0
 static void FS_fseek_empty_file_seek_end()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -1219,6 +1272,7 @@ static void FS_fseek_empty_file_seek_end()
 //fseek non empty file, SEEK_END, offset 0
 static void FS_fseek_non_empty_file_seek_end()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1249,6 +1303,7 @@ static void FS_fseek_non_empty_file_seek_end()
 //fseek empty file, SEEK_END, offset 1 - beyond end of file
 static void FS_fseek_beyond_empty_file_seek_end()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = {};
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1279,6 +1334,7 @@ static void FS_fseek_beyond_empty_file_seek_end()
 //fseek non empty file, SEEK_END, offset data_size + 1 - beyond end of file
 static void FS_fseek_beyond_non_empty_file_seek_end()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char read_buf[small_buf_size] = {};
     char write_buf[small_buf_size] = "123456789";
 
@@ -1313,6 +1369,7 @@ static void FS_fseek_beyond_non_empty_file_seek_end()
 //fseek non empty file, SEEK_END, offset negative
 static void FS_fseek_negative_non_empty_file_seek_end()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1345,6 +1402,7 @@ static void FS_fseek_negative_non_empty_file_seek_end()
 //fgetpos rewrite file and check data
 static void FS_fgetpos_rewrite_check_data()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char rewrite_buf[small_buf_size] = "987654321";
     char read_buf[small_buf_size] = {};
@@ -1387,6 +1445,7 @@ static void FS_fgetpos_rewrite_check_data()
 //fscanf valid flow
 static void FS_fscanf_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = {};
     int num = 0;
@@ -1421,6 +1480,7 @@ static void FS_fscanf_valid_flow()
 //fscanf empty file
 static void FS_fscanf_empty_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int num = 0;
 
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
@@ -1439,6 +1499,7 @@ static void FS_fscanf_empty_file()
 //fscanf more fields than exist
 static void FS_fscanf_more_fields_than_exist()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = {};
     int num = 0;
@@ -1478,6 +1539,7 @@ static void FS_fscanf_more_fields_than_exist()
 //fprintf in mode r
 static void FS_fprintf_read_mode()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -1502,6 +1564,7 @@ static void FS_fprintf_read_mode()
 //freopen point to the same file with two file handler
 static void FS_freopen_point_to_same_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -1520,6 +1583,7 @@ static void FS_freopen_point_to_same_file()
 //freopen valid flow
 static void FS_freopen_valid_flow()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[small_buf_size] = "123456789";
     char read_buf[small_buf_size] = {};
 
@@ -1548,6 +1612,7 @@ static void FS_freopen_valid_flow()
 //create a 1 byte file
 static void FS_fopen_write_one_byte_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf = 1;
     char read_buf[1] = {};
 
@@ -1577,6 +1642,7 @@ static void FS_fopen_write_one_byte_file()
 //create a 2 bytes file
 static void FS_fopen_write_two_byte_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[2] = "1";
     char read_buf[2] = {};
 
@@ -1606,6 +1672,7 @@ static void FS_fopen_write_two_byte_file()
 //create a 5 bytes file
 static void FS_fopen_write_five_byte_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[5] = "1234";
     char read_buf[5] = {};
 
@@ -1635,6 +1702,7 @@ static void FS_fopen_write_five_byte_file()
 //create a 15 bytes file
 static void FS_fopen_write_fifteen_byte_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[15] = "12345678901234";
     char read_buf[15] = {};
 
@@ -1664,6 +1732,7 @@ static void FS_fopen_write_fifteen_byte_file()
 //create a 5000 bytes file
 static void FS_fopen_write_five_Kbyte_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     int buf_sz = 5000;
     char *write_buf = (char *)malloc(buf_sz);
     char read_buf[10] = {};
@@ -1696,6 +1765,7 @@ static void FS_fopen_write_five_Kbyte_file()
 //rewrite file begining
 static void FS_fseek_rewrite_non_empty_file_begining()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[15] = "12345678901234";
     char rewrite_buf[6] = "abcde";
     char check_buf[15] = "abcde678901234";
@@ -1742,6 +1812,7 @@ static void FS_fseek_rewrite_non_empty_file_begining()
 //rewrite file middle
 static void FS_fseek_rewrite_non_empty_file_middle()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[15] = "12345678901234";
     char rewrite_buf[6] = "abcde";
     char check_buf[15] = "12345abcde1234";
@@ -1788,6 +1859,7 @@ static void FS_fseek_rewrite_non_empty_file_middle()
 //rewrite file end
 static void FS_fseek_rewrite_non_empty_file_end()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[15] = "12345678901234";
     char rewrite_buf[6] = "abcde";
     char check_buf[15] = "123456789abcde";
@@ -1834,6 +1906,7 @@ static void FS_fseek_rewrite_non_empty_file_end()
 //append buffer to empty file
 static void FS_append_empty_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[17] = "1234567890123456";
     char read_buf[17] = {};
 
@@ -1863,6 +1936,7 @@ static void FS_append_empty_file()
 //append buffer to non empty file
 static void FS_append_non_empty_file()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[17] = "1234567890123456";
     char rewrite_buf[17] = "abcdefghijklmnop";
     char read_buf[34] = {};
@@ -1906,6 +1980,7 @@ static void FS_append_non_empty_file()
 //fill write_buf buffer with random data, read back the data from the file
 static void FS_write_read_random_data()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     char write_buf[medium_buf_size] = {};
     unsigned int i;
 
@@ -1941,6 +2016,7 @@ static void FS_write_read_random_data()
 //fill write_buf buffer with random data, read back the data from the file
 static void FS_fill_data_and_seek()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     unsigned int i, j;
 
     int res = !((fd[0] = fopen("/default/" "filename", "w")) != NULL);
@@ -1991,6 +2067,7 @@ static void FS_fill_data_and_seek()
 //deinit the blockdevice and unmount the filesystem
 static void bd_deinit_fs_unmount()
 {
+    TEST_SKIP_UNLESS_MESSAGE(strcmp(bd_type, "FLASHIAP") != 0, "Skip FS tests on FlashIAP");
     deinit();
 }
 


### PR DESCRIPTION
### Description
Storage Tests Fix:
1) Prevent FS tests from running on internal FlashIAP
2) Reduce number of threads for general BD multi-thread test
    and verify memory resources before running test

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
