### PR TITLE
Use LP tickers for waiting in no RTOS builds when available

### DIFF
--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -23,16 +23,23 @@
 // if the RTOS is not present.
 #ifndef MBED_CONF_RTOS_PRESENT
 
+#include "hal/lp_ticker_api.h"
 #include "hal/us_ticker_api.h"
 
 void wait(float s)
 {
-    wait_us(s * 1000000.0f);
+    wait_ms(s * 1000.0f);
 }
 
 void wait_ms(int ms)
 {
+#if DEVICE_LPTICKER
+    const ticker_data_t *const ticker = get_lp_ticker_data();
+    uint32_t start = ticker_read(ticker);
+    while ((ticker_read(ticker) - start) < (uint32_t)(ms * 1000));
+#else
     wait_us(ms * 1000);
+#endif
 }
 
 void wait_us(int us)


### PR DESCRIPTION
### Description

For bare metal builds, use the lp_ticker for calls to wait_ms.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

For bare metal builds, use the lp_ticker for calls to wait_ms instead of us ticker if lp_ticker is available.


