### PR TITLE
Nanostack::EthernetInterface::bringdown() can handle blocking mode

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -63,6 +63,7 @@ protected:
     int8_t interface_id;
     int8_t _device_id;
     rtos::Semaphore connect_semaphore;
+    rtos::Semaphore disconnect_semaphore;
 
     mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;

--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -119,9 +119,13 @@ nsapi_error_t MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
 
 void Nanostack::Interface::network_handler(mesh_connection_status_t status)
 {
-    if ((status == MESH_CONNECTED || status == MESH_CONNECTED_LOCAL ||
-            status == MESH_CONNECTED_GLOBAL) && _blocking) {
-        connect_semaphore.release();
+    if (_blocking) {
+        if (status == MESH_CONNECTED || status == MESH_CONNECTED_LOCAL ||
+                status == MESH_CONNECTED_GLOBAL) {
+            connect_semaphore.release();
+        } else if (status == MESH_DISCONNECTED) {
+            disconnect_semaphore.release();
+        }
     }
 
 


### PR DESCRIPTION
### Description

This let the tests-network-interface test suite pass for nanostack.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 