### PR TITLE
BLE SimpleAdvertisingBuilder moved functions out of mbed_assert calls

### DIFF
--- a/features/FEATURE_BLE/ble/gap/AdvertisingDataSimpleBuilder.h
+++ b/features/FEATURE_BLE/ble/gap/AdvertisingDataSimpleBuilder.h
@@ -78,7 +78,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setAppearance(adv_data_appearance_t appearance)
     {
-        MBED_ASSERT(_builder.setAppearance(appearance) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setAppearance(appearance);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -96,7 +97,8 @@ public:
         adv_data_flags_t flags = adv_data_flags_t::default_flags
     )
     {
-        MBED_ASSERT(_builder.setFlags(flags) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setFlags(flags);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -111,7 +113,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setTxPowerAdvertised(advertising_power_t txPower)
     {
-        MBED_ASSERT(_builder.setTxPowerAdvertised(txPower) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setTxPowerAdvertised(txPower);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -129,7 +132,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setName(const char *name, bool complete = true)
     {
-        MBED_ASSERT(_builder.setName(name, complete) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setName(name, complete);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -144,7 +148,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setManufacturerSpecificData(mbed::Span<const uint8_t> data)
     {
-        MBED_ASSERT(_builder.setManufacturerSpecificData(data) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setManufacturerSpecificData(data);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -157,7 +162,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setAdvertisingInterval(adv_interval_t interval)
     {
-        MBED_ASSERT(_builder.setAdvertisingInterval(interval) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setAdvertisingInterval(interval);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -174,7 +180,8 @@ public:
         conn_interval_t max
     )
     {
-        MBED_ASSERT(_builder.setConnectionIntervalPreference(min, max) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setConnectionIntervalPreference(min, max);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -190,7 +197,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setServiceData(UUID service, mbed::Span<const uint8_t> data)
     {
-        MBED_ASSERT(_builder.setServiceData(service, data) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setServiceData(service, data);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -210,11 +218,10 @@ public:
         bool complete = true
     )
     {
-        MBED_ASSERT(
-            _builder.setLocalServiceList(
+        ble_error_t res = _builder.setLocalServiceList(
                 mbed::make_Span(&data, 1), complete
-            ) == BLE_ERROR_NONE
-        );
+            );
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -235,7 +242,8 @@ public:
         bool complete = true
     )
     {
-        MBED_ASSERT(_builder.setLocalServiceList(data, complete) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setLocalServiceList(data, complete);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -250,9 +258,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setRequestedService(const UUID& data)
     {
-        MBED_ASSERT(
-            _builder.setRequestedServiceList(mbed::make_Span(&data, 1)) == BLE_ERROR_NONE
-        );
+        ble_error_t res = _builder.setRequestedServiceList(mbed::make_Span(&data, 1));
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -267,7 +274,8 @@ public:
      */
     AdvertisingDataSimpleBuilder &setRequestedServiceList(mbed::Span<const UUID> data)
     {
-        MBED_ASSERT(_builder.setRequestedServiceList(data) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.setRequestedServiceList(data);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 
@@ -286,7 +294,8 @@ public:
         mbed::Span<const uint8_t> fieldData
     )
     {
-        MBED_ASSERT(_builder.addData(advDataType, fieldData) == BLE_ERROR_NONE);
+        ble_error_t res = _builder.addData(advDataType, fieldData);
+        MBED_ASSERT(res == BLE_ERROR_NONE);
         return *this;
     }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

I had an issue where advertising stopped working in release mode when using this code:
```
    ble::AdvertisingDataSimpleBuilder<0x1F> advertisingBuilder;

    advertisingBuilder.setFlags( GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE );
    advertisingBuilder.setName( DEVICE_NAME );
    advertisingBuilder.setLocalService( SERVICE_UUID, false );
```
Found out that the functions setFlags and setName were optimized away. This is caused by the functions are internally calling functions inside an mbed_assert call resulting in a nop when NDEBUG is defined.

I moved the function calls out of the mbed_assert calls and checked the result later.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

