### PR TITLE
Selectively append changes to exported config files

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -206,15 +206,17 @@ class Exporter(object):
         self.generated_files += [target_path]
 
     def gen_file_nonoverwrite(self, template_file, data, target_file, **kwargs):
-        """Generates a project file from a template using jinja"""
+        """Generates or selectively appends a project file from a template"""
         target_text = self._gen_file_inner(template_file, data, target_file, **kwargs)
         target_path = self.gen_file_dest(target_file)
         if exists(target_path):
             with open(target_path) as fdin:
-                old_text = fdin.read()
-            if target_text not in old_text:
+                old_lines_set = set(fdin.read().splitlines())
+            target_set = set(target_text.splitlines())
+            to_append = target_set - old_lines_set
+            if len(to_append) > 0:
                 with open(target_path, "a") as fdout:
-                    fdout.write(target_text)
+                    fdout.write("\n".join(to_append))
         else:
             logging.debug("Generating: %s", target_path)
             open(target_path, "w").write(target_text)


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
For #10117
In case of a non-overwriting change to an exported config file
the previous logic appended a new block of text to the previous file
every time the to-be-written block of text was not exactly matched.

This parses the old config file and the to-be-written changes into
sets, which can then be compared. If all of the incoming lines are
found in the old config file set, no changes are made. If some
incoming lines are not found in the old config file, only these are
appended.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
Not tested on windows or python 2. 
Uses .splitlines(), and newlines should be correctly handled by the file read and write functions.
