### PR TITLE
Disable exporters for LPC55S69 targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2052,7 +2052,6 @@
             "LPC"
         ],
         "detect_code": ["0236"],
-        "device_name": "LPC55S69JBD100",
         "release_versions": ["5"]
     },
     "LPC55S69_NS": {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

There seem to be further issues with uvision using ARMC6 and the LPC55S69_NS target. Disabling this target for now to unblock the rest of the PRs.

FYI @ARMmbed/mbed-os-maintainers 


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
