### PR TITLE
Cellular: Allow to configure the command for APN authentication

### DIFF
--- a/UNITTESTS/stubs/AT_CellularBase_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularBase_stub.cpp
@@ -47,7 +47,7 @@ intptr_t AT_CellularBase::get_property(CellularProperty key)
         return AT_CellularNetwork::RegistrationModeDisable;
     } else if (key == PROPERTY_C_REG || key == PROPERTY_C_EREG) {
         return AT_CellularNetwork::RegistrationModeEnable;
-    } else if (key == PROPERTY_AT_CGAUTH) {
+    } else if (key == PROPERTY_AT_AUTH) {
         return true;
     } else if (key == PROPERTY_IPV4_PDP_TYPE) {
         return true;

--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -48,7 +48,7 @@ public:
         PROPERTY_C_REG,             // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
         PROPERTY_AT_CGSN_WITH_TYPE, // 0 = not supported, 1 = supported. AT+CGSN without type is likely always supported similar to AT+GSN.
         PROPERTY_AT_CGDATA,         // 0 = not supported, 1 = supported. Alternative is to support only ATD*99***<cid>#
-        PROPERTY_AT_CGAUTH,         // 0 = not supported, 1 = supported. APN authentication AT commands supported
+        PROPERTY_AT_AUTH,           // 0 = not supported, 1 = supported. APN authentication AT commands supported
         PROPERTY_AT_CNMI,           // 0 = not supported, 1 = supported. New message (SMS) indication AT command
         PROPERTY_AT_CSMP,           // 0 = not supported, 1 = supported. Set text mode AT command
         PROPERTY_AT_CMGF,           // 0 = not supported, 1 = supported. Set preferred message format AT command

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -315,10 +315,10 @@ nsapi_error_t AT_CellularContext::do_user_authentication()
 {
     // if user has defined user name and password we need to call CGAUTH before activating or modifying context
     if (_pwd && _uname) {
-        if (!get_property(PROPERTY_AT_CGAUTH)) {
+        if (!get_property(PROPERTY_AT_AUTH)) {
             return NSAPI_ERROR_UNSUPPORTED;
         }
-        _at.cmd_start("AT+CGAUTH=");
+        _at.cmd_start(MBED_CONF_CELLULAR_AUTH_COMMAND);
         _at.write_int(_cid);
         _at.write_int(_authentication_type);
 

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -20,6 +20,10 @@
         "control-plane-opt": {
             "help": "Enables control plane CIoT EPS optimization",
             "value": false
+        },
+        "auth-command": {
+            "help": "Set command for APN authentication",
+            "value": "\"AT+CGAUTH=\""
         }
     }
 }


### PR DESCRIPTION
### Description
Currently the AT command `AT+CGAUTH` is used for APN authentication. Since there are cellular modules that require different commands it should be configurable which command to use. 

Specifically spoken the Cinterion ELS61-E uses the command `AT^SGAUTH` for authentication. 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
