### PR TITLE
Fix functionality for FlashIAPBD & SlicingBD

### DIFF
--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -258,6 +258,7 @@ const char *FlashIAPBlockDevice::get_type() const
 
 bool FlashIAPBlockDevice::is_valid_erase(bd_addr_t addr, bd_size_t size) const
 {
+    /* Calculate address alignment for the full flash */
     bd_addr_t base_addr = addr + (_base - _flash.get_flash_start());
 
     return (

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -256,4 +256,13 @@ const char *FlashIAPBlockDevice::get_type() const
     return "FLASHIAP";
 }
 
+bool FlashIAPBlockDevice::is_valid_erase(bd_addr_t addr, bd_size_t size) const
+{
+    bd_addr_t base_addr = addr + (_base - _flash.get_flash_start());
+
+    return (
+               addr + size <= this->size() &&
+               base_addr % get_erase_size(addr) == 0 &&
+               (base_addr + size) % get_erase_size(addr + size - 1) == 0);
+}
 #endif /* DEVICE_FLASH */

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -127,6 +127,15 @@ public:
      */
     virtual const char *get_type() const;
 
+    /** Convenience function for checking block erase validity
+    *
+    *  @param addr     Address of block to begin erasing
+    *  @param size     Size to erase in bytes
+    *  @return         True if erase is valid for underlying block device
+    */
+    virtual bool is_valid_erase(bd_addr_t addr, bd_size_t size) const;
+
+
 private:
     // Device configuration
     mbed::FlashIAP _flash;

--- a/features/storage/blockdevice/BlockDevice.h
+++ b/features/storage/blockdevice/BlockDevice.h
@@ -198,7 +198,7 @@ public:
      *  @param size     Size to read in bytes
      *  @return         True if read is valid for underlying block device
      */
-    bool is_valid_read(bd_addr_t addr, bd_size_t size) const
+    virtual bool is_valid_read(bd_addr_t addr, bd_size_t size) const
     {
         return (
                    addr % get_read_size() == 0 &&
@@ -212,7 +212,7 @@ public:
      *  @param size     Size to write in bytes
      *  @return         True if program is valid for underlying block device
      */
-    bool is_valid_program(bd_addr_t addr, bd_size_t size) const
+    virtual bool is_valid_program(bd_addr_t addr, bd_size_t size) const
     {
         return (
                    addr % get_program_size() == 0 &&
@@ -226,7 +226,7 @@ public:
      *  @param size     Size to erase in bytes
      *  @return         True if erase is valid for underlying block device
      */
-    bool is_valid_erase(bd_addr_t addr, bd_size_t size) const
+    virtual bool is_valid_erase(bd_addr_t addr, bd_size_t size) const
     {
         return (
                    addr % get_erase_size(addr) == 0 &&

--- a/features/storage/blockdevice/SlicingBlockDevice.h
+++ b/features/storage/blockdevice/SlicingBlockDevice.h
@@ -151,6 +151,31 @@ public:
      */
     virtual const char *get_type() const;
 
+    /** Convenience function for checking block program validity
+     *
+     *  @param addr     Address of block to begin writing to
+     *  @param size     Size to write in bytes
+     *  @return         True if program is valid for underlying block device
+     */
+    virtual bool is_valid_program(bd_addr_t addr, bd_size_t size) const;
+
+    /** Convenience function for checking block read validity
+     *
+     *  @param addr     Address of block to begin reading from
+     *  @param size     Size to read in bytes
+     *  @return         True if read is valid for underlying block device
+     */
+    virtual bool is_valid_read(bd_addr_t addr, bd_size_t size) const;
+
+    /** Convenience function for checking block erase validity
+     *
+     *  @param addr     Address of block to begin erasing
+     *  @param size     Size to erase in bytes
+     *  @return         True if erase is valid for underlying block device
+     */
+    virtual bool is_valid_erase(bd_addr_t addr, bd_size_t size) const;
+
+
 protected:
     BlockDevice *_bd;
     bool _start_from_end;


### PR DESCRIPTION
### Description

Due to discovery of inconsistent sector sizes in devices storage the is_valid_erase function was adjusted,
For FlashIAPBD the 'code size' was included to the calculation, preventing faulty "virtual" addresses calculation.
For SlicingBD the same error was fixed and in all 3 validation functions that sent addresses for validation and program/read/erase different addresses.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-storage 
@geky 
