### PR TITLE
Fallback to ARMC5 when ARMC6 is not configured

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2594,7 +2594,7 @@
     },
     "MTB_MXCHIP_EMW3166": {
         "inherits": ["FAMILY_STM32"],
-        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARMC6", "GCC_ARM", "IAR"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
             "STM32F4",
@@ -2627,7 +2627,7 @@
     },
     "USI_WM_BN_BM_22": {
         "inherits": ["FAMILY_STM32"],
-        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARMC6", "GCC_ARM", "IAR"],
         "components_add": ["SPIF", "FLASHIAP"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -5309,7 +5309,7 @@
     "RZ_A1XX": {
         "inherits": ["Target"],
         "core": "Cortex-A9",
-        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARMC6", "GCC_ARM", "IAR"],
         "extra_labels": ["RENESAS", "RZ_A1XX"],
         "device_has": [
             "SLEEP",

--- a/tools/build.py
+++ b/tools/build.py
@@ -29,24 +29,24 @@ ROOT = abspath(join(dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
 
-from tools.toolchains import TOOLCHAINS, TOOLCHAIN_CLASSES, TOOLCHAIN_PATHS
-from tools.toolchains import mbedToolchain
-from tools.targets import TARGET_NAMES, TARGET_MAP, Target
+from tools.toolchains import TOOLCHAINS
+from tools.targets import TARGET_NAMES, Target
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
 from tools.options import extract_mcus
 from tools.build_api import build_library, build_mbed_libs, build_lib
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import print_build_results
-from tools.build_api import get_toolchain_name
-from tools.settings import CPPCHECK_CMD, CPPCHECK_MSG_FORMAT
-from tools.settings import CPPCHECK_CMD, CPPCHECK_MSG_FORMAT, CLI_COLOR_MAP
+from tools.build_api import target_supports_toolchain
+from tools.build_api import find_valid_toolchain
 from tools.notifier.term import TerminalNotifier
 from tools.utils import argparse_filestring_type, args_error, argparse_many
-from tools.utils import argparse_filestring_type, argparse_dir_not_parent
+from tools.utils import argparse_dir_not_parent
+from tools.utils import NoValidToolchainException
+from tools.utils import print_end_warnings
 from tools.paths import is_relative_to_root
 
-if __name__ == '__main__':
+def main():
     start = time()
 
     # Parse Options
@@ -169,40 +169,37 @@ if __name__ == '__main__':
     failures = []
     successes = []
     skipped = []
+    end_warnings = []
 
-    toolchain_names = set()
     for toolchain in toolchains:
         for target_name in targets:
             target = Target.get_target(target_name)
-            toolchain_names.add(get_toolchain_name(target, toolchain))
 
-    for toolchain_name in toolchain_names:
-        if not TOOLCHAIN_CLASSES[toolchain_name].check_executable():
-            search_path = TOOLCHAIN_PATHS[toolchain_name] or "No path set"
-            args_error(parser, "Could not find executable for %s.\n"
-                               "Currently set search path: %s"
-                       % (toolchain_name, search_path))
+            try:
+                toolchain_name, internal_tc_name, end_warnings = find_valid_toolchain(
+                    target, toolchain
+                )
+            except NoValidToolchainException as e:
+                print_end_warnings(e.end_warnings)
+                args_error(parser, str(e))
 
-    for toolchain in toolchains:
-        for target in targets:
-            tt_id = "%s::%s" % (toolchain, target)
-            if toolchain not in TARGET_MAP[target].supported_toolchains:
+            tt_id = "%s::%s" % (internal_tc_name, target_name)
+            if not target_supports_toolchain(target, toolchain):
                 # Log this later
                 print("%s skipped: toolchain not supported" % tt_id)
                 skipped.append(tt_id)
             else:
                 try:
                     notifier = TerminalNotifier(options.verbose, options.silent)
-                    mcu = TARGET_MAP[target]
-                    profile = extract_profile(parser, options, toolchain)
+                    profile = extract_profile(parser, options, internal_tc_name)
 
-                    if mcu.is_PSA_secure_target and \
+                    if target.is_PSA_secure_target and \
                             not is_relative_to_root(options.source_dir):
                         options.source_dir = ROOT
 
                     if options.source_dir:
                         lib_build_res = build_library(
-                            options.source_dir, options.build_dir, mcu, toolchain,
+                            options.source_dir, options.build_dir, target, toolchain_name,
                             jobs=options.jobs,
                             clean=options.clean,
                             archive=(not options.no_archive),
@@ -214,7 +211,7 @@ if __name__ == '__main__':
                         )
                     else:
                         lib_build_res = build_mbed_libs(
-                            mcu, toolchain,
+                            target, toolchain_name,
                             jobs=options.jobs,
                             clean=options.clean,
                             macros=options.macros,
@@ -225,7 +222,7 @@ if __name__ == '__main__':
 
                     for lib_id in libraries:
                         build_lib(
-                            lib_id, mcu, toolchain,
+                            lib_id, target, toolchain_name,
                             clean=options.clean,
                             macros=options.macros,
                             jobs=options.jobs,
@@ -236,10 +233,15 @@ if __name__ == '__main__':
                         successes.append(tt_id)
                     else:
                         skipped.append(tt_id)
+                except KeyboardInterrupt as e:
+                    print("\n[CTRL+c] exit")
+                    print_end_warnings(end_warnings)
+                    sys.exit(0)
                 except Exception as e:
                     if options.verbose:
                         import traceback
                         traceback.print_exc(file=sys.stdout)
+                        print_end_warnings(end_warnings)
                         sys.exit(1)
                     failures.append(tt_id)
                     print(e)
@@ -254,5 +256,10 @@ if __name__ == '__main__':
         if report:
             print(print_build_results(report, report_name))
 
+    print_end_warnings(end_warnings)
     if failures:
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -365,12 +365,18 @@ def transform_release_toolchains(target, version):
     """
     if int(target.build_tools_metadata["version"]) > 0:
         if version == '5':
+            non_arm_toolchains = set(["IAR", "GCC_ARM"])
             if 'ARMC5' in target.supported_toolchains:
-                return ['ARMC5', 'GCC_ARM', 'IAR']
+                result = ["ARMC5"]
             else:
-                return ['ARM', 'ARMC6', 'GCC_ARM', 'IAR']
-        else:
-            return target.supported_toolchains
+                result = ["ARM", "ARMC6"]
+            result.extend(
+                set(target.supported_toolchains).intersection(
+                    non_arm_toolchains
+                )
+            )
+            return result
+        return target.supported_toolchains
     else:
         if version == '5':
             return ['ARM', 'GCC_ARM', 'IAR']

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1142,30 +1142,6 @@ def _lowercase_release_version(release_version):
     except AttributeError:
         return 'all'
 
-def mcu_toolchain_list(release_version='5'):
-    """  Shows list of toolchains
-
-    """
-    release_version = _lowercase_release_version(release_version)
-    version_release_targets = {}
-    version_release_target_names = {}
-
-    for version in RELEASE_VERSIONS:
-        version_release_targets[version] = get_mbed_official_release(version)
-        version_release_target_names[version] = [x[0] for x in
-                                                 version_release_targets[
-                                                     version]]
-
-    if release_version in RELEASE_VERSIONS:
-        release_targets = version_release_targets[release_version]
-    else:
-        release_targets = None
-
-    unique_supported_toolchains = get_unique_supported_toolchains(
-        release_targets)
-    columns = ["mbed OS %s" % x for x in RELEASE_VERSIONS] + unique_supported_toolchains
-    return "\n".join(columns)
-
 
 def mcu_target_list(release_version='5'):
     """  Shows target list

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -419,8 +419,8 @@ def target_supports_toolchain(target, toolchain_name):
             if(toolchain_name == "ARM"):
                 #we cant find ARM, see if one ARMC5, ARMC6 or uARM listed
                 return any(tc in target.supported_toolchains for tc in ("ARMC5","ARMC6","uARM"))
-            if(toolchain_name == "ARMC6"):
-                #we did not find ARMC6, but check for ARM is listed
+            if(toolchain_name == "ARMC6" or toolchain_name == "ARMC5"):
+                #we did not find ARMC6 or ARMC5, but check if ARM is listed
                 return "ARM" in target.supported_toolchains
         #return False in other cases
         return False

--- a/tools/make.py
+++ b/tools/make.py
@@ -41,10 +41,10 @@ from tools.tests import test_known, test_name_known
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
 from tools.options import extract_mcus
+from tools.options import get_toolchain_list
 from tools.notifier.term import TerminalNotifier
 from tools.build_api import build_project
 from tools.build_api import mcu_toolchain_matrix
-from tools.build_api import mcu_toolchain_list
 from tools.build_api import mcu_target_list
 from tools.build_api import merge_build_data
 from tools.build_api import find_valid_toolchain
@@ -297,11 +297,7 @@ def main():
                 release_version=None
             ))
         elif options.supported_toolchains == "toolchains":
-            toolchain_list = mcu_toolchain_list()
-            # Only print the lines that matter
-            for line in toolchain_list.split("\n"):
-                if "mbed" not in line:
-                    print(line)
+            print('\n'.join(get_toolchain_list()))
         elif options.supported_toolchains == "targets":
             print(mcu_target_list())
     elif options.list_tests is True:

--- a/tools/options.py
+++ b/tools/options.py
@@ -21,7 +21,7 @@ from os.path import join, dirname
 from os import listdir
 from argparse import ArgumentParser, ArgumentTypeError
 
-from .toolchains import TOOLCHAINS
+from .toolchains import TOOLCHAINS, EXTRA_TOOLCHAIN_NAMES
 from .targets import TARGET_NAMES, Target, update_target_data
 from .utils import (argparse_force_uppercase_type, argparse_deprecate,
                     argparse_lowercase_hyphen_type, argparse_many,
@@ -45,6 +45,7 @@ def get_default_options_parser(add_clean=True, add_options=True,
     targetnames = TARGET_NAMES
     targetnames.sort()
     toolchainlist = list(TOOLCHAINS)
+    toolchainlist.extend(EXTRA_TOOLCHAIN_NAMES)
     toolchainlist.sort()
 
     parser.add_argument("-m", "--mcu",

--- a/tools/options.py
+++ b/tools/options.py
@@ -127,7 +127,7 @@ def extract_profile(parser, options, toolchain, fallback="develop"):
         profiles.append(contents)
 
     return profiles
-    
+
 def extract_mcus(parser, options):
     try:
         if options.custom_targets_directory:

--- a/tools/options.py
+++ b/tools/options.py
@@ -32,6 +32,12 @@ FLAGS_DEPRECATION_MESSAGE = "Please use the --profile argument instead.\n"\
                             "Documentation may be found in "\
                             "docs/Toolchain_Profiles.md"
 
+def get_toolchain_list():
+    toolchainlist = list(TOOLCHAINS)
+    toolchainlist.extend(EXTRA_TOOLCHAIN_NAMES)
+    toolchainlist.sort()
+    return toolchainlist
+
 def get_default_options_parser(add_clean=True, add_options=True,
                                add_app_config=False):
     """Create a new options parser with the default compiler options added
@@ -44,9 +50,7 @@ def get_default_options_parser(add_clean=True, add_options=True,
 
     targetnames = TARGET_NAMES
     targetnames.sort()
-    toolchainlist = list(TOOLCHAINS)
-    toolchainlist.extend(EXTRA_TOOLCHAIN_NAMES)
-    toolchainlist.sort()
+    toolchainlist = get_toolchain_list()
 
     parser.add_argument("-m", "--mcu",
                         help=("build for the given MCU (%s)" %

--- a/tools/test.py
+++ b/tools/test.py
@@ -28,27 +28,25 @@ sys.path.insert(0, ROOT)
 
 from tools.config import ConfigException, Config
 from tools.test_configs import get_default_config
-from tools.config import ConfigException
 from tools.test_api import find_tests, get_test_config, print_tests, build_tests, test_spec_from_test_builds
-import tools.test_configs as TestConfig
 from tools.options import get_default_options_parser, extract_profile, extract_mcus
-from tools.build_api import build_project, build_library
+from tools.build_api import build_library
 from tools.build_api import print_build_memory_usage
 from tools.build_api import merge_build_data
-from tools.build_api import get_toolchain_name
-from tools.targets import TARGET_MAP
+from tools.build_api import find_valid_toolchain
 from tools.notifier.term import TerminalNotifier
-from tools.utils import mkdir, ToolException, NotSupportedException, args_error, write_json_to_file
+from tools.utils import ToolException, NotSupportedException, args_error, write_json_to_file
+from tools.utils import NoValidToolchainException
 from tools.test_exporters import ReportExporter, ResultExporterType
 from tools.utils import argparse_filestring_type, argparse_lowercase_type, argparse_many
 from tools.utils import argparse_dir_not_parent
-from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS, TOOLCHAIN_CLASSES
-from tools.settings import CLI_COLOR_MAP
+from tools.utils import print_end_warnings
 from tools.settings import ROOT
 from tools.targets import Target
 from tools.paths import is_relative_to_root
 
-if __name__ == '__main__':
+def main():
+    error = False
     try:
         # Parse Options
         parser = get_default_options_parser(add_app_config=True)
@@ -140,6 +138,7 @@ if __name__ == '__main__':
 
         all_tests = {}
         tests = {}
+        end_warnings = []
 
         # As default both test tools are enabled
         if not (options.greentea or options.icetea):
@@ -158,12 +157,13 @@ if __name__ == '__main__':
             args_error(parser, "argument -t/--tool is required")
         toolchain = options.tool[0]
 
-        toolchain_name = get_toolchain_name(target, toolchain)
-        if not TOOLCHAIN_CLASSES[toolchain_name].check_executable():
-            search_path = TOOLCHAIN_PATHS[toolchain_name] or "No path set"
-            args_error(parser, "Could not find executable for %s.\n"
-                               "Currently set search path: %s"
-                       % (toolchain_name, search_path))
+        try:
+            toolchain_name, internal_tc_name, end_warnings = find_valid_toolchain(
+                target, toolchain
+            )
+        except NoValidToolchainException as e:
+            print_end_warnings(e.end_warnings)
+            args_error(parser, str(e))
 
         # Assign config file. Precedence: test_config>app_config
         # TODO: merge configs if both given
@@ -185,7 +185,7 @@ if __name__ == '__main__':
             all_tests.update(find_tests(
                 base_dir=path,
                 target_name=mcu,
-                toolchain_name=toolchain,
+                toolchain_name=toolchain_name,
                 icetea=options.icetea,
                 greentea=options.greentea,
                 app_config=config))
@@ -229,12 +229,12 @@ if __name__ == '__main__':
             build_properties = {}
 
             library_build_success = False
-            profile = extract_profile(parser, options, toolchain)
+            profile = extract_profile(parser, options, internal_tc_name)
             try:
                 # Build sources
                 notify = TerminalNotifier(options.verbose)
                 build_library(base_source_paths, options.build_dir, mcu,
-                              toolchain, jobs=options.jobs,
+                              toolchain_name, jobs=options.jobs,
                               clean=options.clean, report=build_report,
                               properties=build_properties, name="mbed-build",
                               macros=options.macros,
@@ -267,7 +267,7 @@ if __name__ == '__main__':
                     [os.path.relpath(options.build_dir)],
                     options.build_dir,
                     mcu,
-                    toolchain,
+                    toolchain_name,
                     clean=options.clean,
                     report=build_report,
                     properties=build_properties,
@@ -310,8 +310,16 @@ if __name__ == '__main__':
     except ConfigException as e:
         # Catching ConfigException here to prevent a traceback
         print("[ERROR] %s" % str(e))
+        error = True
     except Exception as e:
         import traceback
         traceback.print_exc(file=sys.stdout)
         print("[ERROR] %s" % str(e))
+        error = True
+
+    print_end_warnings(end_warnings)
+    if error:
         sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -26,6 +26,10 @@ TOOLCHAIN_CLASSES = {
     u'IAR': iar.IAR
 }
 
+EXTRA_TOOLCHAIN_NAMES = [
+    u"ARMC5"
+]
+
 TOOLCHAINS = set(TOOLCHAIN_CLASSES.keys())
 
 # Top level re-exports

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -400,7 +400,7 @@ class ARM_STD(ARM):
         if int(target.build_tools_metadata["version"]) > 0:
             #check only for ARMC5 because ARM_STD means using ARMC5, and thus
             # supported_toolchains must include ARMC5
-            if "ARMC5" not in target.supported_toolchains:
+            if not set(target.supported_toolchains).intersection(set(("ARMC5", "ARM"))):
                 raise NotSupportedException(
                     "ARM compiler 5 support is required for ARM build"
                 )

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -30,6 +30,12 @@ from tools.targets import CORE_ARCH
 from tools.toolchains.mbed_toolchain import mbedToolchain, TOOLCHAIN_PATHS
 from tools.utils import mkdir, NotSupportedException, ToolException, run_cmd
 
+ARMC5_MIGRATION_WARNING = (
+    "Warning: We noticed that you are using Arm Compiler 5. "
+    "We are deprecating the use of Arm Compiler 5 soon. "
+    "Please upgrade your environment to Arm Compiler 6 "
+    "which is free to use with Mbed OS."
+)
 
 class ARM(mbedToolchain):
     LINKER_EXT = '.sct'

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -34,7 +34,8 @@ ARMC5_MIGRATION_WARNING = (
     "Warning: We noticed that you are using Arm Compiler 5. "
     "We are deprecating the use of Arm Compiler 5 soon. "
     "Please upgrade your environment to Arm Compiler 6 "
-    "which is free to use with Mbed OS."
+    "which is free to use with Mbed OS. For more information, "
+    "please visit https://os.mbed.com/docs/mbed-os/latest/tools/index.html"
 )
 
 class ARM(mbedToolchain):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -339,8 +339,7 @@ def args_error(parser, message):
     parser - the ArgumentParser object that parsed the command line
     message - what went wrong
     """
-    parser.error(message)
-    sys.exit(2)
+    parser.exit(status=2, message=message+'\n')
 
 
 def construct_enum(**enums):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -296,6 +296,11 @@ class NotSupportedException(Exception):
 class InvalidReleaseTargetException(Exception):
     pass
 
+class NoValidToolchainException(Exception):
+    """A class representing no valid toolchain configurations found on
+    the system"""
+    pass
+
 def split_path(path):
     """spilt a file name into it's directory name, base name, and extension
 
@@ -597,3 +602,16 @@ def generate_update_filename(name, target):
                     name,
                     getattr(target, "OUTPUT_EXT_UPDATE", "bin")
                 )
+
+def print_end_warnings(end_warnings):
+    """ Print a formatted list of warnings
+
+    Positional arguments:
+    end_warnings - A list of warnings (strings) to print
+    """
+    if end_warnings:
+        warning_separator = "-" * 60
+        print(warning_separator)
+        for end_warning in end_warnings:
+            print(end_warning)
+        print(warning_separator)


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This PR makes it so:
- if `-t ARM` is being supplied as the toolchain
- and if ARMC6 is not configured in the user's environment
- and ARMC5 is configured
- and the the target supports building with both ARMC5 and ARMC6
Then the tools will select `ARMC5` as the toolchain for building. Previously, this was always set to `ARMC6` (with a few targets being the exception).

If the tools fallback to `ARMC5`, the following warning will be printed at the bottom of the log:

```
------------------------------------------------------------
Warning: We noticed that you are using Arm Compiler 5. We are deprecating the use of Arm Compiler 5 soon. Please upgrade your environment to Arm Compiler 6 which is free to use with Mbed OS. For more information, please visit https://os.mbed.com/docs/mbed-os/latest/tools/index.html
------------------------------------------------------------
```

This feature has been documented here (thanks @SenRamakri): https://github.com/ARMmbed/mbed-os-5-docs/pull/1024

Normally I'd write out all the implications of the changes in this PR, however the implementation details are fairly extensive. Reading the docs above is a good place to start, probably followed by the commit history.

FYI @screamerbg 

**TODO**

- [x] The ARMC5 warning needs to be updated with a link to the proper doc.
- ~I would really prefer to bring this in with a unit test. The implementation is quite complex and the details can easily be lost if verifying manually.~ Most likely this will have to come in in a later release due to time constraints.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@SenRamakri @theotherjimmy @bulislaw 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

The `-t ARM` argument defaults to using the Arm Compiler 6 when it is configured in a user's enviroment. However, In cases where a target supports building with both Arm Compiler 5 and Arm Compiler 6 and Arm Compiler 6 **is not** properly configured, the tools will fallback to compiling with Arm Compiler 5.
