### PR TITLE
Cellular: cellular_network_test Compilation Error Removed

### DIFF
--- a/features/cellular/TESTS/api/cellular_network/main.cpp
+++ b/features/cellular/TESTS/api/cellular_network/main.cpp
@@ -188,7 +188,7 @@ static void test_other()
     err = nw->get_operator_params(format, operator_params);
     TEST_ASSERT(err == NSAPI_ERROR_OK);
 
-    nsapi_connection_status_t st =  nw->get_connection_status();
+    nsapi_connection_status_t st =  ctx->get_connection_status();
     TEST_ASSERT(st == NSAPI_STATUS_DISCONNECTED);
 
     // TELIT_HE910 and QUECTEL_BG96 just gives an error and no specific error number so we can't know is this real error or that modem/network does not support the command
@@ -207,13 +207,13 @@ static void test_detach()
     rtos::ThisThread::sleep_for(6 * 1000);
     ((AT_CellularNetwork *)nw)->get_at_handler().flush();
 
-    nsapi_connection_status_t st =  nw->get_connection_status();
+    nsapi_connection_status_t st =  ctx->get_connection_status();
     TEST_ASSERT(st == NSAPI_STATUS_DISCONNECTED);
 
     TEST_ASSERT(nw->detach() == NSAPI_ERROR_OK);
     // wait to process URC's, received after detach
     rtos::ThisThread::sleep_for(500);
-    st =  nw->get_connection_status();
+    st =  ctx->get_connection_status();
     TEST_ASSERT(st == NSAPI_STATUS_DISCONNECTED);
 }
 


### PR DESCRIPTION
### Description
`get_connection_status` is member function of `AT_CellularContext` class.



### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
