### PR TITLE
Dead pointer usage in GenericSecurityManager

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
@@ -883,9 +883,8 @@ ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::init_si
     const csrk_t *pcsrk = _db->get_local_csrk();
     sign_count_t local_sign_counter = _db->get_local_sign_counter();
 
+    csrk_t csrk;
     if (!pcsrk) {
-        csrk_t csrk;
-
         ble_error_t ret = get_random_data(csrk.data(), csrk.size());
         if (ret != BLE_ERROR_NONE) {
             return ret;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

`pscrk` is set to the address of `csrk`, but `csrk` is out of scope when using the resulting value. There's no guarantee that the memory is still valid.

@pan- 


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
