### PR TITLE
Cellular: AT information response to return false on empty prefix

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -1085,7 +1085,7 @@ TEST_F(TestATHandler, test_ATHandler_info_resp)
     filehandle_stub_table = NULL;
 
     ATHandler at(&fh1, que, 0, ",");
-    EXPECT_TRUE(at.info_resp());
+    EXPECT_TRUE(!at.info_resp());
 
     at.resp_start();
     EXPECT_TRUE(!at.info_resp());

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -839,7 +839,7 @@ void ATHandler::resp(const char *prefix, bool check_urc)
             return;
         }
 
-        if (prefix && match(prefix, strlen(prefix))) {
+        if (prefix && strlen(prefix) && match(prefix, strlen(prefix))) {
             _prefix_matched = true;
             return;
         }
@@ -853,14 +853,14 @@ void ATHandler::resp(const char *prefix, bool check_urc)
         // If no match found, look for CRLF and consume everything up to and including CRLF
         if (mem_str(_recv_buff, _recv_len, CRLF, CRLF_LENGTH)) {
             // If no prefix, return on CRLF - means data to read
-            if (!prefix) {
+            if (!prefix || (prefix && !strlen(prefix))) {
                 return;
             }
             consume_to_tag(CRLF, true);
         } else {
             // If no prefix, no CRLF and no more chance to match for OK, ERROR or URC(since max resp length is already in buffer)
             // return so data could be read
-            if (!prefix && ((_recv_len - _recv_pos) >= _max_resp_length)) {
+            if ((!prefix || (prefix && !strlen(prefix))) && ((_recv_len - _recv_pos) >= _max_resp_length)) {
                 return;
             }
             if (!fill_buffer()) {

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -391,7 +391,8 @@ public:
      *   If needed, it ends the scope of a previous information response.
      *   Sets the information response scope if new prefix is found and response scope if prefix is not found.
      *
-     *  @return true if new information response is found, false otherwise
+     *  @return true if prefix defined for information response is not empty string and is found,
+     *          false otherwise.
      */
     bool info_resp();
 


### PR DESCRIPTION
### Description
AT handler's checks for not defined prefix were incomplete for info resp scope, since they were just NULL checks and  _info_resp_prefix is defined as char array so never NULL.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AriParkkila 
