### PR TITLE
BLE: force mandatory services to have lowest handles

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioGattServer.h
@@ -185,6 +185,8 @@ public:
 
 
 private:
+    void add_default_services();
+
     static uint16_t compute_attributes_count(GattService& service);
 
     void insert_service_attribute(
@@ -279,6 +281,8 @@ private:
     alloc_block_t* allocated_blocks;
 
     uint16_t currentHandle;
+
+    bool default_services_added;
 
 private:
     GattServer();

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -71,12 +71,21 @@ void GattServer::initialize()
 #if BLE_FEATURE_SECURITY
     AttsAuthorRegister(atts_auth_cb);
 #endif
-    add_generic_access_service();
-    add_generic_attribute_service();
+    add_default_services();
+}
+
+void GattServer::add_default_services()
+{
+    if (!default_services_added) {
+        default_services_added = true;
+        add_generic_access_service();
+        add_generic_attribute_service();
+    }
 }
 
 ble_error_t GattServer::addService_(GattService &service)
 {
+    add_default_services();
     // create and fill the service structure
     internal_service_t *att_service = new internal_service_t;
     att_service->attGroup.pNext = NULL;
@@ -1344,7 +1353,8 @@ GattServer::GattServer() :
     generic_attribute_service(),
     registered_service(NULL),
     allocated_blocks(NULL),
-    currentHandle(0)
+    currentHandle(0),
+    default_services_added(false)
 {
 }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Mandatory services can be added before or after user added services. The nordic monitor application assumes they are the first service discovered and fail if they are not. This fix makes sure the mandatory service is added before any user service.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@pan-
<!--
    Optional
    Request additional reviewers with @username
-->

