### PR TITLE
Fixing path comparisons in config tests on Windows

### DIFF
--- a/tools/test/config/config_test.py
+++ b/tools/test/config/config_test.py
@@ -19,7 +19,7 @@ import os
 import json
 import pytest
 from mock import patch
-from os.path import join, isfile, dirname, abspath
+from os.path import join, isfile, dirname, abspath, normpath
 from tools.build_api import get_config
 from tools.targets import set_targets_json_location
 from tools.config import (
@@ -93,15 +93,16 @@ def test_config(name):
                 assert sorted(expected_features) == sorted(features)
 
             included_source = [
-                join(test_dir, src) for src in
+                normpath(join(test_dir, src)) for src in
                 expected.get("included_source", [])
             ]
             excluded_source = [
-                join(test_dir, src) for src in
+                normpath(join(test_dir, src)) for src in
                 expected.get("excluded_source", [])
             ]
             for typ in Resources.ALL_FILE_TYPES:
                 for _, path in resources.get_file_refs(typ):
+                    path = normpath(path)
                     if included_source and path in included_source:
                         included_source.remove(path)
                     if excluded_source:


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

The config tests compare some paths to be sure the `requires` keyword is working correctly. However, on Windows, paths are separated with `\` instead of `/`. This PR normalizes the paths to be consistent before comparing them.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
