### PR TITLE
Cellular: Fix deleting of state machine to correct class

### DIFF
--- a/UNITTESTS/features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
@@ -73,9 +73,9 @@ public:
         _state_machine = NULL;
     }
 
-    CellularStateMachine *create_state_machine(CellularDevice &device, events::EventQueue &queue)
+    CellularStateMachine *create_state_machine(CellularDevice &device, events::EventQueue &queue, CellularNetwork &nw)
     {
-        _state_machine = new CellularStateMachine(device, queue);
+        _state_machine = new CellularStateMachine(device, queue, nw);
         return _state_machine;
     }
 
@@ -171,7 +171,7 @@ TEST_F(TestCellularStateMachine, test_create_delete)
     CellularDevice *dev = new myCellularDevice(&fh1);
     EXPECT_TRUE(dev);
 
-    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     ut.delete_state_machine();
 
@@ -187,7 +187,7 @@ TEST_F(TestCellularStateMachine, test_setters)
     CellularDevice *dev = new myCellularDevice(&fh1);
     EXPECT_TRUE(dev);
 
-    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     ut.set_cellular_callback(&cellular_callback);
 
@@ -215,14 +215,14 @@ TEST_F(TestCellularStateMachine, test_start_dispatch)
     CellularDevice *dev = new myCellularDevice(&fh1);
     EXPECT_TRUE(dev);
 
-    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     nsapi_error_t err = ut.start_dispatch();
     ASSERT_EQ(NSAPI_ERROR_OK, err);
     ut.delete_state_machine();
 
     Thread_stub::osStatus_value = osErrorNoMemory;
-    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     err = ut.start_dispatch();
     ASSERT_EQ(NSAPI_ERROR_NO_MEMORY, err);
@@ -240,13 +240,13 @@ TEST_F(TestCellularStateMachine, test_stop)
     CellularDevice *dev = new AT_CellularDevice(&fh1);
     EXPECT_TRUE(dev);
 
-    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
 
     ut.stop(); // nothing created, run through
     ut.delete_state_machine();
 
-    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     nsapi_error_t err = ut.start_dispatch();
     ASSERT_EQ(NSAPI_ERROR_OK, err);
@@ -254,7 +254,7 @@ TEST_F(TestCellularStateMachine, test_stop)
     ut.stop(); // thread is created, now stop will delete it
     ut.delete_state_machine();
 
-    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     err = ut.start_dispatch();
     ASSERT_EQ(NSAPI_ERROR_OK, err);
@@ -270,7 +270,7 @@ TEST_F(TestCellularStateMachine, test_stop)
     ut.stop(); // thread and power are created, now stop will delete them
     ut.delete_state_machine();
 
-    stm = ut.create_state_machine(*dev, *dev->get_queue());
+    stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
     err = ut.start_dispatch();
     ASSERT_EQ(NSAPI_ERROR_OK, err);
@@ -294,7 +294,7 @@ TEST_F(TestCellularStateMachine, test_run_to_state)
     CellularDevice *dev = new AT_CellularDevice(&fh1);
     EXPECT_TRUE(dev);
 
-    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue());
+    CellularStateMachine *stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
     EXPECT_TRUE(stm);
 
     nsapi_error_t err = ut.start_dispatch();

--- a/UNITTESTS/stubs/CellularStateMachine_stub.cpp
+++ b/UNITTESTS/stubs/CellularStateMachine_stub.cpp
@@ -25,8 +25,8 @@ CellularStubState CellularStateMachine_stub::get_current_target_state = STATE_IN
 CellularStubState CellularStateMachine_stub::get_current_current_state = STATE_INIT;
 bool CellularStateMachine_stub::bool_value = false;
 
-CellularStateMachine::CellularStateMachine(CellularDevice &device, events::EventQueue &queue) :
-    _cellularDevice(device), _queue(queue)
+CellularStateMachine::CellularStateMachine(CellularDevice &device, events::EventQueue &queue, CellularNetwork &nw) :
+    _cellularDevice(device), _network(nw), _queue(queue)
 {
 }
 

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -47,8 +47,6 @@ AT_CellularDevice::AT_CellularDevice(FileHandle *fh) : CellularDevice(fh), _netw
 
 AT_CellularDevice::~AT_CellularDevice()
 {
-    delete _state_machine;
-
     // make sure that all is deleted even if somewhere close was not called and reference counting is messed up.
     _network_ref_count = 1;
     _sms_ref_count = 1;

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -44,8 +44,9 @@ private:
      *
      * @param device    reference to CellularDevice
      * @param queue     reference to queue used in state transitions
+     * @param nw        reference to CellularNetwork
      */
-    CellularStateMachine(CellularDevice &device, events::EventQueue &queue);
+    CellularStateMachine(CellularDevice &device, events::EventQueue &queue, CellularNetwork &nw);
     ~CellularStateMachine();
 
     /** Cellular connection states
@@ -161,7 +162,7 @@ private:
 
     Callback<void(nsapi_event_t, intptr_t)> _event_status_cb;
 
-    CellularNetwork *_network;
+    CellularNetwork &_network;
     events::EventQueue &_queue;
     rtos::Thread *_queue_thread;
 


### PR DESCRIPTION
### Description

State machine was deleted in different class than it was created. Now it's deleted in correct place.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AriParkkila 

### Release Notes