### PR TITLE
CellularBase -> CellularInterface tidy

### DIFF
--- a/features/netsocket/CellularBase.h
+++ b/features/netsocket/CellularBase.h
@@ -22,12 +22,13 @@
 #ifndef CELLULAR_BASE_H
 #define CELLULAR_BASE_H
 
+#include "CellularInterface.h"
+
 /**
  * This class is deprecated and will be removed altogether after expiration of
  * deprecation notice.
+ * @deprecated Migrated to CellularInterface
  */
-#include "CellularInterface.h"
-
 MBED_DEPRECATED_SINCE("mbed-os-5.12", "Migrated to CellularInterface")
 typedef CellularInterface CellularBase;
 

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -51,7 +51,7 @@ public:
      * target.network-default-interface-type or other overrides.
      *
      * The type of the interface returned can be tested by calling ethInterface(),
-     * wifiInterface(), meshInterface(), cellularBase(), emacInterface() and checking
+     * wifiInterface(), meshInterface(), cellularInterface(), emacInterface() and checking
      * for NULL pointers.
      *
      * The default behavior is to return the default interface for the
@@ -340,9 +340,10 @@ public:
 
     /** Return pointer to a CellularInterface.
      * @return Pointer to requested interface type or NULL if this class doesn't implement the interface.
+     * @deprecated CellularBase migrated to CellularInterface - use cellularInterface()
      */
-    MBED_DEPRECATED_SINCE("mbed-os-5.12", "Migrated to CellularInterface")
-    virtual CellularInterface *cellularBase()
+    MBED_DEPRECATED_SINCE("mbed-os-5.12", "CellularBase migrated to CellularInterface - use cellularInterface()")
+    virtual CellularInterface *cellularBase() // virtual retained for binary compatibility
     {
         return 0;
     }

--- a/features/netsocket/NetworkInterfaceDefaults.cpp
+++ b/features/netsocket/NetworkInterfaceDefaults.cpp
@@ -18,7 +18,7 @@
 
 #include "EthInterface.h"
 #include "WiFiInterface.h"
-#include "CellularBase.h"
+#include "CellularInterface.h"
 #include "MeshInterface.h"
 
 /* Weak default instance static classes for the various abstract classes.
@@ -40,7 +40,7 @@ MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
     return get_target_default_instance();
 }
 
-MBED_WEAK CellularBase *CellularBase::get_default_instance()
+MBED_WEAK CellularInterface *CellularInterface::get_default_instance()
 {
     return get_target_default_instance();
 }
@@ -87,9 +87,9 @@ void WiFiInterface::set_default_parameters()
 #endif
 }
 
-void CellularBase::set_default_parameters()
+void CellularInterface::set_default_parameters()
 {
-    /* CellularBase is expected to attempt to work without any parameters - we
+    /* CellularInterface is expected to attempt to work without any parameters - we
      * will try, at least.
      */
 #ifdef MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN
@@ -148,7 +148,7 @@ MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
 MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
 {
-    CellularBase *cellular = CellularBase::get_default_instance();
+    CellularInterface *cellular = CellularInterface::get_default_instance();
     if (!cellular) {
         return NULL;
     }


### PR DESCRIPTION
### Description

Remove remaining references to deprecated `CellularBase` in code, avoiding one warning.

Add deprecation to Doxygen.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
