### PR TITLE
Update nanostack-interface error mapping

### DIFF
--- a/features/nanostack/nanostack-interface/Nanostack.cpp
+++ b/features/nanostack/nanostack-interface/Nanostack.cpp
@@ -114,7 +114,7 @@ nsapi_error_t map_mesh_error(mesh_error_t err)
         case MESH_ERROR_MEMORY:
             return NSAPI_ERROR_NO_MEMORY;
         case MESH_ERROR_PARAM:
-            return NSAPI_ERROR_UNSUPPORTED;
+            return NSAPI_ERROR_PARAMETER;
         case MESH_ERROR_STATE:
             return NSAPI_ERROR_DEVICE_ERROR;
         default:
@@ -664,7 +664,7 @@ out:
 nsapi_size_or_error_t Nanostack::socket_sendto(void *handle, const SocketAddress &address, const void *data, nsapi_size_t size)
 {
     if (address.get_ip_version() != NSAPI_IPv6) {
-        return NSAPI_ERROR_UNSUPPORTED;
+        return NSAPI_ERROR_PARAMETER;
     }
 
     ns_address_t ns_address;
@@ -736,7 +736,7 @@ nsapi_error_t Nanostack::socket_bind(void *handle, const SocketAddress &address)
             addr_field = &ns_in6addr_any;
             break;
         default:
-            return NSAPI_ERROR_UNSUPPORTED;
+            return NSAPI_ERROR_PARAMETER;
     }
 
     NanostackLockGuard lock;
@@ -874,7 +874,7 @@ nsapi_error_t Nanostack::socket_connect(void *handle, const SocketAddress &addr)
     NanostackLockGuard lock;
 
     if (addr.get_ip_version() != NSAPI_IPv6) {
-        ret = NSAPI_ERROR_UNSUPPORTED;
+        ret = NSAPI_ERROR_PARAMETER;
         goto out;
     }
 
@@ -1006,3 +1006,4 @@ OnboardNetworkStack &OnboardNetworkStack::get_default_instance()
     return Nanostack::get_instance();
 }
 #endif
+


### PR DESCRIPTION
### Description
Use status NSAPI_ERROR_PARAMETER instead of NSAPI_ERROR_UNSUPPORTED
when error is caused by parameter mismatch.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
<!--
    Optional
    Request additional reviewers with @username
-->
