### PR TITLE
Fix SPIF speed for MTB_ADV_WISE_1570 and max packet size for BC95

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
@@ -54,7 +54,8 @@
              "SPI_MOSI": "PA_7",
              "SPI_MISO": "PA_6",
              "SPI_CLK":  "PA_5",
-             "SPI_CS":   "PB_12"
+             "SPI_CS":   "PB_12",
+             "SPI_FREQ": "20000000"
        }
     }
 }

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -19,6 +19,8 @@
 #include "CellularUtil.h"
 #include "CellularLog.h"
 
+#define PACKET_SIZE_MAX 1358
+
 using namespace mbed;
 using namespace mbed_cellular_util;
 
@@ -174,6 +176,10 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSoc
 {
     int sent_len = 0;
 
+    if (size > PACKET_SIZE_MAX) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
     char *hexstr = new char[size * 2 + 1];
     int hexlen = char_str_to_hex_str((const char *)data, size, hexstr);
     // NULL terminated for write_string
@@ -220,7 +226,7 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_recvfrom_impl(CellularS
 
     _at.cmd_start("AT+NSORF=");
     _at.write_int(socket->id);
-    _at.write_int(size);
+    _at.write_int(size <= PACKET_SIZE_MAX ? size : PACKET_SIZE_MAX);
     _at.cmd_stop();
     _at.resp_start();
     // receiving socket id


### PR DESCRIPTION
### Description

Fix SPI_FREQ on MTB_ADV_WISE_1570 to 20000000, the default 40000000 is unreliable.

Fix BC95 max packet size to 1358, otherwise modem returns unexpected errors.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@juhoeskeli @mirelachirica 

### Release Notes
