### PR TITLE
Allow the use of Mbed Studio's version of ARMC6

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -607,6 +607,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, app_config=app_config,
         build_profile=build_profile, ignore=ignore)
+    toolchain.version_check()
 
     # The first path will give the name to the library
     if name is None:
@@ -781,6 +782,7 @@ def build_lib(lib_id, target, toolchain_name, clean=False, macros=None,
             src_paths, tmp_path, target, toolchain_name, macros=macros,
             notify=notify, build_profile=build_profile, jobs=jobs, clean=clean,
             ignore=ignore)
+        toolchain.version_check()
 
         notify.info("Building library %s (%s, %s)" %
                     (name.upper(), target.name, toolchain_name))
@@ -925,6 +927,7 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
         toolchain = prepare_toolchain(
             [""], tmp_path, target, toolchain_name, macros=macros, notify=notify,
             build_profile=build_profile, jobs=jobs, clean=clean, ignore=ignore)
+        toolchain.version_check()
 
         config = toolchain.config
         config.add_config_files([MBED_CONFIG_FILE])

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -263,7 +263,7 @@ def transform_release_toolchains(target, version):
         if version == '5':
             if 'ARMC5' in target.supported_toolchains:
                 return ['ARMC5', 'GCC_ARM', 'IAR']
-            else:    
+            else:
                 return ['ARM', 'ARMC6', 'GCC_ARM', 'IAR']
         else:
             return target.supported_toolchains
@@ -356,7 +356,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     # If the configuration object was not yet created, create it now
     config = config or Config(target, src_paths, app_config=app_config)
     target = config.target
-    
+
     if not target_supports_toolchain(target, toolchain_name):
         raise NotSupportedException(
             "Target {} is not supported by toolchain {}".format(
@@ -364,11 +364,11 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
 
     selected_toolchain_name = get_toolchain_name(target, toolchain_name)
 
-    #If a target supports ARMC6 and we want to build UARM with it, 
+    #If a target supports ARMC6 and we want to build UARM with it,
     #then set the default_toolchain to uARM to link AC6 microlib.
     if(selected_toolchain_name == "ARMC6" and toolchain_name == "uARM"):
         target.default_toolchain = "uARM"
-    toolchain_name = selected_toolchain_name     
+    toolchain_name = selected_toolchain_name
 
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
@@ -871,7 +871,7 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
 
     selected_toolchain_name = get_toolchain_name(target, toolchain_name)
 
-    #If a target supports ARMC6 and we want to build UARM with it, 
+    #If a target supports ARMC6 and we want to build UARM with it,
     #then set the default_toolchain to uARM to link AC6 microlib.
     if(selected_toolchain_name == "ARMC6" and toolchain_name == "uARM"):
         target.default_toolchain = "uARM"
@@ -1118,10 +1118,10 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
     unique_supported_toolchains = get_unique_supported_toolchains(
         release_targets)
     #Add ARMC5 column as well to the matrix to help with showing which targets are in ARMC5
-    #ARMC5 is not a toolchain class but yet we use that as a toolchain id in supported_toolchains in targets.json 
+    #ARMC5 is not a toolchain class but yet we use that as a toolchain id in supported_toolchains in targets.json
     #capture that info in a separate column
     unique_supported_toolchains.append('ARMC5')
-    
+
     prepend_columns = ["Target"] + ["mbed OS %s" % x for x in RELEASE_VERSIONS]
 
     # All tests status table print

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -92,7 +92,33 @@ def test_armc6_version_check(_run_cmd):
     """, "", 0)
 
     toolchain.version_check()
-    assert notifier.messages == []   
+    assert notifier.messages == []
+    assert not toolchain.is_mbed_studio_armc6
+
+    _run_cmd.return_value = ("""
+    armclang: error: Failed to check out a license.
+    The provided license does not enable these tools.
+    Information about this error is available at: http://ds.arm.com/support/lic56/m5
+     General licensing information is available at: http://ds.arm.com/support/licensing/
+     If you need further help, provide this complete error report to your supplier or license.support@arm.com.
+     - ARMLMD_LICENSE_FILE: unset
+     - LM_LICENSE_FILE: unset
+     - ARM_TOOL_VARIANT: unset
+     - ARM_PRODUCT_PATH: unset
+     - Product location: C:\MbedStudio\tools\ac6\sw\mappings
+     - Toolchain location: C:\MbedStudio\tools\ac6\bin
+     - Selected tool variant: product
+     - Checkout feature: mbed_armcompiler
+     - Feature version: 5.0201810
+     - Flex error code: -5
+    Product: ARM Compiler 6.11 for Mbed Studio
+    Component: ARM Compiler 6.11
+    Tool: armclang [5d3b3c00]
+    """, "", 0)
+
+    toolchain.version_check()
+    assert notifier.messages == []
+    assert toolchain.is_mbed_studio_armc6
 
 @patch('tools.toolchains.iar.run_cmd')
 def test_iar_version_check(_run_cmd):

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -13,7 +13,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations 
+limitations
 """
 
 import sys
@@ -84,14 +84,13 @@ def test_armc5_version_check(_run_cmd):
 def test_armc6_version_check(_run_cmd):
     set_targets_json_location()
     notifier = MockNotifier()
-    print(TARGET_MAP["K64F"])
     toolchain = TOOLCHAIN_CLASSES["ARMC6"](TARGET_MAP["K64F"], notify=notifier)
-    print(toolchain)
     _run_cmd.return_value = ("""
     Product: ARM Compiler 6.11 Professional
     Component: ARM Compiler 6.11
     Tool: armclang [5d3b4200]
     """, "", 0)
+
     toolchain.version_check()
     assert notifier.messages == []   
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -109,7 +109,8 @@ class ARM(mbedToolchain):
 
     def version_check(self):
         # The --ide=mbed removes an instability with checking the version of
-        # the ARMC6 binary that comes with Mbed Studio
+        # the ARMC6 binary that comes with Mbed Studio.
+        # NOTE: the --ide=mbed argument is only for use with Mbed OS
         stdout, _, retcode = run_cmd(
             [self.cc[0], "--vsn", "--ide=mbed"],
             redirect=True
@@ -624,6 +625,7 @@ class ARMC6(ARM_STD):
             ]
 
         if self.is_mbed_studio_armc6:
+            # NOTE: the --ide=mbed argument is only for use with Mbed OS
             opts.insert(0, "--ide=mbed")
 
         return opts
@@ -647,6 +649,7 @@ class ARMC6(ARM_STD):
         )
 
         if self.is_mbed_studio_armc6:
+            # NOTE: the --ide=mbed argument is only for use with Mbed OS
             cmd.insert(1, "--ide=mbed")
 
         return cmd
@@ -655,6 +658,7 @@ class ARMC6(ARM_STD):
         cmd = ARM.get_binary_commands(self, bin_arg, bin, elf)
 
         if self.is_mbed_studio_armc6:
+            # NOTE: the --ide=mbed argument is only for use with Mbed OS
             cmd.insert(1, "--ide=mbed")
 
         return cmd

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -337,7 +337,6 @@ class ARM(mbedToolchain):
         write(handle, "RESOLVE %s AS %s\n" % (source, sync))
         return "--edit=%s" % filename
 
-
 class ARM_STD(ARM):
 
     OFFICIALLY_SUPPORTED = True
@@ -359,7 +358,7 @@ class ARM_STD(ARM):
             build_profile=build_profile
         )
         if int(target.build_tools_metadata["version"]) > 0:
-            #check only for ARMC5 because ARM_STD means using ARMC5, and thus 
+            #check only for ARMC5 because ARM_STD means using ARMC5, and thus
             # supported_toolchains must include ARMC5
             if "ARMC5" not in target.supported_toolchains:
                 raise NotSupportedException(
@@ -565,13 +564,14 @@ class ARMC6(ARM_STD):
         return ["-include", config_header]
 
     def get_compile_options(self, defines, includes, for_asm=False):
-        
+
         opts = ['-D%s' % d for d in defines]
+
         if self.RESPONSE_FILES:
             opts += ['@{}'.format(self.get_inc_file(includes))]
         else:
             opts += ["-I%s" % i for i in includes if i]
-        
+
         config_header = self.get_config_header()
         if config_header:
             opts.extend(self.get_config_option(config_header))


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This seems to be in good working order so far. I need to add a unit test before this is ready to go, hence raising this as a Draft pull request. Raising this early for coordination efforts and to get reviews started.

This allows people to use the ARMC6 compiler bundled with Mbed Studio with the command line tools. It also preserves the ability to use the professional compiler and license server.

FYI @ChiefBureaucraticOfficer @SenRamakri @arekzaluski @thegecko 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

You can use the ARMC6 compiler that is bundled with Mbed Studio with the command line tools. Enable this behavior by adding the ARMC6 executable to your system path (the default location of this on Windows is `C:/MbedStudio/tools/ac6/bin`). Alternatively, you can set this same location with Mbed CLI with the command `mbed config ARMC6_PATH C:/MbedStudio/tools/ac6/bin` (be sure to use the correct path when you run the command). You will also need to set the `ARMLMD_LICENSE_FILE` environment variable to the license file that is bundled with Mbed Studio. Check the Mbed OS documentation for further details.