### PR TITLE
Cinterion Cellular: Setup connection profile with username and password

### DIFF
--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularContext.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularContext.cpp
@@ -38,7 +38,7 @@ NetworkStack *GEMALTO_CINTERION_CellularContext::get_stack()
     }
 
     if (!_stack) {
-        _stack = new GEMALTO_CINTERION_CellularStack(_at, _apn, _cid, (nsapi_ip_stack_t)_pdp_type);
+        _stack = new GEMALTO_CINTERION_CellularStack(_at, _apn, _uname, _pwd, _cid, (nsapi_ip_stack_t)_pdp_type);
     }
     return _stack;
 }

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -32,8 +32,9 @@
 
 using namespace mbed;
 
-GEMALTO_CINTERION_CellularStack::GEMALTO_CINTERION_CellularStack(ATHandler &atHandler, const char *apn,
-                                                                 int cid, nsapi_ip_stack_t stack_type) : AT_CellularStack(atHandler, cid, stack_type), _apn(apn)
+GEMALTO_CINTERION_CellularStack::GEMALTO_CINTERION_CellularStack(ATHandler &atHandler, const char *apn, const char *user, const char* password,
+                                                                 int cid, nsapi_ip_stack_t stack_type) : AT_CellularStack(atHandler, cid, stack_type), _apn(apn),
+                                                                 _user(user), _password(password)
 {
 }
 
@@ -548,6 +549,22 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::create_connection_profile(int con
             _at.write_int(connection_profile_id);
             _at.write_string("apn");
             _at.write_string(_apn);
+            _at.cmd_stop_read_resp();
+        }
+
+        if (_user && strlen(_user) > 0) {
+            _at.cmd_start("AT^SICS=");
+            _at.write_int(connection_profile_id);
+            _at.write_string("user");
+            _at.write_string(_user);
+            _at.cmd_stop_read_resp();
+        }
+
+        if (_password && strlen(_password) > 0) {
+            _at.cmd_start("AT^SICS=");
+            _at.write_int(connection_profile_id);
+            _at.write_string("passwd");
+            _at.write_string(_password);
             _at.cmd_stop_read_resp();
         }
 

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.h
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.h
@@ -24,7 +24,7 @@ namespace mbed {
 
 class GEMALTO_CINTERION_CellularStack : public AT_CellularStack {
 public:
-    GEMALTO_CINTERION_CellularStack(ATHandler &atHandler, const char *apn, int cid, nsapi_ip_stack_t stack_type);
+    GEMALTO_CINTERION_CellularStack(ATHandler &atHandler, const char *apn, const char *username, const char* password, int cid, nsapi_ip_stack_t stack_type);
     virtual ~GEMALTO_CINTERION_CellularStack();
 
 protected:
@@ -62,8 +62,10 @@ private:
     // socket open need to be deferred until sendto due to BGS2 does not support UDP server endpoint
     nsapi_error_t socket_open_defer(CellularSocket *socket, const SocketAddress *address = NULL);
 
-    // connection profile configuration needs Access Point Name
+    // connection profile configuration needs Access Point Name, User Name and Password
     const char *_apn;
+    const char *_user;
+    const char *_password;
 };
 
 } // namespace mbed


### PR DESCRIPTION
### Description
According to the documentation Cinterion Modules like the ELS61 additionally to the APN require a username and a password to setup the Connection Profile.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
