### PR TITLE
Timer: remove hard-coded lp_ticker knowledge

### DIFF
--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -72,11 +72,8 @@ public:
     }
 
     // When low power ticker is in use, then do not disable deep sleep.
-    Ticker(const ticker_data_t *data) : TimerEvent(data), _function(0), _lock_deepsleep(true)
+    Ticker(const ticker_data_t *data) : TimerEvent(data), _function(0), _lock_deepsleep(!data->interface->runs_in_deep_sleep)
     {
-#if DEVICE_LPTICKER
-        _lock_deepsleep = (data != get_lp_ticker_data());
-#endif
     }
 
     /** Attach a function to be called by the Ticker, specifying the interval in seconds

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -18,7 +18,6 @@
 #include "hal/ticker_api.h"
 #include "hal/us_ticker_api.h"
 #include "platform/mbed_critical.h"
-#include "hal/lp_ticker_api.h"
 
 namespace mbed {
 
@@ -27,12 +26,10 @@ Timer::Timer() : _running(), _start(), _time(), _ticker_data(get_us_ticker_data(
     reset();
 }
 
-Timer::Timer(const ticker_data_t *data) : _running(), _start(), _time(), _ticker_data(data), _lock_deepsleep(true)
+Timer::Timer(const ticker_data_t *data) : _running(), _start(), _time(), _ticker_data(data),
+    _lock_deepsleep(!data->interface->runs_in_deep_sleep)
 {
     reset();
-#if DEVICE_LPTICKER
-    _lock_deepsleep = (data != get_lp_ticker_data());
-#endif
 }
 
 Timer::~Timer()

--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -32,6 +32,7 @@ static const ticker_interface_t lp_interface = {
     .fire_interrupt = lp_ticker_fire_interrupt,
     .get_info = lp_ticker_get_info,
     .free = lp_ticker_free,
+    .runs_in_deep_sleep = true,
 };
 
 static const ticker_data_t lp_data = {

--- a/hal/mbed_lp_ticker_wrapper.cpp
+++ b/hal/mbed_lp_ticker_wrapper.cpp
@@ -74,7 +74,8 @@ static const ticker_interface_t lp_interface = {
     lp_ticker_wrapper_set_interrupt,
     lp_ticker_wrapper_fire_interrupt,
     lp_ticker_wrapper_free,
-    lp_ticker_wrapper_get_info
+    lp_ticker_wrapper_get_info,
+    true
 };
 
 void lp_ticker_wrapper_irq_handler(ticker_irq_handler_type handler)

--- a/hal/mbed_us_ticker_api.c
+++ b/hal/mbed_us_ticker_api.c
@@ -29,6 +29,7 @@ static const ticker_interface_t us_interface = {
     .fire_interrupt = us_ticker_fire_interrupt,
     .get_info = us_ticker_get_info,
     .free = us_ticker_free,
+    .runs_in_deep_sleep = false,
 };
 
 static const ticker_data_t us_data = {

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -67,6 +67,7 @@ typedef struct {
     void (*fire_interrupt)(void);                 /**< Fire interrupt right-away */
     void (*free)(void);                           /**< Disable function */
     const ticker_info_t *(*get_info)(void);       /**< Return info about this ticker's implementation */
+    bool runs_in_deep_sleep;                      /**< Whether ticker operates in deep sleep */
 } ticker_interface_t;
 
 /** Ticker's event queue structure


### PR DESCRIPTION
### Description

The knowledge that `lp_ticker` runs in deep sleep was hard-coded with a comparison check of a `ticker_data_t` pointer against `get_lp_ticker_data`.

Remove this hard-coded check, which adds a linker dependency against the low power ticker even if not being used - put a flag into the `ticker_interface_t`.

A future extension might be to move this flag into the `ticker_info_t` provided by the HAL, but for the moment keep the assumption that `lp_ticker` does run, `us_ticker` doesn't.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
