### PR TITLE
KVStore: Support external storage out of mbed-os tree

### DIFF
--- a/features/storage/kvstore/conf/filesystem/mbed_lib.json
+++ b/features/storage/kvstore/conf/filesystem/mbed_lib.json
@@ -14,7 +14,7 @@
             "value": "default"
         },
         "blockdevice": {
-            "help": "Options are default, SPIF, DATAFASH, QSPIF or SD. If default, the block device will be chosen according to the component defined in targets.json",
+            "help": "Options are default, SPIF, DATAFASH, QSPIF, SD or other. If default, the block device will be chosen according to the component defined in targets.json. If other, override get_other_blockdevice() to support block device out of Mbed OS tree.",
             "value": "default"
         },
         "external_size": {

--- a/features/storage/kvstore/conf/filesystem_no_rbp/mbed_lib.json
+++ b/features/storage/kvstore/conf/filesystem_no_rbp/mbed_lib.json
@@ -6,7 +6,7 @@
             "value": "default"
         },
         "blockdevice": {
-            "help": "Options are default, SPIF, DATAFLASH, QSPIF or SD. If default the block device will be chosen by the defined component",
+            "help": "Options are default, SPIF, DATAFLASH, QSPIF, SD or other. If default the block device will be chosen by the defined component. If other, override get_other_blockdevice() to support block device out of Mbed OS tree.",
             "value": "default"
         },
         "external_size": {

--- a/features/storage/kvstore/conf/tdb_external/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_external/mbed_lib.json
@@ -11,7 +11,7 @@
             "value": "0"
         },
         "blockdevice": {
-            "help": "Options are default, SPIF, DATAFASH, QSPIF or SD. If default the block device will be chosen by the defined component",
+            "help": "Options are default, SPIF, DATAFASH, QSPIF, SD or other. If default the block device will be chosen by the defined component. If other, override get_other_blockdevice() to support block device out of Mbed OS tree.",
             "value": "default"
         },
         "external_size": {

--- a/features/storage/kvstore/conf/tdb_external_no_rbp/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_external_no_rbp/mbed_lib.json
@@ -2,7 +2,7 @@
     "name": "storage_tdb_external_no_rbp",
     "config": {
         "blockdevice": {
-            "help": "Options are default, SPIF, DATAFASH, QSPIF or SD. If default the block device will be chosen by the defined component",
+            "help": "Options are default, SPIF, DATAFASH, QSPIF, SD or other. If default the block device will be chosen by the defined component. If other, override get_other_blockdevice() to support block device out of Mbed OS tree.",
             "value": "default"
         },
         "external_size": {


### PR DESCRIPTION
### Description

This PR tries to support external storage out of mbed-os tree in KVStore. To enable it, user needs to:
1. Configure `blockdevice` to `other`.
2. Override `get_other_blockdevice()` to provide block device out of mbed-os tree.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Release issue

#10300

### Release Notes

Support external storage out of mbed-os tree in KVStore. To enable it, user needs to:
1. Configure KVStore configuration parameter `blockdevice` to `other`.
2. Override `get_other_blockdevice()` to provide block device out of mbed-os tree.
    ```C++
    BlockDevice *get_other_blockdevice();
    ```