### PR TITLE
test_configs: generic app config for boards with Wi-Fi

### DIFF
--- a/tools/test_configs/WiFiInterface.json
+++ b/tools/test_configs/WiFiInterface.json
@@ -1,0 +1,68 @@
+{
+    "config": {
+        "wifi-secure-ssid": {
+            "help": "Wi-Fi SSID for WPA2 secured network",
+            "value": "\"WIFI_SSID_SECURED\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "Wi-Fi SSID for unsecure netwrok",
+            "value": "\"WIFI_SSID_UNSECURE\""
+        },
+        "wifi-password": {
+            "help": "Wi-Fi Password",
+            "value": "\"WIFI_PASSWORD\""
+        },
+        "wifi-secure-protocol": {
+            "help": "Wi-Fi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
+            "value": "\"WPA2\""
+        },
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": null
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": null
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
+        },
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        },
+        "echo-server-discard-port" : {
+            "help" : "Discard port of echo server",
+            "value" : "9"
+        },
+        "echo-server-port-tls" : {
+            "help" : "Port of echo server for TLS",
+            "value" : "2007"
+        },
+        "echo-server-discard-port-tls" : {
+            "help" : "Discard port of echo server for TLS",
+            "value" : "2009"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "WIFI",
+            "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
+            "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
+            "nsapi.default-wifi-security": "WPA2"
+        }
+    }
+}


### PR DESCRIPTION
### Description
To be used at least with ESP32 which has all required settings already in its mbed_lib.json. I assume this only works with drivers pulled from external repositories as there can be only be one [default network interface](https://github.com/d-kato/esp32-driver/blob/ccbe1eda4920dd4bed7c08fe40a7fdca83e1b77e/mbed_lib.json#L49). 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@OPpuolitaival 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
