### PR TITLE
Parse M33 + GCC_ARM map files

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -131,6 +131,7 @@ class _GccParser(_Parser):
         return value - A section name, if a new section was found, None
                        otherwise
         """
+        line = line.strip()
         for i in self.ALL_SECTIONS:
             if line.startswith(i):
                 return i

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -131,9 +131,9 @@ class _GccParser(_Parser):
         return value - A section name, if a new section was found, None
                        otherwise
         """
-        line = line.strip()
+        line_s = line.strip()
         for i in self.ALL_SECTIONS:
-            if line.startswith(i):
+            if line_s.startswith(i):
                 return i
         if line.startswith('.'):
             return 'unknown'


### PR DESCRIPTION
### Description

Turns out that under certain circumstances, `GCC_ARM` will emit
whitespace-delimited text in map files. Before this PR, Memap's
`GCC_ARM` map file parsing logic assumes that sections assumes
that the sections always start the string. This PR allows the
sections to be prefixed by whitespace.

Fixes #10109

Note for reviewers: the first commit cleans up lint warnings and
the second commit fixes the bug.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change