### PR TITLE
Add baremetal example to testing

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -25,7 +25,7 @@
       "features" : [],
       "targets" : ["K66F", "NUCLEO_F429ZI", "ARCH_PRO", "LPC1768"],
       "toolchains" : [],
-      "exporters": [],
+      "exporters": ["iar", "make_armc5", "make_armc6", "make_gcc_arm", "make_iar"],
       "compile" : true,
       "export": true,
       "auto-update" : true
@@ -389,10 +389,10 @@
         "mbed": [],
         "test-repo-source": "github",
         "features" : [],
-        "targets" : ["CY8CKIT_062_WIFI_BT_PSA", 
-                     "K64F", 
-                     "K66F", 
-                     "NUCLEO_F429ZI", 
+        "targets" : ["CY8CKIT_062_WIFI_BT_PSA",
+                     "K64F",
+                     "K66F",
+                     "NUCLEO_F429ZI",
                      "UBLOX_ODIN_EVK_W2",
                      "LPC55S69_NS"
                     ],

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -16,6 +16,21 @@
       "auto-update" : true
     },
     {
+      "name": "mbed-os-example-blinky-baremetal",
+      "github": "https://github.com/ARMmbed/mbed-os-example-blinky-baremetal",
+      "mbed": [
+          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-blinky-baremetal"
+      ],
+      "test-repo-source": "github",
+      "features" : [],
+      "targets" : ["K66F", "NUCLEO_F429ZI", "ARCH_PRO", "LPC1768"],
+      "toolchains" : [],
+      "exporters": [],
+      "compile" : true,
+      "export": true,
+      "auto-update" : true
+    },
+    {
       "name": "mbed-os-example-tls",
       "github": "https://github.com/ARMmbed/mbed-os-example-tls",
       "mbed": [


### PR DESCRIPTION
### Description

Add a basic baremetal blinky example to the test framework to get a smoketest of baremetal (currently have none in CI). @bulislaw Does this look like a more reasonable solution than modifying blinky?

~@cmonr Should bare-metal be in 5.11.5? It was merged a couple of weeks before that release branch was made but I don't see it in there. I can either remove the bare-metal build profile from the example until the example is updated to 5.12 or point to a RC branch for the example's mbed-os hash. I wasn't 100% on the examples policy on what we can point to.~
See Martin's reply: https://github.com/ARMmbed/mbed-os/pull/10131#issuecomment-473805434

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers
@bulislaw @SenRamakri 

### Release Notes
