### PR TITLE
STM32L4xx: IAR memory maps updated

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -10,7 +10,9 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 /* Vector table dynamic copy: Total: 98 vectors * 4 = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
 define symbol __NVIC_end__            = 0x10000187;
-define symbol __region_SRAM2_start__  = 0x10000188;
+define symbol __region_CSTACK_start__  = 0x10000188;
+define symbol __region_CSTACK_end__    = __region_CSTACK_start__ + MBED_BOOT_STACK_SIZE;
+define symbol __region_SRAM2_start__  = __region_CSTACK_end__;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
 define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
@@ -20,9 +22,10 @@ define symbol __region_SRAM1_end__    = 0x20017FFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
+define region CSTACK_region = mem:[from __region_CSTACK_start__ to __region_CSTACK_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
-define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
+define region RAM_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__]
+                          | mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 /* Define Crash Data Symbols */
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
@@ -33,9 +36,9 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 }
 
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __size_heap__   = 0x17000;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, alignment = 8, minimum size = __size_heap__     { };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
@@ -43,5 +46,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region { readwrite, block HEAP };
-place in SRAM2_region { first block CSTACK, zeroinit };
+place in CSTACK_region { block CSTACK };
+place in RAM_region                     { block HEAP, readwrite, zeroinit };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -10,7 +10,9 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 /* Vector table dynamic copy: Total: 98 vectors * 4 = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
 define symbol __NVIC_end__            = 0x10000187;
-define symbol __region_SRAM2_start__  = 0x10000188;
+define symbol __region_CSTACK_start__  = 0x10000188;
+define symbol __region_CSTACK_end__    = __region_CSTACK_start__ + MBED_BOOT_STACK_SIZE;
+define symbol __region_SRAM2_start__  = __region_CSTACK_end__;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
 define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
@@ -20,9 +22,10 @@ define symbol __region_SRAM1_end__    = 0x20017FFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
+define region CSTACK_region = mem:[from __region_CSTACK_start__ to __region_CSTACK_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
-define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
+define region RAM_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__]
+                          | mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 /* Define Crash Data Symbols */
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
@@ -35,7 +38,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, alignment = 8, minimum size = __size_heap__     { };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
@@ -43,5 +46,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region { readwrite, block HEAP };
-place in SRAM2_region { block CSTACK };
+place in CSTACK_region { block CSTACK };
+place in RAM_region                     { block HEAP, readwrite, zeroinit };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
@@ -10,7 +10,9 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 /* Vector table dynamic copy: Total: 98 vectors * 4 = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
 define symbol __NVIC_end__            = 0x10000187;
-define symbol __region_SRAM2_start__  = 0x10000188;
+define symbol __region_CSTACK_start__  = 0x10000188;
+define symbol __region_CSTACK_end__    = __region_CSTACK_start__ + MBED_BOOT_STACK_SIZE;
+define symbol __region_SRAM2_start__  = __region_CSTACK_end__;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
 define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
@@ -20,9 +22,10 @@ define symbol __region_SRAM1_end__    = 0x20017FFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
+define region CSTACK_region = mem:[from __region_CSTACK_start__ to __region_CSTACK_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
-define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
+define region RAM_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__]
+                          | mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 /* Define Crash Data Symbols */
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
@@ -35,7 +38,7 @@ if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, alignment = 8, minimum size = __size_heap__     { };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
@@ -43,5 +46,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region { readwrite, block HEAP };
-place in SRAM2_region { block CSTACK };
+place in CSTACK_region { block CSTACK };
+place in RAM_region                     { block HEAP, readwrite, zeroinit };


### PR DESCRIPTION
### Description

Fully utilize target RAM when using IAR. Tested with mbed-os-example-cellular (MTB_ADV_WISE_1570 - L486, MTB_STM_L475).

CSTACK is placed in 32kB RAM. Then the symbols start filling from there and continue to 96kB RAM. Heap placement is left to linker (placed last in my tests) and will grow to take up the rest of the space available.

The change can be even simpler if we don't care where CSTACK ends up. Without specifically allocating it in my tests it goes before the heap.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
