### PR TITLE
TESTS: skip timing accuracy test on FastModels

### DIFF
--- a/TESTS/mbed_platform/wait_ns/main.cpp
+++ b/TESTS/mbed_platform/wait_ns/main.cpp
@@ -23,6 +23,11 @@
 #include "hal/us_ticker_api.h"
 #include "hal/lp_ticker_api.h"
 
+//FastModels not support timing test
+#if defined(__ARM_FM)
+#error [NOT_SUPPORTED] test not supported
+#endif
+
 using namespace utest::v1;
 
 /* This test is created based on the test for Timer class.


### PR DESCRIPTION
### Description

This is the test case for timing accuracy, Software models can't guarantee it's time accuracy as it's nature.
So skip this test for FastModels.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change


