### PR TITLE
Define crash context memory location by linker symbol

### DIFF
--- a/platform/mbed_crash_data_offsets.h
+++ b/platform/mbed_crash_data_offsets.h
@@ -30,8 +30,10 @@ extern uint32_t Image$$RW_m_crash_data$$ZI$$Size;
 #define __CRASH_DATA_RAM_START__    Image$$RW_m_crash_data$$ZI$$Base
 #define __CRASH_DATA_RAM_SIZE__     Image$$RW_m_crash_data$$ZI$$Size
 #elif defined(__ICCARM__)
-extern uint32_t __CRASH_DATA_RAM_START__[];
-extern uint32_t __CRASH_DATA_RAM_END__[];
+extern uint32_t CRASH_DATA_RAM$$Base[];
+extern uint32_t CRASH_DATA_RAM$$Limit[];
+#define __CRASH_DATA_RAM_START__    CRASH_DATA_RAM$$Base
+#define __CRASH_DATA_RAM_END__      CRASH_DATA_RAM$$Limit
 #define __CRASH_DATA_RAM_SIZE__     (__CRASH_DATA_RAM_END__ - __CRASH_DATA_RAM_START__)
 #elif defined(__GNUC__)
 extern uint32_t __CRASH_DATA_RAM_START__[];

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -27,11 +27,9 @@ define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = __ICFEDIT_size_intvec__          { };
-define block CRASH_DATA_RAM   with alignment = 8, size = __ICFEDIT_size_crash_data__          { };
 
-/* Define Crash Data Symbols */
-define exported symbol __CRASH_DATA_RAM_START__ = __ICFEDIT_region_IRAM_start__ + __ICFEDIT_size_cstack__ + __ICFEDIT_size_intvec__;
-define exported symbol __CRASH_DATA_RAM_END__ = __ICFEDIT_region_IRAM_start__ + __ICFEDIT_size_cstack__ + __ICFEDIT_size_intvec__ + __ICFEDIT_size_crash_data__;
+/* Block to store crash data */
+define block CRASH_DATA_RAM   with alignment = 8, size = __ICFEDIT_size_crash_data__          { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };


### PR DESCRIPTION
### Description
This should fix https://github.com/ARMmbed/mbed-os/issues/9069 

1) IAR can place block Out-of-Order.
2) IAR optimization removes memory block if not referenced in code.

So calculation in linker file may not be accurate.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SenRamakri @ccli8 

### Test logs 
```
1554349233.21][GLRM][INF] remote resources reset...
[1554349236.81][GLRM][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1554349236.81][CONN][INF] sending up to 5 __sync packets (specified with --sync=5)
[1554349236.81][CONN][INF] sending preamble 'ca96aad5-2e11-410b-b5d7-cf2796a56dec'
[1554349237.03][GLRM][TXD] {{__sync;ca96aad5-2e11-410b-b5d7-cf2796a56dec}}
[1554349237.17][CONN][RXD] mbedmbedmbedmbedmbedmbedmbedmbed
[1554349237.17][CONN][INF] found SYNC in stream: {{__sync;ca96aad5-2e11-410b-b5d7-cf2796a56dec}} it is #0 sent, queued...
[1554349237.17][CONN][INF] found KV pair in stream: {{__version;1.3.0}}, queued...
[1554349237.17][HTST][INF] sync KV found, uuid=ca96aad5-2e11-410b-b5d7-cf2796a56dec, timestamp=1554349237.170067
[1554349237.17][HTST][INF] DUT greentea-client version: 1.3.0
[1554349237.27][CONN][RXD]
[1554349237.27][CONN][INF] found KV pair in stream: {{__timeout;40}}, queued...
[1554349237.27][CONN][INF] found KV pair in stream: {{__host_test_name;crash_reporting}}, queued...
[1554349237.27][HTST][INF] setting timeout to: 40 sec
[1554349237.27][CONN][INF] found KV pair in stream: {{crash_reporting_ready;0}}, queued...
[1554349237.27][HTST][INF] host test class: '<class 'crash_reporting.CrashReportingTest'>'
[1554349237.27][HTST][INF] host test setup() call...
[1554349237.27][HTST][INF] CALLBACKs updated
[1554349237.27][HTST][INF] host test detected: crash_reporting
[1554349237.37][CONN][RXD] Message sent: crash_reporting_ready
[1554349237.37][CONN][RXD]
[1554349237.37][CONN][RXD] Waiting for crash inject error message: crash_reporting_inject_error
[1554349244.49][GLRM][TXD] {{crash_reporting_inject_error;0}}
[1554349244.55][CONN][RXD]
[1554349244.62][CONN][RXD] Crash inject error message received
[1554349244.62][CONN][RXD]
[1554349244.62][CONN][RXD] Forcing error
[1554349244.62][CONN][RXD]
[1554349244.62][CONN][RXD]
[1554349244.62][CONN][RXD] ++ MbedOS Error Info ++
[1554349244.73][CONN][RXD] Error Status: 0x80FF011F Code: 287 Module: 255
[1554349244.73][CONN][RXD] Error Message: Executing crash reporting test.
[1554349244.73][CONN][RXD] Location: 0x0
[1554349244.73][CONN][RXD] Error Value: 0xDEADBAD
[1554349244.84][CONN][RXD] Current Thread: main  Id: 0x20012B70 Entry: 0x1A9D StackSize: 0x1000 StackMem: 0x20010F18 SP: 0x20011EC0
[1554349244.94][CONN][RXD] For more info, visit: https://mbed.com/s/error?error=0x80FF011F&tgt=NUMAKER_PFM_M487
[1554349244.94][CONN][RXD] -- MbedOS Error Info --
[1554349244.94][CONN][RXD]
[1554349245.06][CONN][RXD] = System will be rebooted due to a fatal error =
[1554349245.17][CONN][RXD] = Reboot count(=1) reached maximum, system will halt a
[1554349245.17][CONN][INF] found KV pair in stream: {{crash_reporting_ready;0}}, queued...
[1554349249.28][HTST][INF] __notify_complete(True)
[1554349249.28][HTST][INF] __exit_event_queue received
[1554349249.28][HTST][INF] test suite run finished after 12.01 sec...
[1554349253.39][HTST][INF] No events in queue
[1554349253.39][HTST][INF] stopped consuming events
[1554349253.39][HTST][INF] host test result() call skipped, received: True
[1554349253.39][HTST][WRN] missing __exit event from DUT
[1554349253.39][HTST][INF] calling blocking teardown()
[1554349253.39][HTST][INF] teardown() finished
[1554349253.39][HTST][INF] {{result;success}}
mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped and returned 'OK'
mbedgt: test case summary event not found
        no test case report present, assuming test suite to be a single test case!
        test suite: tests-mbed_platform-crash_reporting
        test case: tests-mbed_platform-crash_reporting
mbedgt: test on hardware with target id: DUMMY
mbedgt: test suite 'tests-mbed_platform-crash_reporting' ............................................. OK in 48.96 sec
        test case: 'tests-mbed_platform-crash_reporting' ............................................. OK in 48.96 sec
mbedgt: test case summary: 1 pass, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.5446487610
mbedgt: test suite report:
| target               | platform_name    | test suite                          | result | elapsed_time (sec) | copy_method |
|----------------------|------------------|-------------------------------------|--------|--------------------|-------------|
| NUMAKER_PFM_M487-IAR | NUMAKER_PFM_M487 | tests-mbed_platform-crash_reporting | OK     | 48.96              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target               | platform_name    | test suite                          | test case                           | passed | failed | result | elapsed_time (sec) |
|----------------------|------------------|-------------------------------------|-------------------------------------|--------|--------|--------|--------------------|
| NUMAKER_PFM_M487-IAR | NUMAKER_PFM_M487 | tests-mbed_platform-crash_reporting | tests-mbed_platform-crash_reporting | 1      | 0      | OK     | 48.96              |
mbedgt: test case results: 1 OK
mbedgt: completed in 49.19 sec
```
