### PR TITLE
OdinWifiInterface is calling memcpy with a null pointer

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -879,7 +879,7 @@ void OdinWiFiInterface::handle_user_connect(user_connect_s *user_connect)
 
     if(error_code == NSAPI_ERROR_OK) {
         memset(&_wlan_status_connected_info, 0, sizeof(cbWLAN_StatusConnectedInfo));
-        memcpy(&_wlan_status_disconnected_info, 0, sizeof(cbWLAN_StatusDisconnectedInfo));
+        memset(&_wlan_status_disconnected_info, 0, sizeof(cbWLAN_StatusDisconnectedInfo));
 
         _state_sta = entry_wait_connect();
     }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

`memcpy` is called with source address `0`. I *think* this should be `memset` not `memcpy` based on how the function is used.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
