### PR TITLE
Fix crash capture feature for nuvoton 

### DIFF
--- a/platform/mbed_crash_data_offsets.h
+++ b/platform/mbed_crash_data_offsets.h
@@ -28,15 +28,12 @@ extern "C" {
 extern uint32_t Image$$RW_m_crash_data$$ZI$$Base[];
 extern uint32_t Image$$RW_m_crash_data$$ZI$$Size;
 #define __CRASH_DATA_RAM_START__    Image$$RW_m_crash_data$$ZI$$Base
-#define __CRASH_DATA_RAM_SIZE__     Image$$RW_m_crash_data$$ZI$$Size
 #elif defined(__ICCARM__)
 extern uint32_t __CRASH_DATA_RAM_START__[];
 extern uint32_t __CRASH_DATA_RAM_END__[];
-#define __CRASH_DATA_RAM_SIZE__     (__CRASH_DATA_RAM_END__ - __CRASH_DATA_RAM_START__)
 #elif defined(__GNUC__)
 extern uint32_t __CRASH_DATA_RAM_START__[];
 extern uint32_t __CRASH_DATA_RAM_END__[];
-#define __CRASH_DATA_RAM_SIZE__     (__CRASH_DATA_RAM_END__ - __CRASH_DATA_RAM_START__)
 #endif /* defined(__CC_ARM) */
 
 /* Offset definitions for context capture */

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -183,6 +183,10 @@
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
         },
+        "NUMAKER_PFM_NUC472": {
+            "crash-capture-enabled": true,
+            "fatal-error-auto-reboot-enabled": true
+        },
         "NRF52840_DK": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -9,11 +9,12 @@ define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
+define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
+define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
+define symbol __ICFEDIT_region_IRAM_start__ = 0x20000100;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20028000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_crash_data__ = 0x100;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 96));
 define symbol __ICFEDIT_size_heap__   = 0x10000;
 /**** End of ICF editor section. ###ICF###*/
@@ -22,16 +23,16 @@ define symbol __ICFEDIT_size_heap__   = 0x10000;
 define memory mem with size = 4G;
 define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
+define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = __ICFEDIT_size_intvec__          { };
-define block CRASH_DATA_RAM   with alignment = 8, size = __ICFEDIT_size_crash_data__          { };
 
 /* Define Crash Data Symbols */
-define exported symbol __CRASH_DATA_RAM_START__ = __ICFEDIT_region_IRAM_start__ + __ICFEDIT_size_cstack__ + __ICFEDIT_size_intvec__;
-define exported symbol __CRASH_DATA_RAM_END__ = __ICFEDIT_region_IRAM_start__ + __ICFEDIT_size_cstack__ + __ICFEDIT_size_intvec__ + __ICFEDIT_size_crash_data__;
+define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
+define exported symbol __CRASH_DATA_RAM_END__ = __region_CRASH_DATA_RAM_end__;
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };
@@ -41,6 +42,5 @@ place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };
 place at start of IRAM_region   { block CSTACK };
 place in IRAM_region   { block IRAMVEC };
-place in IRAM_region   { block CRASH_DATA_RAM };
 place in IRAM_region   { readwrite };
 place in IRAM_region   { block HEAP };

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -9,10 +9,10 @@ define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
-define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
-define symbol __ICFEDIT_region_IRAM_start__ = 0x20000100;
-define symbol __ICFEDIT_region_IRAM_end__   = 0x20028000 - 1;
+define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
+define symbol __ICFEDIT_region_IRAM_end__   = 0x20027F00 - 1;
+define symbol __region_CRASH_DATA_RAM_start__  = 0x20027F00;
+define symbol __region_CRASH_DATA_RAM_end__  = 0x20028000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 96));

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -47,6 +47,9 @@ LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {
   ER_IRAMVEC  AlignExpr(+0, 1024)  EMPTY  VECTOR_SIZE  {  ; Reserve for vectors
   }
 
+  RW_m_crash_data  AlignExpr(+0, 0x100)  EMPTY  0x100  { ; Reserve for crash data storage
+  }
+
   RW_IRAM1  AlignExpr(+0, 16)  {  ; 16 byte-aligned
    .ANY (+RW +ZI)
   }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -38,10 +38,6 @@ LR_IROM1 MBED_APP_START {
    .ANY (+RW +ZI)
   }
 
-  RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
-   .ANY (+RW +ZI)
-  }
-  
   ; Too large to place into internal SRAM. So place into external SRAM instead.
   ER_XRAM1 0x60000000 {
     *lwip_* (+ZI)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -31,6 +31,13 @@ LR_IROM1 MBED_APP_START {
   ER_IRAMVEC AlignExpr(+0, 1024) EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
+  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 { ; Reserve for crash data storage
+  }
+
+  RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
+   .ANY (+RW +ZI)
+  }
+
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
    .ANY (+RW +ZI)
   }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_SUPPORTED/NUC472.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_SUPPORTED/NUC472.ld
@@ -14,6 +14,7 @@
   #define MBED_BOOT_STACK_SIZE      0x400
 #endif
 
+M_CRASH_DATA_RAM_SIZE = 0x100;
 StackSize = MBED_BOOT_STACK_SIZE;
 
 MEMORY
@@ -132,7 +133,19 @@ SECTIONS
         . += __vector_size;
         PROVIDE(__end_vector_table__ = .);
     } > RAM_INTERN
-    
+
+    .crash_data_ram :
+    {
+        . = ALIGN(8);
+        __CRASH_DATA_RAM__ = .;
+        __CRASH_DATA_RAM_START__ = .; /* Create a global symbol at data start */
+        KEEP(*(.keep.crash_data_ram))
+        *(.m_crash_data_ram)     /* This is a user defined section */
+        . += M_CRASH_DATA_RAM_SIZE;
+        . = ALIGN(8);
+        __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+    } > RAM_INTERN
+
     .data :
     {
         PROVIDE( __etext = LOADADDR(.data) );

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
@@ -9,7 +9,9 @@ define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
+define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
+define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
+define symbol __ICFEDIT_region_IRAM_start__ = 0x20000100;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000 - 1;
 define symbol __ICFEDIT_region_XRAM_start__ = 0x60000000;
 define symbol __ICFEDIT_region_XRAM_end__   = 0x60100000 - 1;
@@ -23,6 +25,11 @@ define memory mem with size = 4G;
 define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 define region XRAM_region  = mem:[from __ICFEDIT_region_XRAM_start__  to __ICFEDIT_region_XRAM_end__];
+define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
+
+/* Define Crash Data Symbols */
+define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
+define exported symbol __CRASH_DATA_RAM_END__ = __region_CRASH_DATA_RAM_end__;
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
@@ -9,10 +9,10 @@ define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __region_CRASH_DATA_RAM_start__  = 0x20000000;
-define symbol __region_CRASH_DATA_RAM_end__  = 0x200000FF;
-define symbol __ICFEDIT_region_IRAM_start__ = 0x20000100;
-define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000 - 1;
+define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
+define symbol __ICFEDIT_region_IRAM_end__   = 0x2000FF00 - 1;
+define symbol __region_CRASH_DATA_RAM_start__  = 0x2000FF00;
+define symbol __region_CRASH_DATA_RAM_end__  = 0x20010000 - 1;
 define symbol __ICFEDIT_region_XRAM_start__ = 0x60000000;
 define symbol __ICFEDIT_region_XRAM_end__   = 0x60100000 - 1;
 /*-Sizes-*/


### PR DESCRIPTION
### Description

This should fix https://github.com/ARMmbed/mbed-os/issues/9069, updated to created a memory region instead of block.

Tested on a set of devices, instead of just one like https://github.com/ARMmbed/mbed-os/pull/10311

| Device| Test | Results |
| :-----| :-: | :-: |
| K64F | tests-mbed_platform-crash_reporting| Pass |
| NRF52840_DK| tests-mbed_platform-crash_reporting| Pass |
| DISCO_L475VG_IOT01A| tests-mbed_platform-crash_reporting| Pass |
| NUMAKER_PFM_NUC472 | tests-mbed_platform-crash_reporting| Pass |
| NUMAKER_PFM_M487| tests-mbed_platform-crash_reporting| Pass |
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@SenRamakri @ccli8 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
