### PR TITLE
Replace qspif's dynamic allocated csel arr with static

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -99,14 +99,10 @@ enum qspif_default_instructions {
 // Local Function
 static int local_math_power(int base, int exp);
 
-///* Init function to initialize Different Devices CS static list */
-//static PinName *generate_initialized_active_qspif_csel_arr();
-
 // Static Members for different devices csel
 // _devices_mutex is used to lock csel list - only one QSPIFBlockDevice instance per csel is allowed
 SingletonPtr<PlatformMutex> QSPIFBlockDevice::_devices_mutex;
 int QSPIFBlockDevice::_number_of_active_qspif_flash_csel = 0;
-//PinName *QSPIFBlockDevice::_active_qspif_flash_csel_arr = generate_initialized_active_qspif_csel_arr();
 PinName QSPIFBlockDevice::_active_qspif_flash_csel_arr[QSPIF_MAX_ACTIVE_FLASH_DEVICES];
 
 
@@ -539,8 +535,8 @@ void QSPIFBlockDevice::initialize_active_qspif_csel_arr()
 int QSPIFBlockDevice::add_new_csel_instance(PinName csel)
 {
     int status = 0;
-    _devices_mutex->lock();
 
+    _devices_mutex->lock();
 
     if (_number_of_active_qspif_flash_csel >= QSPIF_MAX_ACTIVE_FLASH_DEVICES) {
         status = -2;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -224,6 +224,9 @@ private:
     /********************************/
     /*   Different Device Csel Mgmt */
     /********************************/
+    // Initialize the active QSPI device CS array
+    void initialize_active_qspif_csel_arr();
+
     // Add a new QSPI device CS to existing devices list.
     // Only one QSPIFBlockDevice instance per CS is allowed
     int add_new_csel_instance(PinName csel);
@@ -321,7 +324,7 @@ private:
     // _devices_mutex is used to lock csel list - only one QSPIFBlockDevice instance per csel is allowed
     static SingletonPtr<PlatformMutex> _devices_mutex;
     static int _number_of_active_qspif_flash_csel;
-    static PinName *_active_qspif_flash_csel_arr;
+    static PinName _active_qspif_flash_csel_arr[QSPIF_MAX_ACTIVE_FLASH_DEVICES];
 
     int _unique_device_status;
     PinName _csel;


### PR DESCRIPTION
### Description
Replace dynamically allocated active csel array with static, to filter 
targets with non sufficient resources at compiling time

Fixing issue: https://github.com/ARMmbed/mbed-os/issues/10241

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

