### PR TITLE
platform reset API rename

### DIFF
--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -136,7 +136,7 @@ Specification specification(greentea_test_setup, cases);
 int main()
 {
     psa_status_t status = mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
-    TEST_ASSERT_EQUAL(PSA_LIFECYCLE_SUCCESS, status);
+    TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
 #if (defined(COMPONENT_PSA_SRV_IPC) || defined(MBEDTLS_ENTROPY_NV_SEED))
     uint8_t seed[MBEDTLS_PSA_INJECT_ENTROPY_MIN_SIZE] = {0};
     /* inject some seed for test*/

--- a/TESTS/psa/its_ps/main.cpp
+++ b/TESTS/psa/its_ps/main.cpp
@@ -157,7 +157,7 @@ utest::v1::status_t case_its_teardown_handler(const Case *const source, const si
 {
     psa_status_t status;
     status = mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
-    TEST_ASSERT_EQUAL(PSA_LIFECYCLE_SUCCESS, status);
+    TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
     return greentea_case_teardown_handler(source, passed, failed, reason);
 }
 
@@ -167,7 +167,7 @@ utest::v1::status_t case_its_setup_handler(const Case *const source, const size_
     psa_status_t status;
     if (stype == its) {
         status = mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
-        TEST_ASSERT_EQUAL(PSA_LIFECYCLE_SUCCESS, status);
+        TEST_ASSERT_EQUAL(PSA_SUCCESS, status);
     } else {
         status = psa_ps_reset();
         TEST_ASSERT_EQUAL(PSA_SUCCESS, status);

--- a/components/TARGET_PSA/inc/psa/client.h
+++ b/components/TARGET_PSA/inc/psa/client.h
@@ -26,6 +26,7 @@
 #define __MBED_OS_DEFAULT_PSA_CLIENT_API_H__
 
 #include <stddef.h>
+#include "psa/error.h"
 
 #if !defined(UINT32_MAX)
 #define UINT32_MAX ((uint32_t)-1)
@@ -37,13 +38,11 @@
 
 #define PSA_FRAMEWORK_VERSION   (0x0100) /**< Version of the PSA Framework API. */
 #define PSA_VERSION_NONE        (0L)     /**< Identifier for an unimplemented Root of Trust (RoT) Service. */
-#define PSA_SUCCESS             (0L) /**< A general result code for calls to psa_call()  indicating success.*/
 #define PSA_CONNECTION_REFUSED  (INT32_MIN + 1)   /**< The return value from psa_connect() if the RoT Service or SPM was unable to establish a connection.*/
 #define PSA_CONNECTION_BUSY     (INT32_MIN + 2)   /**< The return value from psa_connect() if the RoT Service rejects the connection for a transient reason.*/
 #define PSA_DROP_CONNECTION     (INT32_MIN)       /**< The result code in a call to psa_reply() to indicate a nonrecoverable error in the client.*/
 #define PSA_NULL_HANDLE         ((psa_handle_t)0)   /**< Denotes an invalid handle.*/
 
-typedef int32_t psa_status_t;
 typedef int32_t psa_handle_t;
 
 typedef struct psa_invec {

--- a/components/TARGET_PSA/inc/psa/lifecycle.h
+++ b/components/TARGET_PSA/inc/psa/lifecycle.h
@@ -24,13 +24,13 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "mbed_toolchain.h"
+#include "psa/error.h"
 
 #ifdef   __cplusplus
 extern "C"
 {
 #endif
-
-typedef int32_t psa_status_t;
 
 #define PSA_LIFECYCLE_STATE_MASK    (0xff00u)  /**< A mask value that extracts the main lifecycle state */
 #define PSA_LIFECYCLE_SUBSTATE_MASK (0x00ffu)  /**< A mask value that extracts the IMPLEMENTATION DEFINED lifecycle sub-state */
@@ -43,9 +43,6 @@ typedef int32_t psa_status_t;
 #define PSA_LIFECYCLE_RECOVERABLE_PSA_ROT_DEBUG   (0x5000u)  /**< Recoverable PSA RoT Debug state */
 #define PSA_LIFECYCLE_DECOMMISSIONED              (0x6000u)  /**< Decommissioned state */
 
-#define PSA_LIFECYCLE_SUCCESS 0
-#define PSA_LIFECYCLE_ERROR   (INT32_MIN + 1000)
-
 /** \brief Get PSA RoT lifecycle state
  *
  * \retval The main state and sub-state are encoded as follows:@n
@@ -56,16 +53,24 @@ uint32_t psa_security_lifecycle_state(void);
 
 /** \brief Request state change
  *
- * State change requested and the system.
- * TODO when not drunk
+ * State change requested and the reset the system.
+ * \note System reset will not be performed when switching from PSA_LIFECYCLE_ASSEMBLY_AND_TEST
+ * to PSA_LIFECYCLE_ASSEMBLY_AND_TEST.
+ *
+ * \note state change to follwing states will delete PSA internal storage:
+ *   - PSA_LIFECYCLE_ASSEMBLY_AND_TEST
+ *   - PSA_LIFECYCLE_PSA_ROT_PROVISIONING
+ *   - PSA_LIFECYCLE_DECOMMISSIONED
  */
 psa_status_t mbed_psa_reboot_and_request_new_security_state(uint32_t new_state);
 
 
 /** \brief Resets the system
  *
+ * PSA targets do not allow NSPE to access system power domain.
+ * This API requests system reset to be carried out by SPE once all critical secure tasks are finished.
  */
-void psa_system_reset();
+MBED_NORETURN void mbed_psa_system_reset();
 
 #ifdef   __cplusplus
 }

--- a/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_EMUL/platform_emul.c
+++ b/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_EMUL/platform_emul.c
@@ -21,9 +21,9 @@
 uint32_t psa_security_lifecycle_state(void)
 {
     uint32_t lc_state = 0;
-    psa_status_t status = PSA_LIFECYCLE_SUCCESS;
+    psa_status_t status = PSA_SUCCESS;
     status = psa_platfrom_lifecycle_get_impl(&lc_state);
-    if (status != PSA_LIFECYCLE_SUCCESS) {
+    if (status != PSA_SUCCESS) {
         lc_state = PSA_LIFECYCLE_UNKNOWN;
     }
     return lc_state;
@@ -34,7 +34,7 @@ psa_status_t mbed_psa_reboot_and_request_new_security_state(uint32_t new_state)
     return psa_platfrom_lifecycle_change_request_impl(new_state);
 }
 
-void psa_system_reset(void)
+void mbed_psa_system_reset(void)
 {
-    psa_system_reset_impl();
+    mbed_psa_system_reset_impl();
 }

--- a/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IMPL/platform_srv_impl.c
+++ b/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IMPL/platform_srv_impl.c
@@ -18,7 +18,6 @@
 #include "psa/lifecycle.h"
 #include "psa/internal_trusted_storage.h"
 #include "platform_srv_impl.h"
-#include "mbed_toolchain.h"
 #include "cmsis.h"
 
 #ifndef MBED_CONF_LIFECYCLE_STATE
@@ -28,7 +27,7 @@
 psa_status_t psa_platfrom_lifecycle_get_impl(uint32_t *lc_state)
 {
     *lc_state = MBED_CONF_LIFECYCLE_STATE;
-    return PSA_LIFECYCLE_SUCCESS;
+    return PSA_SUCCESS;
 }
 
 psa_status_t psa_its_reset();
@@ -38,10 +37,10 @@ psa_status_t psa_platfrom_lifecycle_change_request_impl(uint32_t state)
     if (PSA_LIFECYCLE_ASSEMBLY_AND_TEST == state) {
         return psa_its_reset();
     }
-    return PSA_LIFECYCLE_ERROR;
+    return PSA_ERROR_NOT_SUPPORTED;
 }
 
-MBED_WEAK void psa_system_reset_impl(void)
+MBED_WEAK void mbed_psa_system_reset_impl(void)
 {
     /* Reset the system */
     NVIC_SystemReset();

--- a/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IMPL/platform_srv_impl.h
+++ b/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IMPL/platform_srv_impl.h
@@ -19,9 +19,10 @@
 #define __PLATFROM_SRV_IMPL_H__
 
 #include "psa/client.h"
+#include "mbed_toolchain.h"
 
 psa_status_t psa_platfrom_lifecycle_get_impl(uint32_t *lc_state);
 psa_status_t psa_platfrom_lifecycle_change_request_impl(uint32_t lc_state);
-void psa_system_reset_impl(void);
+MBED_NORETURN void mbed_psa_system_reset_impl(void);
 
 #endif // __PLATFROM_SRV_IMPL_H__

--- a/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IPC/platform_ipc.c
+++ b/components/TARGET_PSA/services/platform/COMPONENT_PSA_SRV_IPC/platform_ipc.c
@@ -19,6 +19,7 @@
 #include "psa/lifecycle.h"
 #include "psa/client.h"
 #include "mbed_toolchain.h"
+#include "mbed_error.h"
 
 uint32_t psa_security_lifecycle_state(void)
 {
@@ -57,12 +58,11 @@ psa_status_t mbed_psa_reboot_and_request_new_security_state(uint32_t new_state)
     return status;
 }
 
-MBED_NORETURN void psa_system_reset(void)
+void mbed_psa_system_reset(void)
 {
     psa_handle_t conn = psa_connect(PSA_PLATFORM_SYSTEM_RESET, 1);
-    if (conn <= PSA_NULL_HANDLE) {
-        return;
+    if (conn > PSA_NULL_HANDLE) {
+        psa_call(conn, NULL, 0, NULL, 0);
     }
-
-    psa_call(conn, NULL, 0, NULL, 0);
+    error("reset failed - cannot connect to service handle=%ld", conn);
 }

--- a/components/TARGET_PSA/services/platform/COMPONENT_SPE/platform_partition.c
+++ b/components/TARGET_PSA/services/platform/COMPONENT_SPE/platform_partition.c
@@ -52,10 +52,10 @@ static psa_status_t lifecycle_change_request(psa_msg_t *msg)
 
 }
 
-static psa_status_t system_reset_request(psa_msg_t *msg)
+static MBED_NORETURN psa_status_t system_reset_request(psa_msg_t *msg)
 {
     (void)msg;
-    psa_system_reset_impl();
+    mbed_psa_system_reset_impl();
 }
 
 static void message_handler(psa_msg_t *msg, SignalHandler handler)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/cmsis_nvic_virtual.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/cmsis_nvic_virtual.c
@@ -21,5 +21,5 @@
 
 void __NVIC_TFMSystemReset(void)
 {
-    psa_system_reset();
+    mbed_psa_system_reset();
 }


### PR DESCRIPTION
### Description
Renamed newly added `psa_system_reset()` API to `mbed_system_reset()`
We should not use PSA prefix for APIs not defined in PSA specs.

Must be merged after #9910 

Targeting RC2

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@mikisch81 @orenc17 @mmahadevan108
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
