### PR TITLE
PSA: Fix error codes masking in psa_attestation_inject_key()

### DIFF
--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -23,6 +23,7 @@
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest/utest.h"
+#include "psa/lifecycle.h"
 #include "psa_initial_attestation_api.h"
 #include "psa_attest_inject_key.h"
 #include <string.h>
@@ -126,11 +127,6 @@ utest::v1::status_t case_teardown_handler(const Case *const source, const size_t
     return greentea_case_teardown_handler(source, passed, failed, reason);
 }
 
-utest::v1::status_t case_setup_handler(const Case *const source, const size_t index_of_case)
-{
-    return greentea_case_setup_handler(source, index_of_case);
-}
-
 Case cases[] = {
     Case("PSA attestation get token", check_initial_attestation_get_token, case_teardown_handler),
 };
@@ -139,6 +135,8 @@ Specification specification(greentea_test_setup, cases);
 
 int main()
 {
+    psa_status_t status = mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
+    TEST_ASSERT_EQUAL(PSA_LIFECYCLE_SUCCESS, status);
 #if (defined(COMPONENT_PSA_SRV_IPC) || defined(MBEDTLS_ENTROPY_NV_SEED))
     uint8_t seed[MBEDTLS_PSA_INJECT_ENTROPY_MIN_SIZE] = {0};
     /* inject some seed for test*/

--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IPC/psa_attest_inject_key.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IPC/psa_attest_inject_key.c
@@ -51,9 +51,5 @@ psa_attestation_inject_key(const uint8_t *key_data,
     call_error = psa_call(handle, in_vec, 2, out_vec, 2);
 
     psa_close(handle);
-
-    if (call_error < 0) {
-        call_error = PSA_ERROR_COMMUNICATION_FAILURE;
-    }
     return call_error;
 }

--- a/components/TARGET_PSA/services/attestation/COMPONENT_SPE/psa_attestation_partition.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_SPE/psa_attestation_partition.c
@@ -175,7 +175,7 @@ static void psa_attest_inject_key(void)
             uint32_t bytes_read = 0;
 
             if (msg.in_size[0] != sizeof(psa_key_type_t)) {
-                status = PSA_ERROR_COMMUNICATION_FAILURE;
+                status = PSA_ERROR_INVALID_ARGUMENT;
                 break;
             }
 


### PR DESCRIPTION
### Description

psa_attestation_inject_key() IPC implementation was masking negative error codes as PSA_ERROR_COMMUNICATION_FAILURE instead of returning the actual error code.

Clear the ITS storage in test case setup handler to avoid a situation where a call for psa_attestation_inject_key() would fail for key already exists error.

Did not check regression yet. 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-psa @moranpeker @netanelgonen @itayzafrir @avolinski 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
