### PR TITLE
GigaDevice targets can return uninitialized variable in CAN driver

### DIFF
--- a/targets/TARGET_GigaDevice/TARGET_GD32E10X/can_api.c
+++ b/targets/TARGET_GigaDevice/TARGET_GD32E10X/can_api.c
@@ -305,7 +305,7 @@ void can_free(can_t *obj)
  */
 int can_frequency(can_t *obj, int hz)
 {
-    int reval;
+    int reval = 0;
 
     /* The maximum baud rate support to 1M */
     if (hz <= 1000000) {

--- a/targets/TARGET_GigaDevice/TARGET_GD32F30X/can_api.c
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F30X/can_api.c
@@ -305,7 +305,7 @@ void can_free(can_t *obj)
  */
 int can_frequency(can_t *obj, int hz)
 {
-    int reval;
+    int reval = 0;
 
     /* The maximum baud rate support to 1M */
     if (hz <= 1000000) {

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/can_api.c
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/can_api.c
@@ -306,7 +306,7 @@ void can_free(can_t *obj)
  */
 int can_frequency(can_t *obj, int hz)
 {
-    int reval;
+    int reval = 0;
 
     /* The maximum baud rate support to 1M */
     if (hz <= 1000000) {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

If the CAN frequency passed in is >1MHz then the (uninitialized) value of `reval` is returned from the CAN driver for GigaDevice targets.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
