### PR TITLE
Update the linker script to support RW/ZI/Heap span across RAM banks

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
@@ -28,7 +28,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
@@ -18,8 +18,8 @@ define symbol __region_SRAM1_end__    = 0x2000BFFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
-define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
+define region RAM_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
+                           | mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
     define symbol MBED_BOOT_STACK_SIZE = 0x400;
@@ -37,5 +37,4 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };
+place in RAM_region   { readwrite, zeroinit, block STACKHEAP };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -37,7 +37,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x12000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8   { };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -12,17 +12,19 @@ define symbol __NVIC_start__          = 0x10000000;
 define symbol __NVIC_end__            = 0x10000187;
 define symbol __region_SRAM2_start__  = 0x10000188;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
+
 define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
 define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
+
 define symbol __region_SRAM1_start__  = 0x20000100;
 define symbol __region_SRAM1_end__    = 0x20017FFF;
 
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
-define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
+define region RAM_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__]
+                          | mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 /* Define Crash Data Symbols */
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
@@ -33,7 +35,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 }
 
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __size_heap__   = 0x17000;
+define symbol __size_heap__   = 0x12000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 
@@ -41,7 +43,5 @@ initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
 
 place at address mem:__intvec_start__ { readonly section .intvec };
-
 place in ROM_region   { readonly };
-place in SRAM1_region { readwrite, block HEAP };
-place in SRAM2_region { first block CSTACK, zeroinit };
+place in RAM_region { first block CSTACK, readwrite, zeroinit, block HEAP  };


### PR DESCRIPTION
### Description
As per EWARM Development guide 

A region consists of one or several memory ranges, where each memory range
consists of a continuous sequence of bytes in a specific memory. Several ranges
can be combined by using region expressions. Note that those ranges do
not need to be consecutive or even in the same memory.

RAM region here is made as combination of 2-RAM banks
define region RAM_region = mem:[from __SRAM2_start__ to __SRAM2_end__]
                          | mem:[from __SRAM1_start__ to __SRAM1_end__];

block can be placed in specific region which can have several ranges.
place in RAM_region                    {  block RW };
place in RAM_region                    {  block ZI };
place in RAM_region                    {  block HEAP };

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

