### PR TITLE
BLE - Use low power timing primitives

### DIFF
--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -30,7 +30,8 @@
 #include "ble/pal/ConnectionEventMonitor.h"
 #include "ble/pal/Deprecated.h"
 
-#include "drivers/Timeout.h"
+#include "drivers/LowPowerTimeout.h"
+#include "drivers/LowPowerTicker.h"
 #include "platform/mbed_error.h"
 
 namespace ble {
@@ -802,9 +803,9 @@ private:
     bool _random_address_rotating;
 
     bool _scan_enabled;
-    mbed::Timeout _advertising_timeout;
-    mbed::Timeout _scan_timeout;
-    mbed::Ticker _address_rotation_ticker;
+    mbed::LowPowerTimeout _advertising_timeout;
+    mbed::LowPowerTimeout _scan_timeout;
+    mbed::LowPowerTicker _address_rotation_ticker;
 
     template<size_t bit_size>
     struct BitArray {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioBLE.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioBLE.h
@@ -31,7 +31,7 @@
 #include "ble/generic/GenericGap.h"
 #include "ble/generic/GenericSecurityManager.h"
 #include "SimpleEventQueue.h"
-#include "Timer.h"
+#include "drivers/LowPowerTimer.h"
 #include "SigningMonitorProxy.h"
 #include "CordioPalSecurityManager.h"
 #include "BleImplementationForward.h"
@@ -171,7 +171,7 @@ private:
 
     ::BLE::InstanceID_t instanceID;
     mutable SimpleEventQueue _event_queue;
-    mbed::Timer _timer;
+    mbed::LowPowerTimer _timer;
     uint64_t _last_update_us;
 };
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Use LowPower timing primitives in BLE API and Cordio port.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@paul-szczepanek-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->