### PR TITLE
Update SPI HAL API and example implementations

### DIFF
--- a/TESTS/mbed_hal/spi_com/spi_com_test.h
+++ b/TESTS/mbed_hal/spi_com/spi_com_test.h
@@ -27,6 +27,34 @@
 extern "C" {
 #endif
 
+#if defined(TARGET_NUCLEO_F429ZI)
+
+#define SPI_TEST_MASTER_CS     PA_4
+#define SPI_TEST_MASTER_SCK    PA_5
+#define SPI_TEST_MASTER_MISO   PA_6
+#define SPI_TEST_MASTER_MOSI   PB_5
+#define SPI_TEST_SLAVE_CS      PE_4
+#define SPI_TEST_SLAVE_SCK     PE_2
+#define SPI_TEST_SLAVE_MISO    PE_5
+#define SPI_TEST_SLAVE_MOSI    PE_6
+
+#elif defined(TARGET_K66F)
+
+#define SPI_TEST_MASTER_CS     PTB20 // pin 3 on j6 header
+#define SPI_TEST_MASTER_SCK    PTD12
+#define SPI_TEST_MASTER_MISO   PTB23
+#define SPI_TEST_MASTER_MOSI   PTD13
+#define SPI_TEST_SLAVE_CS      PTD0
+#define SPI_TEST_SLAVE_SCK     PTD1
+#define SPI_TEST_SLAVE_MISO    PTD2
+#define SPI_TEST_SLAVE_MOSI    PTD3
+
+#else
+#error [NOT_SUPPORTED] Provide SPI pins for the communication test in spi_com.h.
+#endif
+
+
+
 /** Test that the SPI transfer can be performed in various configurations.
  *
  * Given board provides at least 2 SPI peripherals, SPI slave and master mode.

--- a/TEST_APPS/device/spi_com/main.cpp
+++ b/TEST_APPS/device/spi_com/main.cpp
@@ -101,9 +101,9 @@ int validate_config_callback(int argc, char *argv[])
     }
 
     if (spi_target == MASTER) {
-        result = check_capabilities(tc_config.symbol_size, false, tc_config.duplex, tc_config.master_sync);
+        result = check_capabilities(&tc_config, false);
     } else {
-        result = check_capabilities(tc_config.symbol_size, true, tc_config.duplex, tc_config.slave_sync);
+        result = check_capabilities(&tc_config, true);
     }
 
     return result;

--- a/TEST_APPS/device/spi_com/spi_slave.h
+++ b/TEST_APPS/device/spi_com/spi_slave.h
@@ -114,7 +114,7 @@ int test_init_slave(spi_t *obj, config_test_case_t *config)
     spi_get_capabilities(spi_get_module(SLAVE_SPI_MOSI,
                                         SLAVE_SPI_MISO,
                                         SLAVE_SPI_CLK),
-                         SLAVE_SPI_SS, &capabilities);
+                         SLAVE_SPI_SS, true, &capabilities);
 
     PinName miso = SLAVE_SPI_MISO;
     PinName mosi = SLAVE_SPI_MOSI;
@@ -151,7 +151,6 @@ int test_transfer_slave(spi_t *obj, config_test_case_t *config)
                                     5 * US_PER_S + 2 * MASTER_TRANSMISSION_DELAY_MS * US_PER_MS);
 
     transfer_finished = false;
-    transm_thread.set_priority(osPriorityNormal);
 
     transm_thread.start(callback(transfer_thread, (void *) &trans_thread_params));
 

--- a/TEST_APPS/testcases/spi_com/test_spi_com.py
+++ b/TEST_APPS/testcases/spi_com/test_spi_com.py
@@ -81,47 +81,47 @@ class SPIComBaseTestEnv(Bench):
         Bench.__init__(self, **testcase_args)
 
     def perform_test(self, tc_config):
-        
-        config_str = CONFIG_STRING % (tc_config['symbol_size'], 
-                                      tc_config['mode'], 
+
+        config_str = CONFIG_STRING % (tc_config['symbol_size'],
+                                      tc_config['mode'],
                                       tc_config['bit_ordering'],
-                                      tc_config['freq_hz'], 
-                                      tc_config['buffers'], 
-                                      tc_config['master_tx_defined'], 
-                                      tc_config['master_rx_defined'], 
-                                      tc_config['slave_tx_defined'], 
-                                      tc_config['slave_rx_defined'], 
-                                      tc_config['auto_ss'], 
-                                      tc_config['duplex'], 
+                                      tc_config['freq_hz'],
+                                      tc_config['buffers'],
+                                      tc_config['master_tx_defined'],
+                                      tc_config['master_rx_defined'],
+                                      tc_config['slave_tx_defined'],
+                                      tc_config['slave_rx_defined'],
+                                      tc_config['auto_ss'],
+                                      tc_config['duplex'],
                                       tc_config['sync'])
-        
+
         resp_master = self.command("master", "validate_config target %d %s" % (MASTER, config_str))
         resp_slave = self.command("slave", "validate_config target %d %s" % (SLAVE, config_str))
-        
-        if (not resp_master.verify_trace("SKIP", break_in_fail=False) and not resp_master.verify_trace("SKIP", break_in_fail=False)):
+
+        if (not resp_master.verify_trace("SKIP", break_in_fail=False) and not resp_slave.verify_trace("SKIP", break_in_fail=False)):
             resp_slave = self.command("slave", "init_test target %d" % SLAVE)
             resp_master = self.command("master", "init_test target %d" % MASTER)
 
-            
+
             async_cmd_slave = self.command("slave", "exec_test target %d" % SLAVE, asynchronous=True)
             resp_master = self.command("master", "exec_test target %d" % MASTER, report_cmd_fail=False)
-            
+
             resp_slave = self.wait_for_async_response("exec_test", async_cmd_slave)
-            
+
             master_error = resp_master.verify_trace("ERROR", break_in_fail=False)
             slave_error = resp_slave.verify_trace("ERROR", break_in_fail=False)
-            
+
             master_timeout = resp_master.verify_trace("timeout", break_in_fail=False)
             slave_timeout = resp_slave.verify_trace("timeout", break_in_fail=False)
-            
+
             resp_master = self.command("master", "finish_test target %d" % MASTER)
             resp_slave = self.command("slave", "finish_test target %d" % SLAVE)
-            
+
             if(master_error or slave_error):
                 raise TestStepFail("Communication failure")
-                
+
             if(master_timeout or slave_timeout):
-                raise TestStepTimeout("Timeout");
+                raise TestStepTimeout("Timeout")
         else:
             self.logger.info("TEST CASE SKIPPED")
 
@@ -134,175 +134,175 @@ class SPIComBaseTestEnv(Bench):
         # teardown code
         pass
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_DEFAULT_CFG",
            title="sync mode/default config")
 def SPI_COM_SYNC_SYNC_DEFAULT_CFG(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_1",
            title="sync mode/symbol size: 1 bit")
 def SPI_COM_SYNC_SYM_SIZE_1(self):
     self.perform_test({'symbol_size': 1 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_7",
            title="sync mode/symbol size: 7 bit")
 def SPI_COM_SYNC_SYM_SIZE_7(self):
     self.perform_test({'symbol_size': 7 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_9",
            title="sync mode/symbol size: 9 bit")
 def SPI_COM_SYNC_SYM_SIZE_9(self):
     self.perform_test({'symbol_size': 9 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_15",
            title="sync mode/symbol size: 15 bit")
 def SPI_COM_SYNC_SYM_SIZE_15(self):
     self.perform_test({'symbol_size': 15, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_16",
            title="sync mode/symbol size: 16 bit")
 def SPI_COM_SYNC_SYM_SIZE_16(self):
     self.perform_test({'symbol_size': 16, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_17",
            title="sync mode/symbol size: 17 bit")
 def SPI_COM_SYNC_SYM_SIZE_17(self):
-    self.perform_test({'symbol_size': 17, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })   
+    self.perform_test({'symbol_size': 17, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_31",
            title="sync mode/symbol size: 31 bit")
 def SPI_COM_SYNC_SYM_SIZE_31(self):
-    self.perform_test({'symbol_size': 31, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })  
+    self.perform_test({'symbol_size': 31, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_SYM_SIZE_32",
            title="sync mode/symbol size: 32 bit")
 def SPI_COM_SYNC_SYM_SIZE_32(self):
-    self.perform_test({'symbol_size': 32, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })  
+    self.perform_test({'symbol_size': 32, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_MODE_CLK_IDLE_LOW_SEC_EDGE",
            title="sync mode/mode: clk idle low/sample on second clk egde")
 def SPI_COM_SYNC_MODE_CLK_IDLE_LOW_SEC_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_SECOND_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_MODE_CLK_IDLE_HIGH_FIRST_EDGE",
            title="sync mode/mode: clk idle high/sample on first clk egde")
 def SPI_COM_SYNC_MODE_CLK_IDLE_HIGH_FIRST_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_HIGH_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_MODE_CLK_IDLE_HIGH_SEC_EDGE",
            title="sync mode/mode: clk idle high/sample on second clk egde")
 def SPI_COM_SYNC_MODE_CLK_IDLE_HIGH_SEC_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_HIGH_SAMPLE_SECOND_EDGE, 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BIT_ORDERING_LSB_FIRST",
            title="sync mode/bit ordering: LBS first")
 def SPI_COM_SYNC_BIT_ORDERING_LSB_FIRST(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_LSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_FREQ_MIN_REQUIRED",
            title="sync mode/freq: min required")
 def SPI_COM_SYNC_FREQ_MIN_REQUIRED(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 200000    , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_FREQ_MAX_REQUIRED",
            title="sync mode/freq: max required")
 def SPI_COM_SYNC_FREQ_MAX_REQUIRED(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 2000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_FREQ_MIN_CAPABILITIES",
            title="sync mode/freq: min defined by capabilities")
 def SPI_COM_SYNC_FREQ_MIN_CAPABILITIES(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': FREQ_MIN  , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_FREQ_MAX_CAPABILITIES",
            title="sync mode/freq: max defined by capabilities")
 def SPI_COM_SYNC_FREQ_MIN_CAPABILITIES(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': FREQ_MAX  , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_MASTER_TX_GT_RX",
            title="sync mode/buffers: master TX > master RX")
 def SPI_COM_SYNC_BUFFERS_MASTER_TX_GT_RX(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_MASTER_TX_GT_RX , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_MASTER_TX_LT_RX",
            title="sync mode/buffers: master TX < master RX")
 def SPI_COM_SYNC_BUFFERS_MASTER_TX_LT_RX(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_MASTER_TX_LT_RX , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_SLAVE_TX_GT_RX",
            title="sync mode/buffers: slave TX > slave RX")
 def SPI_COM_SYNC_BUFFERS_SLAVE_TX_GT_RX(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_SLAVE_TX_GT_RX  , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_SLAVE_TX_LT_RX",
            title="sync mode/buffers: slave TX < slave RX")
 def SPI_COM_SYNC_BUFFERS_SLAVE_LT_GT_RX(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_SLAVE_TX_LT_RX  , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_MASTER_TX_UNDEF",
            title="sync mode/buffers: master TX undefined")
 def SPI_COM_SYNC_BUFFERS_MASTER_TX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'false', 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_MASTER_RX_UNDEF",
            title="sync mode/buffers: master RX undefined")
 def SPI_COM_SYNC_BUFFERS_MASTER_RX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'false', 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_SLAVE_TX_UNDEF",
            title="sync mode/buffers: slave TX undefined")
 def SPI_COM_SYNC_BUFFERS_SLAVE_TX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'false', 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_SLAVE_RX_UNDEF",
            title="sync mode/buffers: slave RX undefined")
 def SPI_COM_SYNC_BUFFERS_SLAVE_RX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'false', 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_LONG",
            title="sync mode/buffers: transfer large number of symbols")
 def SPI_COM_SYNC_BUFFERS_LONG(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_LONG            , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_BUFFERS_ONE_SYM",
            title="sync mode/buffers: transfer only one symbol")
 def SPI_COM_SYNC_BUFFERS_ONE_SYM(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_ONE_SYM         , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_AUTO_SS",
            title="sync mode/slave select: auto ss handling by master")
 def SPI_COM_SYNC_AUTO_SS(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'true' , 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_SYNC_HALF_DUPLEX",
            title="sync mode/half duplex transfer")
 def SPI_COM_SYNC_HALF_DUPLEX(self):
@@ -310,289 +310,289 @@ def SPI_COM_SYNC_HALF_DUPLEX(self):
 
 
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_DEFAULT_CFG",
            title="async master/default config")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_DEFAULT_CFG(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_1",
            title="async master/symbol size: 1 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_1(self):
     self.perform_test({'symbol_size': 1 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_7",
            title="async master/symbol size: 7 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_7(self):
     self.perform_test({'symbol_size': 7 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_9",
            title="async master/symbol size: 9 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_9(self):
     self.perform_test({'symbol_size': 9 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_15",
            title="async master/symbol size: 15 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_15(self):
     self.perform_test({'symbol_size': 15, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_16",
            title="async master/symbol size: 16 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_16(self):
     self.perform_test({'symbol_size': 16, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_17",
            title="async master/symbol size: 17 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_17(self):
-    self.perform_test({'symbol_size': 17, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })   
+    self.perform_test({'symbol_size': 17, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_31",
            title="async master/symbol size: 31 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_31(self):
-    self.perform_test({'symbol_size': 31, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })  
+    self.perform_test({'symbol_size': 31, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_32",
            title="async master/symbol size: 32 bit")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_SYM_SIZE_32(self):
-    self.perform_test({'symbol_size': 32, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })  
+    self.perform_test({'symbol_size': 32, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_MODE_CLK_IDLE_LOW_SEC_EDGE",
            title="async master/mode: clk idle low/sample on second clk egde")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_MODE_CLK_IDLE_LOW_SEC_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_SECOND_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_MODE_CLK_IDLE_HIGH_FIRST_EDGE",
            title="async master/mode: clk idle high/sample on first clk egde")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_MODE_CLK_IDLE_HIGH_FIRST_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_HIGH_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_MODE_CLK_IDLE_HIGH_SEC_EDGE",
            title="async master/mode: clk idle high/sample on second clk egde")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_MODE_CLK_IDLE_HIGH_SEC_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_HIGH_SAMPLE_SECOND_EDGE, 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BIT_ORDERING_LSB_FIRST",
            title="async master/bit ordering: LBS first")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BIT_ORDERING_LSB_FIRST(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_LSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MIN_REQUIRED",
            title="async master/freq: min required")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MIN_REQUIRED(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 200000    , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MAX_REQUIRED",
            title="async master/freq: max required")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MAX_REQUIRED(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 2000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MIN_CAPABILITIES",
            title="async master/freq: min defined by capabilities")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MIN_CAPABILITIES(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': FREQ_MIN  , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MAX_CAPABILITIES",
            title="async master/freq: max defined by capabilities")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_FREQ_MIN_CAPABILITIES(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': FREQ_MAX  , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_MASTER_TX_UNDEF",
            title="async master/buffers: master TX undefined")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_MASTER_TX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'false', 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_MASTER_RX_UNDEF",
            title="async master/buffers: master RX undefined")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_MASTER_RX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'false', 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_SLAVE_TX_UNDEF",
            title="async master/buffers: slave TX undefined")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_SLAVE_TX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'false', 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_SLAVE_RX_UNDEF",
            title="async master/buffers: slave RX undefined")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_SLAVE_RX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'false', 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_LONG",
            title="async master/buffers: transfer large number of symbols")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_LONG(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_LONG            , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_ONE_SYM",
            title="async master/buffers: transfer only one symbol")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_BUFFERS_ONE_SYM(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_ONE_SYM         , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_ASYNC_SLAVE_SYNC_AUTO_SS",
            title="async master/slave select: auto ss handling by master")
 def SPI_COM_MASTER_ASYNC_SLAVE_SYNC_AUTO_SS(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'true' , 'duplex': FULL_DUPLEX     ,'sync': SPI_ASYNC_MASTER_SYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_DEFAULT_CFG",
            title="async slave/default config")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_DEFAULT_CFG(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_1",
            title="async slave/symbol size: 1 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_1(self):
     self.perform_test({'symbol_size': 1 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_7",
            title="async slave/symbol size: 7 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_7(self):
     self.perform_test({'symbol_size': 7 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_9",
            title="async slave/symbol size: 9 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_9(self):
     self.perform_test({'symbol_size': 9 , 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_15",
            title="async slave/symbol size: 15 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_15(self):
     self.perform_test({'symbol_size': 15, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_16",
            title="async slave/symbol size: 16 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_16(self):
     self.perform_test({'symbol_size': 16, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_17",
            title="async slave/symbol size: 17 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_17(self):
-    self.perform_test({'symbol_size': 17, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })   
+    self.perform_test({'symbol_size': 17, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_31",
            title="async slave/symbol size: 31 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_31(self):
-    self.perform_test({'symbol_size': 31, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })  
+    self.perform_test({'symbol_size': 31, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_32",
            title="async slave/symbol size: 32 bit")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_SYM_SIZE_32(self):
-    self.perform_test({'symbol_size': 32, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })  
+    self.perform_test({'symbol_size': 32, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_MODE_CLK_IDLE_LOW_SEC_EDGE",
            title="async slave/mode: clk idle low/sample on second clk egde")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_MODE_CLK_IDLE_LOW_SEC_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_SECOND_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_MODE_CLK_IDLE_HIGH_FIRST_EDGE",
            title="async slave/mode: clk idle high/sample on first clk egde")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_MODE_CLK_IDLE_HIGH_FIRST_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_HIGH_SAMPLE_FIRST_EDGE , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_MODE_CLK_IDLE_HIGH_SEC_EDGE",
            title="async slave/mode: clk idle high/sample on second clk egde")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_MODE_CLK_IDLE_HIGH_SEC_EDGE(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_HIGH_SAMPLE_SECOND_EDGE, 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BIT_ORDERING_LSB_FIRST",
            title="async slave/bit ordering: LBS first")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BIT_ORDERING_LSB_FIRST(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_LSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MIN_REQUIRED",
            title="async slave/freq: min required")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MIN_REQUIRED(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 200000    , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MAX_REQUIRED",
            title="async slave/freq: max required")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MAX_REQUIRED(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 2000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MIN_CAPABILITIES",
            title="async slave/freq: min defined by capabilities")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MIN_CAPABILITIES(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': FREQ_MIN  , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MAX_CAPABILITIES",
            title="async slave/freq: max defined by capabilities")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_FREQ_MIN_CAPABILITIES(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': FREQ_MAX  , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_MASTER_TX_UNDEF",
            title="async slave/buffers: master TX undefined")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_MASTER_TX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'false', 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_MASTER_RX_UNDEF",
            title="async slave/buffers: master RX undefined")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_MASTER_RX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'false', 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
-    
-@test_case(SPIComBaseTestEnv, 
+
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_SLAVE_TX_UNDEF",
            title="async slave/buffers: slave TX undefined")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_SLAVE_TX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'false', 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_SLAVE_RX_UNDEF",
            title="async slave/buffers: slave RX undefined")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_SLAVE_RX_UNDEF(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_EQUAL           , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'false', 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_LONG",
            title="async slave/buffers: transfer large number of symbols")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_LONG(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_LONG            , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_ONE_SYM",
            title="async slave/buffers: transfer only one symbol")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_BUFFERS_ONE_SYM(self):
     self.perform_test({'symbol_size': 8, 'mode': SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE  , 'bit_ordering': SPI_BIT_ORDERING_MSB_FIRST, 'freq_hz': 1000000   , 'buffers': SPI_BUFFERS_ONE_SYM         , 'master_tx_defined': 'true' , 'master_rx_defined': 'true' , 'slave_tx_defined': 'true' , 'slave_rx_defined': 'true' , 'auto_ss': 'false', 'duplex': FULL_DUPLEX     ,'sync': SPI_SYNC_MASTER_ASYNC_SLAVE  })
 
-@test_case(SPIComBaseTestEnv, 
+@test_case(SPIComBaseTestEnv,
            name="SPI_COM_MASTER_SYNC_SLAVE_ASYNC_AUTO_SS",
            title="async slave/slave select: auto ss handling by master")
 def SPI_COM_MASTER_SYNC_SLAVE_ASYNC_AUTO_SS(self):

--- a/docs/design-documents/hal/0000-spi-overhaul.md
+++ b/docs/design-documents/hal/0000-spi-overhaul.md
@@ -6,8 +6,8 @@ This update targets the SPI HAL as the first step of a wide plan for all HAL API
 
 ## Motivation
 
-This work is part of the effort to bring well defined specification to APIs in `mbed-os`. Some users have shown interest in some addition to the supported features of this API ([bit ordering selection #4789](https://github.com/ARMmbed/mbed-os/issues/4789)).  
-Analysis of previous work also revealed some inconsistencies in the current SPI HAL API that this RFC aims at fixing. Those inconsistencies are listed in the next chapter.  
+This work is part of the effort to bring well defined specification to APIs in `mbed-os`. Some users have shown interest in some addition to the supported features of this API ([bit ordering selection #4789](https://github.com/ARMmbed/mbed-os/issues/4789)).
+Analysis of previous work also revealed some inconsistencies in the current SPI HAL API that this RFC aims at fixing. Those inconsistencies are listed in the next chapter.
 Finally, `mbed-os` has grown a lot its supported target count and some of the oldest one could benefit quite significantly in maintenance cost from a factorisation of their code base.
 
 ### Inconsistencies
@@ -32,30 +32,30 @@ In order to provide a meaningful API, this RFC will consider the following use c
 - <details><summary>SPI Master: <a href="https://github.com/ARMmbed/mbed-os/tree/master/features/unsupported/tests/peripherals/C12832">C12832 LCD screen driver</a> and <a href="https://github.com/ARMmbed/mbed-os/tree/master/features/unsupported/tests/peripherals/ADXL345">ADXL345 3 axis accelerometer</a></summary><ul><li>initial freq : 19.2MHz</li><li>clock polarity: high</li><li>clock phase : second edge</li><li>symbol size : 8bits</li><li>Chip select : manual (could be automated).</li></ul></details>
 - <details><summary>SPI Master: <a href="https://github.com/ARMmbed/wifi-ism43362">ism43362</a> (WiFi module)</summary><ul><li>initial freq  : 20MHz</li><li>clock polarity: low</li><li>clock phase : first edge</li><li>symbol size : 16bits</li><li>Chip select : manual (could it be automated ? There seem to be some special delays)</li></ul></details>
 - <details><summary>SPI Master: <a href="https://github.com/ARMmbed/atmel-rf-driver">atmel-rf</a> (802.15.4)</summary><ul><li>initial freq  : 3.75 -> 7.5MHz</li><li>clock polarity: ? default</li><li>clock phase : ? default</li><li>symbol size : ? default</li><li>Chip select : manual (could be automated)</li></ul></details>
-- <details><summary>SPI Master: <a href="https://github.com/ARMmbed/stm-spirit1-rf-driver">stm-spirit1-rf</a> (Sub-1 GHz RF based on the SPSGRF-868 Module)</summary><ul><li>initial freq : 10MHz</li><li>clock polarity: low</li><li>clock phase : first edge</li><li>symbol size : 8bits</li><li>Chip select : manual (could it be automated ? There seem to be some special delays)</li></ul></details> 
+- <details><summary>SPI Master: <a href="https://github.com/ARMmbed/stm-spirit1-rf-driver">stm-spirit1-rf</a> (Sub-1 GHz RF based on the SPSGRF-868 Module)</summary><ul><li>initial freq : 10MHz</li><li>clock polarity: low</li><li>clock phase : first edge</li><li>symbol size : 8bits</li><li>Chip select : manual (could it be automated ? There seem to be some special delays)</li></ul></details>
 - <details><summary>SPI Master: <a href="https://github.com/ARMmbed/ble-x-nucleo-idb0xa1">ble-x-nucleo-idb0xa1</a> (BLE module)</summary><ul><li>initial freq : 8MHz</li><li>clock polarity: low</li><li>clock phase : first edge</li><li>symbol size : 8bits</li><li>Chip select : manual (could be automated as it is sending/receiving byte by byte)</li></ul></details>
 - <details><summary>SPI Master: <a href="https://os.mbed.com/cookbook/SPI-communication-with-external-ADC-MCP3">ADC</a></summary><ul><li>initial freq  : 1MHz</li><li>clock polarity: low</li><li>clock phase : first edge</li><li>symbol size : 7bits</li><li>Chip select : manual (could it be automated ? There seem to be some special delays)</li><li>The comment in the code is confusing as it refers to "high steady state" and "second edge capture".</li></ul></details>
 - <details><summary>SPI Master: <a href="https://os.mbed.com/users/AppNearMe/code/AppNearMe_MuNFC_PN532">AppNearMe MuNFC PN532</a></summary><ul><li>Initial freq: 5MHz</li><li>clock polarity: Idle High</li><li>clock phase: Data on second edge (aka active to idle edge)</li><li>symbol size: 8bits</li><li>chip select: manual</li><li>use of different tx_len & rx_len + some skip offset.</li></ul></details>
 
 ### Other use cases
-- SPI Slave  
-  In this use case the user wants to receive a command frame and send back an answer frame.  
+- SPI Slave
+  In this use case the user wants to receive a command frame and send back an answer frame.
   Both frames are constructed that way :
 
   | size     | frame type | variable length frame | crc
   | ---      | ---        | ---                   | ---
   | 2 bytes  | 1 byte     | \<size> bytes         | 1 byte
 
-  Data are sent as 8 bit symbols, little endian, lsb first. The Frame cannot exceed 2048bytes in length.  
-  CS has to stay asserted between request and response.  
+  Data are sent as 8 bit symbols, little endian, lsb first. The Frame cannot exceed 2048bytes in length.
+  CS has to stay asserted between request and response.
   The master expect to receive the symbol `0xFF` as a place holder.
-- Simultaneous transaction over multiple SPI peripheral.  
+- Simultaneous transaction over multiple SPI peripheral.
   For example: Reading/Writing to an SD Card while using the communication interface over another SPI interface (other peripheral).
-- Asynchronous:  
+- Asynchronous:
   These are basically the same the regular ones except that the function call should return immediately and a callback should be triggered once the operation is completed.
   - SPI Master block transfer
   - SPI Slave block transfer : Not supported in current API
- 
+
   The asynchronous API is particularly important when dealing with multiple interfaces. Indeed, handling simultaneously two SPI transfers would require two thread with a blocking API while only one is required by the asynchronous API saving kilobytes of RAM.
 - Half-duplex mode:
   The [LPS22HB](https://www.st.com/en/mems-and-sensors/lps22hb.html) product family can be controlled through a half-duplex SPI interface (called 3 wire mode in the data sheet).
@@ -98,14 +98,15 @@ typedef struct {
      *  testing.
      */
     uint32_t    maximum_frequency;
-    /** Each bit represents the corresponding symbol length. lsb => 1bit, msb => 32bits.
-     *
-     * For example, if the peripheral supports 8 bits, 12bits to 16bits and 32bits,
-     * the value should be 0x8000F880.
-     */
-    uint32_t    symbol_length;
+    /** Each bit represents the corresponding word length. lsb => 1bit, msb => 32bit. */
+    uint32_t    word_length;
+    uint16_t    slave_delay_between_symbols_ns; /**< specifies required number of ns between transmission of successive symbols in slave mode. */
+    uint8_t     clk_modes; /**< specifies supported modes from spi_mode_t. Each bit represents the corresponding mode. */
+    uint8_t     bit_order; /**< specifies supported bit order from spi_bit_ordering_t. Each bit represents the corresponding bit order. */
     bool        support_slave_mode; /**< If true, the device can handle SPI slave mode using hardware management on the specified ssel pin. */
     bool        half_duplex; /**< If true, the device also supports SPI transmissions using only 3 wires. */
+    bool        hw_cs_handle; /**< If true, in SPI master mode Chip Select can be handled by hardware. */
+    bool        async_mode; /**< If true, in async mode is supported. */
 } spi_capabilities_t;
 
 typedef struct {
@@ -137,7 +138,7 @@ SPIName spi_get_module(PinName mosi, PinName miso, PinName mclk);
 /**
  * Fills the given spi_capabilities_t structure with the capabilities of the given peripheral.
  */
-void spi_get_capabilities(SPIName name, PinName ssel, spi_capabilities_t *cap);
+void spi_get_capabilities(SPIName name, PinName ssel, bool slave, spi_capabilities_t *cap);
 
 void spi_init(spi_t *obj, bool is_slave, PinName mosi, PinName miso, PinName mclk, PinName ssel);
 void spi_format(spi_t *obj, uint8_t bits, spi_mode_t mode, spi_bit_ordering_t bit_ordering);
@@ -153,7 +154,7 @@ void spi_free(spi_t *obj);
 
 - `spi_get_module()` returns the `SPIName` unique identifier to the peripheral associated to this SPI channel.
 - `spi_get_capabilities()` fills the given `spi_capabilities_t` instance
-- `spi_get_capabilities()` should consider the `ssel` pin when evaluation the `support_slave_mode` capability.  
+- `spi_get_capabilities()` should consider the `ssel` pin when evaluation the `support_slave_mode` capability.
   If the given `ssel` pin cannot be managed by hardware in slave mode, `support_slave_mode` should be false.
 - At least a symbol width of 8bit must be supported.
 - The supported frequency range must include the range [0.2..2] MHz.
@@ -188,7 +189,7 @@ void spi_free(spi_t *obj);
   - if `rx` is NULL then inputs are discarded.
   - if `tx` is NULL then `fill_symbol` is used instead.
   - returns the number of symbol clocked on the bus during this transfer.
-  - expects symbols types to be the closest stdint type bigger or equal to its size following the platform's endianness.  
+  - expects symbols types to be the closest stdint type bigger or equal to its size following the platform's endianness.
     e.g.:
     - 7bits => uint8_t
     - 15bits => uint16_t
@@ -199,9 +200,9 @@ void spi_free(spi_t *obj);
   - In Half-duplex mode :
     - as master, `spi_transfer()` sends `tx_len` symbols and then reads `rx_len` symbols.
     - as slave, `spi_transfer()` receives `rx_len` symbols and then sends `tx_len` symbols.
-- `spi_transter_async()` schedules a transfer to be process the same way `spi_transfer()` would have but asynchronously with the following exceptions:  
-    - in async mode only transfers of the same size are allowed (tx size must be equal to rx size)  
-    - async mode only supports full-duplex mode  
+- `spi_transter_async()` schedules a transfer to be process the same way `spi_transfer()` would have but asynchronously with the following exceptions:
+    - in async mode only transfers of the same size are allowed (tx size must be equal to rx size)
+    - async mode only supports full-duplex mode
 - `spi_transter_async()` returns immediately with a boolean indicating whether the transfer was successfully scheduled or not.
 - The callback given to `spi_transfer_async()` is invoked when the transfer completes (with a success or an error).
 - `spi_transfer_async()` saves the handler and the `ctx` pointer.
@@ -221,7 +222,7 @@ void spi_free(spi_t *obj);
 - Passing an invalid pointer as `cap` to `spi_get_capabilities`.
 - Passing pins that cannot be on the same peripheral.
 - Passing an invalid pointer as `obj` to any method.
-- Giving a `ssel` pin to `spi_init()` when using in master mode.  
+- Giving a `ssel` pin to `spi_init()` when using in master mode.
   SS must be managed by hardware in slave mode and must **NOT** be managed by hardware in master mode.
 - Setting a frequency outside of the range given by `spi_get_capabilities()`.
 - Setting a frequency in slave mode.
@@ -242,7 +243,7 @@ Some examples will be created in order to cover the remaining behaviours and use
 
 ## Impact on partners' implementations
 
-The new API does not impact partners much as most of them factorise HAL implementation to family level.  
+The new API does not impact partners much as most of them factorise HAL implementation to family level.
 For example :
 
 | Partner       | #of&nbsp;Implementation | details |
@@ -266,8 +267,8 @@ The partner the most impacted by these changes is definitely Freescale/NXP but o
 
 ## Questions
 
-- To keep consistency between peripherals in terms of design pattern, do we want to expose a peripheral or a communication channel ?  
-  The current SPI driver implementation has 1 instance per slave while i²c driver implementation has 1 instance per peripheral. 
+- To keep consistency between peripherals in terms of design pattern, do we want to expose a peripheral or a communication channel ?
+  The current SPI driver implementation has 1 instance per slave while i²c driver implementation has 1 instance per peripheral.
   - SPI addresses slave in `spi_init` using the chip select.
   - I²C addresses slave in transfer functions using the address.
   See also: [#7358](https://github.com/ARMmbed/mbed-os/issues/7358)

--- a/hal/mbed_pinmap_common.c
+++ b/hal/mbed_pinmap_common.c
@@ -134,13 +134,19 @@ bool pinmap_find_peripheral_pins(const PinList *whitelist, const PinList *blackl
                 if (map->peripheral != per) {
                     continue;
                 }
-                if (!pinmap_list_has_pin(whitelist, map->pin)) {
-                    // Not part of this form factor
-                    continue;
+
+                if (whitelist) {
+                    if (!pinmap_list_has_pin(whitelist, map->pin)) {
+                        // Not part of this form factor
+                        continue;
+                    }
                 }
-                if (pinmap_list_has_pin(blacklist, map->pin)) {
-                    // Restricted pin
-                    continue;
+
+                if (blacklist) {
+                    if (pinmap_list_has_pin(blacklist, map->pin)) {
+                        // Restricted pin
+                        continue;
+                    }
                 }
                 bool already_in_use = false;
                 for (uint32_t j = 0; j < count; j++) {

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -141,6 +141,7 @@ typedef struct {
     uint32_t    word_length;
     bool        support_slave_mode; /**< If true, the device can handle SPI slave mode using hardware management on the specified ssel pin. */
     bool        half_duplex; /**< If true, the device also supports SPI transmissions using only 3 wires. */
+    bool        hw_cs_handle; /**< If true, in SPI master mode Chip Select can be handled by hardware. */
 } spi_capabilities_t;
 
 /**

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -139,9 +139,14 @@ typedef struct {
     uint32_t    maximum_frequency;
     /** Each bit represents the corresponding word length. lsb => 1bit, msb => 32bit. */
     uint32_t    word_length;
+    uint16_t    slave_delay_between_symbols_ns; /**< specifies required number of ns between transmission of successive symbols in slave mode. */
+    uint8_t     clk_modes; /**< specifies supported modes from spi_mode_t. Each bit represents the corresponding mode. */
+    uint8_t     bit_order; /**< specifies supported bit order from spi_bit_ordering_t. Each bit represents the corresponding bit order. */
     bool        support_slave_mode; /**< If true, the device can handle SPI slave mode using hardware management on the specified ssel pin. */
     bool        half_duplex; /**< If true, the device also supports SPI transmissions using only 3 wires. */
     bool        hw_cs_handle; /**< If true, in SPI master mode Chip Select can be handled by hardware. */
+    bool        async_mode; /**< If true, in async mode is supported. */
+
 } spi_capabilities_t;
 
 /**
@@ -183,7 +188,7 @@ SPIName spi_get_module(PinName mosi, PinName miso, PinName mclk);
 /**
  * Fills the given spi_capabilities_t structure with the capabilities of the given peripheral.
  */
-void spi_get_capabilities(SPIName name, PinName ssel, spi_capabilities_t *cap);
+void spi_get_capabilities(SPIName name, PinName ssel, bool slave, spi_capabilities_t *cap);
 
 /**
  * Initialized a spi peripheral.

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -54,6 +54,10 @@ extern "C" {
  *     - if `ssel` is `NC` the hal implementation ignores this pin.
  *     - if `ssel` is not `NC` then the hal implementation owns the pin and its management.
  * - When managed by the hal implementation, `ssel` is always considered active low.
+ * - When managed by the hal implementation, ssel must be asserted for the whole duration of the spi transmission.
+ * - When managed by the hal implementation, the delay from the chip select assert to the first clock edge must be at least half spi clock period.
+ * - When managed by the hal implementation, the delay from the last clock edge to the chip select de-assert to must be at least half spi clock period.
+ * - If hardware can not handle all ssel related requirements, then device capabilities should indicate that ssel cannot be managed by hardware.
  * - When the hardware supports the half-duplex (3-wire) mode, if `miso` (exclusive) or `mosi` is missing in any function that expects pins, the bus is assumed to be half-duplex.
  * - `spi_free()` resets the pins to their default state.
  * - `spi_free()` disables the peripheral clock.
@@ -69,7 +73,6 @@ extern "C" {
  * - `spi_frequency()` sets the frequency to use during the transfer.
  * - `spi_frequency()` returns the actual frequency that will be used.
  * - `spi_frequency()` updates the baud rate generator leaving other configurations unchanged.
- * - `spi_init()`, `spi_frequency()` and `spi_format()` must be called at least once each before initiating any transfer.
  * - `spi_transfer()` :
  *   - writes `tx_len` symbols to the bus.
  *   - reads `rx_len` symbols from the bus.
@@ -87,7 +90,9 @@ extern "C" {
  *   - In Half-duplex mode :
  *     - as master, `spi_transfer()` sends `tx_len` symbols and then reads `rx_len` symbols.
  *     - as slave, `spi_transfer()` receives `rx_len` symbols and then sends `tx_len` symbols.
- * - `spi_transter_async()` schedules a transfer to be process the same way `spi_transfer()` would have but asynchronously.
+ * - `spi_transter_async()` schedules a transfer to be process the same way `spi_transfer()` would have but asynchronously with the following exceptions:
+ *   - in async mode only transfers of the same size are allowed (tx size must be equal to rx size)
+ *   - async mode only supports full-duplex mode.
  * - `spi_transter_async()` returns immediately with a boolean indicating whether the transfer was successfully scheduled or not.
  * - The callback given to `spi_transfer_async()` is invoked when the transfer completes (with a success or an error).
  * - `spi_transfer_async()` saves the handler and the `ctx` pointer.
@@ -116,6 +121,7 @@ extern "C" {
  * - Passing an invalid pointer as `handler` to `spi_transfer_async`.
  * - Calling `spi_transfer_async_abort()` while no async transfer is being processed (no transfer or a synchronous transfer).
  * - In half-duplex mode, any mechanism (if any is present) to detect or prevent collision is implementation defined.
+ * - Initiating any transfer after `spi_init()` but before both the frequency and format have been set with `spi_frequency()` and `spi_format()`
  */
 typedef struct spi_s spi_t;
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PeripheralNames.h
@@ -133,12 +133,6 @@ typedef enum {
     SPI_2 = 2,
 } SPIName;
 
-/* Specify master/slave interfaces for testing purposes. */
-#define SPI_TEST_MASTER SPI_2
-#define SPI_TEST_SLAVE SPI_0
-#define SPI_TEST_MASTER_PIN(SPI_PIN) SPI_2##_##SPI_PIN
-#define SPI_TEST_SLAVE_PIN(SPI_PIN)  SPI_0##_##SPI_PIN
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PinNames.h
@@ -232,26 +232,6 @@ typedef enum {
 
     I2C_SCL = D15,
     I2C_SDA = D14,
-    
-    /* Note: 
-    This board does not provide SPI MOSI/MISO pins, instead we have SIN/SOUT pins which can be used
-    as SPI MOSI/MISO lines depending on SPI operation mode(master or slave):
-    master: SIN  ---> MISO
-            SOUT ---> MOSI
-    slave:  SIN  ---> MOSI
-            SOUT ---> MISO
-
-    SPI_0 interface represents SPI pins configuration for slave and SPI_2 respresents spi configuration
-    for master.
-    */
-    SPI_0_MOSI   = PTD3,
-    SPI_0_MISO   = PTD2,
-    SPI_0_SCK    = PTD1,
-    SPI_0_CS     = PTD0,
-    SPI_2_MOSI   = PTD13,
-    SPI_2_MISO   = PTB23,
-    SPI_2_SCK    = PTD12,
-    SPI_2_CS     = PTB20,
 
     A0 = PTB7,
     A1 = PTB6,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
@@ -314,7 +314,8 @@ void spi_get_capabilities(SPIName name, PinName ssel, spi_capabilities_t *cap)
 {
     cap->word_length = 0x00008080;
     cap->support_slave_mode = false;
-    cap->half_duplex = true;
+    cap->half_duplex = false;
+    cap->hw_cs_handle = true;
 
     cap->minimum_frequency = 200000;
     cap->maximum_frequency = 4000000;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralNames.h
@@ -130,12 +130,6 @@ typedef enum {
     SPI_2 = 2,
 } SPIName;
 
-/* Specify master/slave interfaces for testing purposes. */
-#define SPI_TEST_MASTER SPI_2
-#define SPI_TEST_SLAVE SPI_0
-#define SPI_TEST_MASTER_PIN(SPI_PIN) SPI_2##_##SPI_PIN
-#define SPI_TEST_SLAVE_PIN(SPI_PIN)  SPI_0##_##SPI_PIN
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
@@ -242,27 +242,6 @@ typedef enum {
 
     DAC0_OUT = 0xFEFE, /* DAC does not have Pin Name in RM */
 
-    //SPI Pins configuration
-    /* Note:
-    This board does not provide SPI MOSI/MISO pins, instead we have SIN/SOUT pins which can be used
-    as SPI MOSI/MISO lines depending on SPI operation mode(master or slave):
-    master: SIN  ---> MISO
-            SOUT ---> MOSI
-    slave:  SIN  ---> MOSI
-            SOUT ---> MISO
-
-    SPI_0 interface represents SPI pins configuration for slave and SPI_2 respresents spi configuration
-    for master.
-    */
-    SPI_0_MOSI   = PTD3,
-    SPI_0_MISO   = PTD2,
-    SPI_0_SCK    = PTD1,
-    SPI_0_CS     = PTD0,
-    SPI_2_MOSI   = PTB22,
-    SPI_2_MISO   = PTB23,
-    SPI_2_SCK    = PTB21,
-    SPI_2_CS     = PTB20,
-
     SPI_MOSI    = PTE3,
     SPI_MISO    = PTE1,
     SPI_SCK     = PTE2,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -310,27 +310,48 @@ status_t DSPI_TransferBlockingLimit(SPI_Type *base, dspi_transfer_t *transfer, u
     return kStatus_Success;
 }
 
-void spi_get_capabilities(SPIName name, PinName ssel, spi_capabilities_t *cap)
+void spi_get_capabilities(SPIName name, PinName ssel, bool slave, spi_capabilities_t *cap)
 {
-    cap->word_length = 0x00008080;
-    cap->support_slave_mode = false;
-    cap->half_duplex = true;
+    if (slave) {
+        cap->minimum_frequency = 200000;
+        cap->maximum_frequency = 4000000;
 
-    cap->minimum_frequency = 200000;
-    cap->maximum_frequency = 4000000;
+        cap->word_length = 0x00008080;     // 8, 16 bits
+        cap->support_slave_mode = false;
+        cap->half_duplex = false;
+        cap->hw_cs_handle = true;
+        cap->clk_modes = (1 << SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE) | (1 << SPI_MODE_IDLE_LOW_SAMPLE_SECOND_EDGE) |
+                         (1 << SPI_MODE_IDLE_HIGH_SAMPLE_FIRST_EDGE) | (1 << SPI_MODE_IDLE_HIGH_SAMPLE_SECOND_EDGE);
+        cap->bit_order = (1 << SPI_BIT_ORDERING_MSB_FIRST);
+        cap->async_mode = true;
+        cap->slave_delay_between_symbols_ns = 1000; // 1 us
+    } else {
+        cap->minimum_frequency = 200000;
+        cap->maximum_frequency = 4000000;
 
+        cap->word_length = 0x00008080;     // 8, 16 bits
+        cap->support_slave_mode = false;
+        cap->half_duplex = false;
+        cap->hw_cs_handle = true;
+        cap->clk_modes = (1 << SPI_MODE_IDLE_LOW_SAMPLE_FIRST_EDGE) | (1 << SPI_MODE_IDLE_LOW_SAMPLE_SECOND_EDGE) |
+                         (1 << SPI_MODE_IDLE_HIGH_SAMPLE_FIRST_EDGE) | (1 << SPI_MODE_IDLE_HIGH_SAMPLE_SECOND_EDGE);
+        cap->bit_order = (1 << SPI_BIT_ORDERING_MSB_FIRST) | (1 << SPI_BIT_ORDERING_LSB_FIRST);
+        cap->async_mode = true;
+        cap->slave_delay_between_symbols_ns = 0;
+    }
+
+    // Determine slave mode based on CS pin
+#if DEVICE_SPISLAVE
     const PinMap *cs_pins = spi_master_cs_pinmap();
-
     PinName pin = NC;
-
     while(cs_pins->pin != NC) {
         if (cs_pins->pin == ssel) {
             cap->support_slave_mode = true;
             break;
         }
-
         cs_pins++;
     }
+#endif
 }
 
 SPIName spi_get_module(PinName mosi, PinName miso, PinName sclk) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/objects.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/objects.h
@@ -78,6 +78,10 @@ struct spi_s {
     bool is_slave;
     spi_bit_ordering_t order;
     bool initialised;
+    PinName pin_miso;
+    PinName pin_mosi;
+    PinName pin_sclk;
+    PinName pin_ssel;
 #if DEVICE_SPI_ASYNCH
     spi_async_handler_f handler;
     void *ctx;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PeripheralNames.h
@@ -66,11 +66,6 @@ typedef enum {
     SPI_5 = (int)SPI5_BASE,
     SPI_6 = (int)SPI6_BASE
 } SPIName;
-/* Specify master/slave SPI interfaces for testing purposes. */
-#define SPI_TEST_MASTER SPI_1
-#define SPI_TEST_SLAVE  SPI_4
-#define SPI_TEST_MASTER_PIN(SPI_PIN) SPI_1##_##SPI_PIN
-#define SPI_TEST_SLAVE_PIN(SPI_PIN)  SPI_4##_##SPI_PIN
 
 typedef enum {
     I2C_1 = (int)I2C1_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PinNames.h
@@ -271,15 +271,6 @@ typedef enum {
     I2C_SDA     = D14,
     PWM_OUT     = D9,
 
-    SPI_1_MOSI    = PB_5,
-    SPI_1_MISO    = PA_6,
-    SPI_1_SCK     = PA_5,
-    SPI_1_CS      = PA_4,
-    SPI_4_MOSI    = PE_6,
-    SPI_4_MISO    = PE_5,
-    SPI_4_SCK     = PE_2,
-    SPI_4_CS      = PE_4,
-
     /**** USB pins ****/
     USB_OTG_FS_DM = PA_11,
     USB_OTG_FS_DP = PA_12,

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -109,6 +109,7 @@ void spi_get_capabilities(SPIName name, PinName ssel, spi_capabilities_t *cap)
     cap->word_length = 0x00008080;
     cap->support_slave_mode = false;
     cap->half_duplex = true;
+    cap->hw_cs_handle = false;
 
     cap->minimum_frequency = 200000;
     cap->maximum_frequency = 4000000;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5091,7 +5091,6 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
-            "SERIAL_FC",
             "TSC"
         ]
     },
@@ -5116,7 +5115,6 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
-            "SERIAL_FC",
             "TSC",
             "USTICKER"
         ],
@@ -5165,7 +5163,6 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
-            "SERIAL_FC",
             "TSC",
             "MPU",
             "USTICKER"
@@ -5191,7 +5188,6 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
-            "SERIAL_FC",
             "TSC",
             "MPU",
             "USTICKER"
@@ -5217,7 +5213,6 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
-            "SERIAL_FC",
             "TSC",
             "MPU",
             "USTICKER"
@@ -5262,7 +5257,6 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
-            "SERIAL_FC",
             "TSC",
             "MPU"
         ],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3130,7 +3130,6 @@
             "lpticker_delay_ticks": 4,
             "network-default-interface-type": "WIFI"
         },
-        "components_add": ["SPIF"],
         "detect_code": ["9020"],
         "device_has_add": ["ANALOGOUT", "CAN", "TRNG", "FLASH", "MPU"],
         "device_has_remove": ["SERIAL_FC"],


### PR DESCRIPTION
### Description

This PR provides the following changes:
 - NUCLEO_F429ZI, K66F, K64F SPI driver fixes,
 - spi_api.h: Update defined/undefined behavior,
 - NUCLEO_F429ZI, K66F Spi driver: update capabilities,
 - Rework spi_get_capabilities() function.

Please check commit description for more info.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ithinuel 
@c1728p9 

