### PR TITLE
eclipse_gcc_arm export improvement

### DIFF
--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -45,16 +45,15 @@ class Eclipse(Makefile):
         if configuration in defaults:
             eclipse_config.update(defaults[configuration])
 
-        # Get target-specific options. Use resolution order and extra labels
-        # to find alias for target. This allows to define options within inheritance path
+        # Get target-specific options. Use labels to find alias
+        # for target. This allows to define options within inheritance path
         target_specific = _CONFIGS_OPTIONS['targets']
-        aliases = self.toolchain.target.resolution_order_names \
-            + self.toolchain.target.extra_labels
-        target_alias = next((t for t in aliases if t in target_specific), None)
-        if target_alias:
-            eclipse_config.update(target_specific[target_alias]['generic'])
-            if configuration in target_specific[target_alias]:
-                eclipse_config.update(target_specific[target_alias][configuration])
+        aliases = self.toolchain.target.labels
+        for target_alias in aliases:
+            if target_alias in target_specific:
+                eclipse_config.update(target_specific[target_alias]['generic'])
+                if configuration in target_specific[target_alias]:
+                    eclipse_config.update(target_specific[target_alias][configuration])
 
         return eclipse_config
 

--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -48,12 +48,12 @@ class Eclipse(Makefile):
         # Get target-specific options. Use labels to find alias
         # for target. This allows to define options within inheritance path
         target_specific = _CONFIGS_OPTIONS['targets']
-        aliases = self.toolchain.target.labels
-        for target_alias in aliases:
+        for target_alias in self.toolchain.target.labels:
             if target_alias in target_specific:
                 eclipse_config.update(target_specific[target_alias]['generic'])
                 if configuration in target_specific[target_alias]:
                     eclipse_config.update(target_specific[target_alias][configuration])
+                break
 
         return eclipse_config
 

--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -18,11 +18,11 @@ import re
 import os
 import json
 from collections import namedtuple
-from tools.targets import TARGET_MAP
 from os.path import join, exists
 from os import makedirs, remove
 import shutil
 from copy import deepcopy
+from tools.targets import TARGET_MAP
 
 from tools.export.makefile import Makefile, GccArm, Armc5, IAR
 
@@ -38,19 +38,23 @@ class Eclipse(Makefile):
     """Generic Eclipse project. Intended to be subclassed by classes that
     specify a type of Makefile.
     """
-    def get_target_config(self, ctx, configuration):
+    def get_target_config(self, configuration):
         """Retrieve info from cdt_definitions.json"""
-        tgt = deepcopy(TARGET_MAP[self.target])
-        defaults = deepcopy(_CONFIGS_OPTIONS['default'])
+        defaults = _CONFIGS_OPTIONS['default']
         eclipse_config = deepcopy(defaults['generic'])
         if configuration in defaults:
             eclipse_config.update(defaults[configuration])
 
+        # Get target-specific options. Use resolution order and extra labels
+        # to find alias for target. This allows to define options within inheritance path
         target_specific = _CONFIGS_OPTIONS['targets']
-        if tgt.name in target_specific:
-            eclipse_config.update(target_specific[tgt.name]['generic'])
-            if configuration in target_specific[tgt.name]:
-                eclipse_config.update(target_specific[tgt.name][configuration])
+        aliases = self.toolchain.target.resolution_order_names \
+            + self.toolchain.target.extra_labels
+        target_alias = next((t for t in aliases if t in target_specific), None)
+        if target_alias:
+            eclipse_config.update(target_specific[target_alias]['generic'])
+            if configuration in target_specific[target_alias]:
+                eclipse_config.update(target_specific[target_alias][configuration])
 
         return eclipse_config
 
@@ -63,7 +67,7 @@ class Eclipse(Makefile):
         starting_dot = re.compile(r'(^[.]/|^[.]$)')
         ctx = {
             'name': self.project_name,
-            'elf_location': join('BUILD',self.project_name)+'.elf',
+            'elf_location': join('BUILD', self.project_name)+'.elf',
             'c_symbols': self.toolchain.get_symbols(),
             'asm_symbols': self.toolchain.get_symbols(True),
             'target': self.target,
@@ -74,11 +78,11 @@ class Eclipse(Makefile):
         launch_cfgs = {}
         for launch_name in supported_launches:
             launch = deepcopy(ctx)
-            launch.update({'device': self.get_target_config(ctx, launch_name)})
+            launch.update({'device': self.get_target_config(launch_name)})
             launch_cfgs[launch_name] = launch
             
-        if not exists(join(self.export_dir,'eclipse-extras')):
-            makedirs(join(self.export_dir,'eclipse-extras'))
+        if not exists(join(self.export_dir, 'eclipse-extras')):
+            makedirs(join(self.export_dir, 'eclipse-extras'))
 
         for launch_name, ctx in launch_cfgs.items():
             # Generate launch configurations for former GNU ARM Eclipse plug-in
@@ -95,7 +99,7 @@ class Eclipse(Makefile):
                                                                         conf=launch_name)))
 
         self.gen_file('cdt/necessary_software.tmpl', ctx,
-                      join('eclipse-extras','necessary_software.p2f'))
+                      join('eclipse-extras', 'necessary_software.p2f'))
 
         self.gen_file('cdt/.cproject.tmpl', ctx, '.cproject')
         self.gen_file('cdt/.project.tmpl', ctx, '.project')
@@ -119,7 +123,7 @@ class EclipseArmc5(Eclipse, Armc5):
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
         if int(target.build_tools_metadata["version"]) > 0:
-            return "ARMC5" in target.supported_toolchains;
+            return "ARMC5" in target.supported_toolchains
         else:
             return True
 

--- a/tools/export/cdt/cdt_definitions.json
+++ b/tools/export/cdt/cdt_definitions.json
@@ -41,7 +41,7 @@
   },
 
   "targets": {
-    "CY8CPROTO_062_4343W": {
+    "PSOC6_01": {
       "generic": {
         "gdbServerGdbPortNumber": 3334,
         "gdbServerOther": "-p 3333&#13;&#10;--no-deprecation-warning",
@@ -49,39 +49,7 @@
       }
     },
 
-    "CY8CMOD_062_4343W": {
-      "generic": {
-        "gdbServerGdbPortNumber": 3334,
-        "gdbServerOther": "-p 3333&#13;&#10;--no-deprecation-warning",
-        "corePortNumber": 3334
-      }
-    },
-
-    "CYW943012P6EVB_01": {
-      "generic": {
-        "gdbServerGdbPortNumber": 3334,
-        "gdbServerOther": "-p 3333&#13;&#10;--no-deprecation-warning",
-        "corePortNumber": 3334
-      }
-    },
-
-    "CY8CKIT_062_WIFI_BT": {
-      "generic": {
-        "gdbServerGdbPortNumber": 3334,
-        "gdbServerOther": "-p 3333&#13;&#10;--no-deprecation-warning",
-        "corePortNumber": 3334
-      }
-    },
-
-    "CY8CKIT_062_BLE": {
-      "generic": {
-        "gdbServerGdbPortNumber": 3334,
-        "gdbServerOther": "-p 3333&#13;&#10;--no-deprecation-warning",
-        "corePortNumber": 3334
-      }
-    },
-
-    "CY8CKIT_062_4343W": {
+    "PSOC6_02": {
       "generic": {
         "gdbServerGdbPortNumber": 3334,
         "gdbServerOther": "-p 3333&#13;&#10;--no-deprecation-warning",


### PR DESCRIPTION
### Description

Current implementation of cdt exporter requires modification of `cdt_definitions.json` in order to support launch configuration for new kit (double-core). Usually launch configuration does not change if devices are derived from the same family. This pull request reduces maintenance burden of new kits support by allowing them to be based on extra_labels and not necessarily defined for each kit separately.

Also this pull request fixes:
- unnecessary deepcopy introduced in previous my pull request: https://github.com/ARMmbed/mbed-os/pull/9342
- `cdt_definitions.json` clean-up
- code style issues detected with pylint

All internal tests are passed
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@theotherjimmy

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
