### PR TITLE
Add Multi-adv support

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.cpp
@@ -19,6 +19,7 @@
 
 #include "CyH4TransportDriver.h"
 #include "cycfg_pins.h"
+extern "C" void hci_cy_TrSerialRxIncoming(uint8_t *pBuf, uint8_t len);
 
 namespace ble {
 namespace vendor {
@@ -96,7 +97,7 @@ void CyH4TransportDriver::on_controller_irq()
 
 	while (uart.readable()) {
         uint8_t char_received = uart.getc();
-        on_data_received(&char_received, 1);
+        hci_cy_TrSerialRxIncoming(&char_received, 1);
     }
 
 	deassert_bt_dev_wake();

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyHci_tr.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyHci_tr.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include <algorithm>
+#include <limits>
+#include "wsf_types.h"
+#include "wsf_msg.h"
+#include "wsf_assert.h"
+#include "util/bstream.h"
+#include "hci_api.h"
+#include "hci_core.h"
+#include "hci_drv.h"
+#include <stdint.h>
+#include "CyH4TransportDriver.h"
+
+typedef enum
+{
+  HCI_RX_STATE_IDLE,
+  HCI_RX_STATE_HEADER,
+  HCI_RX_STATE_DATA,
+  HCI_RX_STATE_COMPLETE
+} hciRxState_t;
+
+#define HCI_HDR_LEN_MAX           HCI_ACL_HDR_LEN
+
+extern "C" void cy_post_vsc_complete_event(uint16_t opcode, uint8_t status, uint16_t data_len, uint8_t* data);
+
+extern "C" {
+void hci_cy_TrSerialRxIncoming(uint8_t *pBuf, uint8_t len)
+{
+  static uint8_t    stateRx = HCI_RX_STATE_IDLE;
+  static uint8_t    pktIndRx;
+  static uint16_t   iRx;
+  static uint8_t    hdrRx[HCI_HDR_LEN_MAX];
+  static uint8_t    *pPktRx;
+  static uint8_t    *pDataRx;
+
+  uint8_t dataByte;
+
+  /* loop until all bytes of incoming buffer are handled */
+  while (len--)
+  {
+    /* read single byte from incoming buffer and advance to next byte */
+    dataByte = *pBuf++;
+
+    /* --- Idle State --- */
+    if (stateRx == HCI_RX_STATE_IDLE)
+    {
+      /* save the packet type */
+      pktIndRx = dataByte;
+      iRx      = 0;
+      stateRx  = HCI_RX_STATE_HEADER;
+    }
+
+    /* --- Header State --- */
+    else if (stateRx == HCI_RX_STATE_HEADER)
+    {
+      uint8_t  hdrLen = 0;
+      uint16_t dataLen = 0;
+
+      /* copy current byte into the temp header buffer */
+      hdrRx[iRx++] = dataByte;
+
+      /* determine header length based on packet type */
+      switch (pktIndRx)
+      {
+        case HCI_CMD_TYPE:
+          hdrLen = HCI_CMD_HDR_LEN;
+          break;
+        case HCI_ACL_TYPE:
+          hdrLen = HCI_ACL_HDR_LEN;
+          break;
+        case HCI_EVT_TYPE:
+          hdrLen = HCI_EVT_HDR_LEN;
+          break;
+        default:
+          /* invalid packet type */
+          WSF_ASSERT(0);
+          break;
+      }
+
+      /* see if entire header has been read */
+      if (iRx == hdrLen)
+      {
+        /* extract data length from header */
+        switch (pktIndRx)
+        {
+          case HCI_CMD_TYPE:
+            dataLen = hdrRx[2];
+            break;
+          case HCI_ACL_TYPE:
+            BYTES_TO_UINT16(dataLen, &hdrRx[2]);
+            break;
+          case HCI_EVT_TYPE:
+            dataLen = hdrRx[1];
+            break;
+          default:
+            break;
+        }
+
+        /* allocate data buffer to hold entire packet */
+        if (pktIndRx == HCI_ACL_TYPE)
+        {
+          pPktRx = (uint8_t*)WsfMsgDataAlloc(hdrLen + dataLen, 0);
+        }
+        else
+        {
+          pPktRx = (uint8_t*)WsfMsgAlloc(hdrLen + dataLen);
+        }
+
+        if (pPktRx != NULL)
+        {
+          pDataRx = pPktRx;
+
+          /* copy header into data packet (note: memcpy is not so portable) */
+          {
+            uint8_t  i;
+            for (i = 0; i < hdrLen; i++)
+            {
+              *pDataRx++ = hdrRx[i];
+            }
+          }
+
+          /* save number of bytes left to read */
+          iRx = dataLen;
+          if (iRx == 0)
+          {
+            stateRx = HCI_RX_STATE_COMPLETE;
+          }
+          else
+          {
+            stateRx = HCI_RX_STATE_DATA;
+          }
+        }
+        else
+        {
+          WSF_ASSERT(0); /* allocate falied */
+        }
+
+      }
+    }
+
+    /* --- Data State --- */
+    else if (stateRx == HCI_RX_STATE_DATA)
+    {
+      /* write incoming byte to allocated buffer */
+      *pDataRx++ = dataByte;
+
+      /* determine if entire packet has been read */
+      iRx--;
+      if (iRx == 0)
+      {
+        stateRx = HCI_RX_STATE_COMPLETE;
+      }
+    }
+
+    /* --- Complete State --- */
+    /* ( Note Well!  There is no else-if construct by design. ) */
+    if (stateRx == HCI_RX_STATE_COMPLETE)
+    {
+      /* deliver data */
+      if (pPktRx != NULL)
+      {
+        if ( (pktIndRx == HCI_EVT_TYPE) && ( *(pPktRx) == HCI_CMD_CMPL_EVT) )
+        {
+            uint16_t opcode =  (((*(pPktRx + 4))&0xFF)<<8) + ((*(pPktRx + 3))&0xFF);
+            if (HCI_OGF(opcode) == HCI_OGF_VENDOR_SPEC)
+            {
+                // Its vendor specific command.
+                uint8_t len = *(pPktRx+1);
+                uint8_t status = *(pPktRx+5);
+                cy_post_vsc_complete_event(opcode, status, len-4, (uint8 *) pPktRx+6);
+            }
+        }
+        hciCoreRecv(pktIndRx, pPktRx);
+      }
+
+      /* reset state machine */
+      stateRx = HCI_RX_STATE_IDLE;
+    }
+  }
+}
+}

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyMulti_adv.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyMulti_adv.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "hci_api.h"
+#include "util/bstream.h"
+#include "CyMulti_adv.h"
+#include "CyH4TransportDriver.h"
+#include "CyVscCmd.h"
+
+#define HCIC_PARAM_SIZE_ENABLE_MULTI_ADV                     3
+#define HCIC_PARAM_SIZE_SET_MULTI_ADV_PARAM                  24
+#define HCIC_PARAM_SIZE_SET_MULTI_ADV_MIN_SIZE               3
+#define HCIC_PARAM_SIZE_SET_MULTI_ADV_MAX_SIZE               34
+#define HCIC_PARAM_SIZE_BLE_WRITE_ADV_DATA                   31
+#define HCI_CY_MULTI_ADV                                     0x0154
+
+#define ARRAY_TO_BSTREAM(p, a, len) {int ijk; for (ijk = 0; ijk < len;        ijk++) *(p)++ = (uint8_t) a[ijk];}
+#define INT8_TO_BSTREAM(p, n)    {*(p)++ = (int8_t)(n);}
+
+namespace ble {
+namespace vendor {
+namespace cypress {
+
+static CY_multi_adv_cb_t *multi_adv_cb;
+
+void cy_multi_adv_internal_cb(uint16_t opcode, uint8_t status, uint16_t data_len, uint8_t *data)
+{
+    if ( (opcode == HCI_CY_MULTI_ADV) && (multi_adv_cb != NULL))
+    {
+        (*multi_adv_cb)((HciMultiAdvSubOpcode)*data, (uint8_t)status);
+    }
+}
+void CyMultiAdv::cy_register_multi_adv_cmd_complete_cb(CY_multi_adv_cb_t *cb)
+{
+    multi_adv_cb = cb;
+}
+
+void CyMultiAdv::cy_start_multi_advertisements(uint8_t advertising_enable, uint8_t adv_instance)
+{
+    uint8_t param[HCIC_PARAM_SIZE_ENABLE_MULTI_ADV] = {0};
+    uint8_t *pp = param;
+
+    UINT8_TO_BSTREAM(pp, SET_ADVT_ENABLE);
+    UINT8_TO_BSTREAM(pp, advertising_enable);
+    UINT8_TO_BSTREAM(pp, adv_instance);
+
+    cy_send_vendor_specific_cmd(HCI_CY_MULTI_ADV, HCIC_PARAM_SIZE_SET_MULTI_ADV_PARAM, param, &cy_multi_adv_internal_cb);
+}
+
+
+ble_error_t multi_adv_set_data( uint8_t * p_data, uint8_t data_len, uint8_t adv_instance, uint8_t scan_rsp_or_adv_opcode )
+{
+    uint8_t param[HCIC_PARAM_SIZE_SET_MULTI_ADV_MAX_SIZE] = {0};
+    uint8_t *pp = param;
+    uint8_t total_size = HCIC_PARAM_SIZE_BLE_WRITE_ADV_DATA + HCIC_PARAM_SIZE_SET_MULTI_ADV_MIN_SIZE;
+
+    if (data_len > HCI_ADV_DATA_LEN || (p_data == NULL && data_len > 0))
+    {
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
+    UINT8_TO_BSTREAM  (pp, scan_rsp_or_adv_opcode);
+
+    if (p_data != NULL && data_len > 0)
+    {
+        UINT8_TO_BSTREAM (pp, data_len);
+
+        ARRAY_TO_BSTREAM (pp, p_data, data_len);
+    }
+    pp += (HCIC_PARAM_SIZE_BLE_WRITE_ADV_DATA - data_len);
+
+    UINT8_TO_BSTREAM  (pp, adv_instance);
+
+    cy_send_vendor_specific_cmd(HCI_CY_MULTI_ADV, total_size, param, &cy_multi_adv_internal_cb);
+
+    return BLE_ERROR_NONE;
+}
+
+ble_error_t CyMultiAdv::cy_set_multi_advertisement_scan_response_data( uint8_t * p_data, uint8_t data_len, uint8_t adv_instance )
+{
+    return multi_adv_set_data( p_data, data_len, adv_instance, SET_SCAN_RESP_DATA);
+}
+
+ble_error_t CyMultiAdv::cy_set_multi_advertisement_data( uint8_t * p_data, uint8_t data_len, uint8_t adv_instance )
+{
+    return multi_adv_set_data( p_data, data_len, adv_instance, SET_ADVT_DATA);
+}
+
+ble_error_t CyMultiAdv::cy_set_multi_advertisement_params( uint8_t adv_instance, const CyBleMultiAdvParam p_param )
+{
+    uint8_t param[HCIC_PARAM_SIZE_SET_MULTI_ADV_PARAM] = {0};
+    uint8_t *pp = param;
+
+    // Validate all parameters
+    if ( (p_param._adv_int_min.value() < HCI_ADV_MIN_INTERVAL) || (p_param._adv_int_min.value() > HCI_ADV_MAX_INTERVAL) ||
+         (p_param._adv_int_max.value() < HCI_ADV_MIN_INTERVAL) || (p_param._adv_int_max.value() > HCI_ADV_MAX_INTERVAL) ||
+         (p_param._adv_tx_power < CY_BLE_MULTI_ADV_TX_POWER_MIN) || (p_param._adv_tx_power > CY_BLE_MULTI_ADV_TX_POWER_MAX) ||
+         (adv_instance < 1) || (adv_instance > CY_LE_MULTI_ADV_MAX_NUM_INSTANCES) ||
+         (p_param._adv_type.value() > ble::advertising_type_t::CONNECTABLE_DIRECTED_LOW_DUTY) ||
+         (p_param._channel_map.value() == 0) || (p_param._channel_map.value() > ble::pal::advertising_channel_map_t::ALL_ADVERTISING_CHANNELS) ||
+         (p_param._adv_filter_policy > ble::advertising_filter_policy_t::FILTER_SCAN_AND_CONNECTION_REQUESTS) ) {
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
+    UINT8_TO_BSTREAM  (pp, SET_ADVT_PARAM);
+    UINT16_TO_BSTREAM (pp, p_param._adv_int_min.value());
+    UINT16_TO_BSTREAM (pp, p_param._adv_int_max.value());
+    UINT8_TO_BSTREAM  (pp, (uint8_t)p_param._adv_type.value());
+    UINT8_TO_BSTREAM  (pp, (uint8_t)p_param._own_addr_type.value());
+    BDA_TO_BSTREAM    (pp, (const uint8_t*)p_param._own_bd_addr.data());
+    UINT8_TO_BSTREAM  (pp, (uint8_t)p_param._peer_addr_type.value());
+    BDA_TO_BSTREAM    (pp, (const uint8_t*)p_param._peer_bd_addr.data());
+    UINT8_TO_BSTREAM  (pp, p_param._channel_map.value());
+    UINT8_TO_BSTREAM  (pp, p_param._adv_filter_policy.value());
+    UINT8_TO_BSTREAM  (pp, adv_instance);
+    INT8_TO_BSTREAM   (pp, p_param._adv_tx_power);
+
+    cy_send_vendor_specific_cmd(HCI_CY_MULTI_ADV, HCIC_PARAM_SIZE_SET_MULTI_ADV_PARAM, param, &cy_multi_adv_internal_cb);
+
+    return BLE_ERROR_NONE;
+}
+
+} // namespace cypress
+} // namespace vendor
+} // namespace ble

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyMulti_adv.h
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyMulti_adv.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef CY_MULTI_ADV_H_
+#define CY_MULTI_ADV_H_
+#include <stdio.h>
+#include "ble/BLE.h"
+#include "ble/Gap.h"
+#include "ble/pal/GapTypes.h"
+
+#define CY_BLE_MULTI_ADV_TX_POWER_MIN                     -21
+#define CY_BLE_MULTI_ADV_TX_POWER_MAX                      9
+#define CY_LE_MULTI_ADV_MAX_NUM_INSTANCES                  16
+
+#define DEFAULT_ADVERTISING_INTERVAL_MIN 0x400
+#define DEFAULT_ADVERTISING_INTERVAL_MAX 0x800
+
+namespace ble {
+namespace vendor {
+namespace cypress {
+
+typedef enum
+{
+    SET_ADVT_PARAM      = 0x01,
+    SET_ADVT_DATA       = 0x02,
+    SET_SCAN_RESP_DATA  = 0x03,
+    SET_RANDOM_ADDR     = 0x04,
+    SET_ADVT_ENABLE     = 0x05
+}HciMultiAdvSubOpcode;
+
+/* Multi adv command complete callback */
+typedef void (CY_multi_adv_cb_t)(HciMultiAdvSubOpcode sub_opcode, uint8_t status);
+
+/* LE Multi advertising parameter class */
+class CyBleMultiAdvParam
+{
+public:
+    /* Constructure */
+    CyBleMultiAdvParam(ble::advertising_type_t advType = ble::advertising_type_t::NON_CONNECTABLE_UNDIRECTED,
+        ble::adv_interval_t minInterval = ble::adv_interval_t(DEFAULT_ADVERTISING_INTERVAL_MIN),
+        ble::adv_interval_t maxInterval = ble::adv_interval_t(DEFAULT_ADVERTISING_INTERVAL_MAX)) :
+            _adv_int_min(minInterval),
+            _adv_int_max(maxInterval),
+            _adv_type(advType),
+            _channel_map(ble::pal::advertising_channel_map_t::ALL_ADVERTISING_CHANNELS),
+            _adv_filter_policy(ble::advertising_filter_policy_t::NO_FILTER),
+            _adv_tx_power(9),
+            _peer_bd_addr(),
+            _peer_addr_type(ble::peer_address_type_t::PUBLIC),
+            _own_bd_addr(),
+            _own_addr_type(ble::peer_address_type_t::PUBLIC)
+        {
+        };
+
+    // Minimum adv interval
+    ble::adv_interval_t                  _adv_int_min; 
+    // Maximum adv interval
+    ble::adv_interval_t                  _adv_int_max; 
+    // Adv type
+    ble::advertising_type_t              _adv_type;
+    // Adv channel map
+    ble::pal::advertising_channel_map_t  _channel_map;
+    // Advertising filter policy
+    ble::advertising_filter_policy_t     _adv_filter_policy;
+    // Adv tx power (Max : CY_BLE_MULTI_ADV_TX_POWER_MAX, Min :CY_BLE_MULTI_ADV_TX_POWER_MIN)
+    ble::advertising_power_t             _adv_tx_power;
+    // Peer Device address 
+    ble::address_t                       _peer_bd_addr;
+    // Peer LE Address type
+    ble::peer_address_type_t             _peer_addr_type;
+    // Own LE address
+    ble::address_t                       _own_bd_addr;
+    // Own LE Address type
+    ble::peer_address_type_t             _own_addr_type;
+};
+
+class CyMultiAdv{
+public:
+
+    /* Constructure */
+    CyMultiAdv() {};
+
+    /**
+     * Start/Stop Mulit advertisements.
+     *
+     * cy_start_multi_advertisements gives option to start multiple adverstisment instances
+     * Each of the instances can set different #cy_set_multi_advertisement_params and #cy_set_multi_advertisement_data.
+     * Hence this feature allows the device to advertise to multiple masters at the same time like a multiple peripheral device,
+     * with different advertising data, Random private addresses, tx_power etc.
+     *
+     * @param advertising_enable 1 - Advertising is enabled, 0 : Advertising is disabled
+     * @param adv_instance 1 to CY_LE_MULTI_ADV_MAX_NUM_INSTANCES
+     *
+     * @return void
+     *
+     * NOTE : At a time only one instance can advertise with DIRECTED ADV.
+     */
+    void cy_start_multi_advertisements ( uint8_t advertising_enable, uint8_t adv_instance );
+
+    /**
+     * Set multi advertisement data for each adv_instance
+     *
+     * @param p_data     Advertising Data ( Max length 31 bytess)
+     * @param data_len   Advertising Data len ( Max 31 bytes )
+     * @param adv_instance 1 to CY_LE_MULTI_ADV_MAX_NUM_INSTANCES
+     *
+     * @return BLE_ERROR_NONE if the request has been successfully sent or the
+     * appropriate error otherwise.
+     *
+     */
+    ble_error_t cy_set_multi_advertisement_data( uint8_t * p_data, uint8_t data_len, uint8_t adv_instance );
+
+    /**
+     * Set multi advertisement data for scan response
+     *
+     * @param p_data     Advertising Data ( Max length 31 bytess)
+     * @param data_len   Advertising Data len ( Max 31 bytes )
+     * @param adv_instance 1 to CY_LE_MULTI_ADV_MAX_NUM_INSTANCES
+     *
+     * @return BLE_ERROR_NONE if the request has been successfully sent or the
+     * appropriate error otherwise.
+     *
+     */
+    ble_error_t cy_set_multi_advertisement_scan_response_data( uint8_t * p_data, uint8_t data_len, uint8_t adv_instance );
+
+    /**
+     * Set multi advertisement parameters for each adv_instance
+     *
+     * All the parameters below refered to as "spec" is BT 4.2 core specification, page 1277 (LE Set Advertising Parameter Command)
+     *
+     * @param adv_instance 1 to CY_LE_MULTI_ADV_MAX_NUM_INSTANCES
+     * @p_param object of the adv parameter class
+     *
+     * @return BLE_ERROR_NONE if the request has been successfully sent or the
+     * appropriate error otherwise.
+     *
+     */
+    ble_error_t cy_set_multi_advertisement_params( uint8_t adv_instance, const CyBleMultiAdvParam p_param );
+
+    /**
+     * Register callback for multi adv command status event
+     *
+     * @param vsc_cb callback pointer
+     *
+     * @return void
+     *
+     */
+    void cy_register_multi_adv_cmd_complete_cb(CY_multi_adv_cb_t *vsc_cb);
+};
+} // namespace cypress
+} // namespace vendor
+} // namespace ble
+
+#endif // CY_MULTI_ADV_H_
+

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyVscCmd.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyVscCmd.cpp
@@ -1,0 +1,146 @@
+/* mbed Microcontroller Library
+ *
+ * Copyright 2019 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <string.h>
+#include "wsf_types.h"
+#include "wsf_msg.h"
+#include "wsf_buf.h"
+#include "wsf_cs.h"
+#include "hci_api.h"
+#include "CyVscCmd.h"
+#include "rtos/rtos.h"
+
+uint16_t vsc_event_mask = 0;
+wsfQueue_t      vscCmdQueue;
+wsfQueue_t      vscRspQueue;
+static volatile int number_of_msg = 0;
+static int cy_vsc_init = 0;
+
+typedef struct {
+    void        *pNext;
+    uint16_t opcode;
+    cy_vsc_callback_t *vsc_cb;
+} cy_vendor_specific_cmd_t;
+
+typedef struct {
+    void        *pNext;
+    uint16_t    opcode;
+    uint8_t     status;
+    uint8_t     param_len;
+    uint8_t     *param;
+} cy_vendor_specific_rsp_t;
+
+Thread threadVsc(osPriorityNormal, OS_STACK_SIZE, NULL, "VSC_CMD");
+
+static cy_vendor_specific_cmd_t *cy_find_vsc_form_opcode (uint16_t opcode)
+{
+    if(!(WsfQueueEmpty(&vscCmdQueue)))
+    {
+        cy_vendor_specific_cmd_t *cy_cmd = (cy_vendor_specific_cmd_t *)WsfQueueDeq(&vscCmdQueue);
+        if( cy_cmd != NULL )
+        {
+            if(opcode == cy_cmd->opcode)
+            {
+                return cy_cmd;
+            }
+        }
+    }
+    return NULL;
+}
+
+void vscThread(void)
+{
+    while(1)
+    {
+        if(number_of_msg)
+        {
+            WSF_CS_INIT();
+            WSF_CS_ENTER();
+            number_of_msg--;
+            WSF_CS_EXIT();
+            cy_vendor_specific_rsp_t *cy_rsp = (cy_vendor_specific_rsp_t *)WsfQueueDeq(&vscRspQueue);
+            if( cy_rsp != NULL )
+            {
+                cy_vendor_specific_cmd_t *cy_cmd = cy_find_vsc_form_opcode(cy_rsp->opcode);
+                if (cy_cmd != NULL)
+                {
+                    cy_rsp->opcode &= (~(0x3F << 10));
+                    if (cy_cmd->vsc_cb != NULL)
+                    {
+                         (*(cy_cmd->vsc_cb))(cy_rsp->opcode, cy_rsp->status, cy_rsp->param_len, cy_rsp->param);
+                    }
+                    WsfBufFree(cy_cmd);
+                }
+                WsfBufFree(cy_rsp);
+            }
+        }
+    }
+}
+
+bool cy_send_vendor_specific_cmd(uint16_t opcode, uint8_t param_len, uint8_t *param, cy_vsc_callback_t *vsc_cb)
+{
+    if (cy_vsc_init == 0)
+    {
+        cy_vsc_init = 1;
+        // Create Thread to send the callbacks
+        threadVsc.start(vscThread);
+
+        //Create Queue to store callbacks
+        WSF_QUEUE_INIT(&vscCmdQueue);
+        WSF_QUEUE_INIT(&vscRspQueue);
+    }
+    opcode |= (0x3F << 10);
+
+    cy_vendor_specific_cmd_t *vsc_cmd = (cy_vendor_specific_cmd_t *)WsfBufAlloc(sizeof(cy_vendor_specific_cmd_t));
+    if (vsc_cmd != NULL )
+    {
+        vsc_cmd->opcode = opcode;
+        vsc_cmd->vsc_cb = vsc_cb;
+        WsfQueueEnq(&vscCmdQueue, vsc_cmd);
+        HciVendorSpecificCmd(opcode, param_len, param);
+        return true;
+    }
+    return false;
+}
+
+extern "C" {
+void cy_post_vsc_complete_event(uint16_t opcode, uint8_t status, uint16_t data_len, uint8_t* data)
+{
+    if(cy_vsc_init)
+    {
+        cy_vendor_specific_rsp_t *cmd_rsp = (cy_vendor_specific_rsp_t *)WsfBufAlloc(sizeof(cy_vendor_specific_rsp_t) + data_len);
+        if(cmd_rsp != NULL)
+        {
+
+            cmd_rsp->opcode = opcode;
+            cmd_rsp->status = status;
+            cmd_rsp->param_len = data_len;
+            cmd_rsp->param  = (uint8_t *)(cmd_rsp + 1);
+
+            memcpy((void *)cmd_rsp->param, data, data_len);
+            WsfQueueEnq(&vscRspQueue, cmd_rsp);
+
+            WSF_CS_INIT();
+            WSF_CS_ENTER();
+            number_of_msg++;
+            WSF_CS_EXIT();
+        }
+    }
+}
+}

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyVscCmd.h
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyVscCmd.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef CY_VSC_CMD_H_
+#define CY_VSC_CMD_H_
+/**
+ * Vendor specific command complete
+ */
+typedef void (cy_vsc_callback_t)(uint16_t opcode, uint8_t status, uint16_t data_len, uint8_t* data);
+
+/**
+ * Send a vendor specific HCI command to the controller.
+ *
+ * @param opcode     : Opcode of vendor specific command
+ * @param param_len  : Length of parameter buffer
+ * @param param      : Parameters
+ * @param vsc_cb     : Callback for command complete
+ *
+ * @return true if the request has been successfully sent otherwise false.
+ *
+ */
+bool cy_send_vendor_specific_cmd(uint16_t opcode, uint8_t param_len, uint8_t *param, cy_vsc_callback_t *vsc_cb);
+#endif // CY_VSC_CMD_H_


### PR DESCRIPTION
### Description
Default VSC complete event is not handle in CORDIO, so on receive path one function is replaced.
Added cy_send_vendor_specific_cmd API.
Created Separated thread to invoke registered VSC callback.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@pan- 
@kask01
@rgvn
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
