### PR TITLE
STM: Update linker script for using SRAM1 and SRAM2 in ARM

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_ARM_STD/stm32l443xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_ARM_STD/stm32l443xx.sct
@@ -29,36 +29,82 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START            0x08000000
 #endif
 
+; 256KB FLASH (0x40000)
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x40000
+  #define MBED_APP_SIZE             0x40000
+#endif
+
+; 48KB SRAM (0xC000) + 16KB SRAM (0x4000)
+#if !defined(MBED_RAM_START)
+  #define MBED_RAM_START            0x20000000
+#endif
+
+; RW data 48k L4-SRAM1
+#if !defined(MBED_RAM_SIZE)
+  #define MBED_RAM_SIZE             0xC000
+#endif
+
+#if !defined(MBED_RAM2_START)
+#define MBED_RAM2_START             0x10000000
+#endif
+
+; RW data 16k L4-ECC-SRAM2 retained in standby
+#if !defined(MBED_RAM2_SIZE)
+#define MBED_RAM2_SIZE              0x4000
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
-  #define MBED_BOOT_STACK_SIZE 0x400
+  #define MBED_BOOT_STACK_SIZE      0x400
 #endif
 
-#define Stack_Size MBED_BOOT_STACK_SIZE
+; Total: 99 vectors = 396 bytes (0x18C+0x4) to be reserved in RAM
+#if !defined(VECTOR_SIZE)
+#define VECTOR_SIZE                 0x190
+#endif
 
-; 256KB FLASH (0x40000) + 48KB SRAM (0xC000) + 16KB SRAM (0x4000)
-LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+; Crash report not enabled as default
+#if !defined(MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_CRASH_REPORT_RAM_SIZE  0x0
+#endif
 
-  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
+;Vectors + Crash report - Fixed at start of RAM2 in sequence
+#define MBED_IRAM2_SIZE             (MBED_RAM2_SIZE - VECTOR_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
+
+#define MBED_CRASH_REPORT_RAM_START (MBED_RAM2_START + VECTOR_SIZE)
+#define MBED_IRAM2_START            (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+
+; Minimum heap should be larger then smallest RAM bank (else can use 
+; that bank for heap) and less then largest RAM bank.
+#define MINIMUM_HEAP                0x4000
+#define RAM_FIXED_SIZE              0x0
+
+;Splitting the RW and ZI section in IRAM1 (MBED_RAM_SIZE-MINIMUM_HEAP = 0x8000 available)
+;and IRAM2 (MBED_IRAM2_SIZE = 0x3E70 available)
+LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1  MBED_APP_START  MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
-  RW_IRAM1 0x20000000 0x0000C000-Stack_Size  { ; RW data 48k L4-SRAM1
-  .ANY (+RW +ZI)
+  RW_m_crash_data  MBED_CRASH_REPORT_RAM_START  EMPTY  MBED_CRASH_REPORT_RAM_SIZE { ; RW data
   }
 
-  ; Total: 99 vectors = 396 bytes (0x18C+0x4) to be reserved in RAM
-  RW_IRAM2 (0x10000000+0x190) (0x04000-0x190)  {  ; RW data 16k L4-ECC-SRAM2 retained in standby
-  .ANY (+RW +ZI)
+  RW_IRAM1  MBED_RAM_START  (MBED_RAM_SIZE-MINIMUM_HEAP)  {  ; RW data
+   .ANY (+RW +ZI)
   }
-  ARM_LIB_STACK (0x20000000+0x0000C000) EMPTY -Stack_Size { ; stack
+
+  ARM_LIB_HEAP  AlignExpr(+0, 16)  EMPTY  (MBED_RAM_SIZE-RAM_FIXED_SIZE+MBED_RAM_START-AlignExpr(ImageLimit(RW_IRAM1), 16))  {
+  }
+
+  RW_IRAM2  MBED_IRAM2_START  MBED_IRAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+
+  ARM_LIB_STACK (MBED_RAM_START+MBED_RAM_SIZE) EMPTY -MBED_BOOT_STACK_SIZE { ; stack
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_ARM_STD/stm32l443xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_ARM_STD/stm32l443xx.sct
@@ -79,7 +79,7 @@
 ; Minimum heap should be larger then smallest RAM bank (else can use 
 ; that bank for heap) and less then largest RAM bank.
 #define MINIMUM_HEAP                0x4000
-#define RAM_FIXED_SIZE              0x0
+#define RAM_FIXED_SIZE              MBED_BOOT_STACK_SIZE
 
 ;Splitting the RW and ZI section in IRAM1 (MBED_RAM_SIZE-MINIMUM_HEAP = 0x8000 available)
 ;and IRAM2 (MBED_IRAM2_SIZE = 0x3E70 available)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_STD/stm32l475xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_STD/stm32l475xx.sct
@@ -29,44 +29,82 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START            0x08000000
 #endif
 
+; 1MB FLASH (0x100000)
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x100000
+  #define MBED_APP_SIZE             0x100000
 #endif
 
-#define MBED_RAM_START              0x20000000
-#define MBED_RAM_SIZE               0x00018000
-#define MBED_CRASH_REPORT_RAM_START (MBED_RAM_START)
-#define MBED_CRASH_REPORT_RAM_SIZE  0x100
-#define MBED_RAM0_START  (MBED_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
-#define MBED_RAM0_SIZE   (MBED_RAM_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
+; 128KB SRAM (0x20000)
+#if !defined(MBED_RAM_START)
+  #define MBED_RAM_START            0x20000000
+#endif
+
+; RW data 96k L4-SRAM1
+#if !defined(MBED_RAM_SIZE)
+  #define MBED_RAM_SIZE             0x18000
+#endif
+
+#if !defined(MBED_RAM2_START)
+#define MBED_RAM2_START             0x10000000
+#endif
+
+; RW data 32k L4-ECC-SRAM2
+#if !defined(MBED_RAM2_SIZE)
+#define MBED_RAM2_SIZE              0x8000
+#endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
-  #define MBED_BOOT_STACK_SIZE 0x400
+  #define MBED_BOOT_STACK_SIZE      0x400
 #endif
 
-#define Stack_Size MBED_BOOT_STACK_SIZE
+; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
+#if !defined(VECTOR_SIZE)
+#define VECTOR_SIZE                 0x188
+#endif
 
-; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)
-LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+; Crash report enabled as default
+#if !defined(MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_CRASH_REPORT_RAM_SIZE  0x100
+#endif
 
-  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
+;Vectors + Crash report - Fixed at start of RAM2 in sequence
+#define MBED_IRAM2_SIZE             (MBED_RAM2_SIZE - VECTOR_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
+
+#define MBED_CRASH_REPORT_RAM_START (MBED_RAM2_START + VECTOR_SIZE)
+#define MBED_IRAM2_START            (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+
+; Minimum heap should be larger then smallest RAM bank (else can use 
+; that bank for heap) and less then largest RAM bank.
+#define MINIMUM_HEAP                0x12000
+#define RAM_FIXED_SIZE              MBED_BOOT_STACK_SIZE
+
+;Splitting the RW and ZI section in IRAM1 (MBED_RAM_SIZE-MINIMUM_HEAP = 0x6000 available)
+;and IRAM2 (MBED_IRAM2_SIZE = 0x7D78 available)
+LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1  MBED_APP_START  MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_m_crash_data MBED_CRASH_REPORT_RAM_START EMPTY MBED_CRASH_REPORT_RAM_SIZE { ; RW data
+
+  RW_m_crash_data  MBED_CRASH_REPORT_RAM_START  EMPTY  MBED_CRASH_REPORT_RAM_SIZE { ; RW data
   }
-  RW_IRAM1 MBED_RAM0_START MBED_RAM0_SIZE-Stack_Size  { ; RW data 96k L4-SRAM1
-   .ANY (+RW, +Last)
+
+  RW_IRAM1  MBED_RAM_START  (MBED_RAM_SIZE-MINIMUM_HEAP)  {  ; RW data
+   .ANY (+RW +ZI)
   }
- ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM2 (0x10000000+0x188) (0x08000-0x188)  {  ; ZI data 32k L4-ECC-SRAM2
-   .ANY (+ZI)
+
+  ARM_LIB_HEAP  AlignExpr(+0, 16)  EMPTY  (MBED_RAM_SIZE-RAM_FIXED_SIZE+MBED_RAM_START-AlignExpr(ImageLimit(RW_IRAM1), 16))  {
   }
-  ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
+
+  RW_IRAM2  MBED_IRAM2_START  MBED_IRAM2_SIZE  {
+   .ANY (+RW +ZI)
+  }
+
+  ARM_LIB_STACK (MBED_RAM_START+MBED_RAM_SIZE) EMPTY -MBED_BOOT_STACK_SIZE { ; stack
   }
 }
-

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -139,4 +139,13 @@
 #define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
 #endif
 
+#if (defined(TARGET_STM32L475VG) || defined(TARGET_STM32L443RC))
+#if defined(__ARMCC_VERSION)
+    extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Base[];
+    extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Length[];
+    #define HEAP_START            Image$$ARM_LIB_HEAP$$ZI$$Base
+    #define HEAP_SIZE             Image$$ARM_LIB_HEAP$$ZI$$Length
+#endif
+#endif
+
 #endif  // MBED_MBED_RTX_H


### PR DESCRIPTION
### Description

To have the flexibilty in application; to use any of the section (data/bss/heap) without updating linker script in every use case, following decisions are made:

1. Fixed size and small sections moved to SRAM2 (32K)
    Vectors
    Crash data
    Stack
    Remaining section - RW / ZI
2. Large memory space should be used for variable sections
   RW/ZI
   Heap - (Minimum - xxx target based) 

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change


