### PR TITLE
Cellular: CellularContext must provide access to CellularDevice

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/unittest.cmake
@@ -41,4 +41,5 @@ set(unittest-test-sources
   stubs/us_ticker_stub.cpp
   stubs/UARTSerial_stub.cpp
   stubs/SerialBase_stub.cpp
+  stubs/CellularContext_stub.cpp
 )

--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
@@ -43,6 +43,7 @@ set(unittest-test-sources
   stubs/UARTSerial_stub.cpp
   stubs/SerialBase_stub.cpp
   stubs/CellularStateMachine_stub.cpp
+  stubs/CellularContext_stub.cpp
 )
 
 # defines

--- a/UNITTESTS/features/cellular/framework/device/cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellulardevice/unittest.cmake
@@ -32,6 +32,7 @@ set(unittest-test-sources
   stubs/Semaphore_stub.cpp
   stubs/NetworkInterface_stub.cpp
   stubs/NetworkInterfaceDefaults_stub.cpp
+  stubs/CellularContext_stub.cpp
 )
 
 # defines

--- a/UNITTESTS/features/cellular/framework/device/cellularstatemachine/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellularstatemachine/unittest.cmake
@@ -38,6 +38,7 @@ set(unittest-test-sources
   stubs/Mutex_stub.cpp
   stubs/EventQueue_stub.cpp
   stubs/equeue_stub.c
+  stubs/CellularContext_stub.cpp
 )
 
 # defines

--- a/UNITTESTS/features/netsocket/cellular/CellularNonIPSocket/test_CellularNonIPSocket.cpp
+++ b/UNITTESTS/features/netsocket/cellular/CellularNonIPSocket/test_CellularNonIPSocket.cpp
@@ -17,7 +17,7 @@
 
 #include "gtest/gtest.h"
 #include "features/netsocket/cellular/CellularNonIPSocket.h"
-#include "CellularContext_stub.h"
+#include "myCellularContext.h"
 
 using namespace mbed;
 
@@ -34,7 +34,7 @@ class TestCellularNonIPSocket : public testing::Test {
 protected:
     CellularNonIPSocket *socket;
     ControlPlane_netif_stub *cp_netif;
-    CellularContext_stub cellular_context;
+    myCellularContext cellular_context;
     nsapi_size_t dataSize;
     char dataBuf[10];
 

--- a/UNITTESTS/features/netsocket/cellular/CellularNonIPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/cellular/CellularNonIPSocket/unittest.cmake
@@ -19,4 +19,5 @@ set(unittest-test-sources
   stubs/NetworkStack_stub.cpp
   stubs/EventFlags_stub.cpp
   stubs/Mutex_stub.cpp
+  stubs/CellularContext_stub.cpp
 )

--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -21,7 +21,7 @@ using namespace mbed;
 
 AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn,  bool cp_req, bool nonip_req) :
     AT_CellularBase(at), _is_blocking(true), _is_connected(false),
-    _current_op(OP_INVALID), _device(device), _nw(0), _fh(0), _cp_req(cp_req), _nonip_req(nonip_req), _cp_in_use(false)
+    _current_op(OP_INVALID), _nw(0), _fh(0), _cp_req(cp_req), _nonip_req(nonip_req), _cp_in_use(false)
 {
     _stack = NULL;
     _pdp_type = DEFAULT_PDP_TYPE;
@@ -37,6 +37,7 @@ AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, co
     _new_context_set = false;
     _next = NULL;
     _cp_netif = NULL;
+    _device = device;
 }
 
 AT_CellularContext::~AT_CellularContext()

--- a/UNITTESTS/stubs/CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/CellularContext_stub.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) , Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CellularContext.h"
+
+using namespace mbed;
+
+void CellularContext::cp_data_received()
+{
+    _cp_netif->data_received();
+}
+
+CellularDevice *CellularContext::get_device() const
+{
+    return _device;
+}

--- a/UNITTESTS/target_h/myCellularContext.h
+++ b/UNITTESTS/target_h/myCellularContext.h
@@ -20,18 +20,18 @@
 
 namespace mbed {
 
-class CellularContext_stub : public CellularContext {
+class myCellularContext : public CellularContext {
 public:
     std::list<nsapi_error_t> return_values;
     nsapi_error_t return_value;
     ControlPlane_netif_stub *my_cp_netif;
 
-    CellularContext_stub()
+    myCellularContext()
     {
         return_value = 0;
         my_cp_netif = NULL;
     }
-    ~CellularContext_stub()
+    ~myCellularContext()
     {
         if (my_cp_netif) {
             delete my_cp_netif;

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -172,6 +172,11 @@ public: // from NetworkInterface
      */
     static CellularContext *get_default_nonip_instance();
 
+    /** Get pointer to CellularDevice instance. May be null if not AT-layer.
+     *
+     *  @return pointer to CellularDevice instance
+     */
+    CellularDevice *get_device() const;
 
 // Operations, can be sync/async. Also Connect() is this kind of operation, inherited from NetworkInterface above.
 
@@ -327,6 +332,7 @@ protected: // Device specific implementations might need these so protected
     bool _active_high;
 
     ControlPlane_netif *_cp_netif;
+    CellularDevice *_device;
 };
 
 /**

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -18,6 +18,7 @@
 #include "AT_CellularContext.h"
 #include "AT_CellularNetwork.h"
 #include "AT_CellularStack.h"
+#include "AT_CellularDevice.h"
 #include "CellularLog.h"
 #include "CellularUtil.h"
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
@@ -48,7 +49,7 @@ using namespace mbed;
 
 AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req, bool nonip_req) :
     AT_CellularBase(at), _is_connected(false), _is_blocking(true),
-    _current_op(OP_INVALID), _device(device), _nw(0), _fh(0), _cp_req(cp_req), _nonip_req(nonip_req), _cp_in_use(false)
+    _current_op(OP_INVALID), _nw(0), _fh(0), _cp_req(cp_req), _nonip_req(nonip_req), _cp_in_use(false)
 {
     tr_info("New CellularContext %s (%p)", apn ? apn : "", this);
     _stack = NULL;
@@ -67,6 +68,7 @@ AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, co
     _dcd_pin = NC;
     _active_high = false;
     _cp_netif = NULL;
+    _device = device;
 }
 
 AT_CellularContext::~AT_CellularContext()
@@ -110,6 +112,11 @@ void AT_CellularContext::enable_hup(bool enable)
         static_cast<UARTSerial *>(_fh)->set_data_carrier_detect(enable ? _dcd_pin : NC, _active_high);
 #endif // #if DEVICE_SERIAL
     }
+}
+
+AT_CellularDevice *AT_CellularContext::get_device() const
+{
+    return static_cast<AT_CellularDevice *>(CellularContext::get_device());
 }
 
 nsapi_error_t AT_CellularContext::connect()

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -25,6 +25,8 @@ const int MAX_APN_LENGTH = 63 + 1;
 
 namespace mbed {
 
+class AT_CellularDevice;
+
 class AT_CellularContext : public CellularContext, public AT_CellularBase {
 public:
     AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn = 0, bool cp_req = false, bool nonip_req = false);
@@ -65,6 +67,7 @@ public:
 
     virtual ControlPlane_netif *get_cp_netif();
 
+    AT_CellularDevice *get_device() const;
 protected:
     virtual void cellular_callback(nsapi_event_t ev, intptr_t ptr);
 
@@ -126,7 +129,6 @@ private:
     bool _is_blocking;
     ContextOperation  _current_op;
     char _found_apn[MAX_APN_LENGTH];
-    CellularDevice *_device;
     CellularNetwork *_nw;
     FileHandle *_fh;
     rtos::Semaphore _semaphore;

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -61,4 +61,9 @@ void CellularContext::cp_data_received()
     _cp_netif->data_received();
 }
 
+CellularDevice *CellularContext::get_device() const
+{
+    return _device;
+}
+
 } // namespace mbed


### PR DESCRIPTION
### Description

When using NetworkInterface::get_default_instance() application gets handle
to CellularInterface which is actually CellularContext derived from CellularInterface.
Application needs also handle to CellularDevice to open other interfaces.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila @kivaisan 

### Release Notes

When using NetworkInterface::get_default_instance() application gets handle
to CellularInterface which is actually CellularContext derived from CellularInterface.
Application needs also handle to CellularDevice to open other interfaces.
