### PR TITLE
TCP/TLS Socket tests will skip if TCP is not supported

### DIFF
--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -114,6 +114,17 @@ nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock)
     return tcpsocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT);
 }
 
+bool is_tcp_supported()
+{
+    static bool supported;
+    static bool tested = false;
+    if (!tested) {
+        TCPSocket socket;
+        supported = socket.open(NetworkInterface::get_default_instance()) == NSAPI_ERROR_OK;
+    }
+    return supported;
+}
+
 void fill_tx_buffer_ascii(char *buff, size_t len)
 {
     for (size_t i = 0; i < len; ++i) {

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -24,6 +24,12 @@ nsapi_version_t get_ip_version();
 void fill_tx_buffer_ascii(char *buff, size_t len);
 nsapi_error_t tcpsocket_connect_to_echo_srv(TCPSocket &sock);
 nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock);
+bool is_tcp_supported();
+
+#define SKIP_IF_TCP_UNSUPPORTED() \
+    if (!is_tcp_supported()) { \
+        TEST_SKIP_MESSAGE("TCP not supported"); \
+    }
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
 extern mbed_stats_socket_t tcp_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_ADDRESS()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_invalid.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_ADDRESS_INVALID()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_null.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_null.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_ADDRESS_NULL()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_address_port.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_address_port.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_ADDRESS_PORT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_port.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_port.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_PORT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_port_fail.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_port_fail.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_PORT_FAIL()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_unopened.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_unopened.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_UNOPENED()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_bind_wrong_type.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_BIND_WRONG_TYPE()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_CONNECT_INVALID()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 

--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -59,6 +59,7 @@ static void _sigio_handler(osThreadId id)
 
 void TCPSOCKET_ECHOTEST()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     if (tcpsocket_connect_to_echo_srv(sock) != NSAPI_ERROR_OK) {
         TEST_FAIL();
         return;
@@ -127,6 +128,7 @@ void tcpsocket_echotest_nonblock_receive()
 
 void TCPSOCKET_ECHOTEST_NONBLOCK()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     tc_exec_time.start();
     time_allotted = split2half_rmng_tcp_test_time(); // [s]
 

--- a/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
@@ -39,6 +39,7 @@ static void _sigio_handler(osThreadId id)
 
 void TCPSOCKET_ECHOTEST_BURST()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
     sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
@@ -92,6 +93,7 @@ END:
 
 void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
     sock.set_blocking(false);

--- a/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -51,6 +51,7 @@ static nsapi_error_t _tcpsocket_connect_to_daytime_srv(TCPSocket &sock)
 
 void TCPSOCKET_ENDPOINT_CLOSE()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     static const int MORE_THAN_AVAILABLE = 30;
     char buff[MORE_THAN_AVAILABLE];
     int time_allotted = split2half_rmng_tcp_test_time(); // [s]

--- a/TESTS/netsocket/tcp/tcpsocket_open_close_repeat.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_close_repeat.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_OPEN_CLOSE_REPEAT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_open_destruct.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_destruct.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_OPEN_DESTRUCT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     for (int i = 0; i < 100; i++) {
         TCPSocket *sock = new TCPSocket;
         if (!sock) {

--- a/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
@@ -33,6 +33,7 @@ typedef struct TCPSocketItem {
 
 void TCPSOCKET_OPEN_LIMIT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     int open_sockets[2] = {0};
 
     for (int i = 0; i < 2; i++) {

--- a/TESTS/netsocket/tcp/tcpsocket_open_twice.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_twice.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_OPEN_TWICE()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket *sock = new TCPSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -118,6 +118,7 @@ void rcv_n_chk_against_rfc864_pattern(TCPSocket &sock)
 
 void TCPSOCKET_RECV_100K()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     if (_tcpsocket_connect_to_chargen_srv(sock) != NSAPI_ERROR_OK) {
         TEST_FAIL();
@@ -172,6 +173,7 @@ static void _sigio_handler(osThreadId id)
 
 void TCPSOCKET_RECV_100K_NONBLOCK()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket     sock;
     nsapi_error_t err = _tcpsocket_connect_to_chargen_srv(sock);
 

--- a/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
@@ -36,6 +36,7 @@ static void _sigio_handler(osThreadId id)
 
 void TCPSOCKET_RECV_TIMEOUT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     static const int DATA_LEN = 100;
     char buff[DATA_LEN] = {0};
     int time_allotted = split2half_rmng_tcp_test_time(); // [s]

--- a/TESTS/netsocket/tcp/tcpsocket_send_repeat.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_send_repeat.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_SEND_REPEAT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     tcpsocket_connect_to_discard_srv(sock);
 

--- a/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_SEND_TIMEOUT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     if (tcpsocket_connect_to_discard_srv(sock) != NSAPI_ERROR_OK) {
         TEST_FAIL();

--- a/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
@@ -26,6 +26,7 @@ using namespace utest::v1;
 
 void TCPSOCKET_SETSOCKOPT_KEEPALIVE_VALID()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TCPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     int32_t seconds = 7200;

--- a/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
@@ -159,6 +159,7 @@ END:
 
 void TCPSOCKET_THREAD_PER_SOCKET_SAFETY()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     thread.start(callback(check_const_len_rand_sequence));
 
     check_var_len_rand_sequence();

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -142,6 +142,17 @@ nsapi_error_t tlssocket_connect_to_discard_srv(TLSSocket &sock)
     return tlssocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS);
 }
 
+bool is_tcp_supported()
+{
+    static bool supported;
+    static bool tested = false;
+    if (!tested) {
+        TCPSocket socket;
+        supported = socket.open(NetworkInterface::get_default_instance()) == NSAPI_ERROR_OK;
+    }
+    return supported;
+}
+
 void fill_tx_buffer_ascii(char *buff, size_t len)
 {
     for (size_t i = 0; i < len; ++i) {

--- a/TESTS/netsocket/tls/tls_tests.h
+++ b/TESTS/netsocket/tls/tls_tests.h
@@ -27,6 +27,12 @@ void drop_bad_packets(TLSSocket &sock, int orig_timeout);
 void fill_tx_buffer_ascii(char *buff, size_t len);
 nsapi_error_t tlssocket_connect_to_echo_srv(TLSSocket &sock);
 nsapi_error_t tlssocket_connect_to_discard_srv(TLSSocket &sock);
+bool is_tcp_supported();
+
+#define SKIP_IF_TCP_UNSUPPORTED() \
+    if (!is_tcp_supported()) { \
+        TEST_SKIP_MESSAGE("TCP not supported"); \
+    }
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
 extern mbed_stats_socket_t tls_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];

--- a/TESTS/netsocket/tls/tlssocket_connect_invalid.cpp
+++ b/TESTS/netsocket/tls/tlssocket_connect_invalid.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_CONNECT_INVALID()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -59,6 +59,7 @@ static void _sigio_handler(osThreadId id)
 
 void TLSSOCKET_ECHOTEST()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     sock = new TLSSocket;
     if (tlssocket_connect_to_echo_srv(*sock) != NSAPI_ERROR_OK) {
         printf("Error from tlssocket_connect_to_echo_srv\n");
@@ -133,6 +134,7 @@ void tlssocket_echotest_nonblock_receive()
 
 void TLSSOCKET_ECHOTEST_NONBLOCK()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     sock = new TLSSocket;
     tc_exec_time.start();
     time_allotted = split2half_rmng_tls_test_time(); // [s]

--- a/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
@@ -41,6 +41,7 @@ static void _sigio_handler(osThreadId id)
 
 void TLSSOCKET_ECHOTEST_BURST()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket *sock = new TLSSocket;
     tlssocket_connect_to_echo_srv(*sock);
     sock->sigio(callback(_sigio_handler, ThisThread::get_id()));
@@ -95,6 +96,7 @@ END:
 
 void TLSSOCKET_ECHOTEST_BURST_NONBLOCK()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket *sock = new TLSSocket;
     tlssocket_connect_to_echo_srv(*sock);
     sock->set_blocking(false);

--- a/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
@@ -54,6 +54,7 @@ static nsapi_error_t _tlssocket_connect_to_daytime_srv(TLSSocket &sock)
 
 void TLSSOCKET_ENDPOINT_CLOSE()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     static const int MORE_THAN_AVAILABLE = 30;
     char buff[MORE_THAN_AVAILABLE];
     int time_allotted = split2half_rmng_tls_test_time(); // [s]

--- a/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
+++ b/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_HANDSHAKE_INVALID()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));

--- a/TESTS/netsocket/tls/tlssocket_no_cert.cpp
+++ b/TESTS/netsocket/tls/tlssocket_no_cert.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_NO_CERT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE,

--- a/TESTS/netsocket/tls/tlssocket_open_destruct.cpp
+++ b/TESTS/netsocket/tls/tlssocket_open_destruct.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_OPEN_DESTRUCT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     for (int i = 0; i < 100; i++) {
         TLSSocket *sock = new TLSSocket;
         if (!sock) {

--- a/TESTS/netsocket/tls/tlssocket_open_limit.cpp
+++ b/TESTS/netsocket/tls/tlssocket_open_limit.cpp
@@ -35,6 +35,7 @@ typedef struct TLSSocketItem {
 
 void TLSSOCKET_OPEN_LIMIT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     int open_sockets[2] = {0};
 
     for (int i = 0; i < 2; i++) {

--- a/TESTS/netsocket/tls/tlssocket_open_twice.cpp
+++ b/TESTS/netsocket/tls/tlssocket_open_twice.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_OPEN_TWICE()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket *sock = new TLSSocket;
     if (!sock) {
         TEST_FAIL();

--- a/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
@@ -38,6 +38,7 @@ static void _sigio_handler(osThreadId id)
 
 void TLSSOCKET_RECV_TIMEOUT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     static const int DATA_LEN = 100;
     char buff[DATA_LEN] = {0};
     int time_allotted = split2half_rmng_tls_test_time(); // [s]

--- a/TESTS/netsocket/tls/tlssocket_send_closed.cpp
+++ b/TESTS/netsocket/tls/tlssocket_send_closed.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_SEND_CLOSED()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));

--- a/TESTS/netsocket/tls/tlssocket_send_repeat.cpp
+++ b/TESTS/netsocket/tls/tlssocket_send_repeat.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_SEND_REPEAT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     tlssocket_connect_to_discard_srv(sock);
 

--- a/TESTS/netsocket/tls/tlssocket_send_timeout.cpp
+++ b/TESTS/netsocket/tls/tlssocket_send_timeout.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_SEND_TIMEOUT()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     if (tlssocket_connect_to_discard_srv(sock) != NSAPI_ERROR_OK) {
         TEST_FAIL();

--- a/TESTS/netsocket/tls/tlssocket_send_unconnected.cpp
+++ b/TESTS/netsocket/tls/tlssocket_send_unconnected.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_SEND_UNCONNECTED()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));

--- a/TESTS/netsocket/tls/tlssocket_simultaneous.cpp
+++ b/TESTS/netsocket/tls/tlssocket_simultaneous.cpp
@@ -28,6 +28,7 @@ using namespace utest::v1;
 
 void TLSSOCKET_SIMULTANEOUS()
 {
+    SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock1;
     TLSSocket sock2;
     tlssocket_connect_to_echo_srv(sock1);


### PR DESCRIPTION
### Description

I generally avoid using macros, but I couldn't come up with a better way in this case.
Two reasons why macros are used to wrap the open calls:
1) I wanted to minimise the "boilerplate" which gets copied and pasted into every test.
2) The SKIP_TEST_MESSAGE macro contains a "return;" which is intended to return from a current test code. Therefore we cannot use it inside any wrapper function, as then it would merely return from that function, not from the test as such.

The architectures which could make use of this (for example UBLOX_C030_N211) are not available in any RAAS server, but I agreed with @AriParkkila that he will make sure this executes correctly.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@KariHaapalehto 
@VeijoPesonen 
@mtomczykmobica 
@tymoteuszblochmobica 
@AriParkkila 
