### PR TITLE
Fixed issue with PWM not being freed when the object is destroyed

### DIFF
--- a/drivers/PwmOut.h
+++ b/drivers/PwmOut.h
@@ -68,6 +68,7 @@ public:
     ~PwmOut()
     {
         core_util_critical_section_enter();
+        pwmout_free(&_pwm);
         unlock_deep_sleep();
         core_util_critical_section_exit();
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/pwmout_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/pwmout_api.c
@@ -235,9 +235,13 @@ void pwmout_init(pwmout_t *obj, PinName pin)
 
 void pwmout_free(pwmout_t *obj)
 {
-    /* Does nothing because it is not called in the MBED PWMOUT driver
-    * destructor. The pwmout_init handles multiple calls of constructor.
-    */
+#if DEVICE_SLEEP && DEVICE_LPTICKER
+    if (!Cy_SysPm_UnregisterCallback(&obj->pm_callback_handler)) {
+        error("PM callback unregistration failed!");
+    }
+#endif
+    Cy_TCPWM_PWM_Disable(obj->base, obj->counter_id);
+    Cy_TCPWM_PWM_DeInit(obj->base, obj->counter_id, &pwm_config);
 }
 
 void pwmout_write(pwmout_t *obj, float percent)


### PR DESCRIPTION
### Description

Fixed issue with PWM not being freed when the object is destroyed. This caused the PWM to continue running after the destructor was called and it could cause a crash if another PWM was initialized.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

