### PR TITLE
PSA: Remove unused type which was conflicting wiith errno.h

### DIFF
--- a/components/TARGET_PSA/TARGET_MBED_SPM/psa_defs.h
+++ b/components/TARGET_PSA/TARGET_MBED_SPM/psa_defs.h
@@ -77,7 +77,6 @@ extern "C" {
 
 typedef uint32_t psa_signal_t;
 typedef int32_t psa_handle_t;
-typedef psa_status_t error_t;
 
 /* -------------------------------------- Structs ------------------------------------ */
 


### PR DESCRIPTION
### Description
error_t was defined in MBED_SPM PSA implementation and was conflicting with error_t defined by the toolchains

as it is not being used in the PSA code at all, and not defined in PSA-FF spec we remove it.
The issue was found when compiling psoc6 with pelion-client
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-psa @TaniaMirzin 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
