### PR TITLE
Add option to disable default UART console

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -12,12 +12,12 @@
         },
 
         "stdio-buffered-serial": {
-            "help": "Use UARTSerial driver to obtain buffered serial I/O on stdin/stdout/stderr. If false, unbuffered serial_getc and serial_putc are used directly.",
+            "help": "(Applies if target.console-uart is true.) Use UARTSerial driver to obtain buffered serial I/O on stdin/stdout/stderr. If false, unbuffered serial_getc and serial_putc are used directly.",
             "value": false
         },
 
         "stdio-baud-rate": {
-            "help": "Baud rate for stdio",
+            "help": "(Applies if target.console-uart is true.) Baud rate for stdio",
             "value": 9600
         },
 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -261,7 +261,7 @@ MBED_WEAK FileHandle *mbed::mbed_override_console(int fd)
 
 static FileHandle *default_console()
 {
-#if DEVICE_SERIAL
+#if MBED_CONF_TARGET_CONSOLE_UART && DEVICE_SERIAL
 #  if MBED_CONF_PLATFORM_STDIO_BUFFERED_SERIAL
     static UARTSerial console(STDIO_UART_TX, STDIO_UART_RX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
 #   if   CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTS
@@ -274,7 +274,7 @@ static FileHandle *default_console()
 #  else
     static DirectSerial console(STDIO_UART_TX, STDIO_UART_RX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
 #  endif
-#else // DEVICE_SERIAL
+#else // MBED_CONF_TARGET_CONSOLE_UART && DEVICE_SERIAL
     static Sink console;
 #endif
     return &console;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -15,6 +15,10 @@
         "bootloader_supported": false,
         "static_memory_defines": true,
         "config": {
+            "console-uart": {
+                "help": "Target has UART console on pins STDIO_UART_TX, STDIO_UART_RX. Value is only significant if target has SERIAL device.",
+                "value": true
+            },
             "console-uart-flow-control": {
                 "help": "Console hardware flow control. Options: null, RTS, CTS, RTSCTS.",
                 "value": null


### PR DESCRIPTION
### Description

New `target.console-uart` option added to indicate whether a target has a console UART on `STDIO_UART_TX`/`RX`/`RTS`/`CTS` pins. (The existing option `target.console-uart-flow-control` indicates whether RTS and or CTS is available in addition to TX and RX).

The option defaults to true, and is currently true on all platforms. It only applies if `DEVICE_SERIAL` is true, so no need to go through and mark it false for non-SERIAL platforms.

An application can turn off `target.console-uart` to save ROM/power/etc if they don't want to use the serial console.  If this is turned off, the console won't be activated for stdin/stdout, but the application is
still free to open `UARTSerial(STDIO_UART_TX, STDIO_UART_RX)` themselves.

Fixes #10327.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

* New config option `target.console-uart` to allow default serial console functionality to be deactivated, either because the target has serial but no console, or to save power/memory by not using the console.