### PR TITLE
Use secure/non-secure rom for bl modes

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -604,8 +604,8 @@ class Config(object):
             # name, exit with error
             if cfg["name"] in self.lib_config_data:
                 raise ConfigException(
-                    "Library name '%s' is not unique "
-                    "(defined in '%s' and '%s')".format(
+                    "Library name '{}' is not unique "
+                    "(defined in '{}' and '{}')".format(
                         cfg["name"],
                         full_path,
                         self.lib_config_data[cfg["name"]]["__config_path"]

--- a/tools/test/config/config_test.py
+++ b/tools/test/config/config_test.py
@@ -16,16 +16,15 @@ limitations under the License.
 """
 
 import os
-import sys
 import json
 import pytest
 from mock import patch
-from hypothesis import given
-from hypothesis.strategies import sampled_from
 from os.path import join, isfile, dirname, abspath
 from tools.build_api import get_config
-from tools.targets import set_targets_json_location, Target, TARGET_NAMES
-from tools.config import ConfigException, Config, ConfigParameter, ConfigMacro
+from tools.targets import set_targets_json_location
+from tools.config import (
+    ConfigException, Config, ConfigParameter, ConfigMacro, ROM_ALL_MEMORIES
+)
 from tools.resources import Resources
 
 NOT_CONFIG = [
@@ -250,3 +249,16 @@ def test_parameters_and_config_macros_to_macros():
 
     macro_list = Config._parameters_and_config_macros_to_macros(params, macros)
     assert macro_list == ["CUSTOM_MACRO_NAME=1"]
+
+
+@pytest.mark.parametrize("target_start_size", [
+    ("FUTURE_SEQUANA_PSA", 0x10080000, 0x78000),
+    ("FUTURE_SEQUANA_M0_PSA", 0x10000000, 0x80000)
+])
+def test_PSA_overrides(target_start_size):
+    target, start, size = target_start_size
+    set_targets_json_location()
+    config = Config(target)
+    roms = config.get_all_active_memories(ROM_ALL_MEMORIES)
+    assert("ROM" in roms)
+    assert(roms["ROM"] == [start, size])


### PR DESCRIPTION
### Description

Previously, a porter or application author could configure 
secure or non-secure rom through the use of:
  * `target.secure-rom-start`
  * `target.secure-rom-size`
  * `target.non-secure-rom-start`
  * `target.non-secure-rom-size`

This allows them to configure this once, and have the same 
values for both a secure build and a non-secure build.

This was not used by the bootloader modes and combining
these with either bootloader mode would lead to problems and
heartbreak.

This PR mends these broken hearts by heeding the secure and
non secure start and size in the bootloder modes.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change