### PR TITLE
Reduce 32KB from LPC55S69_S binary size

### DIFF
--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -21,7 +21,7 @@
         },
         "LPC55S69_S": {
             "internal_size": "0x10000",
-            "internal_base_address": "0x00030000"
+            "internal_base_address": "0x00028000"
         }
     }
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_IAR/LPC55S69_cm33_core0_flash.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_IAR/LPC55S69_cm33_core0_flash.icf
@@ -23,8 +23,8 @@
 ** ###################################################################
 */
 
-define symbol NS_CODE_START = 0x00040000;
-define symbol NS_CODE_SIZE  = 0x00058000;
+define symbol NS_CODE_START = 0x00038000;
+define symbol NS_CODE_SIZE  = 0x00060000;
 define symbol NS_DATA_START = 0x20022000;
 define symbol NS_DATA_SIZE  = 0x00022000;
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/partition/flash_layout.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/partition/flash_layout.h
@@ -59,16 +59,16 @@
 /* Secure image */
 #define FLASH_AREA_IMAGE_0_OFFSET       (FLASH_AREA_BL2_OFFSET + \
                                          FLASH_AREA_BL2_SIZE) // 0
-#define FLASH_AREA_IMAGE_0_SIZE         (0x00030000 - FLASH_AREA_BL2_SIZE) // 0x00030000
+#define FLASH_AREA_IMAGE_0_SIZE         (0x00028000 - FLASH_AREA_BL2_SIZE) // 0x00028000
 
 #define FLASH_SST_AREA_OFFSET           (FLASH_AREA_IMAGE_0_OFFSET + \
-                                         FLASH_AREA_IMAGE_0_SIZE)  // 0x00030000
+                                         FLASH_AREA_IMAGE_0_SIZE)  // 0x00028000
 #define FLASH_SST_AREA_SIZE             (0x00010000)   /* 64 KB */
 
 /* Non-secure image */
 #define FLASH_AREA_IMAGE_1_OFFSET       (FLASH_SST_AREA_OFFSET +\
-                                         FLASH_SST_AREA_SIZE) // 0x00040000
-#define FLASH_AREA_IMAGE_1_SIZE         (0x00058000)
+                                         FLASH_SST_AREA_SIZE) // 0x00038000
+#define FLASH_AREA_IMAGE_1_SIZE         (0x00060000)
 
 #define FLASH_AREA_IMAGE_SCRATCH_OFFSET (FLASH_AREA_IMAGE_1_OFFSET +\
                                          FLASH_AREA_IMAGE_1_SIZE)
@@ -76,10 +76,10 @@
 
 /* Offset and size definition in flash area, used by assemble.py */
 #define SECURE_IMAGE_OFFSET             0x0
-#define SECURE_IMAGE_MAX_SIZE           0x00030000
+#define SECURE_IMAGE_MAX_SIZE           0x00028000
 
-#define NON_SECURE_IMAGE_OFFSET         0x00040000
-#define NON_SECURE_IMAGE_MAX_SIZE       0x00058000
+#define NON_SECURE_IMAGE_OFFSET         0x00038000
+#define NON_SECURE_IMAGE_MAX_SIZE       0x00060000
 
 /* Flash device name used by BL2 and SST
  * Name is defined in flash driver file: Driver_Flash.c

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2092,12 +2092,12 @@
         "post_binary_hook": {"function": "LPC55S69Code.binary_hook"},
         "secure_image_filename": "tfm.bin",
         "overrides": {
-            "non-secure-rom-start": "0x00040000",
-            "non-secure-rom-size": "0x58000",
+            "non-secure-rom-start": "0x00038000",
+            "non-secure-rom-size": "0x60000",
             "non-secure-ram-start": "0x20022000",
             "non-secure-ram-size": "0x22000",
             "secure-rom-start": "0x10000000",
-            "secure-rom-size": "0x30000",
+            "secure-rom-size": "0x28000",
             "secure-ram-start": "0x30000000",
             "secure-ram-size": "0x22000"
         },
@@ -2128,12 +2128,12 @@
         "deliver_to_target": "LPC55S69_NS",
         "delivery_dir": "TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/prebuilt",
         "overrides": {
-            "non-secure-rom-start": "0x00040000",
-            "non-secure-rom-size": "0x58000",
+            "non-secure-rom-start": "0x00038000",
+            "non-secure-rom-size": "0x60000",
             "non-secure-ram-start": "0x20022000",
             "non-secure-ram-size": "0x22000",
             "secure-rom-start": "0x10000000",
-            "secure-rom-size": "0x30000",
+            "secure-rom-size": "0x28000",
             "secure-ram-start": "0x30000000",
             "secure-ram-size": "0x22000"
         }


### PR DESCRIPTION
### Description

Reduce the LPC55S69_S targets binary size from 192KB to 160KB.

Tested on LPC55S69 target, all PSA and compliance tests pass.

Targeted for rc3.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@orenc17 @mmahadevan108 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
