### PR TITLE
Applied astyle to files missed during repair of astyle Travis CI job

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1232,7 +1232,7 @@ bool ESP8266::set_country_code_policy(bool track_ap, const char *country_code, i
     }
 
     done &= _parser.send("AT+CWCOUNTRY_CUR=%d,\"%s\",%d,%d", t_ap, country_code, channel_start, channels)
-                    && _parser.recv("OK\n");
+            && _parser.recv("OK\n");
 
     if (!done) {
         tr_error("\"AT+CWCOUNTRY_CUR=%d,\"%s\",%d,%d\" - FAIL", t_ap, country_code, channel_start, channels);

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -893,7 +893,7 @@ nsapi_error_t ESP8266Interface::set_country_code(bool track_ap, const char *coun
 
     // Firmware takes only first three characters
     strncpy(_ch_info.country_code, country_code, sizeof(_ch_info.country_code));
-    _ch_info.country_code[sizeof(_ch_info.country_code)-1] = '\0';
+    _ch_info.country_code[sizeof(_ch_info.country_code) - 1] = '\0';
 
     _ch_info.channel_start = channel_start;
     _ch_info.channels = channels;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Ran the following command to cleanup files that were missed when the astyle Travis CI job was not functioning properly.

```sh
find . -regex '.*\.\(c\|cpp\|h\|hpp\)' \
| sed 's_^./__' \
| grep -v -f ./.astyleignore \
| while read file; do astyle -n --options=.astylerc "${file}" ; done
```

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
