### PR TITLE
Nuvoton: Remove SD component from targets.json

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7121,7 +7121,7 @@
     },
     "NUMAKER_PFM_NUC472": {
         "core": "Cortex-M4F",
-        "components_add": ["SD", "FLASHIAP"],
+        "components_add": ["FLASHIAP"],
         "default_toolchain": "ARM",
         "extra_labels": [
             "NUVOTON",
@@ -7705,7 +7705,7 @@
     },
     "NUMAKER_PFM_M487": {
         "inherits": ["MCU_M480"],
-        "components_add": ["SD", "FLASHIAP"],
+        "components_add": ["FLASHIAP"],
         "device_name": "M487JIDAE"
     },
     "NUMAKER_IOT_M487": {


### PR DESCRIPTION
### Description

Nuvoton targets below don't provide SPI-bus SD on-board, identified by `SD` in
target component list. Instead, these targets provide SD-bus SD on-board, identified
by unofficial `NUSD`, driver of which is provided [outside mbed-os tree](https://github.com/OpenNuvoton/NuMaker-mbed-SD-driver). So `SD` must
be removed to reflect the truth.

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M487
- NUMAKER_IOT_M487
- NUMAKER_PFM_M2351

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
