### PR TITLE
Cellular: Fix plmn trace for IAR

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -259,7 +259,7 @@ nsapi_error_t AT_CellularContext::set_blocking(bool blocking)
 
 void AT_CellularContext::set_plmn(const char *plmn)
 {
-    tr_info("CellularContext plmn %s", plmn);
+    tr_info("CellularContext plmn %s", (plmn ? plmn : "NULL"));
     _device->set_plmn(plmn);
 }
 


### PR DESCRIPTION
### Description

IAR compiler does not seem to like printing null strings. PLMN can be null depending on user configuration.

This is fix for https://github.com/ARMmbed/mbed-os-example-cellular/issues/125.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@AriParkkila @mirelachirica @AnttiKauppila 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
