### PR TITLE
BLE: fix scan timeout being called from interrupt

### DIFF
--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -782,7 +782,7 @@ private:
     );
 
     void on_scan_timeout_();
-
+    void process_legacy_scan_timeout();
 
 private:
     pal::EventQueue &_event_queue;

--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -1607,8 +1607,9 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
 
     _scan_enabled = false;
 
-    /* if timeout happened on a 4.2 chip we need to stop the scan manually */
     if (!is_extended_advertising_available()) {
+        /* if timeout happened on a 4.2 chip this means legacy scanning and a timer timeout
+         * but we need to handle the event from user context - use the event queue to handle it */
         _event_queue.post(
             mbed::callback(
                 this,
@@ -1629,6 +1630,7 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
 template <template<class> class PalGapImpl, class PalSecurityManager, class ConnectionEventMonitorEventHandler>
 void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandler>::process_legacy_scan_timeout()
 {
+    /* legacy scanning timed out is based on timer so we need to stop the scan manually */
     _pal_gap.scan_enable(false, false);
 #if BLE_FEATURE_PRIVACY
     set_random_address_rotation(false);
@@ -3280,7 +3282,6 @@ ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEve
 
         _scan_timeout.detach();
         if (duration.value()) {
-            /**/
             _scan_timeout.attach_us(
                 mbed::callback(this, &GenericGap::on_scan_timeout_),
                 microsecond_t(duration).value()

--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -1613,11 +1613,7 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
         _event_queue.post(
             mbed::callback(
                 this,
-                &GenericGap<
-                    PalGapImpl,
-                    PalSecurityManager,
-                    ConnectionEventMonitorEventHandler
-                >::process_legacy_scan_timeout
+                &GenericGap::process_legacy_scan_timeout
             )
         );
     } else {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Legacy scanning uses a timer to simulate a scan timeout event which causes the timeout to be called from the timer interrupt. This posts the call in the event queue.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@pan- 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
