### PR TITLE
STM32 ADC INTERNAL CHANNEL reset after read

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogin_device.c
@@ -175,11 +175,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32F1/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogin_device.c
@@ -173,11 +173,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_adc.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_adc.h
@@ -43,6 +43,10 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f1xx_hal_def.h"  
+
+/* Include low level driver */
+#include "stm32f1xx_ll_adc.h"
+
 /** @addtogroup STM32F1xx_HAL_Driver
   * @{
   */

--- a/targets/TARGET_STM/TARGET_STM32F2/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/analogin_device.c
@@ -180,11 +180,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_adc.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_adc.h
@@ -46,6 +46,9 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f2xx_hal_def.h"
 
+/* Include low level driver */
+#include "stm32f2xx_ll_adc.h"
+
 /** @addtogroup STM32F2xx_HAL_Driver
   * @{
   */

--- a/targets/TARGET_STM/TARGET_STM32F3/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogin_device.c
@@ -227,7 +227,7 @@ uint16_t adc_read(analogin_t *obj)
     } else {
         debug("HAL_ADC_PollForConversion issue\n");
     }
-
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
     if (HAL_ADC_Stop(&obj->handle) != HAL_OK) {
         debug("HAL_ADC_Stop issue\n");;
     }

--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_device.c
@@ -186,11 +186,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32F7/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogin_device.c
@@ -186,11 +186,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32H7/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/analogin_device.c
@@ -223,11 +223,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_device.c
@@ -179,9 +179,8 @@ uint16_t adc_read(analogin_t *obj)
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
         adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
-    sConfig.Rank = ADC_RANK_NONE;
-    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
-    return adcValue;	
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32L1/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogin_device.c
@@ -226,11 +226,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()

--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
@@ -192,18 +192,12 @@ uint16_t adc_read(analogin_t *obj)
     HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
+    uint16_t adcValue = 0;
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-
-        /* Ref Manual: To prevent any unwanted consumption on the battery,
-        it is recommended to enable the bridge divider only when needed for ADC conversion */
-        if (sConfig.Channel == ADC_CHANNEL_VBAT) {
-            CLEAR_BIT(__LL_ADC_COMMON_INSTANCE(obj->handle.Instance)->CCR, LL_ADC_PATH_INTERNAL_VBAT);
-        }
-
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+        adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+    LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
+    return adcValue;
 }
 
 const PinMap *analogin_pinmap()


### PR DESCRIPTION
### Description

Hi

This is replacing #9560, not only for STM32L0 but for all STM32 families.
Internal channels use is enabling ADC "internal path" which needs to be disabled after measurement.

@RobVlaar please have a look on this new correction

@LMESTM please take it into account for #9814 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
