### PR TITLE
Remove cypress boards from CMSIS pack manager

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8121,7 +8121,6 @@
             "public-ram-start": "0x08047600",
             "public-ram-size": "0x200"
         },
-        "device_name": "CY8C6247BZI-D54",
         "bootloader_supported": true
     },
     "CY8CMOD_062_4343W": {
@@ -8153,7 +8152,6 @@
         "post_binary_hook": {
             "function": "PSOC6Code.complete"
         },
-        "device_name": "CY8C6347BZI-BLD53",
         "bootloader_supported": true
     },
     "CY8CKIT_062_4343W": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8121,6 +8121,7 @@
             "public-ram-start": "0x08047600",
             "public-ram-size": "0x200"
         },
+        "sectors": [[268435456, 512]],
         "bootloader_supported": true
     },
     "CY8CMOD_062_4343W": {
@@ -8152,6 +8153,7 @@
         "post_binary_hook": {
             "function": "PSOC6Code.complete"
         },
+        "sectors": [[268443648, 512]],
         "bootloader_supported": true
     },
     "CY8CKIT_062_4343W": {


### PR DESCRIPTION
### Description

Remove cypress boards from CMSIS pack manager as the values were fabricated and are no longer necessary. (@dannybenor can confirm that)
 
This fixes #10183 

depending on:
* #10187  
* #10188 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@theotherjimmy @ARMmbed/team-cypress 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
