### PR TITLE
BLE: fix missing check for signed requirement on attribute write 

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/att/atts_write.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/att/atts_write.c
@@ -143,12 +143,21 @@ void attsProcWrite(attCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     {
       /* err has been set; fail */
     }
+
+    /* verify non signed write is permitted */
+    else if (((pAttr->settings & ATTS_SET_REQ_SIGNED) != 0) &&
+             (DmConnSecLevel(pCcb->connId) == DM_SEC_LEVEL_NONE))
+    {
+      err = ATT_ERR_ENC;
+    }
+
     /* verify write length, fixed length */
     else if (((pAttr->settings & ATTS_SET_VARIABLE_LEN) == 0) &&
              (writeLen != pAttr->maxLen))
     {
       err = ATT_ERR_LENGTH;
     }
+
     /* verify write length, variable length */
     else if (((pAttr->settings & ATTS_SET_VARIABLE_LEN) != 0) &&
              (writeLen > pAttr->maxLen))


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

An attribute can be written to using a normal write even if the attribute requires signing. This checks the requirement and rejects the write (unless the link is encrypted which supersedes the need for signing).

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
