### PR TITLE
Parse Errors and Warnings from Arm Compiler 6

### DIFF
--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -775,6 +775,7 @@ class mbedToolchain:
         )
         self.notify.debug("Return: %s" % rc)
 
+        self.parse_output(stderr)
         for output_line in stdout.splitlines():
             self.notify.debug("Output: %s" % output_line)
         for error_line in stderr.splitlines():


### PR DESCRIPTION
### Description

Turns out we were not doing this. I think it's really important that
we display warnings when they exists. 

Further, this makes the `parse_output` function run on the linker. It was
not run on the linker before.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change