### PR TITLE
Fix ESP8266 driver behavior on connection failures

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -315,7 +315,7 @@ int ESP8266Interface::disconnect()
     _initialized = false;
 
     nsapi_error_t status = _conn_status_to_error();
-    if (status == NSAPI_ERROR_NO_CONNECTION || !get_ip_address()) {
+    if (status == NSAPI_ERROR_NO_CONNECTION) {
         return NSAPI_ERROR_NO_CONNECTION;
     }
 

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -19,6 +19,7 @@
 
 #if DEVICE_SERIAL && DEVICE_INTERRUPTIN && defined(MBED_CONF_EVENTS_PRESENT) && defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
 #include "drivers/DigitalOut.h"
+#include "drivers/Timer.h"
 #include "ESP8266/ESP8266.h"
 #include "events/EventQueue.h"
 #include "events/mbed_shared_queues.h"
@@ -33,6 +34,9 @@
 #include "rtos/Mutex.h"
 
 #define ESP8266_SOCKET_COUNT 5
+
+#define ESP8266_INTERFACE_CONNECT_INTERVAL_MS (5000)
+#define ESP8266_INTERFACE_CONNECT_TIMEOUT_MS (2 * ESP8266_CONNECT_TIMEOUT + ESP8266_INTERFACE_CONNECT_INTERVAL_MS)
 
 #ifdef TARGET_FF_ARDUINO
 #ifndef MBED_CONF_ESP8266_TX
@@ -93,6 +97,9 @@ public:
     /** Start the interface
      *
      *  Attempts to connect to a WiFi network.
+     *
+     *  If interface is configured blocking it will timeout after up to
+     *  ESP8266_INTERFACE_CONNECT_TIMEOUT_MS + ESP8266_CONNECT_TIMEOUT ms.
      *
      *  @param ssid      Name of the network to connect to
      *  @param pass      Security passphrase to connect to the network
@@ -408,6 +415,7 @@ private:
 
     // connect status reporting
     nsapi_error_t _conn_status_to_error();
+    mbed::Timer _conn_timer;
 
     // Drivers's socket info
     struct _sock_info {


### PR DESCRIPTION
### Description

In case the application calls `disconnect()` the driver will only perform actual disconnection procedure (including a status update and event signalling) if the ESP was really disconnected. This was added in [this commit](https://github.com/ARMmbed/mbed-os/commit/e83b883e08f62f94ddb332f04c4a9c348d414483), but in fact user might call `disconnect()` for example after a failed connection attempt. In this case we should stop trying to connect, so that a retry is possible. This is also how EMAC drivers work.

Furthermore, we did not make use of ESP8266 timeout message, because in fact it kept on trying to connect. Therefore we need to use our own timeout to return a proper error value if the connection really takes too long.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@VeijoPesonen 
@SeppoTakalo 