### PR TITLE
Making ATHandler recv buf size configurable

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -644,7 +644,7 @@ int32_t ATHandler::read_int()
         return -1;
     }
 
-    char buff[BUFF_SIZE];
+    char buff[MBED_CONF_CELLULAR_AT_HANDLER_RECV_BUF_SIZE];
     if (read_string(buff, sizeof(buff)) == 0) {
         return -1;
     }
@@ -913,7 +913,7 @@ void ATHandler::resp_start(const char *prefix, bool stop)
     (void)fill_buffer(false);
 
     if (prefix) {
-        MBED_ASSERT(strlen(prefix) < BUFF_SIZE);
+        MBED_ASSERT(strlen(prefix) < MBED_CONF_CELLULAR_AT_HANDLER_RECV_BUF_SIZE);
         strcpy(_info_resp_prefix, prefix); // copy prefix so we can later use it without having to provide again for info_resp
     }
 

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -42,8 +42,6 @@ class FileHandle;
 extern const char *OK;
 extern const char *CRLF;
 
-#define BUFF_SIZE 16
-
 /* AT Error types enumeration */
 enum DeviceErrorType {
     DeviceErrorTypeNoError = 0,
@@ -447,7 +445,7 @@ public: // just for debugging
 private:
 
     // should fit any prefix and int
-    char _recv_buff[BUFF_SIZE];
+    char _recv_buff[MBED_CONF_CELLULAR_AT_HANDLER_RECV_BUF_SIZE];
     // reading position
     size_t _recv_len;
     // reading length
@@ -489,7 +487,7 @@ private:
     size_t _max_resp_length;
 
     // prefix set during resp_start and used to try matching possible information responses
-    char _info_resp_prefix[BUFF_SIZE];
+    char _info_resp_prefix[MBED_CONF_CELLULAR_AT_HANDLER_RECV_BUF_SIZE];
     bool _debug_on;
     bool _cmd_start;
     bool _use_delimiter;

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -20,6 +20,10 @@
         "control-plane-opt": {
             "help": "Enables control plane CIoT EPS optimization",
             "value": false
+        },
+        "at-handler-recv-buf-size": {
+            "help": "Receive buffer size for the AT handler",
+            "value": 32
         }
     }
 }


### PR DESCRIPTION

### Description

The size of the recv buffer which we use for matching prefixes from the
AT responses can sometimes be too low and that causes overflows,
bloating AT debug output and introducing inconsistencies.
We have now increased the size from 16 bytest to 32 and have made it
configurable.



### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila @kivaisan @AriParkkila @cmonr 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
