### PR TITLE
Generate BLE Static Random Address on U-blox Odin-W2 platform

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO_ODIN_W2/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO_ODIN_W2/HCIDriver.cpp
@@ -337,8 +337,20 @@ void ble::vendor::odin_w2::HCIDriver::handle_reset_sequence(uint8_t *pMsg)
                     randCnt++;
                     HciLeRandCmd();
                 } else {
-                    signal_reset_sequence_done();
+                    uint8_t addr[6] = { 0 };
+                    memcpy(addr, pMsg, sizeof(addr));
+                    DM_RAND_ADDR_SET(addr, DM_RAND_ADDR_STATIC);
+                    // note: will invoke set rand address
+                    cordio::BLE::deviceInstance().getGap().setAddress(
+                        BLEProtocol::AddressType::RANDOM_STATIC,
+                        addr
+                    );
                 }
+                break;
+
+            case HCI_OPCODE_LE_SET_RAND_ADDR:
+                /* send next command in sequence */
+                signal_reset_sequence_done();
                 break;
 
             default:


### PR DESCRIPTION
### Description

This PR adds generation of the BLE Static Random address for the U-blox Odin-W2 platform, which was missing in the current driver.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-pan 
@ARMmbed/team-ublox 

### Release Notes

