### PR TITLE
Fix MBED_RAM_START/MBED_RAM_SIZE symbol generation

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -768,8 +768,6 @@ class Config(object):
                         mem_size = size
                     memory = 'ROM'
                 elif memory in ['IRAM1', 'SRAM_OC', 'SRAM_UPPER', 'SRAM']:
-                    if (self.has_ram_regions):
-                        continue
                     start, size = self._get_primary_memory_override("ram")
                     if start:
                         mem_start = start

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -840,7 +840,7 @@ class mbedToolchain:
     def _add_all_regions(self, region_list, active_region_name):
         for region in region_list:
             self._add_defines_from_region(region)
-            if region.active:
+            if region.active and active_region_name:
                 for define in [
                         ("%s_START" % active_region_name,
                          "0x%x" % region.start),
@@ -874,7 +874,7 @@ class mbedToolchain:
                     "s" if len(regions) > 1 else "",
                     ", ".join(r.name for r in regions)
                 ))
-                self._add_all_regions(regions, "MBED_RAM")
+                self._add_all_regions(regions, None)
             except ConfigException:
                 pass
 


### PR DESCRIPTION
### Description

This PR tries to fix #9716 with build tool-generated `MBED_RAM_START`/`MBED_RAM_SIZE` symbols passed to C/C++ and linker files. It has the effects:
1. Fix `MBED_RAM_START`/`MBED_RAM_SIZE` symbols are not passed to C/C++ file (see build tool-generated **.profile-c**/**.profile-cxx**) when there are `target.mbed_ram_start`/`target.mbed_ram_size` overrides.
1. Avoid duplicate `MBED_RAM_START`/`MBED_RAM_SIZE` symbols passed to linker file (see build tool-generated **.profile-ld**).

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Related issue or PR

#10004 
#9716