### PR TITLE
Semaphore: remove 16-bit limit

### DIFF
--- a/rtos/Semaphore.cpp
+++ b/rtos/Semaphore.cpp
@@ -51,8 +51,11 @@ int32_t Semaphore::wait(uint32_t millisec)
 {
     osStatus_t stat = osSemaphoreAcquire(_id, millisec);
     switch (stat) {
-        case osOK:
-            return osSemaphoreGetCount(_id) + 1;
+        case osOK: {
+            // Need to ensure return remains positive if count is huge.
+            uint32_t count = osSemaphoreGetCount(_id);
+            return count < 0x7FFFFFFFu ? (int32_t)count + 1 : 0x7FFFFFFF;
+        }
         case osErrorTimeout:
         case osErrorResource:
             return 0;

--- a/rtos/Semaphore.cpp
+++ b/rtos/Semaphore.cpp
@@ -27,17 +27,17 @@
 
 namespace rtos {
 
-Semaphore::Semaphore(int32_t count)
+Semaphore::Semaphore(uint32_t count)
 {
-    constructor(count, 0xffff);
+    constructor(count, 0xffffffff);
 }
 
-Semaphore::Semaphore(int32_t count, uint16_t max_count)
+Semaphore::Semaphore(uint32_t count, uint32_t max_count)
 {
     constructor(count, max_count);
 }
 
-void Semaphore::constructor(int32_t count, uint16_t max_count)
+void Semaphore::constructor(uint32_t count, uint32_t max_count)
 {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
     osSemaphoreAttr_t attr = { 0 };

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -49,7 +49,7 @@ public:
 
       @note You cannot call this function from ISR context.
     */
-    Semaphore(int32_t count = 0);
+    Semaphore(uint32_t count = 0);
 
     /** Create and Initialize a Semaphore object used for managing resources.
       @param  count     number of available resources
@@ -57,7 +57,7 @@ public:
 
       @note You cannot call this function from ISR context.
     */
-    Semaphore(int32_t count, uint16_t max_count);
+    Semaphore(uint32_t count, uint32_t max_count);
 
     /** Wait until a Semaphore resource becomes available.
       @param   millisec  timeout value. (default: osWaitForever).
@@ -96,7 +96,7 @@ public:
     ~Semaphore();
 
 private:
-    void constructor(int32_t count, uint16_t max_count);
+    void constructor(uint32_t count, uint32_t max_count);
 
     osSemaphoreId_t               _id;
     mbed_rtos_storage_semaphore_t _obj_mem;


### PR DESCRIPTION
### Description

Semaphore had a historical 16-bit maximum count limit - this was odd, as the initial count was 32-bit.

Remove the limitation - change constructors to take uint32_t, and make the default limit 0xffffffff rather than 0xffff.

Limits of overload resolution prevent adding new constructors while retaining the old ones.

Addresses issue raised in #10216.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [X] Breaking change

### Release Notes

* `Semaphore` now permits the full 32-bit maximum count available in CMSIS RTOS 2. The change to its available constructors breaks binary compatibility, but there should be no source compatibility issues.
* The default maximum count for a `Semaphore` is now 0xffffffff rather than 0xffff.
