### PR TITLE
TF-M config: Add max_ns_thread_count parameter

### DIFF
--- a/components/TARGET_PSA/TARGET_TFM/COMPONENT_SPE/mbed_lib.json
+++ b/components/TARGET_PSA/TARGET_TFM/COMPONENT_SPE/mbed_lib.json
@@ -1,4 +1,11 @@
 {
     "name": "tfm-s",
-    "macros": ["MBED_FAULT_HANDLER_DISABLED", "BYPASS_NVSTORE_CHECK=1"]
+    "macros": ["MBED_FAULT_HANDLER_DISABLED", "BYPASS_NVSTORE_CHECK=1"],
+    "config": {
+        "max_ns_thread_count": {
+            "help": "maximum allowed number of non-secure threads",
+            "macro_name": "TFM_MAX_NS_THREAD_COUNT",
+            "value": 10
+        }
+    }
 }

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -51,7 +51,7 @@ using namespace utest::v1;
 
 #define TEST_BLOCK_COUNT 10
 #define TEST_ERROR_MASK 16
-#define TEST_NUM_OF_THREADS 4
+#define TEST_NUM_OF_THREADS 5
 #define TEST_THREAD_STACK_SIZE 1024
 
 const struct {


### PR DESCRIPTION
### Description

#9931 reduced number of threads in block device test from 5 to 4 due to errors in TF-M targets.
The root cause of the error was the fact that TF-M had a fixed maximum number of non-secure thread allowed (defined by the TFM_MAX_NS_THREAD_COUNT in [tfm_nspm.c)](https://github.com/ARMmbed/mbed-os/blob/master/components/TARGET_PSA/TARGET_TFM/COMPONENT_SPE/secure_fw/core/tfm_nspm.c#L12-L14).

This PR add a configuration parametr for this macro in mbed_lib.json and returns the number of the test to 5.

Tests results on LPC55S69:
```sh
| target            | platform_name | test suite                                                      | result | elapsed_time (sec) | copy_method |
|-------------------|---------------|-----------------------------------------------------------------|--------|--------------------|-------------|
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | OK     | 23.79              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target            | platform_name | test suite                                                      | test case                                         | passed | failed | result | elapsed_time (sec) |
|-------------------|---------------|-----------------------------------------------------------------|---------------------------------------------------|--------|--------|--------|--------------------|
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | DEFAULT Testing get type functionality            | 1      | 0      | OK     | 0.11               |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing BlockDevice erase functionality  | 1      | 0      | OK     | 0.4                |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing Deinit block device              | 1      | 0      | OK     | 0.09               |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing Init block device                | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing contiguous erase, write and read | 1      | 0      | OK     | 0.12               |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing multi threads erase program read | 1      | 0      | OK     | 1.3                |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing program read small data sizes    | 1      | 0      | OK     | 0.13               |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing read write random blocks         | 1      | 0      | OK     | 0.45               |
| LPC55S69_NS-ARMC6 | LPC55S69_NS   | mbed-os-features-storage-tests-blockdevice-general_block_device | FLASHIAP Testing unaligned erase blocks           | 1      | 0      | OK     | 0.12               |
mbedgt: test case results: 9 OK
mbedgt: completed in 24.03 sec

```

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@orenc17 @offirko 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
