### PR TITLE
remove PSA &crypto for UBLOX_EVK_ODIN_W2

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4409,11 +4409,7 @@
         "supported_form_factors": ["ARDUINO"],
         "release_versions": ["5"],
         "device_has_remove": [],
-        "extra_labels_add": ["PSA"],
         "components_add": ["SD", "FLASHIAP"],
-        "macros_add": [
-            "MBEDTLS_PSA_CRYPTO_C"
-        ],
         "config": {
             "stdio_uart_tx_help": {
                 "help": "Value: D8(default) or D1"


### PR DESCRIPTION
### Description

Because of failures in the AES for this board removing it as this is not PSA target.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@avolinski @Alonof @NirSonnenschein 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
