### PR TITLE
Cellular: Power ON Wait Increased for C030_U201

### DIFF
--- a/features/cellular/TESTS/api/cellular_device/main.cpp
+++ b/features/cellular/TESTS/api/cellular_device/main.cpp
@@ -93,11 +93,7 @@ static void other_methods()
     TEST_ASSERT(device->get_queue() != NULL);
     TEST_ASSERT(device->hard_power_on() == NSAPI_ERROR_OK);
     TEST_ASSERT(device->soft_power_on() == NSAPI_ERROR_OK);
-#ifdef TARGET_UBLOX_C030_U201
     wait(10);
-#else
-    wait(5);
-#endif
     TEST_ASSERT_EQUAL_INT(device->init(), NSAPI_ERROR_OK);
 }
 

--- a/features/cellular/TESTS/api/cellular_device/main.cpp
+++ b/features/cellular/TESTS/api/cellular_device/main.cpp
@@ -93,7 +93,11 @@ static void other_methods()
     TEST_ASSERT(device->get_queue() != NULL);
     TEST_ASSERT(device->hard_power_on() == NSAPI_ERROR_OK);
     TEST_ASSERT(device->soft_power_on() == NSAPI_ERROR_OK);
+#ifdef TARGET_UBLOX_C030_U201
+    wait(10);
+#else
     wait(5);
+#endif
     TEST_ASSERT_EQUAL_INT(device->init(), NSAPI_ERROR_OK);
 }
 


### PR DESCRIPTION
### Description
Increased wait for power up of module in `CellularDevice` test case, as UBLOX_C030_U201 took 10-12 sec to power up.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
