### PR TITLE
Fix uvision6 python export

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -272,6 +272,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     toolchain.set_config_data(toolchain.config.get_config_data())
     config_header = toolchain.get_config_header()
     resources.add_file_ref(FileType.HEADER, basename(config_header), config_header)
+    resources.win_to_unix()
 
     # Change linker script if specified
     if linker_script is not None:


### PR DESCRIPTION
### Description


The mbed-os tools Python uVision export script ("-i uvision6") is not implementing the correct path in the resulting project settings. Add "win_to_unix()" to Python export script to address this.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
