### PR TITLE
Removed PSoC6 SystemInit Workaround for ARM compiler

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C62XX/TARGET_MCU_PSOC6_M0/system_psoc6_cm0plus.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C62XX/TARGET_MCU_PSOC6_M0/system_psoc6_cm0plus.c
@@ -193,13 +193,6 @@ void mailbox_init(void);
 *******************************************************************************/
 void SystemInit(void)
 {
-    /* Workaround to avoid twice SystemInit() call when ARMC5 compiler is used */
-    static uint32_t temp_var = 0;
-
-    if (temp_var == 0)
-    {
-    temp_var = 1;
-
     Cy_PDL_Init(CY_DEVICE_CFG);
 
     /* Restore FLL registers to the default state as they are not restored by the ROM code */
@@ -299,8 +292,6 @@ void SystemInit(void)
 #else/* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
     Cy_SemaIpcFlashInit();
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-    }
 }
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C62XX/device/system_psoc6.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8C62XX/device/system_psoc6.h
@@ -539,11 +539,7 @@ extern "C" {
 * \addtogroup group_system_config_system_functions
 * \{
 */
-#if defined(__ARMCC_VERSION)
-    extern void SystemInit(void) __attribute__((constructor));
-#else
-    extern void SystemInit(void);
-#endif /* (__ARMCC_VERSION) */
+extern void SystemInit(void);
 
 extern void SystemCoreClockUpdate(void);
 /** \} group_system_config_system_functions */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_4343W/device/system_psoc6.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_4343W/device/system_psoc6.h
@@ -539,11 +539,7 @@ extern "C" {
 * \addtogroup group_system_config_system_functions
 * \{
 */
-#if defined(__ARMCC_VERSION)
-    extern void SystemInit(void) __attribute__((constructor));
-#else
-    extern void SystemInit(void);
-#endif /* (__ARMCC_VERSION) */
+extern void SystemInit(void);
 
 extern void SystemCoreClockUpdate(void);
 /** \} group_system_config_system_functions */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/system_psoc6.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/system_psoc6.h
@@ -539,11 +539,7 @@ extern "C" {
 * \addtogroup group_system_config_system_functions
 * \{
 */
-#if defined(__ARMCC_VERSION)
-    extern void SystemInit(void) __attribute__((constructor));
-#else
-    extern void SystemInit(void);
-#endif /* (__ARMCC_VERSION) */
+extern void SystemInit(void);
 
 extern void SystemCoreClockUpdate(void);
 /** \} group_system_config_system_functions */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CMOD_062_4343W/device/system_psoc6.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CMOD_062_4343W/device/system_psoc6.h
@@ -539,11 +539,7 @@ extern "C" {
 * \addtogroup group_system_config_system_functions
 * \{
 */
-#if defined(__ARMCC_VERSION)
-    extern void SystemInit(void) __attribute__((constructor));
-#else
-    extern void SystemInit(void);
-#endif /* (__ARMCC_VERSION) */
+extern void SystemInit(void);
 
 extern void SystemCoreClockUpdate(void);
 /** \} group_system_config_system_functions */


### PR DESCRIPTION
### Description

Removed PSoC6 SystemInit declaration as constructor for ARM compiler


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

