### PR TITLE
FUTURE_SEQUANA_PSA fix PSA Protected storage

### DIFF
--- a/features/storage/kvstore/conf/global/mbed_lib.json
+++ b/features/storage/kvstore/conf/global/mbed_lib.json
@@ -14,6 +14,9 @@
         "FUTURE_SEQUANA_M0_PSA": {
             "storage_type": "TDB_INTERNAL"
         },
+        "FUTURE_SEQUANA_PSA": {
+            "storage_type": "TDB_INTERNAL"
+        },
         "CY8CKIT_062_WIFI_BT_M0_PSA": {
             "storage_type": "TDB_INTERNAL"
         },

--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -15,6 +15,10 @@
             "internal_size": "0x8000",
             "internal_base_address": "0x10078000"
         },
+        "FUTURE_SEQUANA_PSA": {
+            "internal_size": "0x8000",
+            "internal_base_address": "0x100F8000"
+        },
         "CY8CKIT_062_WIFI_BT_M0_PSA": {
             "internal_size": "0x8000",
             "internal_base_address": "0x10038000"


### PR DESCRIPTION
### Description

Configure TDBStore explicitly for FUTURE_SEQUANA_PSA to support PSA Protected storage

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@lrusinowicz 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
