### PR TITLE
Collect excluded libraries into ignored_dirs

### DIFF
--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -312,6 +312,10 @@ class Resources(object):
             if ref.name.endswith(MBED_LIB_FILENAME)
         )
         self._excluded_libs = all_library_refs - self._libs_filtered
+        if self._collect_ignores:
+            self.ignored_dirs += [
+                dirname(n) or "." for n, _ in self._excluded_libs
+            ]
 
     def _get_from_refs(self, file_type, key):
         return sorted([key(f) for f in self.get_file_refs(file_type)])


### PR DESCRIPTION
### Description

A few exporters use the resources `ignored_dirs` member to build a list
of directories to ignore when they scan the project for sources.

The `requires` section of `mbed_app.json` may filter a project to
include a specific set of libraries that it defines. However, this does
not update the `resources.ignored_dirs` member, and projects using
`requires` do not build when exported to `gnuarmeclipse`.

This PR tests this bug and corrects it.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change