### PR TITLE
LoRaWAN: Adding TOA and Channel info in RX metadata

### DIFF
--- a/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
+++ b/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
@@ -77,6 +77,9 @@ TEST_F(Test_LoRaMac, initialize)
     conn.connection_u.otaa.nb_trials = 2;
     object->prepare_join(&conn, true);
 
+    channel_params_t params[] = {868300000, 0, { ((DR_5 << 4) | DR_0) }, 1};
+    LoRaPHY_stub::channel_params_ptr = params;
+
     LoRaWANTimer_stub::call_cb_immediately = true;
     EXPECT_TRUE(LORAWAN_STATUS_OK == object->initialize(NULL, my_cb));
 }

--- a/UNITTESTS/stubs/LoRaPHY_stub.cpp
+++ b/UNITTESTS/stubs/LoRaPHY_stub.cpp
@@ -416,4 +416,8 @@ uint8_t LoRaPHY::apply_DR_offset(int8_t dr, int8_t dr_offset)
     return LoRaPHY_stub::uint8_value;
 }
 
+uint32_t LoRaPHY::get_rx_time_on_air(uint8_t modem, uint16_t pkt_len)
+{
+    return LoRaPHY_stub::uint32_value;
+}
 

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -795,6 +795,8 @@ void LoRaWANStack::make_rx_metadata_available(void)
     _rx_metadata.rx_datarate = _loramac.get_mcps_indication()->rx_datarate;
     _rx_metadata.rssi = _loramac.get_mcps_indication()->rssi;
     _rx_metadata.snr = _loramac.get_mcps_indication()->snr;
+    _rx_metadata.channel = _loramac.get_mcps_indication()->channel;
+    _rx_metadata.rx_toa = _loramac.get_mcps_indication()->rx_toa;
 }
 
 bool LoRaWANStack::is_port_valid(const uint8_t port, bool allow_port_0)

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -520,6 +520,12 @@ public:
      */
     bool is_custom_channel_plan_supported();
 
+    /**
+     * @brief get_rx_time_on_air(...) calculates the time the received spent on air
+     * @return time spent on air in milliseconds
+     */
+    uint32_t get_rx_time_on_air(uint8_t modem, uint16_t pkt_len);
+
 public: //Verifiers
 
     /**

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -666,6 +666,14 @@ typedef struct {
      * A boolean to mark if the meta data is stale
      */
     bool stale;
+    /**
+     * Frequency for the downlink channel
+     */
+    uint32_t channel;
+    /**
+     * Time spent on air by the RX frame
+     */
+    uint32_t rx_toa;
 } lorawan_rx_metadata;
 
 #endif /* MBED_LORAWAN_TYPES_H_ */

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -681,6 +681,14 @@ typedef struct {
      * The downlink counter value for the received frame.
      */
     uint32_t dl_frame_counter;
+    /*!
+     * The downlink channel
+     */
+    uint32_t channel;
+    /*!
+     * The time on air of the received frame.
+     */
+    lorawan_time_t rx_toa;
 } loramac_mcps_indication_t;
 
 /*!
@@ -986,6 +994,10 @@ typedef struct lorawan_session {
  * The parameter structure for the function for regional rx configuration.
  */
 typedef struct {
+    /*!
+     * Type of modulation used (LoRa or FSK)
+     */
+    uint8_t modem_type;
     /*!
      * The RX channel.
      */


### PR DESCRIPTION


### Description

We provide now downlink channel frequency and time on air for the
received frame in the RX metadata.
Previously the channel information in both TX and RX metada contained
the index number of the channel. That information wasn't very useful
except the index numbers of default channels. To make more sense of the
meta data, we now store the channel frequency in the channel parameter
rather than the index number of the channel.

RX time on air is collected from the radio driver and it is assumed that
the downlink frame had 8 downlink preamble symbols (plus 4.25 of the
preambles added by the chip) for LoRa modulation.

This commit also include a bit of tidying of RX frequency storage in rx
configuration parameters storage. Previously we were missing filling in
the RX1 frequency correctly.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila @kjbracey-arm @cmonr 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
