### PR TITLE
PSA: PSoC 6 Correct TRNG behaviour

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/trng_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/trng_api.c
@@ -19,6 +19,8 @@
 
 #if DEVICE_TRNG
 
+#if !(defined(TARGET_PSA) && defined(COMPONENT_NSPE))
+
 #include "trng_api.h"
 #include "psoc6_utils.h"
 #include "cy_crypto_core_trng.h"
@@ -70,4 +72,5 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
     return (ret);
 }
 
+#endif // #if !(defined(TARGET_PSA) && defined(COMPONENT_NSPE))
 #endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8042,7 +8042,6 @@
             "MBED_TICKLESS",
             "MBEDTLS_PSA_CRYPTO_SPM",
             "MBEDTLS_PSA_CRYPTO_C",
-            "MBEDTLS_ENTROPY_NV_SEED",
             "CY_IPC_DEFAULT_CFG_DISABLE",
             "PU_ENABLE"
         ],
@@ -8067,7 +8066,7 @@
         "inherits": ["NSPE_Target", "CY8CKIT_062_WIFI_BT"],
         "extra_labels_add": ["PSA", "MBED_SPM"],
         "components_add": ["SPM_MAILBOX", "FLASHIAP"],
-        "device_has_remove": ["TRNG", "CRC"],
+        "device_has_remove": ["CRC"],
         "macros_add": ["MBEDTLS_PSA_CRYPTO_C"],
         "hex_filename": "psa_release_1.0.hex",
         "overrides": {


### PR DESCRIPTION
### Description
On PSA targets the TRNG should be accessible from the secure-side only.
By removing NVSEED and restricting TRNG to secure-core we achieve that requirement.

Relevant tests passed

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes
@ARMmbed/team-cypress @ARMmbed/mbed-os-psa 
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
