### PR TITLE
Fix single-threaded apps for IAR v8 builds

### DIFF
--- a/rtos/TARGET_CORTEX/TOOLCHAIN_IAR/mbed_boot_iar.c
+++ b/rtos/TARGET_CORTEX/TOOLCHAIN_IAR/mbed_boot_iar.c
@@ -87,7 +87,7 @@ void __iar_program_start(void)
 
 void mbed_toolchain_init(void)
 {
-#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ >= 8000000)
+#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ >= 8000000) && !defined(MBED_RTOS_SINGLE_THREAD)
     __iar_Initlocks();
 #endif
 


### PR DESCRIPTION
For single-threaded apps ```__iar_Initlocks()``` is not required and must not be called because the proper IAR library is brought in only if ```--threaded_lib``` is defined in the linker command.

### Description

If one doesn't link with ```--threaded_lib``` then an IAR run-time library is brought in which doesn't include ```__iar_Initlocks()``` and a linker error is generated when building:
```
Error[Li005]: no definition for "__iar_Initlocks" [referenced from C:\_nrf\ble_
          project\BUILD\NRF52840_DK\IAR-TOOLCHAINS_PROFILE\mbed-os\r
          tos\TARGET_CORTEX\TOOLCHAIN_IAR\mbed_boot_iar.o]
```
So calls to __iar_Initlocks() now need to be protected by "MBED_RTOS_SINGLE_THREAD".  


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

This was discovered on an internal BLE project which used the following ```toolchains_profile.json```:

    "IAR": {
        "common": [
            "--no_wrap_diagnostics", "-e",
            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "-DMBED_RTOS_SINGLE_THREAD", "--enable_restrict"],
        "asm": [],
        "c": ["--vla"],
        "cxx": ["--guard_calls", "--no_static_destruction", 
                "--no_exceptions", "--no_rtti", "--no_static_destruction"],
        "ld": ["--skip_dynamic_initialization", "--inline", "--merge_duplicate_sections", "--no_exceptions", "--basic_heap"]
    }
