### PR TITLE
Reconcile mbed trace and greentea

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
@@ -61,6 +61,6 @@ void ASYNCHRONOUS_DNS_CACHE()
         TEST_ASSERT_TRUE(i == 0 || delay_ms <= delay_first);
 
         greentea_serial->printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
-               dns_test_hosts[0], data.addr.get_ip_address(), delay_ms);
+                                dns_test_hosts[0], data.addr.get_ip_address(), delay_ms);
     }
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
@@ -56,11 +56,11 @@ void ASYNCHRONOUS_DNS_CACHE()
         int delay_ms = (ticker_us - started_us) / 1000;
 
         static int delay_first = delay_ms / 2;
-        printf("Delays: first: %i, delay_ms: %i\n", delay_first, delay_ms);
+        greentea_serial->printf("Delays: first: %i, delay_ms: %i\n", delay_first, delay_ms);
         // Check that cached accesses are at least twice as fast as the first one
         TEST_ASSERT_TRUE(i == 0 || delay_ms <= delay_first);
 
-        printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
+        greentea_serial->printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
                dns_test_hosts[0], data.addr.get_ip_address(), delay_ms);
     }
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
@@ -69,7 +69,7 @@ void ASYNCHRONOUS_DNS_CANCEL()
         TEST_ASSERT(data[i].result == NSAPI_ERROR_OK || data[i].result == NSAPI_ERROR_NO_MEMORY || data[i].result == NSAPI_ERROR_DNS_FAILURE || data[i].result == NSAPI_ERROR_TIMEOUT);
         if (data[i].result == NSAPI_ERROR_OK) {
             greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
-                   dns_test_hosts[i], data[i].addr.get_ip_address());
+                                    dns_test_hosts[i], data[i].addr.get_ip_address());
         } else if (data[i].result == NSAPI_ERROR_DNS_FAILURE) {
             greentea_serial->printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_TIMEOUT) {

--- a/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
@@ -42,7 +42,7 @@ void ASYNCHRONOUS_DNS_CANCEL()
             count++;
         } else {
             // No memory to initiate DNS query, callback will not be called
-            printf("Error: No memory to initiate DNS query for %s\n", dns_test_hosts[i]);
+            greentea_serial->printf("Error: No memory to initiate DNS query for %s\n", dns_test_hosts[i]);
             data[i].result = NSAPI_ERROR_NO_MEMORY;
             data[i].value_set = true;
         }
@@ -63,19 +63,19 @@ void ASYNCHRONOUS_DNS_CANCEL()
 
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {
         if (!data[i].value_set) {
-            printf("DNS: query \"%s\" => cancel\n", dns_test_hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => cancel\n", dns_test_hosts[i]);
             continue;
         }
         TEST_ASSERT(data[i].result == NSAPI_ERROR_OK || data[i].result == NSAPI_ERROR_NO_MEMORY || data[i].result == NSAPI_ERROR_DNS_FAILURE || data[i].result == NSAPI_ERROR_TIMEOUT);
         if (data[i].result == NSAPI_ERROR_OK) {
-            printf("DNS: query \"%s\" => \"%s\"\n",
+            greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
                    dns_test_hosts[i], data[i].addr.get_ip_address());
         } else if (data[i].result == NSAPI_ERROR_DNS_FAILURE) {
-            printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_TIMEOUT) {
-            printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_NO_MEMORY) {
-            printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
         }
     }
 

--- a/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -38,7 +38,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
         SocketAddress addr;
         int err = get_interface()->gethostbyname(dns_test_hosts[i], &addr);
         greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
-               dns_test_hosts[i], addr.get_ip_address());
+                                dns_test_hosts[i], addr.get_ip_address());
 
         TEST_ASSERT_EQUAL(0, err);
         TEST_ASSERT((bool)addr);
@@ -50,7 +50,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
 
     greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
-           dns_test_hosts_second[0], data.addr.get_ip_address());
+                            dns_test_hosts_second[0], data.addr.get_ip_address());
 
     TEST_ASSERT(strlen(data.addr.get_ip_address()) > 1);
 }

--- a/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -37,7 +37,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {
         SocketAddress addr;
         int err = get_interface()->gethostbyname(dns_test_hosts[i], &addr);
-        printf("DNS: query \"%s\" => \"%s\"\n",
+        greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
                dns_test_hosts[i], addr.get_ip_address());
 
         TEST_ASSERT_EQUAL(0, err);
@@ -49,7 +49,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
 
-    printf("DNS: query \"%s\" => \"%s\"\n",
+    greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
            dns_test_hosts_second[0], data.addr.get_ip_address());
 
     TEST_ASSERT(strlen(data.addr.get_ip_address()) > 1);

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -90,17 +90,17 @@ void do_asynchronous_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsign
         TEST_ASSERT(data[i].result == NSAPI_ERROR_OK || data[i].result == NSAPI_ERROR_NO_MEMORY || data[i].result == NSAPI_ERROR_DNS_FAILURE || data[i].result == NSAPI_ERROR_TIMEOUT);
         if (data[i].result == NSAPI_ERROR_OK) {
             (*exp_ok)++;
-            printf("DNS: query \"%s\" => \"%s\"\n",
+            greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
                    hosts[i], data[i].addr.get_ip_address());
         } else if (data[i].result == NSAPI_ERROR_DNS_FAILURE) {
             (*exp_dns_failure)++;
-            printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_TIMEOUT) {
             (*exp_timeout)++;
-            printf("DNS: query \"%s\" => timeout\n", hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => timeout\n", hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_NO_MEMORY) {
             (*exp_no_mem)++;
-            printf("DNS: query \"%s\" => no memory\n", hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => no memory\n", hosts[i]);
         }
     }
 
@@ -124,19 +124,19 @@ void do_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_cou
 
         if (err == NSAPI_ERROR_OK) {
             (*exp_ok)++;
-            printf("DNS: query \"%s\" => \"%s\"\n",
+            greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
                    hosts[i], address.get_ip_address());
         } else if (err == NSAPI_ERROR_DNS_FAILURE) {
             (*exp_dns_failure)++;
-            printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
         } else if (err == NSAPI_ERROR_TIMEOUT) {
             (*exp_timeout)++;
-            printf("DNS: query \"%s\" => timeout\n", hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => timeout\n", hosts[i]);
         } else if (err == NSAPI_ERROR_NO_MEMORY) {
             (*exp_no_mem)++;
-            printf("DNS: query \"%s\" => no memory\n", hosts[i]);
+            greentea_serial->printf("DNS: query \"%s\" => no memory\n", hosts[i]);
         } else {
-            printf("DNS: query \"%s\" => %d, unexpected answer\n", hosts[i], err);
+            greentea_serial->printf("DNS: query \"%s\" => %d, unexpected answer\n", hosts[i], err);
             TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_NO_MEMORY || err == NSAPI_ERROR_DNS_FAILURE || err == NSAPI_ERROR_TIMEOUT);
         }
     }
@@ -154,13 +154,13 @@ static void net_bringup()
     net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: IP address is '%s'\n", net->get_ip_address());
+    greentea_serial->printf("MBED: IP address is '%s'\n", net->get_ip_address());
 }
 
 static void net_bringdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    greentea_serial->printf("MBED: ifdown\n");
 }
 
 // Test setup

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -92,7 +92,7 @@ void do_asynchronous_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsign
         if (data[i].result == NSAPI_ERROR_OK) {
             (*exp_ok)++;
             greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
-                   hosts[i], data[i].addr.get_ip_address());
+                                    hosts[i], data[i].addr.get_ip_address());
         } else if (data[i].result == NSAPI_ERROR_DNS_FAILURE) {
             (*exp_dns_failure)++;
             greentea_serial->printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
@@ -126,7 +126,7 @@ void do_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_cou
         if (err == NSAPI_ERROR_OK) {
             (*exp_ok)++;
             greentea_serial->printf("DNS: query \"%s\" => \"%s\"\n",
-                   hosts[i], address.get_ip_address());
+                                    hosts[i], address.get_ip_address());
         } else if (err == NSAPI_ERROR_DNS_FAILURE) {
             (*exp_dns_failure)++;
             greentea_serial->printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
@@ -196,14 +196,17 @@ Case cases[] = {
 
 Specification specification(test_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
@@ -195,7 +196,16 @@ Case cases[] = {
 
 Specification specification(test_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/dns/synchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_cache.cpp
@@ -51,6 +51,6 @@ void SYNCHRONOUS_DNS_CACHE()
         TEST_ASSERT_TRUE(i == 0 || delay_ms <= delay_first);
 
         greentea_serial->printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
-               dns_test_hosts_second[0], address.get_ip_address(), delay_ms);
+                                dns_test_hosts_second[0], address.get_ip_address(), delay_ms);
     }
 }

--- a/TESTS/netsocket/dns/synchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_cache.cpp
@@ -50,7 +50,7 @@ void SYNCHRONOUS_DNS_CACHE()
         // Check that cached accesses are at least twice as fast as the first one
         TEST_ASSERT_TRUE(i == 0 || delay_ms <= delay_first);
 
-        printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
+        greentea_serial->printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
                dns_test_hosts_second[0], address.get_ip_address(), delay_ms);
     }
 }

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -181,14 +181,17 @@ Case cases[] = {
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -71,13 +71,13 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
+    greentea_serial->printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
 }
 
 static void _ifdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    greentea_serial->printf("MBED: ifdown\n");
 }
 
 nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
@@ -87,17 +87,17 @@ nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
     NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(port);
 
-    printf("MBED: Server '%s', port %d\n", tcp_addr.get_ip_address(), tcp_addr.get_port());
+    greentea_serial->printf("MBED: Server '%s', port %d\n", tcp_addr.get_ip_address(), tcp_addr.get_port());
 
     nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.open: %d\n", err);
+        greentea_serial->printf("Error from sock.open: %d\n", err);
         return err;
     }
 
     err = sock.connect(tcp_addr);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.connect: %d\n", err);
+        greentea_serial->printf("Error from sock.connect: %d\n", err);
         return err;
     }
 

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest.h"
@@ -180,7 +181,16 @@ Case cases[] = {
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -72,7 +72,7 @@ void TCPSOCKET_ECHOTEST()
 
         sent = sock.send(tcp_global::tx_buffer, pkt_s);
         if (sent < 0) {
-            printf("[Round#%02d] network error %d\n", x, sent);
+            greentea_serial->printf("[Round#%02d] network error %d\n", x, sent);
             TEST_FAIL();
             TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
             return;
@@ -82,7 +82,7 @@ void TCPSOCKET_ECHOTEST()
         while (bytes2recv) {
             recvd = sock.recv(&(tcp_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", x, recvd);
+                greentea_serial->printf("[Round#%02d] network error %d\n", x, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
                 return;
@@ -105,7 +105,7 @@ void tcpsocket_echotest_nonblock_receive()
             }
             return;
         } else if (recvd < 0) {
-            printf("sock.recv returned an error %d", recvd);
+            greentea_serial->printf("sock.recv returned an error %d", recvd);
             TEST_FAIL();
             receive_error = true;
         } else {
@@ -173,7 +173,7 @@ void TCPSOCKET_ECHOTEST_NONBLOCK()
                 }
                 continue;
             } else if (sent <= 0) {
-                printf("[Sender#%02d] network error %d\n", s_idx, sent);
+                greentea_serial->printf("[Sender#%02d] network error %d\n", s_idx, sent);
                 TEST_FAIL();
                 goto END;
             }

--- a/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
@@ -60,7 +60,7 @@ void TCPSOCKET_ECHOTEST_BURST()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                greentea_serial->printf("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -71,7 +71,7 @@ void TCPSOCKET_ECHOTEST_BURST()
         while (bt_left > 0) {
             recvd = sock.recv(&(tcp_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
             if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[%02d] network error %d\n", i, recvd);
                 break;
             }
             bt_left -= recvd;
@@ -112,7 +112,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                greentea_serial->printf("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -128,19 +128,19 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
             recvd = sock.recv(&(tcp_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 if (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
-                    printf("[bt#%02d] packet timeout...", i);
+                    greentea_serial->printf("[bt#%02d] packet timeout...", i);
                     break;
                 }
                 continue;
             } else if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[%02d] network error %d\n", i, recvd);
                 break;
             }
             bt_left -= recvd;
         }
 
         if (bt_left != 0) {
-            printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
+            greentea_serial->printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
             TEST_FAIL();
             goto END;
         }

--- a/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
@@ -48,7 +48,7 @@ void TCPSOCKET_OPEN_LIMIT()
             }
             ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
-                printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
+                greentea_serial->printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
                 delete sock;
                 break;
             }
@@ -90,7 +90,7 @@ void TCPSOCKET_OPEN_LIMIT()
             delete tmp->sock;
             delete tmp;
         }
-        printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
+        greentea_serial->printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
     }
     TEST_ASSERT_EQUAL(open_sockets[0], open_sockets[1]);
     TEST_ASSERT(open_sockets[0] >= 4);

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -113,7 +113,7 @@ void rcv_n_chk_against_rfc864_pattern(TCPSocket &sock)
         recvd_size += rd;
     }
     timer.stop();
-    printf("MBED: Time taken: %fs\n", timer.read());
+    greentea_serial->printf("MBED: Time taken: %fs\n", timer.read());
 }
 
 void TCPSOCKET_RECV_100K()
@@ -159,7 +159,7 @@ void rcv_n_chk_against_rfc864_pattern_nonblock(TCPSocket &sock)
         }
     }
     timer.stop();
-    printf("MBED: Time taken: %fs\n", timer.read());
+    greentea_serial->printf("MBED: Time taken: %fs\n", timer.read());
 }
 
 static void _sigio_handler(osThreadId id)

--- a/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
@@ -66,11 +66,11 @@ void TCPSOCKET_RECV_TIMEOUT()
                     TEST_FAIL();
                     goto CLEANUP;
                 }
-                printf("MBED: recv() took: %dus\n", timer.read_us());
+                greentea_serial->printf("MBED: recv() took: %dus\n", timer.read_us());
                 TEST_ASSERT_INT_WITHIN(51, 150, (timer.read_us() + 500) / 1000);
                 continue;
             } else if (recvd < 0) {
-                printf("[pkt#%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[pkt#%02d] network error %d\n", i, recvd);
                 TEST_FAIL();
                 goto CLEANUP;
             }

--- a/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
@@ -44,7 +44,7 @@ void TCPSOCKET_SEND_TIMEOUT()
                 (timer.read_ms() <= 800)) {
             continue;
         }
-        printf("send: err %d, time %d", err, timer.read_ms());
+        greentea_serial->printf("send: err %d, time %d", err, timer.read_ms());
         TEST_FAIL();
         break;
     }

--- a/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
@@ -69,7 +69,7 @@ static void check_const_len_rand_sequence()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("network error %d\n", sent);
+                greentea_serial->printf("network error %d\n", sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -82,7 +82,7 @@ static void check_const_len_rand_sequence()
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 continue;
             } else if (recvd < 0) {
-                printf("network error %d\n", recvd);
+                greentea_serial->printf("network error %d\n", recvd);
                 TEST_FAIL();
                 goto END;
             }
@@ -126,7 +126,7 @@ static void check_var_len_rand_sequence()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                greentea_serial->printf("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -139,7 +139,7 @@ static void check_var_len_rand_sequence()
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 continue;
             } else if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[%02d] network error %d\n", i, recvd);
                 TEST_FAIL();
                 goto END;
             }

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -93,13 +93,13 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TLSClient IP address is '%s'\n", net->get_ip_address());
+    greentea_serial->printf("MBED: TLSClient IP address is '%s'\n", net->get_ip_address());
 }
 
 static void _ifdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    greentea_serial->printf("MBED: ifdown\n");
 }
 
 nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
@@ -109,23 +109,23 @@ nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
     NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tls_addr);
     tls_addr.set_port(port);
 
-    printf("MBED: Server '%s', port %d\n", tls_addr.get_ip_address(), tls_addr.get_port());
+    greentea_serial->printf("MBED: Server '%s', port %d\n", tls_addr.get_ip_address(), tls_addr.get_port());
 
     nsapi_error_t err = sock.set_root_ca_cert(tls_global::cert);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.set_root_ca_cert: %d\n", err);
+        greentea_serial->printf("Error from sock.set_root_ca_cert: %d\n", err);
         return err;
     }
 
     err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.open: %d\n", err);
+        greentea_serial->printf("Error from sock.open: %d\n", err);
         return err;
     }
 
     err = sock.connect(tls_addr);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.connect: %d\n", err);
+        greentea_serial->printf("Error from sock.connect: %d\n", err);
         return err;
     }
 

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -213,14 +213,17 @@ void run_test(void)
 }
 
 static unsigned char stack_mem[8192];
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest.h"
@@ -212,8 +213,17 @@ void run_test(void)
 }
 
 static unsigned char stack_mem[8192];
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     Thread *th = new Thread(osPriorityNormal, 8192, stack_mem, "tls_gt_thread");
     th->start(callback(run_test));
     th->join();

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -61,7 +61,7 @@ void TLSSOCKET_ECHOTEST()
 {
     sock = new TLSSocket;
     if (tlssocket_connect_to_echo_srv(*sock) != NSAPI_ERROR_OK) {
-        printf("Error from tlssocket_connect_to_echo_srv\n");
+        greentea_serial->printf("Error from tlssocket_connect_to_echo_srv\n");
         TEST_FAIL();
         delete sock;
         return;
@@ -75,7 +75,7 @@ void TLSSOCKET_ECHOTEST()
 
         sent = sock->send(tls_global::tx_buffer, pkt_s);
         if (sent < 0) {
-            printf("[Round#%02d] network error %d\n", x, sent);
+            greentea_serial->printf("[Round#%02d] network error %d\n", x, sent);
             TEST_FAIL();
             TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
             delete sock;
@@ -86,7 +86,7 @@ void TLSSOCKET_ECHOTEST()
         while (bytes2recv) {
             recvd = sock->recv(&(tls_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", x, recvd);
+                greentea_serial->printf("[Round#%02d] network error %d\n", x, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
                 delete sock;
@@ -111,7 +111,7 @@ void tlssocket_echotest_nonblock_receive()
             }
             return;
         } else if (recvd < 0) {
-            printf("sock.recv returned an error %d", recvd);
+            greentea_serial->printf("sock.recv returned an error %d", recvd);
             TEST_FAIL();
             receive_error = true;
         } else {
@@ -178,7 +178,7 @@ void TLSSOCKET_ECHOTEST_NONBLOCK()
                 }
                 continue;
             } else if (sent <= 0) {
-                printf("[Sender#%02d] network error %d\n", s_idx, sent);
+                greentea_serial->printf("[Sender#%02d] network error %d\n", s_idx, sent);
                 TEST_FAIL();
                 goto END;
             }

--- a/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
@@ -62,7 +62,7 @@ void TLSSOCKET_ECHOTEST_BURST()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                greentea_serial->printf("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -73,7 +73,7 @@ void TLSSOCKET_ECHOTEST_BURST()
         while (bt_left > 0) {
             recvd = sock->recv(&(tls_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
             if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[%02d] network error %d\n", i, recvd);
                 break;
             }
             bt_left -= recvd;
@@ -115,7 +115,7 @@ void TLSSOCKET_ECHOTEST_BURST_NONBLOCK()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                greentea_serial->printf("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -131,19 +131,19 @@ void TLSSOCKET_ECHOTEST_BURST_NONBLOCK()
             recvd = sock->recv(&(tls_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 if (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
-                    printf("[bt#%02d] packet timeout...", i);
+                    greentea_serial->printf("[bt#%02d] packet timeout...", i);
                     break;
                 }
                 continue;
             } else if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[%02d] network error %d\n", i, recvd);
                 break;
             }
             bt_left -= recvd;
         }
 
         if (bt_left != 0) {
-            printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
+            greentea_serial->printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
             TEST_FAIL();
             goto END;
         }

--- a/TESTS/netsocket/tls/tlssocket_open_limit.cpp
+++ b/TESTS/netsocket/tls/tlssocket_open_limit.cpp
@@ -50,7 +50,7 @@ void TLSSOCKET_OPEN_LIMIT()
             }
             ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
-                printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
+                greentea_serial->printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
                 delete sock;
                 break;
             }
@@ -92,7 +92,7 @@ void TLSSOCKET_OPEN_LIMIT()
             delete tmp->sock;
             delete tmp;
         }
-        printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
+        greentea_serial->printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
     }
     TEST_ASSERT_EQUAL(open_sockets[0], open_sockets[1]);
     TEST_ASSERT(open_sockets[0] >= 4);

--- a/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
@@ -68,10 +68,10 @@ void TLSSOCKET_RECV_TIMEOUT()
                     TEST_FAIL();
                     goto CLEANUP;
                 }
-                printf("MBED: recv() took: %dus\n", timer.read_us());
+                greentea_serial->printf("MBED: recv() took: %dus\n", timer.read_us());
                 continue;
             } else if (recvd < 0) {
-                printf("[pkt#%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[pkt#%02d] network error %d\n", i, recvd);
                 TEST_FAIL();
                 goto CLEANUP;
             }

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest.h"
@@ -137,7 +138,16 @@ Case cases[] = {
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -138,14 +138,17 @@ Case cases[] = {
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -58,13 +58,13 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: UDPClient IP address is '%s'\n", net->get_ip_address());
+    greentea_serial->printf("MBED: UDPClient IP address is '%s'\n", net->get_ip_address());
 }
 
 static void _ifdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    greentea_serial->printf("MBED: ifdown\n");
 }
 
 

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -83,7 +83,7 @@ void UDPSOCKET_ECHOTEST()
                 packets_sent++;
             }
             if (sent != pkt_s) {
-                printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
+                greentea_serial->printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
                 continue;
             }
             recvd = sock.recvfrom(NULL, rx_buffer, pkt_s);
@@ -98,7 +98,7 @@ void UDPSOCKET_ECHOTEST()
     // Packet loss up to 30% tolerated
     if (packets_sent > 0) {
         double loss_ratio = 1 - ((double)packets_recv / (double)packets_sent);
-        printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n", packets_sent, packets_recv, loss_ratio);
+        greentea_serial->printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n", packets_sent, packets_recv, loss_ratio);
         TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
@@ -118,7 +118,7 @@ void udpsocket_echotest_nonblock_receiver(void *receive_bytes)
             --retry_cnt;
             continue;
         } else if (recvd < 0) {
-            printf("sock.recvfrom returned %d\n", recvd);
+            greentea_serial->printf("sock.recvfrom returned %d\n", recvd);
             TEST_FAIL();
             break;
         } else if (recvd == expt2recv) {
@@ -182,7 +182,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
                 }
                 --retry_cnt;
             } else if (sent != pkt_s) {
-                printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
+                greentea_serial->printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
                 continue;
             }
             if (tx_sem.wait(WAIT2RECV_TIMEOUT * 2) == 0) { // RX might wait up to WAIT2RECV_TIMEOUT before recvfrom
@@ -201,7 +201,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
     // Packet loss up to 30% tolerated
     if (packets_sent > 0) {
         double loss_ratio = 1 - ((double)packets_recv / (double)packets_sent);
-        printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n", packets_sent, packets_recv, loss_ratio);
+        greentea_serial->printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n", packets_sent, packets_recv, loss_ratio);
         TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
@@ -214,7 +214,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
             }
         }
         loss_ratio = 1 - ((double)udp_stats[j].recv_bytes / (double)udp_stats[j].sent_bytes);
-        printf("Bytes sent: %d, bytes received %d, loss ratio %.2lf\r\n", udp_stats[j].sent_bytes, udp_stats[j].recv_bytes, loss_ratio);
+        greentea_serial->printf("Bytes sent: %d, bytes received %d, loss ratio %.2lf\r\n", udp_stats[j].sent_bytes, udp_stats[j].recv_bytes, loss_ratio);
         TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
 
 #endif

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -138,7 +138,7 @@ void UDPSOCKET_ECHOTEST_BURST()
 
     double loss_ratio = 1 - ((double)(BURST_CNT * BURST_PKTS - pkg_fail) / (double)(BURST_CNT * BURST_PKTS));
     greentea_serial->printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
-           BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
+                            BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
     // Packet loss up to 30% tolerated
     TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
     // 70% of the bursts need to be successful
@@ -221,7 +221,7 @@ PKT_OK:
 
     double loss_ratio = 1 - ((double)(BURST_CNT * BURST_PKTS - pkg_fail) / (double)(BURST_CNT * BURST_PKTS));
     greentea_serial->printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
-           BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
+                            BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
     // Packet loss up to 30% tolerated
     TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
     // 70% of the bursts need to be successful

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -105,12 +105,12 @@ void UDPSOCKET_ECHOTEST_BURST()
                 }
             } else if (recvd < 0) {
                 pkg_fail += BURST_PKTS - j; // Assume all the following packets of the burst to be lost
-                printf("[%02d] network error %d\n", i, recvd);
+                greentea_serial->printf("[%02d] network error %d\n", i, recvd);
                 wait(recv_timeout);
                 recv_timeout *= 2; // Back off,
                 break;
             } else if (temp_addr != udp_addr) {
-                printf("[%02d] packet from wrong address\n", i);
+                greentea_serial->printf("[%02d] packet from wrong address\n", i);
                 --j;
                 continue;
             }
@@ -130,14 +130,14 @@ void UDPSOCKET_ECHOTEST_BURST()
             ok_bursts++;
         } else {
             drop_bad_packets(sock, TIMEOUT);
-            printf("[%02d] burst failure, rcv %d\n", i, bt_total);
+            greentea_serial->printf("[%02d] burst failure, rcv %d\n", i, bt_total);
         }
     }
 
     free_tx_buffers();
 
     double loss_ratio = 1 - ((double)(BURST_CNT * BURST_PKTS - pkg_fail) / (double)(BURST_CNT * BURST_PKTS));
-    printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
+    greentea_serial->printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
            BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
     // Packet loss up to 30% tolerated
     TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
@@ -202,7 +202,7 @@ void UDPSOCKET_ECHOTEST_BURST_NONBLOCK()
                     goto PKT_OK;
                 }
             }
-            printf("[bt#%02d] corrupted packet...", i);
+            greentea_serial->printf("[bt#%02d] corrupted packet...", i);
             pkg_fail++;
             break;
 PKT_OK:
@@ -220,7 +220,7 @@ PKT_OK:
     free_tx_buffers();
 
     double loss_ratio = 1 - ((double)(BURST_CNT * BURST_PKTS - pkg_fail) / (double)(BURST_CNT * BURST_PKTS));
-    printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
+    greentea_serial->printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
            BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
     // Packet loss up to 30% tolerated
     TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);

--- a/TESTS/netsocket/udp/udpsocket_open_limit.cpp
+++ b/TESTS/netsocket/udp/udpsocket_open_limit.cpp
@@ -49,7 +49,7 @@ void UDPSOCKET_OPEN_LIMIT()
             }
             ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
-                printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
+                greentea_serial->printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
                 delete sock;
                 break;
             }
@@ -89,7 +89,7 @@ void UDPSOCKET_OPEN_LIMIT()
             delete tmp->sock;
             delete tmp;
         }
-        printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
+        greentea_serial->printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
     }
     TEST_ASSERT_EQUAL(open_sockets[0], open_sockets[1]);
     // In case of lwIP one is taken by DHCP -> reduction by one to three

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -61,14 +61,14 @@ void UDPSOCKET_RECV_TIMEOUT()
 
         if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
             osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT);
-            printf("MBED: recvfrom() took: %dms\n", timer.read_ms());
+            greentea_serial->printf("MBED: recvfrom() took: %dms\n", timer.read_ms());
             TEST_ASSERT_INT_WITHIN(51, 150, timer.read_ms());
             continue;
         } else if (recvd < 0) {
-            printf("[bt#%02d] network error %d\n", i, recvd);
+            greentea_serial->printf("[bt#%02d] network error %d\n", i, recvd);
             continue;
         } else if (temp_addr != udp_addr) {
-            printf("[bt#%02d] packet from wrong address\n", i);
+            greentea_serial->printf("[bt#%02d] packet from wrong address\n", i);
             continue;
         }
         TEST_ASSERT_EQUAL(DATA_LEN, recvd);

--- a/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
@@ -41,7 +41,7 @@ void UDPSOCKET_SENDTO_TIMEOUT()
     int sent = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
     timer.stop();
     TEST_ASSERT_EQUAL(sizeof(tx_buffer), sent);
-    printf("MBED: Time taken: %fs\n", timer.read());
+    greentea_serial->printf("MBED: Time taken: %fs\n", timer.read());
     sock.set_timeout(1000);
 
     timer.reset();
@@ -49,7 +49,7 @@ void UDPSOCKET_SENDTO_TIMEOUT()
     sent = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
     timer.stop();
     TEST_ASSERT_EQUAL(sizeof(tx_buffer), sent);
-    printf("MBED: Time taken: %fs\n", timer.read());
+    greentea_serial->printf("MBED: Time taken: %fs\n", timer.read());
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }

--- a/TESTS/network/interface/main.cpp
+++ b/TESTS/network/interface/main.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest.h"
@@ -50,7 +51,16 @@ Case cases[] = {
 
 Specification specification(test_setup, cases);
 
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/TESTS/network/interface/main.cpp
+++ b/TESTS/network/interface/main.cpp
@@ -51,14 +51,17 @@ Case cases[] = {
 
 Specification specification(test_setup, cases);
 
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/network/l3ip/main.cpp
+++ b/TESTS/network/l3ip/main.cpp
@@ -79,14 +79,17 @@ Case cases[] = {
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/network/l3ip/main.cpp
+++ b/TESTS/network/l3ip/main.cpp
@@ -17,6 +17,7 @@
 
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest.h"
@@ -78,7 +79,16 @@ Case cases[] = {
 
 Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -89,14 +89,17 @@ Case cases[] = {
 
 Specification specification(test_setup, cases, greentea_continue_handlers);
 
-static void my_mutex_wait() {
+static void my_mutex_wait()
+{
     greentea_serial->lock();
 }
-static void my_mutex_release() {
+static void my_mutex_release()
+{
     greentea_serial->unlock();
 }
 
-int main() {
+int main()
+{
     mbed_trace_mutex_wait_function_set(my_mutex_wait);
     mbed_trace_mutex_release_function_set(my_mutex_release);
     mbed_trace_init();

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "mbed.h"
+#include "mbed_trace.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
@@ -88,8 +89,16 @@ Case cases[] = {
 
 Specification specification(test_setup, cases, greentea_continue_handlers);
 
-// Entry point into the tests
-int main()
-{
+static void my_mutex_wait() {
+    greentea_serial->lock();
+}
+static void my_mutex_release() {
+    greentea_serial->unlock();
+}
+
+int main() {
+    mbed_trace_mutex_wait_function_set(my_mutex_wait);
+    mbed_trace_mutex_release_function_set(my_mutex_release);
+    mbed_trace_init();
     return !Harness::run(specification);
 }

--- a/drivers/RawSerial.cpp
+++ b/drivers/RawSerial.cpp
@@ -63,9 +63,15 @@ int RawSerial::puts(const char *str)
 // length is above a certain threshold, otherwise we use just the stack.
 int RawSerial::printf(const char *format, ...)
 {
-    lock();
     std::va_list arg;
     va_start(arg, format);
+    int len = this->vprintf(format, arg);
+    va_end(arg);
+    return len;
+}
+
+int RawSerial::vprintf(const char *format, std::va_list arg) {
+    lock();
     // ARMCC microlib does not properly handle a size of 0.
     // As a workaround supply a dummy buffer with a size of 1.
     char dummy_buf[1];
@@ -80,7 +86,6 @@ int RawSerial::printf(const char *format, ...)
         puts(temp);
         delete[] temp;
     }
-    va_end(arg);
     unlock();
     return len;
 }

--- a/drivers/RawSerial.cpp
+++ b/drivers/RawSerial.cpp
@@ -70,7 +70,8 @@ int RawSerial::printf(const char *format, ...)
     return len;
 }
 
-int RawSerial::vprintf(const char *format, std::va_list arg) {
+int RawSerial::vprintf(const char *format, std::va_list arg)
+{
     lock();
     // ARMCC microlib does not properly handle a size of 0.
     // As a workaround supply a dummy buffer with a size of 1.

--- a/drivers/RawSerial.h
+++ b/drivers/RawSerial.h
@@ -25,6 +25,7 @@
 #include "drivers/SerialBase.h"
 #include "hal/serial_api.h"
 #include "platform/NonCopyable.h"
+#include <cstdarg>
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -89,6 +90,7 @@ public:
     int puts(const char *str);
 
     int printf(const char *format, ...) MBED_PRINTF_METHOD(1, 2);
+    int vprintf(const char *format, std::va_list arg);
 
 #if !(DOXYGEN_ONLY)
 protected:

--- a/features/frameworks/greentea-client/greentea-client/greentea_serial.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_serial.h
@@ -6,10 +6,15 @@
 
 #include "RawSerial.h"
 #include "SingletonPtr.h"
+#include "Mutex.h"
 
 class GreenteaSerial : public mbed::RawSerial {
 public:
     GreenteaSerial();
+    void virtual lock();
+    void virtual unlock();
+private:
+    rtos::Mutex _mutex;
 };
 
 extern SingletonPtr<GreenteaSerial> greentea_serial;

--- a/features/frameworks/greentea-client/source/greentea_serial.cpp
+++ b/features/frameworks/greentea-client/source/greentea_serial.cpp
@@ -21,3 +21,11 @@ GreenteaSerial::GreenteaSerial() : mbed::RawSerial(USBTX, USBRX, MBED_CONF_PLATF
     set_flow_control(SerialBase::RTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
 #endif
 }
+
+void GreenteaSerial::lock() {
+    _mutex.lock();
+}
+
+void GreenteaSerial::unlock() {
+    _mutex.unlock();
+}

--- a/features/frameworks/greentea-client/source/greentea_serial.cpp
+++ b/features/frameworks/greentea-client/source/greentea_serial.cpp
@@ -29,3 +29,10 @@ void GreenteaSerial::lock() {
 void GreenteaSerial::unlock() {
     _mutex.unlock();
 }
+
+extern "C" void UnityPrintLock() {
+    greentea_serial->lock();
+}
+extern "C" void UnityPrintUnlock() {
+    greentea_serial->unlock();
+}

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -215,6 +215,7 @@ void greentea_notify_coverage_end() {
  */
 inline void greentea_write_preamble()
 {
+    greentea_serial->lock();
     greentea_serial->putc('{');
     greentea_serial->putc('{');
 }
@@ -237,6 +238,7 @@ inline void greentea_write_postamble()
     greentea_serial->putc('}');
     greentea_serial->putc('\r');
     greentea_serial->putc('\n');
+    greentea_serial->unlock();
 }
 
 /**

--- a/features/frameworks/unity/source/unity.c
+++ b/features/frameworks/unity/source/unity.c
@@ -81,6 +81,8 @@ static const _U_UINT UnitySizeMask[] =
 /*-----------------------------------------------
  * Pretty Printers & Test Result Output Handlers
  *-----------------------------------------------*/
+void UnityPrintLock();
+void UnityPrintUnlock();
 
 void UnityPrint(const char* string)
 {
@@ -88,6 +90,7 @@ void UnityPrint(const char* string)
 
     if (pch != NULL)
     {
+        UnityPrintLock();
         while (*pch)
         {
             /* printable characters plus CR & LF are printed */
@@ -115,6 +118,7 @@ void UnityPrint(const char* string)
             }
             pch++;
         }
+        UnityPrintUnlock();
     }
 }
 
@@ -125,6 +129,7 @@ void UnityPrintLen(const char* string, const _UU32 length)
 
     if (pch != NULL)
     {
+        UnityPrintLock();
         while (*pch && (_UU32)(pch - string) < length)
         {
             /* printable characters plus CR & LF are printed */
@@ -152,6 +157,7 @@ void UnityPrintLen(const char* string, const _UU32 length)
             }
             pch++;
         }
+                UnityPrintUnlock();
     }
 }
 
@@ -177,6 +183,7 @@ void UnityPrintNumber(const _U_SINT number_to_print)
 {
     _U_UINT number = (_U_UINT)number_to_print;
 
+        UnityPrintLock();
     if (number_to_print < 0)
     {
         /* A negative number, including MIN negative */
@@ -184,6 +191,8 @@ void UnityPrintNumber(const _U_SINT number_to_print)
         number = (_U_UINT)(-number_to_print);
     }
     UnityPrintNumberUnsigned(number);
+                UnityPrintUnlock();
+
 }
 
 /*-----------------------------------------------
@@ -198,6 +207,7 @@ void UnityPrintNumberUnsigned(const _U_UINT number)
         divisor *= 10;
     }
 
+        UnityPrintLock();
     /* now mod and print, then divide divisor */
     do
     {
@@ -205,6 +215,7 @@ void UnityPrintNumberUnsigned(const _U_UINT number)
         divisor /= 10;
     }
     while (divisor > 0);
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
@@ -212,6 +223,7 @@ void UnityPrintNumberHex(const _U_UINT number, const char nibbles_to_print)
 {
     _U_UINT nibble;
     char nibbles = nibbles_to_print;
+        UnityPrintLock();
     UNITY_OUTPUT_CHAR('0');
     UNITY_OUTPUT_CHAR('x');
 
@@ -227,6 +239,7 @@ void UnityPrintNumberHex(const _U_UINT number, const char nibbles_to_print)
             UNITY_OUTPUT_CHAR((char)('A' - 10 + nibble));
         }
     }
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
@@ -235,6 +248,7 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
     _U_UINT current_bit = (_U_UINT)1 << (UNITY_INT_WIDTH - 1);
     _US32 i;
 
+        UnityPrintLock();
     for (i = 0; i < UNITY_INT_WIDTH; i++)
     {
         if (current_bit & mask)
@@ -254,6 +268,7 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
         }
         current_bit = current_bit >> 1;
     }
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
@@ -295,12 +310,14 @@ static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line);
 static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 {
 #ifndef UNITY_FIXTURES
+        UnityPrintLock();
     UnityPrint(file);
     UNITY_OUTPUT_CHAR(':');
     UnityPrintNumber((_U_SINT)line);
     UNITY_OUTPUT_CHAR(':');
     UnityPrint(Unity.CurrentTestName);
     UNITY_OUTPUT_CHAR(':');
+                UnityPrintUnlock();
 #else
     UNITY_UNUSED(file);
     UNITY_UNUSED(line);
@@ -311,6 +328,7 @@ static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line);
 static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
 {
+        UnityPrintLock();
 #ifndef UNITY_FIXTURES
     UnityTestResultsBegin(Unity.TestFile, line);
 #else
@@ -318,11 +336,13 @@ static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
 #endif
     UnityPrint(UnityStrFail);
     UNITY_OUTPUT_CHAR(':');
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
 void UnityConcludeTest(void)
 {
+        UnityPrintLock();
     if (Unity.CurrentTestIgnored)
     {
         Unity.TestIgnores++;
@@ -341,6 +361,7 @@ void UnityConcludeTest(void)
     Unity.CurrentTestIgnored = 0;
     UNITY_PRINT_EOL();
     UNITY_OUTPUT_FLUSH();
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
@@ -349,6 +370,7 @@ static void UnityAddMsgIfSpecified(const char* msg)
 {
     if (msg)
     {
+        UnityPrintLock();
         UnityPrint(UnityStrSpacer);
 #ifndef UNITY_EXCLUDE_DETAILS
         if (Unity.CurrentDetail1)
@@ -364,6 +386,7 @@ static void UnityAddMsgIfSpecified(const char* msg)
         }
 #endif
         UnityPrint(msg);
+                UnityPrintUnlock();
     }
 }
 
@@ -371,6 +394,7 @@ static void UnityAddMsgIfSpecified(const char* msg)
 static void UnityPrintExpectedAndActualStrings(const char* expected, const char* actual);
 static void UnityPrintExpectedAndActualStrings(const char* expected, const char* actual)
 {
+        UnityPrintLock();
     UnityPrint(UnityStrExpected);
     if (expected != NULL)
     {
@@ -393,11 +417,13 @@ static void UnityPrintExpectedAndActualStrings(const char* expected, const char*
     {
       UnityPrint(UnityStrNull);
     }
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
 static void UnityPrintExpectedAndActualStringsLen(const char* expected, const char* actual, const _UU32 length)
 {
+        UnityPrintLock();
     UnityPrint(UnityStrExpected);
     if (expected != NULL)
     {
@@ -420,6 +446,7 @@ static void UnityPrintExpectedAndActualStringsLen(const char* expected, const ch
     {
       UnityPrint(UnityStrNull);
     }
+                UnityPrintUnlock();
 }
 
 
@@ -434,12 +461,14 @@ static int UnityCheckArraysForNull(UNITY_INTERNAL_PTR expected, UNITY_INTERNAL_P
     if ((expected == NULL) && (actual == NULL))
         return 1;
 
+    UnityPrintLock();
     /* throw error if just expected is NULL */
     if (expected == NULL)
     {
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrNullPointerForExpected);
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -449,9 +478,11 @@ static int UnityCheckArraysForNull(UNITY_INTERNAL_PTR expected, UNITY_INTERNAL_P
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrNullPointerForActual);
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 
+                UnityPrintUnlock();
     /* return false if neither is NULL */
     return 0;
 }
@@ -470,12 +501,14 @@ void UnityAssertBits(const _U_SINT mask,
 
     if ((mask & expected) != (mask & actual))
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrExpected);
         UnityPrintMask((_U_UINT)mask, (_U_UINT)expected);
         UnityPrint(UnityStrWas);
         UnityPrintMask((_U_UINT)mask, (_U_UINT)actual);
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -491,12 +524,14 @@ void UnityAssertEqualNumber(const _U_SINT expected,
 
     if (expected != actual)
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrExpected);
         UnityPrintNumberByStyle(expected, style);
         UnityPrint(UnityStrWas);
         UnityPrintNumberByStyle(actual, style);
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -530,6 +565,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
         return;
 
+    UnityPrintLock();
     /* If style is UNITY_DISPLAY_STYLE_INT, we'll fall into the default case rather than the INT16 or INT32 (etc) case
      * as UNITY_DISPLAY_STYLE_INT includes a flag for UNITY_DISPLAY_RANGE_AUTO, which the width-specific
      * variants do not. Therefore remove this flag. */
@@ -550,6 +586,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                     UnityPrint(UnityStrWas);
                     UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US8*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
                     UNITY_FAIL_AND_BAIL;
                 }
                 ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 1);
@@ -571,6 +608,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                     UnityPrint(UnityStrWas);
                     UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US16*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
                     UNITY_FAIL_AND_BAIL;
                 }
                 ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 2);
@@ -593,6 +631,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                     UnityPrint(UnityStrWas);
                     UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US64*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
                     UNITY_FAIL_AND_BAIL;
                 }
                 ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 8);
@@ -613,6 +652,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                     UnityPrint(UnityStrWas);
                     UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US32*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
                     UNITY_FAIL_AND_BAIL;
                 }
                 ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 4);
@@ -620,6 +660,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
             }
             break;
     }
+                UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
@@ -645,6 +686,7 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const _UF* expected,
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
         return;
 
+    UnityPrintLock();
     while (elements--)
     {
         diff = *ptr_expected - *ptr_actual;
@@ -669,6 +711,7 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const _UF* expected,
             UnityPrint(UnityStrDelta);
 #endif
             UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
             UNITY_FAIL_AND_BAIL;
         }
         ptr_expected++;
@@ -700,6 +743,7 @@ void UnityAssertFloatsWithin(const _UF delta,
     /* This first part of this condition will catch any NaN or Infinite values */
     if (isnan(diff) || isinf(diff) || (pos_delta < diff))
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
 #ifdef UNITY_FLOAT_VERBOSE
         UnityPrint(UnityStrExpected);
@@ -710,6 +754,7 @@ void UnityAssertFloatsWithin(const _UF delta,
         UnityPrint(UnityStrDelta);
 #endif
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -763,6 +808,7 @@ void UnityAssertFloatSpecial(const _UF actual,
 
     if (is_trait != should_be_trait)
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrExpected);
         if (!should_be_trait)
@@ -777,6 +823,7 @@ void UnityAssertFloatSpecial(const _UF actual,
         UnityPrint(trait_names[trait_index]);
 #endif
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -818,6 +865,7 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const _UD* expected,
         /* This first part of this condition will catch any NaN or Infinite values */
         if (isnan(diff) || isinf(diff) || (diff > tol))
         {
+        UnityPrintLock();
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);
             UnityPrintNumberUnsigned(num_elements - elements - 1);
@@ -830,6 +878,7 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const _UD* expected,
             UnityPrint(UnityStrDelta);
 #endif
             UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
             UNITY_FAIL_AND_BAIL;
         }
         ptr_expected++;
@@ -861,6 +910,7 @@ void UnityAssertDoublesWithin(const _UD delta,
     /* This first part of this condition will catch any NaN or Infinite values */
     if (isnan(diff) || isinf(diff) || (pos_delta < diff))
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
 #ifdef UNITY_DOUBLE_VERBOSE
         UnityPrint(UnityStrExpected);
@@ -871,6 +921,7 @@ void UnityAssertDoublesWithin(const _UD delta,
         UnityPrint(UnityStrDelta);
 #endif
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -925,6 +976,7 @@ void UnityAssertDoubleSpecial(const _UD actual,
 
     if (is_trait != should_be_trait)
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrExpected);
         if (!should_be_trait)
@@ -939,6 +991,7 @@ void UnityAssertDoubleSpecial(const _UD actual,
         UnityPrint(trait_names[trait_index]);
 #endif
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -973,6 +1026,7 @@ void UnityAssertNumbersWithin( const _U_UINT delta,
 
     if (Unity.CurrentTestFailed)
     {
+        UnityPrintLock();
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrDelta);
         UnityPrintNumberByStyle((_U_SINT)delta, style);
@@ -981,6 +1035,7 @@ void UnityAssertNumbersWithin( const _U_UINT delta,
         UnityPrint(UnityStrWas);
         UnityPrintNumberByStyle(actual, style);
         UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
         UNITY_FAIL_AND_BAIL;
     }
 }
@@ -1017,9 +1072,11 @@ void UnityAssertEqualString(const char* expected,
 
     if (Unity.CurrentTestFailed)
     {
+        UnityPrintLock();
       UnityTestResultsFailBegin(lineNumber);
       UnityPrintExpectedAndActualStrings(expected, actual);
       UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
       UNITY_FAIL_AND_BAIL;
     }
 }
@@ -1057,9 +1114,11 @@ void UnityAssertEqualStringLen(const char* expected,
 
     if (Unity.CurrentTestFailed)
     {
+        UnityPrintLock();
       UnityTestResultsFailBegin(lineNumber);
       UnityPrintExpectedAndActualStringsLen(expected, actual, length);
       UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
       UNITY_FAIL_AND_BAIL;
     }
 }
@@ -1109,6 +1168,7 @@ void UnityAssertEqualStringArray( const char** expected,
 
         if (Unity.CurrentTestFailed)
         {
+        UnityPrintLock();
             UnityTestResultsFailBegin(lineNumber);
             if (num_elements > 1)
             {
@@ -1117,6 +1177,7 @@ void UnityAssertEqualStringArray( const char** expected,
             }
             UnityPrintExpectedAndActualStrings((const char*)(expected[j]), (const char*)(actual[j]));
             UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
             UNITY_FAIL_AND_BAIL;
         }
     } while (++j < num_elements);
@@ -1153,6 +1214,7 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
         {
             if (*ptr_exp != *ptr_act)
             {
+        UnityPrintLock();
                 UnityTestResultsFailBegin(lineNumber);
                 UnityPrint(UnityStrMemory);
                 if (num_elements > 1)
@@ -1167,6 +1229,7 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
                 UnityPrint(UnityStrWas);
                 UnityPrintNumberByStyle(*ptr_act, UNITY_DISPLAY_STYLE_HEX8);
                 UnityAddMsgIfSpecified(msg);
+                UnityPrintUnlock();
                 UNITY_FAIL_AND_BAIL;
             }
             ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 1);
@@ -1185,6 +1248,7 @@ void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
 {
     UNITY_SKIP_EXECUTION;
 
+        UnityPrintLock();
     UnityTestResultsBegin(Unity.TestFile, line);
     UnityPrintFail();
     if (msg != NULL)
@@ -1210,6 +1274,7 @@ void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
         }
         UnityPrint(msg);
     }
+    UnityPrintUnlock();
     UNITY_FAIL_AND_BAIL;
 }
 
@@ -1217,6 +1282,7 @@ void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
 void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
 {
     UNITY_SKIP_EXECUTION;
+        UnityPrintLock();
 
     UnityTestResultsBegin(Unity.TestFile, line);
     UnityPrint(UnityStrIgnore);
@@ -1226,12 +1292,14 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
       UNITY_OUTPUT_CHAR(' ');
       UnityPrint(msg);
     }
+    UnityPrintUnlock();
     UNITY_IGNORE_AND_BAIL;
 }
 
 /*-----------------------------------------------*/
 void UnitySkipPrint(const char* msg, const UNITY_LINE_TYPE line)
 {
+        UnityPrintLock();
     UnityTestResultsBegin(Unity.TestFile, line);
     UnityPrint(UnityStrSkip);
     if (msg != NULL)
@@ -1240,6 +1308,7 @@ void UnitySkipPrint(const char* msg, const UNITY_LINE_TYPE line)
       UNITY_OUTPUT_CHAR(' ');
       UnityPrint(msg);
     }
+    UnityPrintUnlock();
 }
 
 /*-----------------------------------------------*/
@@ -1290,6 +1359,7 @@ void UnityBegin(const char* filename)
 /*-----------------------------------------------*/
 int UnityEnd(void)
 {
+    UnityPrintLock();
     UNITY_PRINT_EOL();
     UnityPrint(UnityStrBreaker);
     UNITY_PRINT_EOL();
@@ -1314,6 +1384,7 @@ int UnityEnd(void)
     UNITY_PRINT_EOL();
     UNITY_OUTPUT_FLUSH();
     UNITY_OUTPUT_COMPLETE();
+    UnityPrintUnlock();
     return (int)(Unity.TestFailures);
 }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
This PR fixes the broken output of netsocket tests when mbed_trace is enabled.
Without this fix both outputs get intermingled and hardly readable by humans (for the traces) and by machines (as greentea's tokens also get messed up).

**Note:**
There might be a better solution than adding `greentea_serial->` before each printf. If so please let me know and I will update this PR accordingly.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
