### PR TITLE
Reduce greentea socket tests failures related to network issues

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -859,9 +859,6 @@ Within each loop, one `recvfrom()` may return the received packet size
 When `NSAPI_ERROR_WOULD_BLOCK` is received, check that time consumed is
 more that 100 milliseconds but less than 200 milliseconds.
 
-After repeating for 10 times, at least 5 packets must have been
-received.
-
 
 ### UDPSOCKET_SENDTO_TIMEOUT
 

--- a/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
@@ -28,7 +28,7 @@ using namespace utest::v1;
 
 namespace {
 static const int SIGNAL_SIGIO = 0x1;
-static const int SIGIO_TIMEOUT = 20000; //[ms]
+static const int SIGIO_TIMEOUT = 50000; //[ms]
 }
 
 static void _sigio_handler(osThreadId id)

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -27,6 +27,7 @@ using namespace utest::v1;
 namespace {
 static const int SIGNAL_SIGIO = 0x1;
 static const int SIGIO_TIMEOUT = 5000; //[ms]
+static const int PKT_NUM = 2;
 }
 
 static void _sigio_handler(osThreadId id)
@@ -52,7 +53,7 @@ void UDPSOCKET_RECV_TIMEOUT()
     Timer timer;
     SocketAddress temp_addr;
     int pkt_success = 0;
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < PKT_NUM; i++) {
         TEST_ASSERT_EQUAL(DATA_LEN, sock.sendto(udp_addr, buff, DATA_LEN));
         timer.reset();
         timer.start();
@@ -75,6 +76,6 @@ void UDPSOCKET_RECV_TIMEOUT()
         pkt_success++;
     }
 
-    TEST_ASSERT(pkt_success >= 5);
+    printf("MBED: %d out of %d packets were received.\n", pkt_success, PKT_NUM);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }


### PR DESCRIPTION
### Description

Netsocket greentea tests are meant to test Socket API. However they highly depend on the quality of the underlying network connection, especially when it comes to using the echo server.
I tried to identify the most common and fixable failures, which seem to result from the underlying infrastructure rather than the socket operation itself. These failures obscure the overall view of the CI results and might in result hide some actual errors.

The first improvement is in UDPSOCKET_RECV_TIMEOUT. The test was checking that at least 5 out of 10 UDP packets were received from the echo server. I do not see how this is related to socket timeout. We have separate tests UDPSOCKET_ECHO* for UDP sockets to test echo responses and that test can handle WOULD_BLOCK responses in a more reasonable way and will also check if the data in echo responses match. 
I suggest we remove the packet success ratio expectation from this test to avoid random failures due to network glitches.

The second potential improvement is in TLSSOCKET_RECV_TIMEOUT. Here we sometimes fail to receive a packet within 20 seconds, especially in the tests using wifi, which we know is rather unreliable. There is a separate mechanism in this test, which guarantees that we will not exceed  half of the total time for the test suite, so increasing the sigio timeout is safe and might reduce the number of failures due to network issues.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@KariHaapalehto 
@mtomczykmobica 
@tymoteuszblochmobica 