### PR TITLE
TARGET_STM32F7: Refresh cache when erasing or programming flash

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
@@ -36,6 +36,7 @@
 
 static uint32_t GetSector(uint32_t Address);
 static uint32_t GetSectorSize(uint32_t Sector);
+static uint32_t GetSectorBase(uint32_t SectorId);
 
 int32_t flash_init(flash_t *obj)
 {
@@ -130,6 +131,9 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
         status = -1;
     }
 
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)GetSectorBase(SectorId), GetSectorSize(SectorId));
+    SCB_InvalidateICache();
+
     flash_lock();
 
     return status;
@@ -139,6 +143,8 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data,
                            uint32_t size)
 {
     int32_t status = 0;
+    uint32_t StartAddress = address;
+    uint32_t FullSize = size;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
         return -1;
@@ -166,6 +172,9 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data,
             data++;
         }
     }
+
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)StartAddress, FullSize);
+    SCB_InvalidateICache();
 
     flash_lock();
 
@@ -264,6 +273,23 @@ static uint32_t GetSectorSize(uint32_t Sector)
 #endif
     return sectorsize;
 }
+
+/**
+  * @brief  Gets sector base address
+  * @param  SectorId
+  * @retval base address of a given sector
+  */
+static uint32_t GetSectorBase(uint32_t SectorId)
+{
+    int i = 0;
+    uint32_t address_sector = FLASH_BASE;
+
+    for(i=0;i<SectorId;i++){
+        address_sector += GetSectorSize(i);
+    }
+    return address_sector;
+}
+
 
 uint8_t flash_get_erase_value(const flash_t *obj)
 {


### PR DESCRIPTION
TARGET_STM32F7: Refresh cache when erasing or programming flash
    
The cache must be refreshed when we erase or program flash memory.
It fix 2 issues :
    Fix #9934
    Fix #6380
    
This solution was initially proposed in #6380.

Solution tested on mbed-os-5.12.0 and STM32F746 Disco board with this command: 
    mbed test -t ARM -m DISCO_F746NG -v -n *features-storage-tests-blockdevice-general_block_device* -v

