### PR TITLE
BLE:Fix cordio reset sequence

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -223,6 +223,11 @@ void CordioHCIDriver::handle_reset_sequence(uint8_t *pMsg)
             }   break;
 
             case HCI_OPCODE_LE_WRITE_DEF_DATA_LEN:
+                /* send next command in sequence */
+                HciReadLocalVerInfoCmd();
+                break;
+
+            case HCI_OPCODE_READ_LOCAL_VER_INFO:
                 if (hciCoreCb.extResetSeq) {
                     /* send first extended command */
                     (*hciCoreCb.extResetSeq)(pMsg, opcode);


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

With this [commit](https://github.com/ARMmbed/mbed-os/commit/dc66204c1b2fe9d9eb6566b1519e804f88a777e6?diff=split#diff-4e038f0a438d4c0c5032b4c83d028e86) on this [code line](https://github.com/ARMmbed/mbed-os/blob/dc66204c1b2fe9d9eb6566b1519e804f88a777e6/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/hci/dual_chip/hci_vs_ae.c#L127), Cordio reset sequence won't get done.
The handling case for `HCI_OPCODE_LE_WRITE_DEF_DATA_LEN` should send `HciReadLocalVerInfoCmd()`.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
