### PR TITLE
Update flash algo default with CPM 0.2.4

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -93,7 +93,7 @@ class DeviceUvision(DeviceCMSIS):
             if not info["default"]:
                 continue
             name = info['file_name']
-            name_reg = "\w*/([\w_]+)\.flm"
+            name_reg = "\w*[/\\\\]([\w_]+)\.flm"
             m = re.search(name_reg, name.lower())
             fl_name = m.group(1) if m else None
             name_flag = "-FF" + str(fl_count) + fl_name


### PR DESCRIPTION
### Description

Cmsis Pack Manager 0.2.4 corrected parsing of specifically the flash
algorithm default attribute. It was allowed to be "0", "1", "true"
and "false". CPM 0.2.3 parsed "1" into false, and this behavior was
corrected in 0.2.4.

This PR uses 0.2.4 to update the index.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change