### PR TITLE
Add missing RSPIF component to the defaut BlockDevice handler

### DIFF
--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -25,6 +25,10 @@
 #include "SPIFBlockDevice.h"
 #endif
 
+#if COMPONENT_RSPIF
+#include "SPIFReducedBlockDevice.h"
+#endif
+
 #if COMPONENT_QSPIF
 #include "QSPIFBlockDevice.h"
 #endif
@@ -88,6 +92,18 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_SPIF_DRIVER_SPI_CLK,
         MBED_CONF_SPIF_DRIVER_SPI_CS,
         MBED_CONF_SPIF_DRIVER_SPI_FREQ
+    );
+
+    return &default_bd;
+
+#elif COMPONENT_RSPIF
+
+    static SPIFReducedBlockDevice default_bd(
+        MBED_CONF_RSPIF_DRIVER_SPI_MOSI,
+        MBED_CONF_RSPIF_DRIVER_SPI_MISO,
+        MBED_CONF_RSPIF_DRIVER_SPI_CLK,
+        MBED_CONF_RSPIF_DRIVER_SPI_CS,
+        MBED_CONF_RSPIF_DRIVER_SPI_FREQ
     );
 
     return &default_bd;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Add missing support for RSPIF when using `BlockDevice::get_default_instance()`.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
