### PR TITLE
Nanostack 802.15.4 RF drivers update

### DIFF
--- a/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
@@ -17,7 +17,7 @@
 #ifndef NANOSTACK_PHY_MCR20A_H_
 #define NANOSTACK_PHY_MCR20A_H_
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && defined(MBED_CONF_RTOS_PRESENT)
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
 #include "inttypes.h"
 #include "NanostackRfPhy.h"
 #include "DigitalIn.h"

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
@@ -42,7 +42,7 @@
 #include "MCR20Reg.h"
 #include "XcvrSpi.h"
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "platform/mbed_critical.h"
 

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "NanostackRfPhyMcr20a.h"
 
 #if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
 
+#include "NanostackRfPhyMcr20a.h"
 #include "ns_types.h"
 #include "platform/arm_hal_interrupt.h"
 #include "nanostack/platform/arm_hal_phy.h"

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
@@ -931,8 +931,6 @@ static void rf_sync_detected_handler(void)
     rf_state = RF_RX_STARTED;
     TEST_RX_STARTED
     rf_disable_interrupt(SYNC_WORD);
-    rf_enable_interrupt(RX_FIFO_ALMOST_FULL);
-    rf_enable_interrupt(RX_DATA_READY);
     rf_backup_timer_start(MAX_PACKET_SENDING_TIME);
 }
 
@@ -955,13 +953,15 @@ static void rf_receive(uint8_t rx_channel)
         rf_rx_channel = rf_new_channel = rx_channel;
     }
     rf_send_command(S2LP_CMD_RX);
+    rf_poll_state_change(S2LP_STATE_RX);
     rf_enable_interrupt(SYNC_WORD);
+    rf_enable_interrupt(RX_FIFO_ALMOST_FULL);
+    rf_enable_interrupt(RX_DATA_READY);
     rf_enable_interrupt(RX_FIFO_UNF_OVF);
     rx_data_length = 0;
     if (rf_state != RF_CSMA_STARTED) {
         rf_state = RF_IDLE;
     }
-    rf_poll_state_change(S2LP_STATE_RX);
     rf_unlock();
 }
 


### PR DESCRIPTION
### Description

Sync Nanostack RF drivers from master copy:
-MCR20A: v1.0.5

A Fix to DEVICE_INTERRUPTIN flagging made in https://github.com/ARMmbed/mbed-os/pull/10142

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@JarkkoPaso 
<!--
    Optional
    Request additional reviewers with @username
-->

