### PR TITLE
Cellular: Make CellularStateMachine timeouts configurable

### DIFF
--- a/UNITTESTS/stubs/CellularStateMachine_stub.cpp
+++ b/UNITTESTS/stubs/CellularStateMachine_stub.cpp
@@ -79,3 +79,11 @@ void CellularStateMachine::get_retry_timeout_array(uint16_t *timeout, int &array
 {
 
 }
+
+void CellularStateMachine::set_retry_timeout_array(const uint16_t timeout[], int array_len)
+{
+}
+
+void CellularStateMachine::set_timeout(int timeout)
+{
+}

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -332,9 +332,25 @@ public:
 
     /** Set the default response timeout.
      *
+     *  @remark CellularStateMachine timeouts for all states are also changed to `timeout`.
+     *
      *  @param timeout    milliseconds to wait response from modem
      */
     virtual void set_timeout(int timeout) = 0;
+
+    /** Set an array of timeouts to wait before CellularStateMachine retries after failure.
+     *  To disable retry behavior completely use `set_retry_timeout_array(NULL, 0)`.
+     *  CellularContext callback event `cell_callback_data_t.final_try` indicates true when all retries have failed.
+     *
+     *  @remark Use `set_retry_timeout_array` for CellularStateMachine to wait before it retries again after failure,
+     *          this is useful to send repetitive requests when don't know exactly when modem is ready to accept requests.
+     *          Use `set_timeout` for timeout how long to wait for a response from modem for each request,
+     *          this is useful if modem can accept requests but processing takes long time before sending response.
+     *
+     *  @param timeout      timeout array using seconds
+     *  @param array_len    length of the array
+     */
+    void set_retry_timeout_array(const uint16_t timeout[], int array_len);
 
     /** Turn modem debug traces on
      *

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -903,6 +903,12 @@ void AT_CellularContext::cellular_callback(nsapi_event_t ev, intptr_t ptr)
         cell_callback_data_t *data = (cell_callback_data_t *)ptr;
         cellular_connection_status_t st = (cellular_connection_status_t)ev;
         _cb_data.error = data->error;
+        _cb_data.final_try = data->final_try;
+        if (data->final_try) {
+            if (_current_op != OP_INVALID) {
+                _semaphore.release();
+            }
+        }
 #if USE_APN_LOOKUP
         if (st == CellularSIMStatusChanged && data->status_data == CellularDevice::SimStateReady &&
                 _cb_data.error == NSAPI_ERROR_OK) {
@@ -924,7 +930,9 @@ void AT_CellularContext::cellular_callback(nsapi_event_t ev, intptr_t ptr)
                     _device->stop();
                     if (_is_blocking) {
                         // operation failed, release semaphore
-                        _semaphore.release();
+                        if (_current_op != OP_INVALID) {
+                            _semaphore.release();
+                        }
                     }
                 }
                 _device->close_information();
@@ -948,8 +956,10 @@ void AT_CellularContext::cellular_callback(nsapi_event_t ev, intptr_t ptr)
         if (_is_blocking) {
             if (_cb_data.error != NSAPI_ERROR_OK) {
                 // operation failed, release semaphore
-                _current_op = OP_INVALID;
-                _semaphore.release();
+                if (_current_op != OP_INVALID) {
+                    _current_op = OP_INVALID;
+                    _semaphore.release();
+                }
             } else {
                 if ((st == CellularDeviceReady && _current_op == OP_DEVICE_READY) ||
                         (st == CellularSIMStatusChanged && _current_op == OP_SIM_READY &&

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -344,6 +344,10 @@ void AT_CellularDevice::set_timeout(int timeout)
     _default_timeout = timeout;
 
     ATHandler::set_at_timeout_list(_default_timeout, true);
+
+    if (_state_machine) {
+        _state_machine->set_timeout(_default_timeout);
+    }
 }
 
 uint16_t AT_CellularDevice::get_send_delay() const

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -70,6 +70,12 @@ CellularDevice *CellularContext::get_device() const
 
 void CellularContext::do_connect_with_retry()
 {
+    if (_cb_data.final_try) {
+        _cb_data.final_try = false;
+        _cb_data.error == NSAPI_ERROR_NO_CONNECTION;
+        call_network_cb(NSAPI_STATUS_DISCONNECTED);
+        return;
+    }
     do_connect();
     if (_cb_data.error == NSAPI_ERROR_OK) {
         return;

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -237,4 +237,11 @@ nsapi_error_t CellularDevice::shutdown()
     return NSAPI_ERROR_OK;
 }
 
+void CellularDevice::set_retry_timeout_array(const uint16_t timeout[], int array_len)
+{
+    if (create_state_machine() == NSAPI_ERROR_OK) {
+        _state_machine->set_retry_timeout_array(timeout, array_len);
+    }
+}
+
 } // namespace mbed

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -184,6 +184,15 @@ private:
     cellular_connection_status_t _current_event;
     int _status;
     PlatformMutex _mutex;
+
+    // Cellular state timeouts
+    int _state_timeout_power_on;
+    int _state_timeout_sim_pin;
+    int _state_timeout_registration;
+    int _state_timeout_network;
+    int _state_timeout_connect; // timeout for PS attach, PDN connect and socket operations
+    // Change all cellular state timeouts to `timeout`
+    void set_timeout(int timeout);
     cell_signal_quality_t _signal_quality;
 };
 


### PR DESCRIPTION
### Description

Make CellularStateMachine timeouts user configurable, as requested in #9735.

This change depends on PR #9937 (included so please review only the top commit).

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarvte 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
