### PR TITLE
Queue_buffer was not properly aligned causing the hardfault

### DIFF
--- a/events/mbed_shared_queues.cpp
+++ b/events/mbed_shared_queues.cpp
@@ -57,7 +57,7 @@ EventQueue *mbed_event_queue()
 {
 #if MBED_CONF_EVENTS_SHARED_DISPATCH_FROM_APPLICATION || !defined MBED_CONF_RTOS_PRESENT
     /* Only create the EventQueue, but no dispatching thread */
-    static uint64_t queue_buffer[MBED_CONF_EVENTS_SHARED_EVENTSIZE];
+    static uint64_t queue_buffer[MBED_CONF_EVENTS_SHARED_EVENTSIZE / sizeof(uint64_t)];
     static EventQueue queue(sizeof queue_buffer, (unsigned char *) queue_buffer);
 
     return &queue;

--- a/events/mbed_shared_queues.cpp
+++ b/events/mbed_shared_queues.cpp
@@ -57,8 +57,8 @@ EventQueue *mbed_event_queue()
 {
 #if MBED_CONF_EVENTS_SHARED_DISPATCH_FROM_APPLICATION || !defined MBED_CONF_RTOS_PRESENT
     /* Only create the EventQueue, but no dispatching thread */
-    static unsigned char queue_buffer[MBED_CONF_EVENTS_SHARED_EVENTSIZE];
-    static EventQueue queue(sizeof queue_buffer, queue_buffer);
+    static uint64_t queue_buffer[MBED_CONF_EVENTS_SHARED_EVENTSIZE];
+    static EventQueue queue(sizeof queue_buffer, (unsigned char *) queue_buffer);
 
     return &queue;
 #else


### PR DESCRIPTION
### Description

The queue_buffer for the EventQueue was not properly aligned, therefore, would cause hardfault when using instructions such as STRD, which prohibits unaligned accesses. Fixes https://jira.arm.com/browse/IOTCORE-1112


### Pull request type


    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SenRamakri @teetak01 @JanneKiiskila 