### PR TITLE
GR_LYCHEE,RZ_A1H,VK_RZ_A1H: Fix greentea ticker test case failures

### DIFF
--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -75,9 +75,8 @@ void wait_us(int us)
 #endif
 #elif defined __CORTEX_A
 #if __CORTEX_A == 9
-// Cortex-A9 is dual-issue, so let's assume same performance as Cortex-M7.
-// TODO - test.
-#define LOOP_SCALER 2000
+// Cortex-A9 can dual issue for 3 cycles per iteration (SUB,NOP) = 1, (NOP,BCS) = 2
+#define LOOP_SCALER 3000
 #endif
 #endif
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
@@ -26,10 +26,7 @@
 
 #include "os_tick.h"
 #include "irq_ctrl.h"
-
-#include <MBRZA1LU.h>
-
-#include <cmsis.h>
+#include "cmsis.h"
 #include "mbed_drv_cfg.h"
 
 
@@ -145,7 +142,8 @@ void  OS_Tick_Enable (void)
 }
 
 /// Disable OS Tick.
-void  OS_Tick_Disable (void) {
+void  OS_Tick_Disable (void)
+{
 
   // Stop the OSTM counter
   OSTM.OSTMnTT = 0x01U;
@@ -157,7 +155,7 @@ void  OS_Tick_Disable (void) {
 }
 
 // Acknowledge OS Tick IRQ.
-void OS_Tick_AcknowledgeIRQ (void)
+void  OS_Tick_AcknowledgeIRQ (void)
 {
   IRQ_ClearPending (OSTM_IRQn);
 }

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
@@ -30,6 +30,7 @@
 #include <MBRZA1LU.h>
 
 #include <cmsis.h>
+#include "mbed_drv_cfg.h"
 
 
 // Define OS TImer interrupt priority
@@ -62,15 +63,15 @@ int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler)
   // Get CPG.FRQCR[IFC] bits
   clock = (CPG.FRQCR >> 8) & 0x03;
 
-  // Determine Divider 2 output clock by using SystemCoreClock
+  // Determine Divider 2 output clock by using RENESAS_RZ_A1_P0_CLK
   if (clock == 0x03U) {
-    clock = (SystemCoreClock * 3U);
+    clock = (RENESAS_RZ_A1_P0_CLK * 3U);
   }
   else if (clock == 0x01U) {
-    clock = (SystemCoreClock * 3U)/2U;
+    clock = (RENESAS_RZ_A1_P0_CLK * 3U)/2U;
   }
   else {
-    clock = SystemCoreClock;
+    clock = RENESAS_RZ_A1_P0_CLK;
   }
 
   // Determine tick frequency

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
@@ -26,15 +26,10 @@
  * limitations under the License.
  */
 
-#include <RZ_A1LU.h>
+#include "RZ_A1LU.h"
 #include "RZ_A1_Init.h"
 #include "irq_ctrl.h"
 #include "mbed_drv_cfg.h"
-
-
-#define CS2_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFD040)
-#define CS3_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFE040)
-#define GPIO_PORT0_BOOTMODE_BITMASK (0x000fu)
 
 /*
  Port 0 (P0) MD pin assignment
@@ -66,12 +61,11 @@ void SystemCoreClockUpdate (void)
   if (ifc == 0x03U) {
     /* Division ratio is 1/3 */
     freq = (freq / 3U);
-  }
-  else {
-    if (ifc == 0x01U) {
-      /* Division ratio is 2/3 */
-      freq = (freq * 2U) / 3U;
-    }
+  } else if (ifc == 0x01U) {
+    /* Division ratio is 2/3 */
+    freq = (freq * 2U) / 3U;
+  } else {
+    /* do nothing */
   }
 
   SystemCoreClock = freq;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
@@ -55,22 +55,9 @@ uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
 void SystemCoreClockUpdate (void)
 {
   uint32_t freq;
-  uint16_t mode;
   uint16_t ifc;
 
-  mode = (GPIO.PPR0 >> 2U) & 0x01U;
-
-  if (mode == 0) {
-    /* Clock Mode 0 */
-    /* CLKIN is between 10MHz and 13.33MHz */
-    /* Divider 1 uses 1/1 ratio, PLL x30 is ON */
-    freq = CM0_RENESAS_RZ_A1_CLKIN * 30U;
-  } else {
-    /* Clock Mode 1 */
-    /* CLKIN is 48MHz */
-    /* Divider 1 uses 1/4 ratio, PLL x32 is ON */
-    freq = (CM1_RENESAS_RZ_A1_CLKIN * 32U) / 4U;
-  }
+  freq = RENESAS_RZ_A1_SYS_CLK;
 
   /* Get CPG.FRQCR[IFC] bits */
   ifc = (CPG.FRQCR >> 8U) & 0x03U;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
@@ -29,6 +29,8 @@
 #include <RZ_A1LU.h>
 #include "RZ_A1_Init.h"
 #include "irq_ctrl.h"
+#include "mbed_drv_cfg.h"
+
 
 #define CS2_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFD040)
 #define CS3_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFE040)
@@ -45,7 +47,7 @@
 /*----------------------------------------------------------------------------
   System Core Clock Variable
  *----------------------------------------------------------------------------*/
-uint32_t SystemCoreClock = CM1_RENESAS_RZ_A1_P0_CLK;
+uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
 
 /*----------------------------------------------------------------------------
   System Core Clock update function

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/mbed_drv_cfg.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/mbed_drv_cfg.h
@@ -34,6 +34,11 @@
 
 #define RENESAS_RZ_A1_P0_CLK   CM1_RENESAS_RZ_A1_P0_CLK
 
+/* Clock Mode 1 */
+/* CLKIN is 48MHz */
+/* Divider 1 uses 1/4 ratio, PLL x32 is ON */
+#define RENESAS_RZ_A1_SYS_CLK  ((CM1_RENESAS_RZ_A1_CLKIN * 32U) / 4U)
+
 #define LP_TICKER_MTU2_CH      2
 
 /* flash (W25Q64JV) */

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
@@ -30,6 +30,7 @@
 #include <MBRZA1H.h>
 
 #include <cmsis.h>
+#include "mbed_drv_cfg.h"
 
 
 // Define OS TImer interrupt priority
@@ -62,15 +63,15 @@ int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler)
   // Get CPG.FRQCR[IFC] bits
   clock = (CPG.FRQCR >> 8) & 0x03;
 
-  // Determine Divider 2 output clock by using SystemCoreClock
+  // Determine Divider 2 output clock by using RENESAS_RZ_A1_P0_CLK
   if (clock == 0x03U) {
-    clock = (SystemCoreClock * 3U);
+    clock = (RENESAS_RZ_A1_P0_CLK * 3U);
   }
   else if (clock == 0x01U) {
-    clock = (SystemCoreClock * 3U)/2U;
+    clock = (RENESAS_RZ_A1_P0_CLK * 3U)/2U;
   }
   else {
-    clock = SystemCoreClock;
+    clock = RENESAS_RZ_A1_P0_CLK;
   }
 
   // Determine tick frequency

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
@@ -26,10 +26,7 @@
 
 #include "os_tick.h"
 #include "irq_ctrl.h"
-
-#include <MBRZA1H.h>
-
-#include <cmsis.h>
+#include "cmsis.h"
 #include "mbed_drv_cfg.h"
 
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
@@ -29,6 +29,7 @@
 #include <RZ_A1H.h>
 #include "RZ_A1_Init.h"
 #include "irq_ctrl.h"
+#include "mbed_drv_cfg.h"
 
 #define CS2_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFD040)
 #define CS3_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFE040)
@@ -45,7 +46,7 @@
 /*----------------------------------------------------------------------------
   System Core Clock Variable
  *----------------------------------------------------------------------------*/
-uint32_t SystemCoreClock = CM0_RENESAS_RZ_A1_P0_CLK;
+uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
 
 /*----------------------------------------------------------------------------
   System Core Clock update function

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
@@ -54,22 +54,9 @@ uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
 void SystemCoreClockUpdate (void)
 {
   uint32_t freq;
-  uint16_t mode;
   uint16_t ifc;
 
-  mode = (GPIO.PPR0 >> 2U) & 0x01U;
-
-  if (mode == 0) {
-    /* Clock Mode 0 */
-    /* CLKIN is between 10MHz and 13.33MHz */
-    /* Divider 1 uses 1/1 ratio, PLL x30 is ON */
-    freq = CM0_RENESAS_RZ_A1_CLKIN * 30U;
-  } else {
-    /* Clock Mode 1 */
-    /* CLKIN is 48MHz */
-    /* Divider 1 uses 1/4 ratio, PLL x32 is ON */
-    freq = (CM1_RENESAS_RZ_A1_CLKIN * 32U) / 4U;
-  }
+  freq = RENESAS_RZ_A1_SYS_CLK;
 
   /* Get CPG.FRQCR[IFC] bits */
   ifc = (CPG.FRQCR >> 8U) & 0x03U;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
@@ -26,14 +26,10 @@
  * limitations under the License.
  */
 
-#include <RZ_A1H.h>
+#include "RZ_A1H.h"
 #include "RZ_A1_Init.h"
 #include "irq_ctrl.h"
 #include "mbed_drv_cfg.h"
-
-#define CS2_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFD040)
-#define CS3_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFE040)
-#define GPIO_PORT0_BOOTMODE_BITMASK (0x000fu)
 
 /*
  Port 0 (P0) MD pin assignment
@@ -65,12 +61,11 @@ void SystemCoreClockUpdate (void)
   if (ifc == 0x03U) {
     /* Division ratio is 1/3 */
     freq = (freq / 3U);
-  }
-  else {
-    if (ifc == 0x01U) {
-      /* Division ratio is 2/3 */
-      freq = (freq * 2U) / 3U;
-    }
+  } else if (ifc == 0x01U) {
+    /* Division ratio is 2/3 */
+    freq = (freq * 2U) / 3U;
+  } else {
+    /* do nothing */
   }
 
   SystemCoreClock = freq;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/mbed_drv_cfg.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/mbed_drv_cfg.h
@@ -34,6 +34,11 @@
 
 #define RENESAS_RZ_A1_P0_CLK   CM0_RENESAS_RZ_A1_P0_CLK
 
+/* Clock Mode 0 */
+/* CLKIN is between 10MHz and 13.33MHz */
+/* Divider 1 uses 1/1 ratio, PLL x30 is ON */
+#define RENESAS_RZ_A1_SYS_CLK  (CM0_RENESAS_RZ_A1_CLKIN * 30U)
+
 #define LP_TICKER_MTU2_CH      3
 
 /* flash (MX25L6433FM2I) */

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/os_tick_ostm.c
@@ -30,6 +30,7 @@
 #include <VKRZA1H.h>
 
 #include <cmsis.h>
+#include "mbed_drv_cfg.h"
 
 
 // Define OS TImer interrupt priority
@@ -62,15 +63,15 @@ int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler)
   // Get CPG.FRQCR[IFC] bits
   clock = (CPG.FRQCR >> 8) & 0x03;
 
-  // Determine Divider 2 output clock by using SystemCoreClock
+  // Determine Divider 2 output clock by using RENESAS_RZ_A1_P0_CLK
   if (clock == 0x03U) {
-    clock = (SystemCoreClock * 3U);
+    clock = (RENESAS_RZ_A1_P0_CLK * 3U);
   }
   else if (clock == 0x01U) {
-    clock = (SystemCoreClock * 3U)/2U;
+    clock = (RENESAS_RZ_A1_P0_CLK * 3U)/2U;
   }
   else {
-    clock = SystemCoreClock;
+    clock = RENESAS_RZ_A1_P0_CLK;
   }
 
   // Determine tick frequency

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/os_tick_ostm.c
@@ -26,10 +26,7 @@
 
 #include "os_tick.h"
 #include "irq_ctrl.h"
-
-#include <VKRZA1H.h>
-
-#include <cmsis.h>
+#include "cmsis.h"
 #include "mbed_drv_cfg.h"
 
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
@@ -54,23 +54,10 @@ uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
 void SystemCoreClockUpdate (void)
     {
   uint32_t freq;
-  uint16_t mode;
   uint16_t ifc;
 
-  mode = (GPIO.PPR0 >> 2U) & 0x01U;
+  freq = RENESAS_RZ_A1_SYS_CLK;
 
-  if (mode == 0) {
-    /* Clock Mode 0 */
-    /* CLKIN is between 10MHz and 13.33MHz */
-    /* Divider 1 uses 1/1 ratio, PLL x30 is ON */
-    freq = CM0_RENESAS_RZ_A1_CLKIN * 30U;
-  } else {
-    /* Clock Mode 1 */
-    /* CLKIN is 48MHz */
-    /* Divider 1 uses 1/4 ratio, PLL x32 is ON */
-    freq = (CM1_RENESAS_RZ_A1_CLKIN * 32U) / 4U;
-} 
- 
   /* Get CPG.FRQCR[IFC] bits */
   ifc = (CPG.FRQCR >> 8U) & 0x03U;
  

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
@@ -26,14 +26,10 @@
  * limitations under the License.
  */
 
-#include <VK_RZ_A1H.h>
+#include "VK_RZ_A1H.h"
 #include "RZ_A1_Init.h"
 #include "irq_ctrl.h"
 #include "mbed_drv_cfg.h"
-
-#define CS2_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFD040)
-#define CS3_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFE040)
-#define GPIO_PORT0_BOOTMODE_BITMASK (0x000fu)
 
 /*
  Port 0 (P0) MD pin assignment
@@ -52,7 +48,7 @@ uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
   System Core Clock update function
  *----------------------------------------------------------------------------*/
 void SystemCoreClockUpdate (void)
-    {
+{
   uint32_t freq;
   uint16_t ifc;
 
@@ -60,21 +56,20 @@ void SystemCoreClockUpdate (void)
 
   /* Get CPG.FRQCR[IFC] bits */
   ifc = (CPG.FRQCR >> 8U) & 0x03U;
- 
+
   /* Determine Divider 2 output clock */
   if (ifc == 0x03U) {
     /* Division ratio is 1/3 */
     freq = (freq / 3U);
+  } else if (ifc == 0x01U) {
+    /* Division ratio is 2/3 */
+    freq = (freq * 2U) / 3U;
+  } else {
+    /* do nothing */
   }
-  else {
-    if (ifc == 0x01U) {
-      /* Division ratio is 2/3 */
-      freq = (freq * 2U) / 3U;
-    } 
-} 
 
   SystemCoreClock = freq;
-} 
+}
 
 /*----------------------------------------------------------------------------
   IRQ Handler Register/Unregister

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
@@ -29,6 +29,7 @@
 #include <VK_RZ_A1H.h>
 #include "RZ_A1_Init.h"
 #include "irq_ctrl.h"
+#include "mbed_drv_cfg.h"
 
 #define CS2_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFD040)
 #define CS3_SDRAM_MODE_16BIT_CAS2_BR_BW (*(volatile uint16_t*)0x3FFFE040)
@@ -45,7 +46,7 @@
 /*----------------------------------------------------------------------------
   System Core Clock Variable
  *----------------------------------------------------------------------------*/
-uint32_t SystemCoreClock = CM0_RENESAS_RZ_A1_P0_CLK;
+uint32_t SystemCoreClock = RENESAS_RZ_A1_SYS_CLK;
 
 /*----------------------------------------------------------------------------
   System Core Clock update function

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/mbed_drv_cfg.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/mbed_drv_cfg.h
@@ -34,4 +34,9 @@
 
 #define RENESAS_RZ_A1_P0_CLK   CM0_RENESAS_RZ_A1_P0_CLK
 
+/* Clock Mode 0 */
+/* CLKIN is between 10MHz and 13.33MHz */
+/* Divider 1 uses 1/1 ratio, PLL x30 is ON */
+#define RENESAS_RZ_A1_SYS_CLK  (CM0_RENESAS_RZ_A1_CLKIN * 30U)
+
 #endif


### PR DESCRIPTION
### Description
Fix for issue #10119
Fixed the greentea test failur of mbed-os-tests-mbed_platform-wait_ns.

```
+-------------------+---------------+--------------------------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                                 | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+--------------------------------------------+--------+--------------------+-------------+
| GR_LYCHEE-GCC_ARM | GR_LYCHEE     | mbed-os-tests-mbed_drivers-ticker          | OK     | 44.42              | default     |
| GR_LYCHEE-GCC_ARM | GR_LYCHEE     | mbed-os-tests-mbed_drivers-timeout         | OK     | 58.35              | default     |
| GR_LYCHEE-GCC_ARM | GR_LYCHEE     | mbed-os-tests-mbed_hal-common_tickers_freq | OK     | 37.13              | default     |
| GR_LYCHEE-GCC_ARM | GR_LYCHEE     | mbed-os-tests-mbed_platform-wait_ns        | OK     | 16.27              | default     |
| GR_LYCHEE-GCC_ARM | GR_LYCHEE     | mbed-os-tests-mbedmicro-rtos-mbed-basic    | OK     | 26.42              | default     |
+-------------------+---------------+--------------------------------------------+--------+--------------------+-------------+

+----------------+---------------+--------------------------------------------+--------+--------------------+-------------+
| target         | platform_name | test suite                                 | result | elapsed_time (sec) | copy_method |
+----------------+---------------+--------------------------------------------+--------+--------------------+-------------+
| RZ_A1H-GCC_ARM | RZ_A1H        | mbed-os-tests-mbed_drivers-ticker          | OK     | 45.21              | default     |
| RZ_A1H-GCC_ARM | RZ_A1H        | mbed-os-tests-mbed_drivers-timeout         | OK     | 57.98              | default     |
| RZ_A1H-GCC_ARM | RZ_A1H        | mbed-os-tests-mbed_hal-common_tickers_freq | OK     | 38.49              | default     |
| RZ_A1H-GCC_ARM | RZ_A1H        | mbed-os-tests-mbed_platform-wait_ns        | OK     | 16.96              | default     |
| RZ_A1H-GCC_ARM | RZ_A1H        | mbed-os-tests-mbedmicro-rtos-mbed-basic    | OK     | 27.02              | default     |
+----------------+---------------+--------------------------------------------+--------+--------------------+-------------+
```

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@VeijoPesonen
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
