### PR TITLE
FUTURE_SEQUANA: Fixed LP ticker for M0 core

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/lp_ticker.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/lp_ticker.c
@@ -63,8 +63,8 @@ static cy_stc_mcwdt_config_t config = {
 // Interrupt configuration.
 static cy_stc_sysint_t lpt_sysint_config = {
 #if defined(TARGET_MCU_PSOC6_M0)
-    .intrSrc = (IRQn_Type)(-1),
-    .cm0pSrc = CY_M0_CORE_IRQ_CHANNEL_LP_TICKER,
+    .intrSrc = CY_M0_CORE_IRQ_CHANNEL_LP_TICKER,
+    .cm0pSrc = LPT_INTERRUPT_SOURCE,
 #else
     .intrSrc = LPT_INTERRUPT_SOURCE,
 #endif


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixed interrupt vector settings on M0 core - this was likely merge error (on my side) when submitting #9678. Wrong vector settings prevented LP_TICKER from working, resulting in deep sleep tests failing.
Also regenerated PSA M0 image to fix SEQUANA PSA deep sleep tests (fixes issue #9095).

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
