### PR TITLE
Adding variable length attributes to Maxim Feather

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_Maxim/MaximGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Maxim/MaximGattServer.cpp
@@ -146,6 +146,12 @@ ble_error_t MaximGattServer::addService_(GattService &service)
         currAtt->pLen = p_char->getValueAttribute().getLengthPtr();
         currAtt->maxLen = p_char->getValueAttribute().getMaxLength();
         currAtt->settings = ATTS_SET_WRITE_CBACK | ATTS_SET_READ_CBACK;
+
+        if(p_char->getValueAttribute().hasVariableLength())
+        {
+            currAtt->settings |= ATTS_SET_VARIABLE_LEN;
+        }
+        
         if (p_char->getValueAttribute().getUUID().shortOrLong() == UUID::UUID_TYPE_LONG) {
             currAtt->settings |= ATTS_SET_UUID_128;
         }

--- a/features/FEATURE_BLE/targets/TARGET_Maxim/MaximGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Maxim/MaximGattServer.cpp
@@ -147,11 +147,10 @@ ble_error_t MaximGattServer::addService_(GattService &service)
         currAtt->maxLen = p_char->getValueAttribute().getMaxLength();
         currAtt->settings = ATTS_SET_WRITE_CBACK | ATTS_SET_READ_CBACK;
 
-        if(p_char->getValueAttribute().hasVariableLength())
-        {
+        if(p_char->getValueAttribute().hasVariableLength()) {
             currAtt->settings |= ATTS_SET_VARIABLE_LEN;
         }
-        
+
         if (p_char->getValueAttribute().getUUID().shortOrLong() == UUID::UUID_TYPE_LONG) {
             currAtt->settings |= ATTS_SET_UUID_128;
         }


### PR DESCRIPTION
### Description
The Max Feather board does not currently handle variable length attributes. With the released version of mbed-os, all attribute writes that are not maxLen are ignored. 

This fix is tested locally with a MAX32630Fthr board using the BLE Scanner Android App to manually write attributes.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
