### PR TITLE
PSA Crypto Service - multipart operation memory fixes

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -240,6 +240,10 @@ psa_status_t psa_hash_abort(psa_hash_operation_t *operation)
 psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
                             psa_algorithm_t alg)
 {
+    if (operation->handle != PSA_NULL_HANDLE) {
+        return (PSA_ERROR_BAD_STATE);
+    }
+
     psa_crypto_ipc_t psa_crypto_ipc = {
         .func   = PSA_HASH_SETUP,
         .handle = 0,
@@ -253,6 +257,9 @@ psa_status_t psa_hash_setup(psa_hash_operation_t *operation,
         return (status);
     }
     status = ipc_call(&operation->handle, &in_vec, 1, NULL, 0, false);
+    if (status != PSA_SUCCESS) {
+        ipc_close(&operation->handle);
+    }
     return (status);
 }
 
@@ -272,6 +279,9 @@ psa_status_t psa_hash_update(psa_hash_operation_t *operation,
     };
 
     psa_status_t status = ipc_call(&operation->handle, in_vec, 2, NULL, 0, false);
+    if (status != PSA_SUCCESS) {
+        ipc_close(&operation->handle);
+    }
     return (status);
 }
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -1006,6 +1006,10 @@ psa_status_t psa_key_derivation(psa_crypto_generator_t *generator,
                                 size_t label_length,
                                 size_t capacity)
 {
+    if (generator->handle != PSA_NULL_HANDLE) {
+        return (PSA_ERROR_BAD_STATE);
+    }
+
     psa_crypto_derivation_ipc_t psa_crypto_ipc = {
         .func       = PSA_KEY_DERIVATION,
         .handle     = key_handle,
@@ -1024,6 +1028,9 @@ psa_status_t psa_key_derivation(psa_crypto_generator_t *generator,
         return (status);
     }
     status = ipc_call(&generator->handle, in_vec, 3, NULL, 0, false);
+    if (status != PSA_SUCCESS) {
+        ipc_close(&generator->handle);
+    }
     return (status);
 }
 
@@ -1033,6 +1040,10 @@ psa_status_t psa_key_agreement(psa_crypto_generator_t *generator,
                                size_t peer_key_length,
                                psa_algorithm_t alg)
 {
+    if (generator->handle != PSA_NULL_HANDLE) {
+        return (PSA_ERROR_BAD_STATE);
+    }
+
     psa_crypto_derivation_ipc_t psa_crypto_ipc = {
         .func       = PSA_KEY_AGREEMENT,
         .handle     = private_key_handle,
@@ -1050,6 +1061,9 @@ psa_status_t psa_key_agreement(psa_crypto_generator_t *generator,
         return (status);
     }
     status = ipc_call(&generator->handle, in_vec, 2, NULL, 0, false);
+    if (status != PSA_SUCCESS) {
+        ipc_close(&generator->handle);
+    }
     return (status);
 }
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -120,6 +120,10 @@ static psa_status_t psa_mac_setup(psa_mac_operation_t *operation,
                                   psa_algorithm_t alg,
                                   psa_sec_function_t func)
 {
+    if (operation->handle != PSA_NULL_HANDLE) {
+        return (PSA_ERROR_BAD_STATE);
+    }
+
     psa_crypto_ipc_t psa_crypto_ipc = {
         .func   = func,
         .handle = key_handle,
@@ -133,6 +137,9 @@ static psa_status_t psa_mac_setup(psa_mac_operation_t *operation,
         return (status);
     }
     status = ipc_call(&operation->handle, &in_vec, 1, NULL, 0, false);
+    if (status != PSA_SUCCESS) {
+        ipc_close(&operation->handle);
+    }
     return (status);
 }
 
@@ -168,6 +175,9 @@ psa_status_t psa_mac_update(psa_mac_operation_t *operation,
     };
 
     psa_status_t status = ipc_call(&operation->handle, in_vec, 2, NULL, 0, false);
+    if (status != PSA_SUCCESS) {
+        ipc_close(&operation->handle);
+    }
     return (status);
 }
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -1522,10 +1522,14 @@ static void psa_rng_operation(void)
 
         case PSA_IPC_CALL: {
             size_t random_size = msg.out_size[0];
-            unsigned char *random = mbedtls_calloc(1, random_size);
-            if (random == NULL) {
-                status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                break;
+            unsigned char *random = NULL;
+
+            if (random_size > 0) {
+                random = mbedtls_calloc(1, random_size);
+                if (random == NULL) {
+                    status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                    break;
+                }
             }
 
             status = psa_generate_random(random, random_size);

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -1467,6 +1467,7 @@ static void psa_entropy_operation(void)
 
         case PSA_IPC_CALL: {
 #if (defined(MBEDTLS_ENTROPY_NV_SEED) && defined(MBEDTLS_PSA_HAS_ITS_IO))
+            unsigned char *seed = NULL;
             uint32_t bytes_read;
             size_t seed_size = msg.in_size[0];
             if (MBEDTLS_ENTROPY_MAX_SEED_SIZE < seed_size) {
@@ -1474,10 +1475,12 @@ static void psa_entropy_operation(void)
                 break;
             }
 
-            unsigned char *seed = mbedtls_calloc(1, seed_size);
-            if (seed == NULL) {
-                status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                break;
+            if (seed_size > 0) {
+                seed = mbedtls_calloc(1, seed_size);
+                if (seed == NULL) {
+                    status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                    break;
+                }
             }
 
             bytes_read = psa_read(msg.handle, 0, seed, seed_size);

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -114,6 +114,12 @@ static inline psa_status_t get_hash_clone(size_t index, int32_t partition_id,
     return PSA_SUCCESS;
 }
 
+static void free_message_context(psa_msg_t *msg)
+{
+    mbedtls_free(msg->rhandle);
+    psa_set_rhandle(msg->handle, NULL);
+}
+
 // ------------------------- Partition's Main Thread ---------------------------
 static void psa_crypto_init_operation(void)
 {
@@ -234,8 +240,7 @@ static void psa_mac_operation(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -248,8 +253,7 @@ static void psa_mac_operation(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -289,8 +293,7 @@ static void psa_mac_operation(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -322,8 +325,7 @@ static void psa_mac_operation(void)
                         psa_mac_abort(msg.rhandle);
                     }
 
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
@@ -355,15 +357,13 @@ static void psa_mac_operation(void)
                         psa_mac_abort(msg.rhandle);
                     }
 
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
                 case PSA_MAC_ABORT: {
                     status = psa_mac_abort(msg.rhandle);
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
@@ -381,7 +381,7 @@ static void psa_mac_operation(void)
         case PSA_IPC_DISCONNECT: {
             if (msg.rhandle != NULL) {
                 psa_mac_abort(msg.rhandle);
-                mbedtls_free(msg.rhandle);
+                free_message_context(&msg);
             }
 
             break;
@@ -435,8 +435,7 @@ static void psa_hash_operation(void)
                     status = psa_hash_setup(msg.rhandle,
                                             psa_crypto.alg);
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -477,8 +476,7 @@ static void psa_hash_operation(void)
 
                     if (status != PSA_SUCCESS) {
                         clear_hash_clone(msg.rhandle);
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -511,8 +509,7 @@ static void psa_hash_operation(void)
                     }
 
                     clear_hash_clone(msg.rhandle);
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
@@ -545,16 +542,14 @@ static void psa_hash_operation(void)
                     }
 
                     clear_hash_clone(msg.rhandle);
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
                 case PSA_HASH_ABORT: {
                     status = psa_hash_abort(msg.rhandle);
                     clear_hash_clone(msg.rhandle);
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
@@ -582,8 +577,7 @@ static void psa_hash_operation(void)
                         release_hash_clone(hash_clone);
                     }
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -601,7 +595,7 @@ static void psa_hash_operation(void)
             if (msg.rhandle != NULL) {
                 psa_hash_abort(msg.rhandle);
                 clear_hash_clone(msg.rhandle);
-                mbedtls_free(msg.rhandle);
+                free_message_context(&msg);
             }
 
             break;
@@ -954,8 +948,7 @@ static void psa_symmetric_operation(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -968,8 +961,7 @@ static void psa_symmetric_operation(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -986,8 +978,7 @@ static void psa_symmetric_operation(void)
                         psa_write(msg.handle, 1, &iv_length,
                                   sizeof(iv_length));
                     } else {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -1002,8 +993,7 @@ static void psa_symmetric_operation(void)
                     }
                     status = psa_cipher_set_iv(msg.rhandle, iv, iv_length);
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -1047,8 +1037,7 @@ static void psa_symmetric_operation(void)
                     mbedtls_free(input);
                     mbedtls_free(output);
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -1076,15 +1065,13 @@ static void psa_symmetric_operation(void)
                         psa_cipher_abort(msg.rhandle);
                     }
 
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
                 case PSA_CIPHER_ABORT: {
                     status = psa_cipher_abort(msg.rhandle);
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
@@ -1100,7 +1087,7 @@ static void psa_symmetric_operation(void)
         case PSA_IPC_DISCONNECT: {
             if (msg.rhandle != NULL) {
                 psa_cipher_abort(msg.rhandle);
-                mbedtls_free(msg.rhandle);
+                free_message_context(&msg);
             }
 
             break;
@@ -1649,8 +1636,7 @@ void psa_crypto_generator_operations(void)
 
                 case PSA_GENERATOR_ABORT: {
                     status = psa_generator_abort(msg.rhandle);
-                    mbedtls_free(msg.rhandle);
-                    psa_set_rhandle(msg.handle, NULL);
+                    free_message_context(&msg);
                     break;
                 }
 
@@ -1695,8 +1681,7 @@ void psa_crypto_generator_operations(void)
                     mbedtls_free(salt);
                     mbedtls_free(label);
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -1729,8 +1714,7 @@ void psa_crypto_generator_operations(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        mbedtls_free(msg.rhandle);
-                        psa_set_rhandle(msg.handle, NULL);
+                        free_message_context(&msg);
                     }
                     break;
                 }
@@ -1746,7 +1730,7 @@ void psa_crypto_generator_operations(void)
         case PSA_IPC_DISCONNECT: {
             if (msg.rhandle != NULL) {
                 psa_generator_abort(msg.rhandle);
-                mbedtls_free(msg.rhandle);
+                free_message_context(&msg);
             }
 
             break;

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -89,7 +89,7 @@ static inline void release_hash_clone(psa_spm_hash_clone_t *hash_clone)
     }
 }
 
-static void destroy_hash_clone(void *source_operation)
+static void clear_hash_clone(void *source_operation)
 {
     for (size_t i = 0; i < MAX_CONCURRENT_HASH_CLONES; i++) {
         if (psa_spm_hash_clones[i].source_operation == source_operation) {
@@ -476,7 +476,7 @@ static void psa_hash_operation(void)
                     }
 
                     if (status != PSA_SUCCESS) {
-                        destroy_hash_clone(msg.rhandle);
+                        clear_hash_clone(msg.rhandle);
                         mbedtls_free(msg.rhandle);
                         psa_set_rhandle(msg.handle, NULL);
                     }
@@ -510,7 +510,7 @@ static void psa_hash_operation(void)
                         psa_hash_abort(msg.rhandle);
                     }
 
-                    destroy_hash_clone(msg.rhandle);
+                    clear_hash_clone(msg.rhandle);
                     mbedtls_free(msg.rhandle);
                     psa_set_rhandle(msg.handle, NULL);
                     break;
@@ -544,7 +544,7 @@ static void psa_hash_operation(void)
                         psa_hash_abort(msg.rhandle);
                     }
 
-                    destroy_hash_clone(msg.rhandle);
+                    clear_hash_clone(msg.rhandle);
                     mbedtls_free(msg.rhandle);
                     psa_set_rhandle(msg.handle, NULL);
                     break;
@@ -552,7 +552,7 @@ static void psa_hash_operation(void)
 
                 case PSA_HASH_ABORT: {
                     status = psa_hash_abort(msg.rhandle);
-                    destroy_hash_clone(msg.rhandle);
+                    clear_hash_clone(msg.rhandle);
                     mbedtls_free(msg.rhandle);
                     psa_set_rhandle(msg.handle, NULL);
                     break;
@@ -600,7 +600,7 @@ static void psa_hash_operation(void)
         case PSA_IPC_DISCONNECT: {
             if (msg.rhandle != NULL) {
                 psa_hash_abort(msg.rhandle);
-                destroy_hash_clone(msg.rhandle);
+                clear_hash_clone(msg.rhandle);
                 mbedtls_free(msg.rhandle);
             }
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -1212,16 +1212,17 @@ static void psa_key_management_operation(void)
                     size_t key_length = msg.in_size[1];
                     uint8_t *key = NULL;
 
-                    if (!psa_crypto_access_control_is_handle_permitted(psa_key_mng.handle,
-                                                                       partition_id)) {
+                    if (!psa_crypto_access_control_is_handle_permitted(psa_key_mng.handle, partition_id)) {
                         status = PSA_ERROR_INVALID_HANDLE;
                         break;
                     }
 
-                    key = mbedtls_calloc(1, key_length);
-                    if (key == NULL) {
-                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                        break;
+                    if (key_length > 0) {
+                        key = mbedtls_calloc(1, key_length);
+                        if (key == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                            break;
+                        }
                     }
 
                     bytes_read = psa_read(msg.handle, 1, key, key_length);
@@ -1229,9 +1230,7 @@ static void psa_key_management_operation(void)
                         SPM_PANIC("SPM read length mismatch");
                     }
 
-                    status = psa_import_key(psa_key_mng.handle,
-                                            psa_key_mng.type,
-                                            key, key_length);
+                    status = psa_import_key(psa_key_mng.handle, psa_key_mng.type, key, key_length);
                     mbedtls_free(key);
                     break;
                 }
@@ -1277,26 +1276,25 @@ static void psa_key_management_operation(void)
                     size_t data_length;
                     uint8_t *key = NULL;
 
-                    if (!psa_crypto_access_control_is_handle_permitted(psa_key_mng.handle,
-                                                                       partition_id)) {
+                    if (!psa_crypto_access_control_is_handle_permitted(psa_key_mng.handle, partition_id)) {
                         status = PSA_ERROR_INVALID_HANDLE;
                         break;
                     }
 
-                    key = mbedtls_calloc(1, key_length);
-                    if (key == NULL) {
-                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                        break;
+                    if (key_length > 0) {
+                        key = mbedtls_calloc(1, key_length);
+                        if (key == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                            break;
+                        }
                     }
 
-                    status = psa_export_key(psa_key_mng.handle, key,
-                                            key_length, &data_length);
+                    status = psa_export_key(psa_key_mng.handle, key, key_length, &data_length);
                     if (status == PSA_SUCCESS) {
                         psa_write(msg.handle, 0, key, data_length);
                     }
+                    psa_write(msg.handle, 1, &data_length, sizeof(size_t));
 
-                    psa_write(msg.handle, 1,
-                              &data_length, sizeof(size_t));
                     mbedtls_free(key);
                     break;
                 }
@@ -1306,26 +1304,25 @@ static void psa_key_management_operation(void)
                     size_t data_length;
                     uint8_t *key = NULL;
 
-                    if (!psa_crypto_access_control_is_handle_permitted(psa_key_mng.handle,
-                                                                       partition_id)) {
+                    if (!psa_crypto_access_control_is_handle_permitted(psa_key_mng.handle, partition_id)) {
                         status = PSA_ERROR_INVALID_HANDLE;
                         break;
                     }
 
-                    key = mbedtls_calloc(1, key_length);
-                    if (key == NULL) {
-                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                        break;
+                    if (key_length > 0) {
+                        key = mbedtls_calloc(1, key_length);
+                        if (key == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                            break;
+                        }
                     }
 
-                    status = psa_export_public_key(psa_key_mng.handle, key,
-                                                   key_length, &data_length);
+                    status = psa_export_public_key(psa_key_mng.handle, key, key_length, &data_length);
                     if (status == PSA_SUCCESS) {
                         psa_write(msg.handle, 0, key, data_length);
                     }
+                    psa_write(msg.handle, 1, &data_length, sizeof(size_t));
 
-                    psa_write(msg.handle, 1,
-                              &data_length, sizeof(size_t));
                     mbedtls_free(key);
                     break;
                 }

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -1009,30 +1009,39 @@ static void psa_symmetric_operation(void)
                 }
 
                 case PSA_CIPHER_UPDATE: {
-                    size_t input_length = msg.in_size[1];
-                    size_t output_size = msg.out_size[0];
-                    size_t output_length = 0;
+                    size_t input_length = msg.in_size[1],
+                           output_size = msg.out_size[0],
+                           output_length = 0;
                     uint8_t *input = NULL;
                     unsigned char *output = NULL;
 
-                    input = mbedtls_calloc(1, input_length);
-                    output = mbedtls_calloc(1, output_size);
-                    if (input == NULL || output == NULL) {
-                        psa_cipher_abort(msg.rhandle);
-                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                    } else {
-                        bytes_read = psa_read(msg.handle, 1, input, input_length);
-                        if (bytes_read != input_length) {
-                            SPM_PANIC("SPM read length mismatch");
+                    if (input_length > 0) {
+                        input = mbedtls_calloc(1, input_length);
+                        if (input == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                        } else {
+                            bytes_read = psa_read(msg.handle, 1, input, input_length);
+                            if (bytes_read != input_length) {
+                                SPM_PANIC("SPM read length mismatch");
+                            }
                         }
+                    }
+                    if (status == PSA_SUCCESS && output_size > 0) {
+                        output = mbedtls_calloc(1, output_size);
+                        if (output == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                        }
+                    }
 
+                    if (status == PSA_SUCCESS) {
                         status = psa_cipher_update(msg.rhandle, input, input_length, output, output_size,
                                                    &output_length);
                         if (status == PSA_SUCCESS) {
                             psa_write(msg.handle, 0, output, output_length);
                             psa_write(msg.handle, 1, &output_length, sizeof(output_length));
                         }
-
+                    } else {
+                        psa_cipher_abort(msg.rhandle);
                     }
 
                     mbedtls_free(input);
@@ -1045,21 +1054,26 @@ static void psa_symmetric_operation(void)
                 }
 
                 case PSA_CIPHER_FINISH: {
-                    uint8_t *output;
-                    size_t output_size = msg.out_size[0];
-                    size_t output_length = 0;
+                    uint8_t *output = NULL;
+                    size_t output_size = msg.out_size[0],
+                           output_length = 0;
 
-                    output = mbedtls_calloc(1, output_size);
-                    if (output == NULL) {
-                        psa_cipher_abort(msg.rhandle);
-                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                    } else {
+                    if (output_size > 0) {
+                        output = mbedtls_calloc(1, output_size);
+                        if (output == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                        }
+                    }
+
+                    if (status == PSA_SUCCESS) {
                         status = psa_cipher_finish(msg.rhandle, output, output_size, &output_length);
                         if (status == PSA_SUCCESS) {
                             psa_write(msg.handle, 0, output, output_length);
                             psa_write(msg.handle, 1, &output_length, sizeof(output_length));
                         }
                         mbedtls_free(output);
+                    } else {
+                        psa_cipher_abort(msg.rhandle);
                     }
 
                     mbedtls_free(msg.rhandle);


### PR DESCRIPTION
### Description
Prevent potential memory leaks on the SPM side and also free dynamically allocated memory as soon as possible.

Summary of changes in this PR:
1. Make the service behavior consistent with the library - e.g. in the library if `psa_hash_update` fails then the operation is aborted and the caller doesn't have to call `psa_hash_abort` (as abort is called by the library). The service behavior was not consistent with the library and could lead to memory leaks on the server side.
1. Free dynamically allocated memory on the SPM side as soon as possible - whenever possible, don't rely on a call to `psa_close` to free dynamically allocated contexts but free them ASAP.
1. Don't allow various (client) setup operations (such as `psa_hash_setup`) if the context is active (part of an active session), this could lead to memory leaks on the SPM side.
1. Don't allocate zero sized buffers, pass the input/output buffers to the library as is and let the library decide how to handle them.
1. Rename internal function destroy_hash_clone to clear_hash_clone.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@avolinski @NirSonnenschein 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
