### PR TITLE
Set RX1 frequency in config for logging

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -868,6 +868,7 @@ bool LoRaPHY::rx_config(rx_config_params_t *rx_conf)
         if (phy_params.channels.channel_list[rx_conf->channel].rx1_frequency != 0) {
             frequency = phy_params.channels.channel_list[rx_conf->channel].rx1_frequency;
         }
+        rx_conf->frequency = frequency;
     }
 
     // Read the physical datarate from the datarates table


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

The logged frequency of the open RX1 slot is wrong at this line; https://github.com/ARMmbed/mbed-os/blob/master/features/lorawan/lorastack/mac/LoRaMac.cpp#L910

This is because the `channel` is filled out, but not the `frequency`. Only `rx_config()` should know the frequency (as it knows the frequency plan and RX1 DR offsets), so this change sets the `frequency` in there, so it gets logged correctly.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@hasnainvirk @janjongboom 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->