### PR TITLE
Add missing .vscode directory to the zipped export

### DIFF
--- a/tools/export/vscode/__init__.py
+++ b/tools/export/vscode/__init__.py
@@ -1,5 +1,5 @@
 # mbed SDK
-# Copyright (c) 2011-2016 ARM Limited
+# Copyright (c) 2011-2019 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ class VSCode(Makefile):
             else:
                 print('Keeping existing %s.json' % file)
 
+        # add .vscode to resources so that it is available in zipped and exported project
+        self.resources.add_directory(".vscode")
         # So.... I want all .h and .hpp files in self.resources.inc_dirs
         all_directories = []
 


### PR DESCRIPTION
### Description

The zipped project should include the .vscode directory. This is a fix for https://github.com/ARMmbed/mbed-os/issues/8411

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

