### PR TITLE
Increased timeout for lwip waiting netif_is_link_up

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -647,7 +647,7 @@ nsapi_error_t LWIP::Interface::bringup(bool dhcp, const char *ip, const char *ne
 
     if (!netif_is_link_up(&netif)) {
         if (blocking) {
-            if (osSemaphoreAcquire(linked, 15000) != osOK) {
+            if (osSemaphoreAcquire(linked, LINK_TIMEOUT * 1000) != osOK) {
                 if (ppp) {
                     (void) ppp_lwip_disconnect(hw);
                 }

--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -58,6 +58,7 @@
 #endif
 
 #define DHCP_TIMEOUT                60
+#define LINK_TIMEOUT                60
 
 #define PREF_IPV4                   1
 #define PREF_IPV6                   2


### PR DESCRIPTION
### Description

Cellular PPP connect fails too often if timeout is 15s so increased to 60 seconds.
Tested to be enough with BG96 and MTB_MTS_DRAGONFLY.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes
