### PR TITLE
Fixed compilation error in LWIPStack class if lwip tcp is disabled.

### DIFF
--- a/features/lwipstack/LWIPStack.cpp
+++ b/features/lwipstack/LWIPStack.cpp
@@ -514,11 +514,11 @@ nsapi_error_t LWIP::setsockopt(nsapi_socket_t handle, int level, int optname, co
             if (optlen > NSAPI_INTERFACE_NAME_MAX_SIZE) {
                 return NSAPI_ERROR_UNSUPPORTED;
             }
-
+#if LWIP_TCP
             if (NETCONNTYPE_GROUP(s->conn->type) == NETCONN_TCP) {
                 s->conn->pcb.tcp->interface_name = (const char *)optval;
             }
-
+#endif
             if (NETCONNTYPE_GROUP(s->conn->type) == NETCONN_UDP) {
                 s->conn->pcb.udp->interface_name = (const char *)optval;
             }


### PR DESCRIPTION
### Description
LWIP setsockopt member has  now #if LWIP_TCP  to prevent using of TCP PCB if TCP is disabled.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
