### PR TITLE
RTOS API: minor tidies

### DIFF
--- a/rtos/EventFlags.cpp
+++ b/rtos/EventFlags.cpp
@@ -38,8 +38,7 @@ EventFlags::EventFlags(const char *name)
 
 void EventFlags::constructor(const char *name)
 {
-    memset(&_obj_mem, 0, sizeof(_obj_mem));
-    osEventFlagsAttr_t attr;
+    osEventFlagsAttr_t attr = { 0 };
     attr.name = name ? name : "application_unnamed_event_flags";
     attr.cb_mem = &_obj_mem;
     attr.cb_size = sizeof(_obj_mem);

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -57,7 +57,6 @@ public:
     MemoryPool()
     {
         memset(_pool_mem, 0, sizeof(_pool_mem));
-        memset(&_obj_mem, 0, sizeof(_obj_mem));
         osMemoryPoolAttr_t attr = { 0 };
         attr.mp_mem = _pool_mem;
         attr.mp_size = sizeof(_pool_mem);

--- a/rtos/Mutex.cpp
+++ b/rtos/Mutex.cpp
@@ -40,7 +40,6 @@ Mutex::Mutex(const char *name)
 
 void Mutex::constructor(const char *name)
 {
-    memset(&_obj_mem, 0, sizeof(_obj_mem));
     osMutexAttr_t attr =
     { 0 };
     attr.name = name ? name : "aplication_unnamed_mutex";

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -65,7 +65,6 @@ public:
     */
     Queue()
     {
-        memset(&_obj_mem, 0, sizeof(_obj_mem));
         osMessageQueueAttr_t attr = { 0 };
         attr.mq_mem = _queue_mem;
         attr.mq_size = sizeof(_queue_mem);

--- a/rtos/RtosTimer.cpp
+++ b/rtos/RtosTimer.cpp
@@ -31,11 +31,10 @@ namespace rtos {
 void RtosTimer::constructor(mbed::Callback<void()> func, os_timer_type type)
 {
     _function = func;
-    memset(&_obj_mem, 0, sizeof(_obj_mem));
     osTimerAttr_t attr = { 0 };
     attr.cb_mem = &_obj_mem;
     attr.cb_size = sizeof(_obj_mem);
-    _id = osTimerNew((void (*)(void *))mbed::Callback<void()>::thunk, type, &_function, &attr);
+    _id = osTimerNew(mbed::Callback<void()>::thunk, type, &_function, &attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/Semaphore.cpp
+++ b/rtos/Semaphore.cpp
@@ -39,7 +39,6 @@ Semaphore::Semaphore(int32_t count, uint16_t max_count)
 
 void Semaphore::constructor(int32_t count, uint16_t max_count)
 {
-    memset(&_obj_mem, 0, sizeof(_obj_mem));
     osSemaphoreAttr_t attr = { 0 };
     attr.cb_mem = &_obj_mem;
     attr.cb_size = sizeof(_obj_mem);

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -52,7 +52,6 @@ void Thread::constructor(uint32_t tz_module, osPriority priority,
     _tid = 0;
     _dynamic_stack = (stack_mem == NULL);
     _finished = false;
-    memset(&_obj_mem, 0, sizeof(_obj_mem));
     memset(&_attr, 0, sizeof(_attr));
     _attr.priority = priority;
     _attr.stack_size = aligned_size;


### PR DESCRIPTION
### Description

Remove unneeded `memset`s and an unneeded cast.

Add missing initialisation of `EventFlags` attributes - no all fields were being initialised.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
