### PR TITLE
Workaround for ARMC6 Windows 7 assembler issue

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -583,11 +583,21 @@ class ARMC6(ARM_STD):
         return opts
 
     def assemble(self, source, object, includes):
-        cmd_pre = copy(self.asm)
+        # Preprocess first, then assemble
+        root, _ = splitext(object)
+        tempfile = root + '.E'
+
+        # Build preprocess assemble command
+        cmd_pre = copy(self.cc)
         cmd_pre.extend(self.get_compile_options(
-            self.get_symbols(True), includes, for_asm=True))
-        cmd_pre.extend(["-o", object, source])
-        return [cmd_pre]
+            self.get_symbols(True), includes, for_asm=False))
+        cmd_pre.extend(["-E", "-MT", object, "-o", tempfile, source])
+
+        # Build main assemble command
+        cmd = self.asm + ["-o", object, tempfile]
+
+        # Return command array, don't execute
+        return [cmd_pre, cmd]
 
     def compile(self, cc, source, object, includes):
         cmd = copy(cc)


### PR DESCRIPTION
### Description

On Windows 7 using --preproc option in ARMC6 assembler doesn't work when -MD option is also specified. Compiler creates incorrect filename for dependency file and compilation files.
To workaround this issue, this change returns to using a temporary file and separately calling preprocessor and assembler (as in a case of ARMC5).

I have done only a limited testing, because I have only access to ARMC6 compiler on a Windows 7 machine.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
<!--
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
