### PR TITLE
Test for and Recompute sector information for all targets

### DIFF
--- a/tools/test/targets/target_test.py
+++ b/tools/test/targets/target_test.py
@@ -37,6 +37,21 @@ def test_device_name():
             ("Target %s contains invalid device_name %s" %
              (target.name, target.device_name))
 
+def test_bl_has_sectors():
+    """Assert a bootloader supporting pack has sector information"""
+    cache = Cache(True, True)
+    named_targets = (
+        target for target in TARGETS if
+        (hasattr(target, "device_name") and getattr(target, "bootloader_supported", False))
+    )
+    for target in named_targets:
+        assert target.device_name in cache.index,\
+            ("Target %s contains invalid device_name %s" %
+             (target.name, target.device_name))
+        assert cache.index[target.device_name]["sectors"],\
+            ("Device name %s is misssing sector information" %
+             (target.device_name))
+
 @contextmanager
 def temp_target_file(extra_target, json_filename='custom_targets.json'):
     """Create an extra targets temp file in a context manager


### PR DESCRIPTION
### Description

The use cmsis-pack-manager PR did not include these in the index because
they failed to download when I last did the index update.

This PR adds a test for sector information, and recomputes all missing
sector information so that the test passes (in that order).

Note: This was marked as a blocker bug, so I expect to see it in
5.12.0-rcX for some X.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change