### PR TITLE
ESP8266: treats Wi-Fi scan results as out-of-band data; new API to adjusting Wi-Fi scan settings

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -44,6 +44,11 @@
 #define ESP8266_MISC_TIMEOUT    2000
 #endif
 
+#define ESP8266_SCAN_TIME_MIN 0     // [ms]
+#define ESP8266_SCAN_TIME_MAX 1500  // [ms]
+#define ESP8266_SCAN_TIME_MIN_DEFAULT 120 // [ms]
+#define ESP8266_SCAN_TIME_MAX_DEFAULT 360 // [ms]
+
 // Firmware version
 #define ESP8266_SDK_VERSION 2000000
 #define ESP8266_SDK_VERSION_MAJOR ESP8266_SDK_VERSION/1000000
@@ -193,14 +198,23 @@ public:
      */
     int8_t rssi();
 
+    /** Scan mode
+     */
+    enum scan_mode {
+        SCANMODE_ACTIVE = 0, /*!< active mode */
+        SCANMODE_PASSIVE = 1 /*!< passive mode */
+    };
+
     /** Scan for available networks
      *
      * @param  ap    Pointer to allocated array to store discovered AP
      * @param  limit Size of allocated @a res array, or 0 to only count available AP
+     * @param  t_max Maximum scan time per channel
+     * @param  t_min Minimum scan time per channel in active mode, can be omitted in passive mode
      * @return       Number of entries in @a res, or if @a count was 0 number of available networks, negative on error
      *               see @a nsapi_error
      */
-    int scan(WiFiAccessPoint *res, unsigned limit);
+    int scan(WiFiAccessPoint *res, unsigned limit, scan_mode mode, unsigned t_max, unsigned t_min);
 
     /**Perform a dns query
     *

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -438,6 +438,7 @@ private:
     void _oob_busy();
     void _oob_tcp_data_hdlr();
     void _oob_ready();
+    void _oob_scan_results();
 
     // OOB state variables
     int _connect_error;
@@ -465,6 +466,14 @@ private:
         int32_t tcp_data_rcvd;
     };
     struct _sock_info _sock_i[SOCKET_COUNT];
+
+    // Scan results
+    struct _scan_results {
+        WiFiAccessPoint *res;
+        unsigned limit;
+        unsigned cnt;
+    };
+    struct _scan_results _scan_r;
 
     // Connection state reporting
     nsapi_connection_status_t _conn_status;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -361,14 +361,25 @@ int8_t ESP8266Interface::get_rssi()
 
 int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count)
 {
-    nsapi_error_t status;
+    return scan(res, count, SCANMODE_ACTIVE, 0, 0);
+}
 
-    status = _init();
+int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count, scan_mode mode, unsigned t_max, unsigned t_min)
+{
+    if (t_max > ESP8266_SCAN_TIME_MAX) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+    if (mode == SCANMODE_ACTIVE && t_min > t_max) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+    nsapi_error_t status = _init();
     if (status != NSAPI_ERROR_OK) {
         return status;
     }
 
-    return _esp.scan(res, count);
+    return _esp.scan(res, count, (mode == SCANMODE_ACTIVE ? ESP8266::SCANMODE_ACTIVE : ESP8266::SCANMODE_PASSIVE),
+                     t_min, t_max);
 }
 
 bool ESP8266Interface::_get_firmware_ok()

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -145,17 +145,37 @@ public:
      */
     virtual int8_t get_rssi();
 
+    /** Scan mode
+     */
+    enum scan_mode {
+        SCANMODE_ACTIVE, /*!< active mode */
+        SCANMODE_PASSIVE /*!< passive mode */
+    };
+
     /** Scan for available networks
      *
      * This function will block.
      *
-     * @param  ap       Pointer to allocated array to store discovered AP
-     * @param  count    Size of allocated @a res array, or 0 to only count available AP
-     * @param  timeout  Timeout in milliseconds; 0 for no timeout (Default: 0)
-     * @return          Number of entries in @a, or if @a count was 0 number of available networks, negative on error
-     *                  see @a nsapi_error
+     * @param  ap    Pointer to allocated array to store discovered AP
+     * @param  count Size of allocated @a res array, or 0 to only count available AP
+     * @return       Number of entries in @a, or if @a count was 0 number of available networks, negative on error
+     *               see @a nsapi_error
      */
     virtual int scan(WiFiAccessPoint *res, unsigned count);
+
+    /** Scan for available networks
+     *
+     * This function will block.
+     *
+     * @param  ap    Pointer to allocated array to store discovered AP
+     * @param  count Size of allocated @a res array, or 0 to only count available AP
+     * @param  t_max Scan time for each channel - 0-1500ms. If 0 - uses default value
+     * @param  t_min Minimum for each channel in active mode - 0-1500ms. If 0 - uses default value. Omit in passive mode
+     * @return       Number of entries in @a, or if @a count was 0 number of available networks, negative on error
+     *               see @a nsapi_error
+     */
+    virtual int scan(WiFiAccessPoint *res, unsigned count, scan_mode mode = SCANMODE_PASSIVE,
+                     unsigned t_max = 0, unsigned t_min = 0);
 
     /** Translates a hostname to an IP address with specific version
      *


### PR DESCRIPTION
### Description
No reason to wait for 15 seconds for the results if those happen to arrive earlier.

Makes possible to decide between Wi-Fi scan active and passive mode.

Makes possible to adjust for how long a single channel is scanned.

Should address the issue #8609 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@michalpasztamobica 
@SeppoTakalo 

### Release Notes
ESP8266: new Wi-Fi scan API for active and passive mode. Making channel scan time configurable