### PR TITLE
Allow toolchain paths to be wrapped in quotes

### DIFF
--- a/tools/settings.py
+++ b/tools/settings.py
@@ -88,8 +88,10 @@ _ENV_PATHS = ['ARM_PATH', 'GCC_ARM_PATH', 'IAR_PATH', 'ARMC6_PATH']
 
 for _n in _ENV_PATHS:
     if getenv('MBED_'+_n):
-        if exists(getenv('MBED_'+_n)):
-            globals()[_n] = getenv('MBED_'+_n)
+        # It's common to provide paths with quotes for certain OSes
+        env_path = getenv('MBED_'+_n).strip("\"'")
+        if exists(env_path):
+            globals()[_n] = env_path
         else:
             print("WARNING: MBED_%s set as environment variable but doesn't"
                   " exist" % _n)


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixes https://github.com/ARMmbed/mbed-cli/issues/875. This allows you to specify toolchain paths with quotes surrounding the location (ex `MBED_ARM_PATH="C:\path\to\toolchain"`)

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

@theotherjimmy 