### PR TITLE
Fix lwip to compile if MBED_CONF_LWIP_DEBUG_ENABLED is defined

### DIFF
--- a/features/lwipstack/lwip-sys/arch/cc.h
+++ b/features/lwipstack/lwip-sys/arch/cc.h
@@ -34,6 +34,7 @@
 
 #include <stdint.h>
 #include <stddef.h> /* for size_t */
+#include "mbed_toolchain.h"
 
 #if LWIP_USE_EXTERNAL_MBEDTLS
 #include "mbedtls/md5.h"


### PR DESCRIPTION
### Description

File features/lwipstack/lwip-sys/arch/cc.h fails to compile
with error: 'MBED_NORETURN' does not name a type.
Fix with adding correct include.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes
