### PR TITLE
Cellular: Using new rather than malloc in debug_print

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1289,7 +1289,7 @@ void ATHandler::debug_print(const char *p, int len, ATType type)
 #if MBED_CONF_CELLULAR_DEBUG_AT
     if (_debug_on) {
         const int buf_size = len * 4 + 1; // x4 -> reserve space for extra characters, +1 -> terminating null
-        char *buffer = (char *)malloc(buf_size);
+        char *buffer = new char [buf_size];
         if (buffer) {
             memset(buffer, 0, buf_size);
 
@@ -1319,7 +1319,7 @@ void ATHandler::debug_print(const char *p, int len, ATType type)
                 tr_info("AT ERR (%2d): %s", len, buffer);
             }
 
-            free(buffer);
+            delete [] buffer;
         } else {
             tr_error("AT trace unable to allocate buffer!");
         }


### PR DESCRIPTION

### Description

Using malloc will require us to add stdlib.h somewhere in the path for
the application. Maybe the CI apps are adding stdlib.h and that's why
the code would have worked. In a custom app, it can happen that the
header is not included. Using new avoids the need to add stdlib.h
anywhere and it is more in line with C++.

Fixes the issue defined here https://github.com/ARMmbed/mbed-os/issues/10352


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kivaisan @AnttiKauppila @0xc0170 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
