### PR TITLE
MIMXRT1050: Fix ENET issues

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_IMX/imx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_IMX/imx_emac.cpp
@@ -189,7 +189,8 @@ bool Kinetis_EMAC::low_level_init_successful()
 
     /* Create buffers for each receive BD */
     for (i = 0; i < ENET_RX_RING_LEN; i++) {
-        rx_buff[i] = memory_manager->alloc_heap(ENET_ETH_MAX_FLEN, ENET_BUFF_ALIGNMENT);
+        rx_buff[i] = memory_manager->alloc_heap(ENET_ALIGN(ENET_ETH_MAX_FLEN, ENET_BUFF_ALIGNMENT),
+                                                ENET_BUFF_ALIGNMENT);
         if (NULL == rx_buff[i])
             return false;
 
@@ -279,7 +280,8 @@ emac_mem_buf_t *Kinetis_EMAC::low_level_input(int idx)
         memory_manager->set_len(p, length);
 
         /* Attempt to queue new buffer */
-        temp_rxbuf = memory_manager->alloc_heap(ENET_ETH_MAX_FLEN, ENET_BUFF_ALIGNMENT);
+        temp_rxbuf = memory_manager->alloc_heap(ENET_ALIGN(ENET_ETH_MAX_FLEN, ENET_BUFF_ALIGNMENT),
+                                                ENET_BUFF_ALIGNMENT);
         if (NULL == temp_rxbuf) {
             /* Re-queue the same buffer */
             update_read_buffer(NULL);


### PR DESCRIPTION
### Description
This is a fix for [Issue#10239](https://github.com/ARMmbed/mbed-os/issues/10239). The change aligns the receive buffer lengths

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
