### PR TITLE
PSA: automatic mocking of PSA targets in test builds

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2380,6 +2380,12 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
 
 
 def test_spec_from_test_builds(test_builds):
+    for build in test_builds:
+        if Target.get_target(test_builds[build]['platform']).is_PSA_non_secure_target:
+            if test_builds[build]['platform'].endswith('_NS'):
+                test_builds[build]['platform'] = test_builds[build]['platform'][:-3]
+            if test_builds[build]['platform'].endswith('_PSA'):
+                test_builds[build]['platform'] = test_builds[build]['platform'][:-4]
     return {
         "builds": test_builds
     }


### PR DESCRIPTION
### Description

When creating test_spec.json for PSA targets builds, removing the `_PSA` and `_NS` suffixes from the platform field will allow to run the tests without the need for mbedls mock 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@bridadan 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
