### PR TITLE
Cellular: Fix network interface test for cellular targets

### DIFF
--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -36,7 +36,9 @@ nsapi_connection_status_t statuses[status_buffer_size];
 
 void status_cb(nsapi_event_t event, intptr_t value)
 {
-    TEST_ASSERT_EQUAL(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, event);
+    if (event != NSAPI_EVENT_CONNECTION_STATUS_CHANGE) {
+        return;
+    }
 
     statuses[status_write_counter] = static_cast<nsapi_connection_status_t>(value);
     status_write_counter++;


### PR DESCRIPTION
### Description

Test's status_cb() can ignore cellular specific events because the values they are delivering are not connection statuses. Cellular connection statuses are still delivered with 
NSAPI_EVENT_CONNECTION_STATUS_CHANGE events.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change