### PR TITLE
TEST_APPS socket_app leaks memory when cannot initialize packetSizes

### DIFF
--- a/TEST_APPS/device/socket_app/cmd_socket.cpp
+++ b/TEST_APPS/device/socket_app/cmd_socket.cpp
@@ -673,6 +673,7 @@ static nsapi_size_or_error_t start_udp_receiver_thread(SInfo *info, int argc, ch
     int *packetSizes = new (nothrow) int[PACKET_SIZE_ARRAY_LEN];
     if (!packetSizes) {
         cmd_printf("Allocation failed\r\n");
+        free(dataIn);
         return CMDLINE_RETCODE_FAIL;
     }
     for (int i = 0; i < PACKET_SIZE_ARRAY_LEN; i++) {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

When packetSizes cannot be initialized we don't free dataIn.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
