### PR TITLE
Deduplicate IAR MBED_ROM__xxxx defines

### DIFF
--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -926,24 +926,14 @@ class mbedToolchain:
             self.ld.append(define_string)
             self.flags["ld"].append(define_string)
 
-        flags2params = {}
-        if self.target.is_PSA_non_secure_target:
-            flags2params = {
-                "MBED_RAM_START": "target.non-secure-ram-start",
-                "MBED_RAM_SIZE": "target.non-secure-ram-size"
-            }
         if self.target.is_PSA_secure_target:
-            flags2params = {
-                "MBED_RAM_START": "target.secure-ram-start",
-                "MBED_RAM_SIZE": "target.secure-ram-size",
-                "MBED_PUBLIC_RAM_START": "target.public-ram-start",
-                "MBED_PUBLIC_RAM_SIZE": "target.public-ram-size"
-            }
-
-        for flag, param in flags2params.items():
-            define_string = self.make_ld_define(flag, params[param].value)
-            self.ld.append(define_string)
-            self.flags["ld"].append(define_string)
+            for flag, param in [
+                ("MBED_PUBLIC_RAM_START", "target.public-ram-start"),
+                ("MBED_PUBLIC_RAM_SIZE", "target.public-ram-size")
+            ]:
+                define_string = self.make_ld_define(flag, params[param].value)
+                self.ld.append(define_string)
+                self.flags["ld"].append(define_string)
 
     # Set the configuration data
     def set_config_data(self, config_data):

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -929,15 +929,11 @@ class mbedToolchain:
         flags2params = {}
         if self.target.is_PSA_non_secure_target:
             flags2params = {
-                "MBED_ROM_START": "target.non-secure-rom-start",
-                "MBED_ROM_SIZE": "target.non-secure-rom-size",
                 "MBED_RAM_START": "target.non-secure-ram-start",
                 "MBED_RAM_SIZE": "target.non-secure-ram-size"
             }
         if self.target.is_PSA_secure_target:
             flags2params = {
-                "MBED_ROM_START": "target.secure-rom-start",
-                "MBED_ROM_SIZE": "target.secure-rom-size",
                 "MBED_RAM_START": "target.secure-ram-start",
                 "MBED_RAM_SIZE": "target.secure-ram-size",
                 "MBED_PUBLIC_RAM_START": "target.public-ram-start",


### PR DESCRIPTION
### Description

PR #10113 allowed a porter or application author to configure 
secure or non-secure rom through the use of:
  * `target.secure-rom-start`
  * `target.secure-rom-size`
  * `target.non-secure-rom-start`
  * `target.non-secure-rom-size`

and use these in managed bootloader modes and report them as ROM. 
This created a duplicate `MBED_ROM_START` and `MBED_ROM_SIZE`
define on the IAR linker command line. 

Further, the overrides:
  * `target.secure-ram-start`
  * `target.secure-ram-size`
  * `target.non-secure-ram-start`
  * `target.non-secure-ram-size`

Would create further command line defines that conflicted with RAM 
reporting.

This PR removes the duplicated command line arguments.

Fixes #10153


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change