### PR TITLE
Correct thread status callback functionality

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -147,9 +147,6 @@ nsapi_error_t Nanostack::ThreadInterface::bringup(bool dhcp, const char *ip,
     // -end devices will get connectivity once attached to existing network
     // -devices without network settings gets connectivity once commissioned and attached to network
     _connect_status = NSAPI_STATUS_CONNECTING;
-    if (_connection_status_cb) {
-        _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_CONNECTING);
-    }
     if (_blocking) {
         int32_t count = connect_semaphore.wait(osWaitForever);
 

--- a/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
@@ -245,10 +245,7 @@ void thread_tasklet_poll_network_status(void *param)
             }
         }
     } else {
-        if (thread_tasklet_data_ptr->connection_status != MESH_DISCONNECTED &&
-                thread_tasklet_data_ptr->connection_status != MESH_BOOTSTRAP_STARTED) {
-            thread_tasklet_network_state_changed(MESH_DISCONNECTED);
-        }
+        thread_tasklet_data_ptr->connection_status = MESH_DISCONNECTED;
     }
 }
 


### PR DESCRIPTION
### Description

Status callback correct.

Tested locally with k64f using thread mesh network.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
