### PR TITLE
test_soap_connection_handler leaks memory when open_connection fails

### DIFF
--- a/features/nanostack/coap-service/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
+++ b/features/nanostack/coap-service/test/coap-service/unittest/coap_connection_handler/test_coap_connection_handler.c
@@ -403,6 +403,7 @@ bool test_socket_api_callbacks()
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
     if (0 != coap_connection_handler_open_connection(handler, 22, false, false, true, false)) {
+        free(sckt_data);
         return false;
     }
 
@@ -483,6 +484,7 @@ bool test_security_callbacks()
     coap_conn_handler_t *handler = connection_handler_create(&receive_from_sock_cb, &send_to_sock_cb, NULL, NULL);
     nsdynmemlib_stub.returnCounter = 2;
     if (0 != coap_connection_handler_open_connection(handler, 22, false, true, true, false)) {
+        free(sckt_data);
         return false;
     }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

sckt_data is not free'd when `coap_connection_handler_open_connection` fails.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
