### PR TITLE
Flagging WEAK method implementation for default construction

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -73,6 +73,7 @@ QUECTEL_EC2X::QUECTEL_EC2X(FileHandle *fh, PinName pwr, bool active_high, PinNam
     AT_CellularBase::set_cellular_properties(cellular_properties);
 }
 
+#if MBED_CONF_QUECTEL_EC2X_PROVIDE_DEFAULT
 CellularDevice *CellularDevice::get_default_instance()
 {
     static UARTSerial serial(MBED_CONF_QUECTEL_EC2X_TX,
@@ -87,6 +88,7 @@ CellularDevice *CellularDevice::get_default_instance()
                                MBED_CONF_QUECTEL_EC2X_RST);
     return &device;
 }
+#endif
 
 nsapi_error_t QUECTEL_EC2X::press_power_button(uint32_t timeout)
 {


### PR DESCRIPTION


### Description

CellularDevice::get_default_instance() is a weak method and is overriden
by either a default construction provided in the code or by application
at some stage. This method needs to be flagged otherwise using another
driver will be hindered by the default overriding of this driver.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila @AriParkkila @cmonr @0xc0170 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
