### PR TITLE
Fix crypto compliance tests

### DIFF
--- a/components/TARGET_PSA/TESTS/compliance_crypto/test_c024/test_c024.c
+++ b/components/TARGET_PSA/TESTS/compliance_crypto/test_c024/test_c024.c
@@ -90,12 +90,18 @@ int32_t psa_aead_encrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].nonce, check1[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check1[i].nonce_length = 0;
+        }
         else
             nonce = check1[i].nonce;
 
         if (is_buffer_empty(check1[i].additional_data, check1[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check1[i].additional_data_length = 0;
+        }
         else
             additional_data = check1[i].additional_data;
 
@@ -152,12 +158,18 @@ int32_t psa_aead_encrypt_negative_test(security_t caller)
                                                                           check2[i].key_alg);
 
         if (is_buffer_empty(check2[i].nonce, check2[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check2[i].nonce_length = 0;
+        }
         else
             nonce = check2[i].nonce;
 
         if (is_buffer_empty(check2[i].additional_data, check2[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check2[i].additional_data_length = 0;
+        }
         else
             additional_data = check2[i].additional_data;
 

--- a/components/TARGET_PSA/TESTS/compliance_crypto/test_c025/test_c025.c
+++ b/components/TARGET_PSA/TESTS/compliance_crypto/test_c025/test_c025.c
@@ -89,12 +89,18 @@ int32_t psa_aead_decrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].nonce, check1[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check1[i].nonce_length = 0;
+        }
         else
             nonce = check1[i].nonce;
 
         if (is_buffer_empty(check1[i].additional_data, check1[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check1[i].additional_data_length = 0;
+        }
         else
             additional_data = check1[i].additional_data;
 
@@ -149,12 +155,18 @@ int32_t psa_aead_decrypt_negative_test(security_t caller)
                                                                           check2[i].key_alg);
 
         if (is_buffer_empty(check2[i].nonce, check2[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check2[i].nonce_length = 0;
+        }
         else
             nonce = check2[i].nonce;
 
         if (is_buffer_empty(check2[i].additional_data, check2[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check2[i].additional_data_length = 0;
+        }
         else
             additional_data = check2[i].additional_data;
 

--- a/components/TARGET_PSA/TESTS/compliance_crypto/test_c039/test_c039.c
+++ b/components/TARGET_PSA/TESTS/compliance_crypto/test_c039/test_c039.c
@@ -128,7 +128,10 @@ int32_t psa_asymmetric_encrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 
@@ -223,7 +226,10 @@ int32_t psa_asymmetric_encrypt_negative_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 

--- a/components/TARGET_PSA/TESTS/compliance_crypto/test_c040/test_c040.c
+++ b/components/TARGET_PSA/TESTS/compliance_crypto/test_c040/test_c040.c
@@ -128,7 +128,10 @@ int32_t psa_asymmetric_decrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 
@@ -209,7 +212,10 @@ int32_t psa_asymmetric_decrypt_negative_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 


### PR DESCRIPTION
Function `is_buffer_empty` tests if all data in the buffer is `0`. If it is `0` then it sets the buffer to `NULL` but does not change the buffer size eventually sending to the functions a null pointer for buffer with a size greater than `0`. This PR sets the size to `0` when `is_buffer_empty` is true thus preventing passing a NULL buffer with a non-zero size.

PR to the tests repo: https://github.com/ARM-software/psa-arch-tests/pull/78

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@avolinski @NirSonnenschein 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
