### PR TITLE
TARGET_STM32F7: Reset QSPI in default mode on abort for all versions.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/stm32f746xx.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/stm32f746xx.h
@@ -9668,8 +9668,6 @@ typedef struct
 /*                                    QUADSPI                                 */
 /*                                                                            */
 /******************************************************************************/
-/* QUADSPI IP version */
-#define QSPI1_V1_0
 /*****************  Bit definition for QUADSPI_CR register  *******************/
 #define QUADSPI_CR_EN_Pos                (0U)                                  
 #define QUADSPI_CR_EN_Msk                (0x1U << QUADSPI_CR_EN_Pos)           /*!< 0x00000001 */

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/stm32f756xx.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/stm32f756xx.h
@@ -9937,8 +9937,6 @@ typedef struct
 /*                                    QUADSPI                                 */
 /*                                                                            */
 /******************************************************************************/
-/* QUADSPI IP version */
-#define QSPI1_V1_0
 /*****************  Bit definition for QUADSPI_CR register  *******************/
 #define QUADSPI_CR_EN_Pos                (0U)                                  
 #define QUADSPI_CR_EN_Msk                (0x1U << QUADSPI_CR_EN_Pos)           /*!< 0x00000001 */

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_qspi.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_qspi.c
@@ -490,10 +490,9 @@ void HAL_QSPI_IRQHandler(QSPI_HandleTypeDef *hqspi)
         __HAL_DMA_DISABLE(hqspi->hdma);
       }
 
-#if defined(QSPI1_V1_0)
-/* Clear Busy bit */
+      /* MBED, see #10049 */
+      /* Clear Busy bit */
       HAL_QSPI_Abort_IT(hqspi);
-#endif
       
       /* Change state of QSPI */
       hqspi->State = HAL_QSPI_STATE_READY;
@@ -529,10 +528,10 @@ void HAL_QSPI_IRQHandler(QSPI_HandleTypeDef *hqspi)
           }
         }
       }
-#if defined(QSPI1_V1_0)
+
+      /* MBED, see #10049 */
       /* Workaround - Extra data written in the FIFO at the end of a read transfer */
       HAL_QSPI_Abort_IT(hqspi);
-#endif /* QSPI_V1_0*/      
       
       /* Change state of QSPI */
       hqspi->State = HAL_QSPI_STATE_READY;
@@ -879,11 +878,10 @@ HAL_StatusTypeDef HAL_QSPI_Transmit(QSPI_HandleTypeDef *hqspi, uint8_t *pData, u
         {
           /* Clear Transfer Complete bit */
           __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
-          
-#if defined(QSPI1_V1_0)
+
+          /* MBED, see #10049 */
           /* Clear Busy bit */
           status = HAL_QSPI_Abort(hqspi);
-#endif /* QSPI_V1_0 */ 
         }
       }
     
@@ -968,11 +966,10 @@ HAL_StatusTypeDef HAL_QSPI_Receive(QSPI_HandleTypeDef *hqspi, uint8_t *pData, ui
         {
           /* Clear Transfer Complete bit */
           __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
-          
-#if defined(QSPI1_V1_0)
+
+         /* MBED, see #10049 */
          /* Workaround - Extra data written in the FIFO at the end of a read transfer */
          status = HAL_QSPI_Abort(hqspi);
-#endif /* QSPI_V1_0 */  
         }
       }
 
@@ -1921,6 +1918,10 @@ HAL_StatusTypeDef HAL_QSPI_Abort(QSPI_HandleTypeDef *hqspi)
     
     if (status == HAL_OK)
     {
+      /* MBED, see #10049 */
+      /* Reset functional mode configuration to indirect write mode by default */
+      CLEAR_BIT(hqspi->Instance->CCR, QUADSPI_CCR_FMODE);
+
       /* Update state */
       hqspi->State = HAL_QSPI_STATE_READY;
     }


### PR DESCRIPTION
### Description

This patch is missing in F7 HAL. By default, we set the QSPI in Indirect write mode.
This modification will be included in next HAL release.

Fix #10049

This has been tested with : 
mbed test -t IAR -m DISCO_F746NG -v -n *features-storage-tests-kvstore-static_tests* -v

The problem can occur on the whole F7 family.

### Pull request type
    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@offirko 
@jeromecoutant 

