### PR TITLE
tools: fix the path generated to the sct file

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -1,6 +1,6 @@
 """
 mbed SDK
-Copyright (c) 2011-2016 ARM Limited
+Copyright (c) 2011-2019 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -272,11 +272,10 @@ class Arm(Makefile):
         if self.resources.linker_script:
             sct_file = self.resources.get_file_refs(FileType.LD_SCRIPT)[-1]
             new_script = self.toolchain.correct_scatter_shebang(
-                sct_file.path, join("..", dirname(sct_file.name)))
+                sct_file, dirname(sct_file.name))
             if new_script is not sct_file:
                 self.resources.add_files_to_type(
                     FileType.LD_SCRIPT, [new_script])
-                self.generated_files.append(new_script)
         return super(Arm, self).generate()
 
 class Armc5(Arm):

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -272,7 +272,7 @@ class Arm(Makefile):
         if self.resources.linker_script:
             sct_file = self.resources.get_file_refs(FileType.LD_SCRIPT)[-1]
             new_script = self.toolchain.correct_scatter_shebang(
-                sct_file, dirname(sct_file.name)
+                sct_file, join("..", dirname(sct_file.name))
             )
             if new_script is not sct_file:
                 self.resources.add_file_ref(

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -272,10 +272,14 @@ class Arm(Makefile):
         if self.resources.linker_script:
             sct_file = self.resources.get_file_refs(FileType.LD_SCRIPT)[-1]
             new_script = self.toolchain.correct_scatter_shebang(
-                sct_file, dirname(sct_file.name))
+                sct_file, dirname(sct_file.name)
+            )
             if new_script is not sct_file:
-                self.resources.add_files_to_type(
-                    FileType.LD_SCRIPT, [new_script])
+                self.resources.add_file_ref(
+                    FileType.LD_SCRIPT,
+                    new_script.name,
+                    new_script.path
+                )
         return super(Arm, self).generate()
 
 class Armc5(Arm):

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -244,12 +244,14 @@ class Uvision(Exporter):
                                       self.resources.inc_dirs),
             'device': DeviceUvision(self.target),
         }
-        sct_name, sct_path = self.resources.get_file_refs(
-            FileType.LD_SCRIPT)[0]
-        ctx['linker_script'] = self.toolchain.correct_scatter_shebang(
-            sct_path, dirname(sct_name))
-        if ctx['linker_script'] != sct_path:
-            self.generated_files.append(ctx['linker_script'])
+        sct_file_ref = self.resources.get_file_refs(FileType.LD_SCRIPT)[0]
+        sct_file_ref = self.toolchain.correct_scatter_shebang(
+            sct_file_ref, dirname(sct_file_ref.name)
+        )
+        self.resources.add_file_ref(
+            FileType.LD_SCRIPT, sct_file_ref.name, sct_file_ref.path
+        )
+        ctx['linker_script'] = sct_file_ref.name
         fpu_included_core_name = ctx['device'].core.replace("-NS", "")
         ctx['cputype'] = fpu_included_core_name.rstrip("FDE")
         if fpu_included_core_name.endswith("FD"):

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -269,6 +269,10 @@ class Resources(object):
         if file_type:
             if sep != self._sep:
                 file_name = file_name.replace(sep, self._sep)
+            # Mbed OS projects only use one linker script at a time, so remove
+            # any existing linker script when adding a new one
+            if file_type == FileType.LD_SCRIPT:
+                self._file_refs[file_type].clear()
             self._file_refs[file_type].add(FileRef(file_name, file_path))
 
     def _include_file(self, ref):

--- a/tools/test/resources/resource_test.py
+++ b/tools/test/resources/resource_test.py
@@ -146,6 +146,20 @@ class ResourcesTest(unittest.TestCase):
         exc_names = [dirname(name) or "." for name, _ in excluded_libs]
         assert(all(e in res.ignored_dirs for e in exc_names))
 
+    def test_only_one_linker_script(self):
+        """
+        Verify that when multiple linker scripts are added to a resource object,
+        only the last one added is used.
+        """
+        resources = Resources(MockNotifier())
+        linker_scripts = ["first_linker_script.sct", "second_linker_script.sct"]
+        for linker_script in linker_scripts:
+            resources.add_file_ref(FileType.LD_SCRIPT, linker_script, linker_script)
+
+        assert(len(resources.get_file_refs(FileType.LD_SCRIPT)) == 1)
+        assert(resources.get_file_refs(FileType.LD_SCRIPT)[-1].name == linker_scripts[-1])
+        assert(resources.get_file_refs(FileType.LD_SCRIPT)[-1].path == linker_scripts[-1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -284,7 +284,7 @@ class ARM(mbedToolchain):
                         scatter file
 
         Return:
-        The location of the correct scatter file
+        The FileRef of the correct scatter file
 
         Side Effects:
         This method MAY write a new scatter file to disk


### PR DESCRIPTION
### Description
The sct file path generated in the online compiler
is incorrect. Fix that by changing the correct_scatter_shebang
API to accept a FileRef object instead and use the path.

This change should go with change in online compiler that removes
the override for correct_scatter_shebang.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
