### PR TITLE
Fix for LoRaWAN downlink sequence counter rollover

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -319,10 +319,13 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     sequence_counter_prev = (uint16_t) * downlink_counter;
     sequence_counter_diff = sequence_counter - sequence_counter_prev;
     *downlink_counter += sequence_counter_diff;
-    if (sequence_counter < sequence_counter_prev) {
-        *downlink_counter += 0x10000;
+    
+    if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
+        _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
+        _mcps_indication.dl_frame_counter = *downlink_counter;
+        return false;
     }
-
+    
     // sizeof nws_skey must be the same as _params.keys.nwk_skey,
     _lora_crypto.compute_mic(payload, size - LORAMAC_MFR_LEN,
                              nwk_skey,
@@ -332,13 +335,7 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     if (mic_rx != mic) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
         return false;
-    }
-
-    if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
-        _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
-        _mcps_indication.dl_frame_counter = *downlink_counter;
-        return false;
-    }
+    }   
 
     return true;
 }

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -319,13 +319,13 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     sequence_counter_prev = (uint16_t) * downlink_counter;
     sequence_counter_diff = sequence_counter - sequence_counter_prev;
     *downlink_counter += sequence_counter_diff;
-    
+
     if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
         _mcps_indication.dl_frame_counter = *downlink_counter;
         return false;
     }
-    
+
     // sizeof nws_skey must be the same as _params.keys.nwk_skey,
     _lora_crypto.compute_mic(payload, size - LORAMAC_MFR_LEN,
                              nwk_skey,
@@ -335,7 +335,7 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
     if (mic_rx != mic) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
         return false;
-    }   
+    }
 
     return true;
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Fix issue related to downlink sequence counter rollover in LoRaWAN.
For the test, the downlink sequence counter of the downlink messages has been incremented by 1600 (< MAX_FCNT_GAP) several times. For example, until 64005 and following situation was shown:

Downlink sequence counter increased to 64005 (by 1600 steps)
The radio module accepts this, as expected.
After that, downlink sequence counter increased to 65536 (rollover for 32 bits sequence counter)
The radio module rejects this frame
With the change everything works fine.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
