### PR TITLE
Remove fuzzywuzzy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ mbed-ls>=1.5.1,<1.8
 mbed-host-tests>=1.4.4,<1.6
 mbed-greentea>=0.2.24,<1.7
 beautifulsoup4>=4,<=4.6.3
-fuzzywuzzy>=0.11,<=0.17
 pyelftools>=0.24,<=0.25
 git+https://github.com/armmbed/manifest-tool.git@v1.4.6
 icetea>=1.2.1,<1.3


### PR DESCRIPTION
### Description

Remove `fuzzywuzzy` (https://pypi.org/project/fuzzywuzzy/) from the list of dependencies. I believe that it is no longer required.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [x] Breaking change

### Reviewers

@theotherjimmy @adbridge @bridadan 

### Release Notes

- Remove fuzzywuzzy dependency

@thegecko
