### PR TITLE
add needed crypto macros to secure side

### DIFF
--- a/tools/psa/tfm/mbed_app.json
+++ b/tools/psa/tfm/mbed_app.json
@@ -1,5 +1,6 @@
 {
     "name": "tfm_build",
     "requires" : ["psa-services", "tfm", "tfm-s", "psa"],
+    "macros": ["MBEDTLS_CIPHER_MODE_CTR", "MBEDTLS_CMAC_C"],
     "artifact_name": "tfm"
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
The PSA crypto / mbedTLS configuration to the non-secure side of the PSA NXP board was configured to support AES CTR encryption but the tfm build [secure size] was not (which caused failures in the compliance test due to unsupported features). This PR should make the configurations the same for both builds and allow the tests to pass.
Note: this change is also important for secure store functionality
Also Note: This is a small fix to a problem which will required a more architectural solution to how we keep these two configurations synchronized in platforms where the images are built using different procedures. 


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@avolinski @itayzafrir

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
