### PR TITLE
BLE: fix tick rate set to 10 ms

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -1,5 +1,6 @@
 {
     "name": "cordio",
+    "macros": [ "WSF_MS_PER_TICK=1" ],
     "config": {
         "max-connections": {
             "help": "Maximum number of connections",


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Match cordio tick rate to os tick rate.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan- 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
