### PR TITLE
Nuvoton: Add button names BUTTON1/BUTTON2

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PinNames.h
@@ -170,7 +170,9 @@ typedef enum {
     // Button naming
     SW2 = PB_0,
     SW3 = PB_1,
-    
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
+
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_M451/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/PinNames.h
@@ -131,7 +131,9 @@ typedef enum {
     // Button naming
     SW2 = PA_15,
     SW3 = PA_14,
-    
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
+
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -136,8 +136,9 @@ typedef enum {
     SW2 = PF_11,
     SW3 = PG_5,
 #endif
-    
-    
+    BUTTON1 = SW2,
+    BUTTON2 = SW3,
+
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/PinNames.h
@@ -128,7 +128,9 @@ typedef enum {
     // Button naming
     SW1 = PE_5,
     SW2 = PE_6,
-    
+    BUTTON1 = SW1,
+    BUTTON2 = SW2,
+
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/PinNames.h
@@ -134,7 +134,9 @@ typedef enum {
     // Button naming
     SW1 = PC_12,
     SW2 = PC_13,
-    
+    BUTTON1 = SW1,
+    BUTTON2 = SW2,
+
 } PinName;
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description

This PR adds button name definitions `BUTTON1`/`BUTTON2` for Nuvoton targets:

- NUMAKER_PFM_NANO130
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487/NUMAKER_IOT_M487
- NUMAKER_PFM_M2351

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
