### PR TITLE
Implement VerifyReadBlockDevice as a workaround for Cypress CY8* read failures

### DIFF
--- a/features/storage/blockdevice/VerifyReadBlockDevice.cpp
+++ b/features/storage/blockdevice/VerifyReadBlockDevice.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** \addtogroup storage */
+/** @{*/
+
+#include "VerifyReadBlockDevice.h"
+#include "platform/mbed_error.h"
+#include "MbedCRC.h"
+
+const int max_reads = 64;
+
+namespace mbed {
+
+VerifyReadBlockDevice::VerifyReadBlockDevice(BlockDevice *bd)
+    : _bd(bd)
+{
+    // Does nothing
+}
+
+VerifyReadBlockDevice::~VerifyReadBlockDevice()
+{
+    // Does nothing
+}
+
+int VerifyReadBlockDevice::init()
+{
+    return _bd->init();
+}
+
+int VerifyReadBlockDevice::deinit()
+{
+    return _bd->deinit();
+}
+
+int VerifyReadBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
+int VerifyReadBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
+{
+    int ret, num_reads = 0;
+    uint32_t crc, prev_crc;
+
+    while ((num_reads < 2) || (crc != prev_crc)) {
+        prev_crc = crc;
+        num_reads++;
+        if (num_reads > max_reads) {
+            return BD_ERROR_DEVICE_ERROR;
+        }
+        ret = _bd->read(buffer, addr, size);
+        if (ret) {
+            return ret;
+        }
+        MbedCRC<POLY_32BIT_ANSI, 32> ct(0xFFFFFFFF, 0x0, true, false);
+        ct.compute(const_cast<void *>(buffer), size, &crc);
+    }
+    return ret;
+}
+
+int VerifyReadBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
+{
+    return _bd->program(buffer, addr, size);
+}
+
+int VerifyReadBlockDevice::erase(bd_addr_t addr, bd_size_t size)
+{
+    return _bd->erase(addr, size);
+}
+
+bd_size_t VerifyReadBlockDevice::get_read_size() const
+{
+    return _bd->get_read_size();
+}
+
+bd_size_t VerifyReadBlockDevice::get_program_size() const
+{
+    return _bd->get_program_size();
+}
+
+bd_size_t VerifyReadBlockDevice::get_erase_size() const
+{
+    return _bd->get_erase_size();
+}
+
+bd_size_t VerifyReadBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(addr);
+}
+
+int VerifyReadBlockDevice::get_erase_value() const
+{
+    return _bd->get_erase_value();
+}
+
+bd_size_t VerifyReadBlockDevice::size() const
+{
+    return _bd->size();
+}
+
+const char *VerifyReadBlockDevice::get_type() const
+{
+    if (_bd != NULL) {
+        return _bd->get_type();
+    }
+
+    return NULL;
+}
+
+} // namespace mbed
+
+/** @}*/
+
+

--- a/features/storage/blockdevice/VerifyReadBlockDevice.h
+++ b/features/storage/blockdevice/VerifyReadBlockDevice.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2019 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** \addtogroup storage */
+/** @{*/
+
+#ifndef MBED_VERIFY_READ_BLOCK_DEVICE_H
+#define MBED_VERIFY_READ_BLOCK_DEVICE_H
+
+#include "BlockDevice.h"
+#include "PlatformMutex.h"
+
+namespace mbed {
+
+class VerifyReadBlockDevice : public BlockDevice {
+public:
+
+    /** Lifetime of the block device
+     *
+     * @param bd        Block device to wrap as read only
+     */
+    VerifyReadBlockDevice(BlockDevice *bd);
+    virtual ~VerifyReadBlockDevice();
+
+    /** Initialize a block device
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int init();
+
+    /** Deinitialize a block device
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int deinit();
+
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
+    /** Read blocks from a block device
+     *
+     *  @param buffer   Buffer to read blocks into
+     *  @param addr     Address of block to begin reading from
+     *  @param size     Size to read in bytes, must be a multiple of read block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+
+    /** Program blocks to a block device
+     *
+     *  The blocks must have been erased prior to being programmed
+     *
+     *  @param buffer   Buffer of data to write to blocks
+     *  @param addr     Address of block to begin writing to
+     *  @param size     Size to write in bytes, must be a multiple of program block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+
+    /** Erase blocks on a block device
+     *
+     *  The state of an erased block is undefined until it has been programmed,
+     *  unless get_erase_value returns a non-negative byte value
+     *
+     *  @param addr     Address of block to begin erasing
+     *  @param size     Size to erase in bytes, must be a multiple of erase block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int erase(bd_addr_t addr, bd_size_t size);
+
+    /** Get the size of a readable block
+     *
+     *  @return         Size of a readable block in bytes
+     */
+    virtual bd_size_t get_read_size() const;
+
+    /** Get the size of a programmable block
+     *
+     *  @return         Size of a programmable block in bytes
+     */
+    virtual bd_size_t get_program_size() const;
+
+    /** Get the size of an erasable block
+     *
+     *  @return         Size of an erasable block in bytes
+     */
+    virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+
+    /** Get the value of storage when erased
+     *
+     *  If get_erase_value returns a non-negative byte value, the underlying
+     *  storage is set to that value when erased, and storage containing
+     *  that value can be programmed without another erase.
+     *
+     *  @return         The value of storage when erased, or -1 if you can't
+     *                  rely on the value of erased storage
+     */
+    virtual int get_erase_value() const;
+
+    /** Get the total size of the underlying device
+     *
+     *  @return         Size of the underlying device in bytes
+     */
+    virtual bd_size_t size() const;
+
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string represent the BlockDevice class type.
+     */
+    virtual const char *get_type() const;
+
+private:
+    BlockDevice *_bd;
+};
+
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::VerifyReadBlockDevice;
+#endif
+
+#endif
+
+/** @}*/

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -15,6 +15,9 @@
  */
 #include "SystemStorage.h"
 #include "BlockDevice.h"
+#ifdef VERIFY_READ_DEF_BD
+#include "VerifyReadBlockDevice.h"
+#endif
 #include "FileSystem.h"
 #include "FATFileSystem.h"
 #include "LittleFileSystem.h"
@@ -94,8 +97,6 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_SPIF_DRIVER_SPI_FREQ
     );
 
-    return &default_bd;
-
 #elif COMPONENT_RSPIF
 
     static SPIFReducedBlockDevice default_bd(
@@ -105,8 +106,6 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_RSPIF_DRIVER_SPI_CS,
         MBED_CONF_RSPIF_DRIVER_SPI_FREQ
     );
-
-    return &default_bd;
 
 #elif COMPONENT_QSPIF
 
@@ -121,8 +120,6 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_QSPIF_QSPI_FREQ
     );
 
-    return &default_bd;
-
 #elif COMPONENT_DATAFLASH
 
     static DataFlashBlockDevice default_bd(
@@ -132,8 +129,6 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_DATAFLASH_SPI_CS
     );
 
-    return &default_bd;
-
 #elif COMPONENT_SD
 
     static SDBlockDevice default_bd(
@@ -142,8 +137,6 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_SD_SPI_CLK,
         MBED_CONF_SD_SPI_CS
     );
-
-    return &default_bd;
 
 #elif COMPONENT_FLASHIAP
 
@@ -174,14 +167,20 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
 #endif
 
-    return &default_bd;
-
 #else
-
+#define NO_BD 1
     return NULL;
 
 #endif
 
+#ifdef VERIFY_READ_DEF_BD
+    static VerifyReadBlockDevice verify_read_bd(&default_bd);
+    return &verify_read_bd;
+#else
+#ifndef NO_BD
+    return &default_bd;
+#endif
+#endif
 }
 
 MBED_WEAK FileSystem *FileSystem::get_default_instance()

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8121,7 +8121,7 @@
         "inherits": ["MCU_PSOC6_M0"],
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["CY8C62XX", "CY8CKIT_062_WIFI_BT"],
-        "macros_add": ["CY8C6247BZI_D54", "PSOC6_DYNSRM_DISABLE=1"],
+        "macros_add": ["CY8C6247BZI_D54", "PSOC6_DYNSRM_DISABLE=1", "VERIFY_READ_DEF_BD=1"],
         "detect_code": ["1900"],
         "post_binary_hook": {
             "function": "PSOC6Code.complete"
@@ -8132,7 +8132,7 @@
         "features": ["BLE"],
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["PSOC6_01", "WICED", "CYW43XXX", "CYW4343X", "CORDIO", "CY8C62XX"],
-        "macros_add": ["CY8C6247BZI_D54", "PSOC6_DYNSRM_DISABLE=1"],
+        "macros_add": ["CY8C6247BZI_D54", "PSOC6_DYNSRM_DISABLE=1", "VERIFY_READ_DEF_BD=1"],
         "detect_code": ["1900"],
         "hex_filename": "psoc6_01_cm0p_sleep.hex",
         "post_binary_hook": {
@@ -8152,7 +8152,8 @@
             "MBEDTLS_PSA_CRYPTO_SPM",
             "MBEDTLS_PSA_CRYPTO_C",
             "CY_IPC_DEFAULT_CFG_DISABLE",
-            "PU_ENABLE"
+            "PU_ENABLE",
+            "VERIFY_READ_DEF_BD=1"
         ],
         "deliver_to_target": "CY8CKIT_062_WIFI_BT_PSA",
         "delivery_dir": "TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT_PSA/prebuilt",
@@ -8176,7 +8177,7 @@
         "extra_labels_add": ["PSA", "MBED_SPM"],
         "components_add": ["SPM_MAILBOX", "FLASHIAP"],
         "device_has_remove": ["CRC"],
-        "macros_add": ["MBEDTLS_PSA_CRYPTO_C"],
+        "macros_add": ["MBEDTLS_PSA_CRYPTO_C", "VERIFY_READ_DEF_BD=1"],
         "hex_filename": "psa_release_1.0.hex",
         "overrides": {
             "secure-rom-start": "0x10000000",
@@ -8218,7 +8219,7 @@
         "inherits": ["MCU_PSOC6_M4"],
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["PSOC6_01"],
-        "macros_add": ["CY8C6347BZI_BLD53", "PSOC6_DYNSRM_DISABLE=1"],
+        "macros_add": ["CY8C6347BZI_BLD53", "PSOC6_DYNSRM_DISABLE=1", "VERIFY_READ_DEF_BD=1"],
         "detect_code": ["1902"],
         "hex_filename": "psoc6_01_cm0p_sleep.hex",
         "post_binary_hook": {
@@ -8233,7 +8234,7 @@
         "supported_form_factors": ["ARDUINO"],
         "device_has_remove": ["ANALOGOUT"],
         "extra_labels_add": ["PSOC6_02", "WICED", "CYW43XXX", "CYW4343X", "CORDIO"],
-        "macros_add": ["CY8C624ABZI_D44", "PSOC6_DYNSRM_DISABLE=1"],
+        "macros_add": ["CY8C624ABZI_D44", "PSOC6_DYNSRM_DISABLE=1", "VERIFY_READ_DEF_BD=1"],
         "detect_code": ["1905"],
         "hex_filename": "psoc6_02_cm0p_sleep.hex",
         "post_binary_hook": {


### PR DESCRIPTION
### Description
The `VerifyReadBlockDevice` utility block device performs multiple reads of the data and calculates CRC on each read, until two consecutive reads have the same CRC.
This is a workaround for read failures in the Cypress CY8* boards. They have this utility block device wrapping the default one to overcome these failures.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

