### PR TITLE
add vprintf to Rawserial.

### DIFF
--- a/drivers/RawSerial.cpp
+++ b/drivers/RawSerial.cpp
@@ -63,9 +63,16 @@ int RawSerial::puts(const char *str)
 // length is above a certain threshold, otherwise we use just the stack.
 int RawSerial::printf(const char *format, ...)
 {
-    lock();
     std::va_list arg;
     va_start(arg, format);
+    int len = this->vprintf(format, arg);
+    va_end(arg);
+    return len;
+}
+
+int RawSerial::vprintf(const char *format, std::va_list arg)
+{
+    lock();
     // ARMCC microlib does not properly handle a size of 0.
     // As a workaround supply a dummy buffer with a size of 1.
     char dummy_buf[1];
@@ -80,7 +87,6 @@ int RawSerial::printf(const char *format, ...)
         puts(temp);
         delete[] temp;
     }
-    va_end(arg);
     unlock();
     return len;
 }

--- a/drivers/RawSerial.h
+++ b/drivers/RawSerial.h
@@ -25,6 +25,7 @@
 #include "drivers/SerialBase.h"
 #include "hal/serial_api.h"
 #include "platform/NonCopyable.h"
+#include <cstdarg>
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -89,6 +90,7 @@ public:
     int puts(const char *str);
 
     int printf(const char *format, ...) MBED_PRINTF_METHOD(1, 2);
+    int vprintf(const char *format, std::va_list arg);
 
 #if !(DOXYGEN_ONLY)
 protected:


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Adds `vprintf` to `RawSerial` and make `printf` use it.
This methods enables using `printf` formatting in functions already using variadic arguments.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
