### PR TITLE
Fix detection of supported targets for mbed 2 builds

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6646,7 +6646,7 @@
             "TC_ASYNC=true"
         ],
         "extra_labels": ["Atmel", "SAM_CortexM0P", "SAMR21"],
-        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "supported_toolchains": ["GCC_ARM", "ARMC5", "uARM"],
         "device_has": [
             "ANALOGIN",
             "I2C",
@@ -6679,7 +6679,7 @@
             "TC_ASYNC=true"
         ],
         "extra_labels": ["Atmel", "SAM_CortexM0P", "SAMD21"],
-        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "supported_toolchains": ["GCC_ARM", "ARMC5", "uARM"],
         "device_has": [
             "ANALOGIN",
             "ANALOGOUT",
@@ -6713,7 +6713,7 @@
             "TC_ASYNC=true"
         ],
         "extra_labels": ["Atmel", "SAM_CortexM0P", "SAMD21"],
-        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "supported_toolchains": ["GCC_ARM", "ARMC5", "uARM"],
         "device_has": [
             "ANALOGIN",
             "ANALOGOUT",
@@ -6747,7 +6747,7 @@
             "TC_ASYNC=true"
         ],
         "extra_labels": ["Atmel", "SAM_CortexM0P", "SAML21"],
-        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "supported_toolchains": ["GCC_ARM", "ARMC5", "uARM"],
         "device_has": [
             "ANALOGIN",
             "ANALOGOUT",

--- a/tools/build.py
+++ b/tools/build.py
@@ -182,9 +182,8 @@ def main():
             except NoValidToolchainException as e:
                 print_end_warnings(e.end_warnings)
                 args_error(parser, str(e))
-
             tt_id = "%s::%s" % (internal_tc_name, target_name)
-            if not target_supports_toolchain(target, toolchain):
+            if not target_supports_toolchain(target, toolchain_name):
                 # Log this later
                 print("%s skipped: toolchain not supported" % tt_id)
                 skipped.append(tt_id)
@@ -196,7 +195,6 @@ def main():
                     if target.is_PSA_secure_target and \
                             not is_relative_to_root(options.source_dir):
                         options.source_dir = ROOT
-
                     if options.source_dir:
                         lib_build_res = build_library(
                             options.source_dir, options.build_dir, target, toolchain_name,

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -988,7 +988,6 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
     #then set the default_toolchain to uARM to link AC6 microlib.
     if(selected_toolchain_name == "ARMC6" and toolchain_name == "uARM"):
         target.default_toolchain = "uARM"
-    toolchain_name = selected_toolchain_name
 
     if report is not None:
         start = time()
@@ -1003,7 +1002,7 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
             prep_properties(
                 properties, target.name, toolchain_name, vendor_label)
 
-    if toolchain_name not in target.supported_toolchains:
+    if not target_supports_toolchain(target, toolchain_name):
         supported_toolchains_text = ", ".join(target.supported_toolchains)
         notify.info('The target {} does not support the toolchain {}'.format(
             target.name,
@@ -1023,14 +1022,16 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
 
     try:
         # Source and Build Paths
+
         build_toolchain = join(
-            MBED_LIBRARIES, mbed2_obj_path(target.name, toolchain_name))
+            MBED_LIBRARIES, mbed2_obj_path(target.name, selected_toolchain_name)
+        )
         mkdir(build_toolchain)
 
         tmp_path = join(
             MBED_LIBRARIES,
             '.temp',
-            mbed2_obj_path(target.name, toolchain_name)
+            mbed2_obj_path(target.name, selected_toolchain_name)
         )
         mkdir(tmp_path)
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fix #10107.

This should get Mbed 2 builds going again with ARMC6. The uARM logic doesn't seem to be 100%, but honestly I'm not really sure what the expected behavior is for it.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
@jeromecoutant 
