### PR TITLE
Remove intervaltree from requirements.txt for mbed-os as it contradic…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ idna>=2,<2.8
 pyserial>=3,<=3.4
 Jinja2>=2.7.3,<=2.10
 intelhex>=1.3,<=2.2.1
-intervaltree>=2,<3
 mbed-ls>=1.5.1,<1.8
 mbed-host-tests>=1.4.4,<1.6
 mbed-greentea>=0.2.24,<1.7


### PR DESCRIPTION
…ts pyocd requirements

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Remove version requirement of intervaltree because it contradicts what pyocd requires.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
