### PR TITLE
update vscode default gcc arm version to 6-2017-q1-update

### DIFF
--- a/tools/export/vscode/launch.tmpl
+++ b/tools/export/vscode/launch.tmpl
@@ -46,7 +46,7 @@
             "windows": {
                 "preLaunchTask": "make.exe",
                 "MIMode": "gdb",
-                "MIDebuggerPath": "C:\\Program Files (x86)\\GNU Tools ARM Embedded\\4.9 2015q3\\bin\\arm-none-eabi-gdb.exe",
+                "MIDebuggerPath": "C:\\Program Files (x86)\\GNU Tools ARM Embedded\\6 2017-q1-update\\bin\\arm-none-eabi-gdb.exe",
                 "debugServerPath": "pyocd-gdbserver.exe",
                 "setupCommands": [
                     { "text": "-environment-cd ${workspaceRoot}\\BUILD" },


### PR DESCRIPTION
### Description
When we export a project for vscode, `launch.json`  on windows gets populated  with older version of gcc_arm

`"MIDebuggerPath": "C:\\Program Files (x86)\\GNU Tools ARM Embedded\\4.9 2015q3\\bin\\arm-none-eabi-gdb.exe",`

Default template point to an older version of gcc arm.  updating the template to officially supported version of gcc arm `6-2017-q1-update` 

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@theotherjimmy @bridadan @TacoGrandeTX 



