### PR TITLE
Remove dependency on us_ticker HAL apis for non USTICKER targets

### DIFF
--- a/hal/mbed_us_ticker_api.c
+++ b/hal/mbed_us_ticker_api.c
@@ -14,7 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <stddef.h>
 #include "hal/us_ticker_api.h"
+
+#if DEVICE_USTICKER
 
 static ticker_event_queue_t events = { 0 };
 
@@ -56,3 +60,12 @@ void us_ticker_irq_handler(void)
         irq_handler(&us_data);
     }
 }
+
+#else
+
+const ticker_data_t *get_us_ticker_data(void)
+{
+    return NULL;
+}
+
+#endif  // DEVICE_USTICKER

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/us_ticker.c
@@ -18,6 +18,8 @@
 #include "fsl_ctimer.h"
 #include "PeripheralNames.h"
 
+#if DEVICE_USTICKER
+
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 #define CTIMER       CTIMER0
 #define CTIMER_IRQn  CTIMER0_IRQn
@@ -117,3 +119,6 @@ void us_ticker_free(void)
     NVIC_DisableIRQ(CTIMER_IRQn);
     us_ticker_inited = false;
 }
+
+#endif // DEVICE_USTICKER
+

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -663,7 +663,8 @@
             "STDIO_MESSAGES",
             "FLASH",
             "MPU",
-            "USBDEVICE"
+            "USBDEVICE",
+            "USTICKER"
         ],
         "release_versions": ["2", "5"],
         "device_name": "LPC1768",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -873,7 +873,8 @@
             "SPI",
             "SPISLAVE",
             "STDIO_MESSAGES",
-            "MPU"
+            "MPU",
+            "USTICKER"
         ],
         "device_name": "LPC4088FBD144",
         "overrides": {
@@ -5414,7 +5415,8 @@
             "SERIAL_FC",
             "SLEEP",
             "SPI",
-            "STDIO_MESSAGES"
+            "STDIO_MESSAGES",
+            "USTICKER"
         ],
         "release_versions": ["2", "5"]
     },
@@ -6486,7 +6488,8 @@
             "SERIAL",
             "SPI",
             "SPISLAVE",
-            "STDIO_MESSAGES"
+            "STDIO_MESSAGES",
+            "USTICKER"
         ],
         "release_versions": ["2", "5"]
     },
@@ -6511,7 +6514,8 @@
             "SERIAL",
             "SPI",
             "SPISLAVE",
-            "STDIO_MESSAGES"
+            "STDIO_MESSAGES",
+            "USTICKER"
         ],
         "release_versions": ["2", "5"]
     },
@@ -6535,7 +6539,8 @@
             "SERIAL",
             "SPI",
             "SPISLAVE",
-            "STDIO_MESSAGES"
+            "STDIO_MESSAGES",
+            "USTICKER"
         ],
         "release_versions": ["2", "5"]
     },
@@ -7244,7 +7249,8 @@
             "TRNG",
             "SPISLAVE",
             "802_15_4_PHY",
-            "MPU"
+            "MPU",
+            "USTICKER"
         ],
         "release_versions": ["2", "5"]
     },


### PR DESCRIPTION
### Description

During #9221 there were difficulties building a secure image without `USTICKER` and as a workaround a dummy implementation of us_ticker HAL apis was built in the secure image.

#9896 handled part of the problem by calling `wait_ns()` in wait APIs when there is no USTICKER, but still `mbed_us_ticker_api.c` defined a static struct of function pointers pointing to the usticker hal APIs and there are multiple places in the tree which call `get_us_ticker_data()`.

So this PR solves these issues by:
- Surround mbed_us_ticker_api.c with if DEVICE_USTICKER.
- get_us_ticker_data() returns NULL for non-usticker targets.

Fixes #10139 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-psa @kjbracey-arm 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
