### PR TITLE
BLE - Notify HCI driver of host stack inactivity

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -283,6 +283,10 @@ uint16_t CordioHCIDriver::write(uint8_t type, uint16_t len, uint8_t *pData)
     return _transport_driver.write(type, len, pData);
 }
 
+void CordioHCIDriver::on_host_stack_inactivity()
+{
+}
+
 } // namespace cordio
 } // namespace vendor
 } // namespace ble

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
@@ -134,6 +134,16 @@ public:
      */
     uint16_t write(uint8_t type, uint16_t len, uint8_t *pData);
 
+    /**
+     * React to host stack inactivity.
+     *
+     * The host stack invoke this function when it is inactive. It allows a
+     * driver to put its controller to sleep if all the conditions are met.
+     *
+     * Any call to write signals to the driver that the host stack is active.
+     */
+     virtual void on_host_stack_inactivity();
+
 protected:
     /**
      * Return a default set of memory pool that the Cordio stack can use.

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -564,6 +564,9 @@ void BLE::callDispatcher()
         timestamp_t nextTimestamp = (timestamp_t) (WsfTimerNextExpiration(&pTimerRunning) * WSF_MS_PER_TICK) * 1000;
         if (pTimerRunning) {
             nextTimeout.attach_us(timeoutCallback, nextTimestamp);
+        } else {
+            critical_section.disable();
+            _hci_driver->on_host_stack_inactivity();
         }
     }
 }

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -555,7 +555,7 @@ void BLE::callDispatcher()
 
     wsfOsDispatcher();
 
-    static Timeout nextTimeout;
+    static LowPowerTimeout nextTimeout;
     CriticalSectionLock critical_section;
 
     if (wsfOsReadyToSleep()) {


### PR DESCRIPTION
### Description

This PR adds a new function to the CordioHCIDriver interface: `on_host_stack_inactivity`. That function is called by the host stack when it becomes inactive.  It leave the opportunity to the driver to put the controller to sleep if all the conditions are met. Activity is resumed whenever `CordioHCIDriver::write` is called. 

This PR also fixes the type of the timeout local to `cardio::BLE::callDispatcher `.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@paul-szczepanek-arm @ARMmbed/team-cypress 
