### PR TITLE
Fix issues found in LPC55S69 integration

### DIFF
--- a/TESTS/psa/spm_client/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_client/COMPONENT_NSPE/main.cpp
@@ -460,7 +460,6 @@ Case cases[] = {
     Case("Testing client tx_buff_null", tx_buff_null),
     Case("Testing client rx_tx_null", rx_tx_null),
     Case("Testing client multiple_call from a single thread", multiple_call),
-    Case("Testing client exceed num of max channels allowed", exceed_num_of_max_channels),
     Case("Testing client close on NULL handle", client_close_null_handle),
     Case("Testing DROP_CONNECTION State", drop_connection),
     Case("Testing client psa_framework_version() API", verify_psa_framework_version),
@@ -468,6 +467,9 @@ Case cases[] = {
     Case("Testing client psa_version() API on non-existing SID", psa_version_non_existing),
     Case("Testing client psa_version() API to a service that is not NSPE callable", psa_version_secure_access_only),
     Case("Testing client multiple calls on different channels to the same SID", multi_thread_diff_handles),
+#if defined TARGET_MBED_SPM // TF-M issue: https://developer.trustedfirmware.org/T244
+    Case("Testing client exceed num of max channels allowed", exceed_num_of_max_channels),
+#endif
 };
 
 utest::v1::status_t test_setup(const size_t number_of_cases)

--- a/TESTS/psa/spm_server/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_server/COMPONENT_NSPE/main.cpp
@@ -264,7 +264,9 @@ Case cases[] = {
     SPM_UTEST_CASE("Try to skip more bytes than left while reading", skip_more_than_left),
     SPM_UTEST_CASE("Test rhandle implementation by calculating the factorial function", rhandle_factorial),
     SPM_UTEST_CASE("Test a call flow between 2 secure partitions", cross_partition_call),
+#if defined TARGET_MBED_SPM // TF-M issue: https://developer.trustedfirmware.org/T273
     SPM_UTEST_CASE("Test a common DOORBELL scenario", doorbell_test),
+#endif
 };
 
 //Declare your test specification with a custom setup handler

--- a/TESTS/psa/spm_server/COMPONENT_SPE/tests.c
+++ b/TESTS/psa/spm_server/COMPONENT_SPE/tests.c
@@ -698,6 +698,8 @@ psa_test_server_side_func test_list[] = {
     PSA_TEST_SERVER_NAME(skip_more_than_left),
     PSA_TEST_SERVER_NAME(rhandle_factorial),
     PSA_TEST_SERVER_NAME(cross_partition_call),
+#if defined TARGET_MBED_SPM // TF-M issue: https://developer.trustedfirmware.org/T273
     PSA_TEST_SERVER_NAME(doorbell_test),
+#endif
     NULL
 };

--- a/components/TARGET_PSA/TARGET_TFM/mbed_lib.json
+++ b/components/TARGET_PSA/TARGET_TFM/mbed_lib.json
@@ -17,7 +17,7 @@
         "rot_pool_size": {
             "help": "maximum number of RoT services allowed",
             "macro_name": "TFM_SPM_MAX_ROT_SERV_NUM",
-            "value": 30
+            "value": 32
         },
         "message_pool_size": {
             "help": "maximum number of active messages allowed",


### PR DESCRIPTION
### Description

Fix issues found in LPC55S69 integration

- Disable SPM-IPC tests which fail due to issues in TF-M.
- Increase allowed ROT service count from 30 to 32.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
