### PR TITLE
STM32: protect compilation when DEVICE_USTICKER is disabled

### DIFF
--- a/targets/TARGET_STM/hal_tick_overrides.c
+++ b/targets/TARGET_STM/hal_tick_overrides.c
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if DEVICE_USTICKER
+
 #include "hal/us_ticker_api.h"
 #include "us_ticker_data.h"
 
@@ -75,3 +78,5 @@ void HAL_ResumeTick(void)
 {
     // Do nothing
 }
+
+#endif /* DEVICE_USTICKER */

--- a/targets/TARGET_STM/us_ticker.c
+++ b/targets/TARGET_STM/us_ticker.c
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if DEVICE_USTICKER
+
 #include <stddef.h>
 #include "us_ticker_api.h"
 #include "PeripheralNames.h"
@@ -264,3 +267,4 @@ void us_ticker_free(void)
     us_ticker_disable_interrupt();
 }
 
+#endif /* DEVICE_USTICKER */


### PR DESCRIPTION
### Description

Issue seen during PSA/TFM integration, us ticker file should be protected like lp ticker one depending on DEVICE feature.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
