### PR TITLE
Update for downlink sequence counter rollover

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/at_cellularnetworktest.cpp
@@ -668,3 +668,19 @@ TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_set_receive_period)
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_DEVICE_ERROR;
     EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.set_receive_period(1, CellularNetwork::EDRXUTRAN_Iu_mode, 3));
 }
+
+TEST_F(TestAT_CellularNetwork, test_AT_CellularNetwork_set_packet_domain_event_reporting)
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularNetwork cn(at);
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    EXPECT_TRUE(NSAPI_ERROR_OK == cn.set_packet_domain_event_reporting(true));
+    EXPECT_TRUE(NSAPI_ERROR_OK == cn.set_packet_domain_event_reporting(false));
+
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_DEVICE_ERROR;
+    EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.set_packet_domain_event_reporting(true));
+    EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == cn.set_packet_domain_event_reporting(false));
+}

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -166,3 +166,8 @@ nsapi_error_t AT_CellularNetwork::set_receive_period(int mode, EDRXAccessTechnol
 void AT_CellularNetwork::get_context_state_command()
 {
 }
+
+nsapi_error_t AT_CellularNetwork::set_packet_domain_event_reporting(bool on)
+{
+    return NSAPI_ERROR_OK;
+}

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -385,6 +385,19 @@ public:
     };
     virtual nsapi_error_t set_receive_period(int mode, EDRXAccessTechnology act_type, uint8_t edrx_value) = 0;
 
+    /** Sets the packet domain network reporting. Useful for getting events when detached from the
+     *  network. When detach event arrives it is propagated as NSAPI_STATUS_DISCONNECTED to callback set
+     *  with attach(...).
+     *
+     *  @param on   true for enabling event reporting, false for disabling
+     *  @return     NSAPI_ERROR_OK on success
+     *              NSAPI_ERROR_UNSUPPORTED is command is not supported by the modem
+     *              NSAPI_ERROR_DEVICE_ERROR on failure
+     */
+    virtual nsapi_error_t set_packet_domain_event_reporting(bool on)
+    {
+        return NSAPI_ERROR_UNSUPPORTED;
+    }
 };
 
 /**

--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -57,6 +57,7 @@ public:
         PROPERTY_IPV6_PDP_TYPE,     // 0 = not supported, 1 = supported. Does modem support IPV6?
         PROPERTY_IPV4V6_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support dual stack IPV4V6?
         PROPERTY_NON_IP_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support Non-IP?
+        PROPERTY_AT_CGEREP,         // 0 = not supported, 1 = supported. Does modem support AT command AT+CGEREP.
         PROPERTY_MAX
     };
 

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -94,6 +94,8 @@ public: // CellularNetwork
 
     virtual nsapi_error_t set_receive_period(int mode, EDRXAccessTechnology act_type, uint8_t edrx_value);
 
+    virtual nsapi_error_t set_packet_domain_event_reporting(bool on);
+
 protected:
 
     /** Sets access technology to be scanned. Modem specific implementation.

--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -404,6 +404,14 @@ void CellularStateMachine::state_sim_pin()
             tr_debug("Cellular already attached.");
         }
 
+        // if packet domain event reporting is not set it's not a stopper. We might lack some events when we are
+        // dropped from the network.
+        _cb_data.error = _network->set_packet_domain_event_reporting(true);
+        if (_cb_data.error == NSAPI_STATUS_ERROR_UNSUPPORTED) {
+            tr_warning("Packet domain event reporting not supported!");
+        } else if (_cb_data.error) {
+            tr_warning("Packet domain event reporting set failed!");
+        }
         enter_to_state(STATE_REGISTERING_NETWORK);
     } else {
         retry_state_or_fail();

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.cpp
@@ -108,6 +108,8 @@ void GEMALTO_CINTERION::init_module_bgs2()
         1,  // PROPERTY_IPV4_STACK
         0,  // PROPERTY_IPV6_STACK
         0,  // PROPERTY_IPV4V6_STACK
+        0,  // PROPERTY_NON_IP_PDP_TYPE
+        1,  // PROPERTY_AT_CGEREP
     };
     AT_CellularBase::set_cellular_properties(cellular_properties);
     _module = ModuleBGS2;
@@ -126,6 +128,8 @@ void GEMALTO_CINTERION::init_module_els61()
         1,  // PROPERTY_IPV4_STACK
         1,  // PROPERTY_IPV6_STACK
         0,  // PROPERTY_IPV4V6_STACK
+        0,  // PROPERTY_NON_IP_PDP_TYPE
+        1,  // PROPERTY_AT_CGEREP
     };
     AT_CellularBase::set_cellular_properties(cellular_properties);
     _module = ModuleELS61;
@@ -144,6 +148,8 @@ void GEMALTO_CINTERION::init_module_ems31()
         1,  // PROPERTY_IPV4_STACK
         1,  // PROPERTY_IPV6_STACK
         1,  // PROPERTY_IPV4V6_STACK
+        0,  // PROPERTY_NON_IP_PDP_TYPE
+        1,  // PROPERTY_AT_CGEREP
     };
     AT_CellularBase::set_cellular_properties(cellular_properties);
     _module = ModuleEMS31;

--- a/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
+++ b/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
@@ -35,6 +35,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     1,  // PROPERTY_IPV6_STACK
     1,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 GENERIC_AT3GPP::GENERIC_AT3GPP(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
+++ b/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
@@ -35,6 +35,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 SARA4_PPP::SARA4_PPP(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -42,6 +42,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 QUECTEL_BC95::QUECTEL_BC95(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -46,6 +46,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     1,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 QUECTEL_BG96::QUECTEL_BG96(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
@@ -38,6 +38,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 QUECTEL_M26::QUECTEL_M26(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.cpp
@@ -41,6 +41,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 QUECTEL_UG96::QUECTEL_UG96(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
@@ -35,6 +35,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 
 TELIT_HE910::TELIT_HE910(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -37,6 +37,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 #else
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
@@ -53,6 +55,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 #endif
 

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -36,6 +36,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 #else
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
@@ -52,6 +54,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
 };
 #endif
 

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -319,10 +319,13 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     sequence_counter_prev = (uint16_t) * downlink_counter;
     sequence_counter_diff = sequence_counter - sequence_counter_prev;
     *downlink_counter += sequence_counter_diff;
-    if (sequence_counter < sequence_counter_prev) {
-        *downlink_counter += 0x10000;
+    
+    if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
+        _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
+        _mcps_indication.dl_frame_counter = *downlink_counter;
+        return false;
     }
-
+    
     // sizeof nws_skey must be the same as _params.keys.nwk_skey,
     _lora_crypto.compute_mic(payload, size - LORAMAC_MFR_LEN,
                              nwk_skey,
@@ -332,13 +335,7 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     if (mic_rx != mic) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
         return false;
-    }
-
-    if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
-        _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
-        _mcps_indication.dl_frame_counter = *downlink_counter;
-        return false;
-    }
+    }   
 
     return true;
 }

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -319,13 +319,13 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     sequence_counter_prev = (uint16_t) * downlink_counter;
     sequence_counter_diff = sequence_counter - sequence_counter_prev;
     *downlink_counter += sequence_counter_diff;
-    
+
     if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
         _mcps_indication.dl_frame_counter = *downlink_counter;
         return false;
     }
-    
+
     // sizeof nws_skey must be the same as _params.keys.nwk_skey,
     _lora_crypto.compute_mic(payload, size - LORAMAC_MFR_LEN,
                              nwk_skey,
@@ -335,7 +335,7 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     if (mic_rx != mic) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
         return false;
-    }   
+    }
 
     return true;
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Fix issue related to downlink sequence counter rollover in LoRaWAN.
For the test, the downlink sequence counter of the downlink messages has been incremented by 1600 (< MAX_FCNT_GAP) several times. For example, until 64005 and following situation was shown:
1. Downlink sequence counter increased to 64005 (by 1600 steps)
The radio module accepts this, as expected.
2. After that, downlink sequence counter increased to 65536 (rollover for 32 bits sequence counter)
The radio module rejects this frame

With the change everything works fine.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
