### PR TITLE
Port spi_get_peripheral_name fix to some Freescale boards

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PeripheralNames.h
@@ -124,7 +124,7 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
-
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_0 = 0,
     SPI_1 = 1,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
@@ -32,7 +32,8 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
-SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
+{
     SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
     SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
     SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
@@ -113,7 +114,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -137,17 +138,18 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     // Default write is done in each and every call, in future can create HAL API instead
     DSPI_SetDummyData(spi_address[obj->instance], write_fill);
 
-    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t){
-          .txData = (uint8_t *)tx_buffer,
-          .rxData = (uint8_t *)rx_buffer,
-          .dataSize = total,
-          .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
     });
 
     DSPI_ClearStatusFlags(spi_address[obj->instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+
+    SPIName spi_per;
+
+    // If 3 wire SPI is used, the miso is not connected.
+    if (miso == NC) {
+        spi_per = (SPIName)pinmap_merge(spi_mosi, spi_sclk);
+    } else {
+        SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+        spi_per = (SPIName)pinmap_merge(spi_data, spi_sclk);
+    }
+
+    return spi_per;
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/PeripheralNames.h
@@ -93,7 +93,7 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
-
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_0 = 0,
     SPI_1 = 1,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
@@ -32,7 +32,8 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
-SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
+{
     SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
     SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
     SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
@@ -112,7 +113,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -136,7 +137,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+
+    SPIName spi_per;
+
+    // If 3 wire SPI is used, the miso is not connected.
+    if (miso == NC) {
+        spi_per = (SPIName)pinmap_merge(spi_mosi, spi_sclk);
+    } else {
+        SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+        spi_per = (SPIName)pinmap_merge(spi_data, spi_sclk);
+    }
+
+    return spi_per;
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/PeripheralNames.h
@@ -63,7 +63,7 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
-
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_0 = 0,
     SPI_1 = 1,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_RAPIDIOT/PeripheralNames.h
@@ -64,7 +64,7 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
-
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_0 = 0,
     SPI_1 = 1,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
@@ -32,7 +32,8 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
-SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
+{
     SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
     SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
     SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
@@ -112,7 +113,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -136,7 +137,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+
+    SPIName spi_per;
+
+    // If 3 wire SPI is used, the miso is not connected.
+    if (miso == NC) {
+        spi_per = (SPIName)pinmap_merge(spi_mosi, spi_sclk);
+    } else {
+        SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+        spi_per = (SPIName)pinmap_merge(spi_data, spi_sclk);
+    }
+
+    return spi_per;
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralNames.h
@@ -123,7 +123,7 @@ typedef enum {
     DAC_0 = 0
 } DACName;
 
-
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_0 = 0,
     SPI_1 = 1,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -33,7 +33,8 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
-SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
+{
     SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
     SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
     SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
@@ -122,7 +123,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->spi.instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->spi.instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -146,17 +147,18 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     // Default write is done in each and every call, in future can create HAL API instead
     DSPI_SetDummyData(spi_address[obj->spi.instance], write_fill);
 
-    DSPI_MasterTransferBlocking(spi_address[obj->spi.instance], &(dspi_transfer_t){
-          .txData = (uint8_t *)tx_buffer,
-          .rxData = (uint8_t *)rx_buffer,
-          .dataSize = total,
-          .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    DSPI_MasterTransferBlocking(spi_address[obj->spi.instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
     });
 
     DSPI_ClearStatusFlags(spi_address[obj->spi.instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
@@ -199,7 +201,7 @@ static int32_t spi_master_transfer_asynch(spi_t *obj)
     obj->spi.status = kDSPI_Busy;
 
     if (obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_ALLOCATED ||
-        obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
+            obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
         status = DSPI_MasterTransferEDMA(spi_address[obj->spi.instance], &obj->spi.spi_dma_master_handle, &masterXfer);
         if (status ==  kStatus_DSPI_OutOfRange) {
             if (obj->spi.bits > 8) {
@@ -331,14 +333,14 @@ static void spi_buffer_set(spi_t *obj, const void *tx, uint32_t tx_length, void 
 
 void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
-    if(spi_active(obj)) {
+    if (spi_active(obj)) {
         return;
     }
 
     /* check corner case */
-    if(tx_length == 0) {
+    if (tx_length == 0) {
         tx_length = rx_length;
-        tx = (void*) 0;
+        tx = (void *) 0;
     }
 
     /* First, set the buffer */
@@ -439,13 +441,13 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
 void spi_abort_asynch(spi_t *obj)
 {
     // If we're not currently transferring, then there's nothing to do here
-    if(spi_active(obj) == 0) {
+    if (spi_active(obj) == 0) {
         return;
     }
 
     // Determine whether we're running DMA or interrupt
     if (obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_ALLOCATED ||
-        obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
+            obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
         DSPI_MasterTransferAbortEDMA(spi_address[obj->spi.instance], &obj->spi.spi_dma_master_handle);
         /* Release the dma channels if they were opportunistically allocated */
         if (obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -33,6 +33,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk) {
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+
+    SPIName spi_per;
+
+    // If 3 wire SPI is used, the miso is not connected.
+    if (miso == NC) {
+        spi_per = (SPIName)pinmap_merge(spi_mosi, spi_sclk);
+    } else {
+        SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+        spi_per = (SPIName)pinmap_merge(spi_data, spi_sclk);
+    }
+
+    return spi_per;
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use


### PR DESCRIPTION
### Description
Fix issue https://github.com/ARMmbed/mbed-os/issues/9149 (duplicated in https://jira.arm.com/browse/IOTTHD-3315) on K64F and some other MCUExpresso boards.

Port changes from https://github.com/ARMmbed/mbed-os/pull/9845 also to targets: K64F, K66F, KW24D and KW41Z

This PR allows application https://github.com/ARMmbed/mbed-cloud-client-example to connect to Pelion cloud using Freescale boards with Mesh connectivity. Without this fix the application will hang when it is writing data and Mesh radio (802.15.4) is using a SPI bus. If application is configured to use TCP protocol, it will hang 100%.

This PR enables usage of multiple SPI channels for several boards and therefore allows simultaneous usage of SPI bus.

Full details of the original issue are available here: https://github.com/ARMmbed/mbed-os/issues/9149 , correction PR https://github.com/ARMmbed/mbed-os/pull/9845.
 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@jarlamsa , @kjbracey-arm, @teetak01 
cc: @davidsaada 

