### PR TITLE
Add imports of basestring for python 3

### DIFF
--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -21,6 +21,7 @@ from os.path import join, abspath, dirname, normpath
 from optparse import OptionParser
 import json
 from shutil import copy
+from past.builtins import basestring
 
 # Be sure that the tools directory is in the search path
 ROOT = abspath(join(dirname(__file__), ".."))

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -24,6 +24,7 @@ from os import makedirs, walk
 import copy
 from shutil import rmtree, copyfile
 import zipfile
+from past.builtins import basestring
 
 from ..resources import Resources, FileType, FileRef
 from ..config import ALLOWED_FEATURES

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
 from copy import copy
 from yaml import dump_all
 import argparse
+from past.builtins import basestring
 
 from tools.targets import Target, set_targets_json_location, TARGET_MAP
 
@@ -274,4 +275,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Low priority fix/clean up. Noticed when exporting locally to a zip with Python 3 a traceback occurs about the reference to `basestring`. This adds the necessary import, as well to the rest of the tools that also referenced `basestring` without an import.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@cmonr 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

