### PR TITLE
Cellular: Basic driver for Quectel EC25/EC21

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -28,7 +28,7 @@ using namespace events;
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeLAC,    // C_EREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
-    AT_CellularNetwork::RegistrationModeEnable,    // C_REG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
     1,  // AT_CGSN_WITH_TYPE
     1,  // AT_CGDATA
     0,  // AT_CGAUTH

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -66,11 +66,11 @@ CellularDevice *CellularDevice::get_default_instance()
     return &device;
 }
 
-nsapi_error_t QUECTEL_EC2X::hard_power_on()
+nsapi_error_t QUECTEL_EC2X::press_power_button(uint32_t timeout)
 {
     if (_pwr_key.is_connected()) {
         _pwr_key = 1;
-        ThisThread::sleep_for(600);
+        ThisThread::sleep_for(timeout);
         _pwr_key = 0;
         ThisThread::sleep_for(100);
     }
@@ -78,17 +78,15 @@ nsapi_error_t QUECTEL_EC2X::hard_power_on()
     return NSAPI_ERROR_OK;
 }
 
+nsapi_error_t QUECTEL_EC2X::hard_power_on()
+{
+    return press_power_button(600);
+}
+
 nsapi_error_t QUECTEL_EC2X::hard_power_off()
 
 {
-    if (_pwr_key.is_connected()) {
-        _pwr_key = 1;
-        ThisThread::sleep_for(750);
-        _pwr_key = 0;
-        ThisThread::sleep_for(100);
-    }
-
-    return NSAPI_ERROR_OK;
+    return press_power_button(750);
 }
 
 nsapi_error_t QUECTEL_EC2X::soft_power_on()
@@ -119,14 +117,7 @@ nsapi_error_t QUECTEL_EC2X::soft_power_on()
 
 nsapi_error_t QUECTEL_EC2X::soft_power_off()
 {
-    if (_pwr_key.is_connected()) {
-        _pwr_key = 1;
-        ThisThread::sleep_for(750);
-        _pwr_key = 0;
-        ThisThread::sleep_for(100);
-    }
-
-    return NSAPI_ERROR_OK;
+    return hard_power_off();
 }
 
 #endif

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -20,6 +20,7 @@
 #include "PinNames.h"
 #include "AT_CellularNetwork.h"
 #include "rtos/ThisThread.h"
+#include "UARTSerial.h"
 
 using namespace mbed;
 using namespace rtos;
@@ -31,6 +32,14 @@ using namespace events;
 
 #if !defined(MBED_CONF_QUECTEL_EC2X_RST)
 #define MBED_CONF_QUECTEL_EC2X_RST    NC
+#endif
+
+#if !defined(MBED_CONF_QUECTEL_EC2X_TX)
+#define MBED_CONF_QUECTEL_EC2X_TX    NC
+#endif
+
+#if !defined(MBED_CONF_QUECTEL_EC2X_RX)
+#define MBED_CONF_QUECTEL_EC2X_RX    NC
 #endif
 
 #if !defined(MBED_CONF_QUECTEL_EC2X_POLARITY)
@@ -64,7 +73,6 @@ QUECTEL_EC2X::QUECTEL_EC2X(FileHandle *fh, PinName pwr, bool active_high, PinNam
     AT_CellularBase::set_cellular_properties(cellular_properties);
 }
 
-#include "UARTSerial.h"
 CellularDevice *CellularDevice::get_default_instance()
 {
     static UARTSerial serial(MBED_CONF_QUECTEL_EC2X_TX,

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QUECTEL_EC2X.h"
+
+#include "PinNames.h"
+#include "AT_CellularNetwork.h"
+#include "rtos/ThisThread.h"
+
+using namespace mbed;
+using namespace rtos;
+using namespace events;
+
+static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
+    AT_CellularNetwork::RegistrationModeLAC,    // C_EREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
+    AT_CellularNetwork::RegistrationModeEnable,    // C_REG
+    1,  // AT_CGSN_WITH_TYPE
+    1,  // AT_CGDATA
+    0,  // AT_CGAUTH
+    1,  // AT_CNMI
+    1,  // AT_CSMP
+    1,  // AT_CMGF
+    1,  // AT_CSDH
+    1,  // PROPERTY_IPV4_STACK
+    1,  // PROPERTY_IPV6_STACK
+    1,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
+};
+
+QUECTEL_EC2X::QUECTEL_EC2X(FileHandle *fh, PinName pwr, PinName rst)
+    : AT_CellularDevice(fh),
+      _pwr_key(pwr, 0),
+      _rst(rst, 0)
+
+{
+    AT_CellularBase::set_cellular_properties(cellular_properties);
+}
+
+#if MBED_CONF_QUECTEL_EC2X_PROVIDE_DEFAULT
+#include "UARTSerial.h"
+CellularDevice *CellularDevice::get_default_instance()
+{
+    static UARTSerial serial(MBED_CONF_QUECTEL_EC2X_TX,
+                             MBED_CONF_QUECTEL_EC2X_RX,
+                             MBED_CONF_QUECTEL_EC2X_BAUDRATE);
+#if defined(MBED_CONF_QUECTEL_EC2X_RTS) && defined(MBED_CONF_QUECTEL_EC2X_CTS)
+    tr_debug("QUECTEL_EC2X_PPP flow control: RTS %d CTS %d", MBED_CONF_QUECTEL_EC2X_RTS, MBED_CONF_QUECTEL_EC2X_CTS);
+    serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_QUECTEL_EC2X_RTS, MBED_CONF_QUECTEL_EC2X_CTS);
+#endif
+    static QUECTEL_EC2X device(&serial, MBED_CONF_QUECTEL_EC2X_PWR, MBED_CONF_QUECTEL_EC2X_RST);
+    return &device;
+}
+
+nsapi_error_t QUECTEL_EC2X::hard_power_on()
+{
+    if (_pwr_key.is_connected()) {
+        _pwr_key = 1;
+        ThisThread::sleep_for(600);
+        _pwr_key = 0;
+        ThisThread::sleep_for(100);
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+nsapi_error_t QUECTEL_EC2X::hard_power_off()
+
+{
+    if (_pwr_key.is_connected()) {
+        _pwr_key = 1;
+        ThisThread::sleep_for(750);
+        _pwr_key = 0;
+        ThisThread::sleep_for(100);
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+nsapi_error_t QUECTEL_EC2X::soft_power_on()
+{
+    if (_rst.is_connected()) {
+        _rst = 1;
+        ThisThread::sleep_for(460);
+        _rst = 0;
+        ThisThread::sleep_for(100);
+    }
+
+    _at->lock();
+
+    _at->set_at_timeout(5000);
+    _at->resp_start();
+    _at->set_stop_tag("RDY");
+    bool rdy = _at->consume_to_stop_tag();
+    _at->set_stop_tag(OK);
+
+    _at->unlock();
+
+    if (!rdy) {
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+nsapi_error_t QUECTEL_EC2X::soft_power_off()
+{
+    if (_pwr_key.is_connected()) {
+        _pwr_key = 1;
+        ThisThread::sleep_for(750);
+        _pwr_key = 0;
+        ThisThread::sleep_for(100);
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+#endif

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -29,7 +29,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeLAC,    // C_EREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_REG
-    1,  // AT_CGSN_WITH_TYPE
+    0,  // AT_CGSN_WITH_TYPE
     1,  // AT_CGDATA
     0,  // AT_CGAUTH
     1,  // AT_CNMI

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -60,7 +60,6 @@ CellularDevice *CellularDevice::get_default_instance()
                              MBED_CONF_QUECTEL_EC2X_RX,
                              MBED_CONF_QUECTEL_EC2X_BAUDRATE);
 #if defined(MBED_CONF_QUECTEL_EC2X_RTS) && defined(MBED_CONF_QUECTEL_EC2X_CTS)
-    tr_debug("QUECTEL_EC2X_PPP flow control: RTS %d CTS %d", MBED_CONF_QUECTEL_EC2X_RTS, MBED_CONF_QUECTEL_EC2X_CTS);
     serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_QUECTEL_EC2X_RTS, MBED_CONF_QUECTEL_EC2X_CTS);
 #endif
     static QUECTEL_EC2X device(&serial, MBED_CONF_QUECTEL_EC2X_PWR, MBED_CONF_QUECTEL_EC2X_RST);

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.h
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.h
@@ -18,15 +18,6 @@
 #ifndef QUECTEL_EC2X_H
 #define QUECTEL_EC2X_H
 
-#ifdef TARGET_FF_ARDUINO
-#ifndef MBED_CONF_QUECTEL_EC2X_TX
-#define MBED_CONF_QUECTEL_EC2X_TX D1
-#endif
-#ifndef MBED_CONF_QUECTEL_EC2X_RX
-#define MBED_CONF_QUECTEL_EC2X_RX D0
-#endif
-#endif /* TARGET_FF_ARDUINO */
-
 #include "DigitalOut.h"
 #include "AT_CellularDevice.h"
 
@@ -34,7 +25,14 @@ namespace mbed {
 
 class QUECTEL_EC2X : public AT_CellularDevice {
 public:
-    QUECTEL_EC2X(FileHandle *fh, PinName pwr = NC, PinName rst = NC);
+
+    /**
+     * Constructs the Quectel EC2X series driver. It is mandatory to provide
+     * a FileHandle object, the power pin and the polarity of the pin.
+     * Providing reset pin is optional.
+     */
+    QUECTEL_EC2X(FileHandle *fh, PinName pwr, bool active_high, PinName rst = NC);
+
     virtual nsapi_error_t hard_power_on();
     virtual nsapi_error_t hard_power_off();
     virtual nsapi_error_t soft_power_on();
@@ -42,6 +40,7 @@ public:
 
 private:
     nsapi_error_t press_power_button(uint32_t timeout);
+    bool _active_high;
     DigitalOut _pwr_key;
     DigitalOut _rst;
 };

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.h
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef QUECTEL_EC2X_H
+#define QUECTEL_EC2X_H
+
+#ifdef TARGET_FF_ARDUINO
+#ifndef MBED_CONF_QUECTEL_EC2X_TX
+#define MBED_CONF_QUECTEL_EC2X_TX D1
+#endif
+#ifndef MBED_CONF_QUECTEL_EC2X_RX
+#define MBED_CONF_QUECTEL_EC2X_RX D0
+#endif
+#endif /* TARGET_FF_ARDUINO */
+
+#include "DigitalOut.h"
+#include "AT_CellularDevice.h"
+
+namespace mbed {
+
+class QUECTEL_EC2X : public AT_CellularDevice {
+public:
+    QUECTEL_EC2X(FileHandle *fh, PinName pwr = NC, PinName rst = NC);
+    virtual nsapi_error_t hard_power_on();
+    virtual nsapi_error_t hard_power_off();
+    virtual nsapi_error_t soft_power_on();
+    virtual nsapi_error_t soft_power_off();
+
+private:
+    DigitalOut _pwr_key;
+    DigitalOut _rst;
+};
+
+} // namespace mbed
+
+#endif // QUECTEL_EC2X_H

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.h
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.h
@@ -41,6 +41,7 @@ public:
     virtual nsapi_error_t soft_power_off();
 
 private:
+    nsapi_error_t press_power_button(uint32_t timeout);
     DigitalOut _pwr_key;
     DigitalOut _rst;
 };

--- a/features/cellular/framework/targets/QUECTEL/EC2X/mbed_lib.json
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/mbed_lib.json
@@ -25,6 +25,10 @@
             "help": "Reset control pin",
             "value": null
         },
+        "polarity": {
+            "help": "Pin polarity, 1 = Active high, 0 = Active low",
+            "value": null
+        },
         "baudrate" : {
             "help": "Serial connection baud rate",
             "value": 115200

--- a/features/cellular/framework/targets/QUECTEL/EC2X/mbed_lib.json
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/mbed_lib.json
@@ -1,0 +1,37 @@
+{
+    "name": "QUECTEL_EC2X",
+    "config": {
+        "tx": {
+            "help": "TX pin for serial connection. D1 assumed if Arduino Form Factor, needs to be set/overwritten otherwise.",
+            "value": null
+        },
+        "rx": {
+            "help": "RX pin for serial connection. D0 assumed if Arduino Form Factor, needs to be set/overwritten otherwise.",
+            "value": null
+        },
+        "rts": {
+            "help": "RTS pin for serial connection",
+            "value": null
+        },
+        "cts": {
+            "help": "CTS pin for serial connection",
+            "value": null
+        },
+        "pwr": {
+            "help": "Power control pin",
+            "value": null
+        },
+        "rst": {
+            "help": "Reset control pin",
+            "value": null
+        },
+        "baudrate" : {
+            "help": "Serial connection baud rate",
+            "value": 115200
+        },
+        "provide-default": {
+            "help": "Provide as default CellularDevice [true/false]",
+            "value": false
+        }
+    }
+}


### PR DESCRIPTION
### Description

Provides basic power up / power down sequences for Quectel EC2X series
modems. Can be used in PPP mode. For using the on-board IP stack, we
will need to add and implement classes that provide context.

Driver constructor takes power and reset control pins along with the
FileHandle. A default construction is provided which can be chosen by
the application in its mbed_app.json. Otherwise the user is free to
construct as per demand.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
