### PR TITLE
ECHOTEST internal loop simplification and fix

### DIFF
--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -67,16 +67,16 @@ void TCPSOCKET_ECHOTEST()
 
     int recvd;
     int sent;
-    int x = 0;
-    for (int pkt_s = pkt_sizes[x]; x < PKTS; pkt_s = pkt_sizes[x++]) {
+    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); s_idx++) {
+        int pkt_s = pkt_sizes[s_idx];
         fill_tx_buffer_ascii(tcp_global::tx_buffer, BUFF_SIZE);
         sent = sock.send(tcp_global::tx_buffer, pkt_s);
         if (sent < 0) {
-            printf("[Round#%02d] network error %d\n", x, sent);
+            printf("[Round#%02d] network error %d\n", s_idx, sent);
             TEST_FAIL();
             break;
         } else if (sent != pkt_s) {
-            printf("[%02d] sock.send return size %d does not match the expectation %d\n", x, sent, pkt_s);
+            printf("[%02d] sock.send return size %d does not match the expectation %d\n", s_idx, sent, pkt_s);
             TEST_FAIL();
             break;
         }
@@ -85,7 +85,7 @@ void TCPSOCKET_ECHOTEST()
         while (bytes2recv) {
             recvd = sock.recv(&(tcp_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", x, recvd);
+                printf("[Round#%02d] network error %d\n", s_idx, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
                 return;
@@ -143,7 +143,6 @@ void TCPSOCKET_ECHOTEST_NONBLOCK()
 
     int bytes2send;
     int sent;
-    int s_idx = 0;
     receive_error = false;
     unsigned char *stack_mem = (unsigned char *)malloc(tcp_global::TCP_OS_STACK_SIZE);
     TEST_ASSERT_NOT_NULL(stack_mem);
@@ -154,8 +153,8 @@ void TCPSOCKET_ECHOTEST_NONBLOCK()
 
     TEST_ASSERT_EQUAL(osOK, receiver_thread->start(callback(&queue, &EventQueue::dispatch_forever)));
 
-    for (int pkt_s = pkt_sizes[s_idx]; s_idx < PKTS; ++s_idx) {
-        pkt_s = pkt_sizes[s_idx];
+    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
+        int pkt_s = pkt_sizes[s_idx];
         bytes2recv = pkt_s;
         bytes2recv_total = pkt_s;
 

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -70,17 +70,17 @@ void TLSSOCKET_ECHOTEST()
 
     int recvd;
     int sent;
-    int x = 0;
-    for (int pkt_s = pkt_sizes[x]; x < PKTS; pkt_s = pkt_sizes[x++]) {
+    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); s_idx++) {
+        int pkt_s = pkt_sizes[s_idx];
         fill_tx_buffer_ascii(tls_global::tx_buffer, BUFF_SIZE);
 
         sent = sock->send(tls_global::tx_buffer, pkt_s);
         if (sent < 0) {
-            printf("[Round#%02d] network error %d\n", x, sent);
+            printf("[Round#%02d] network error %d\n", s_idx, sent);
             TEST_FAIL();
             break;
         } else if (sent != pkt_s) {
-            printf("[%02d] sock.send return size %d does not match the expectation %d\n", x, sent, pkt_s);
+            printf("[%02d] sock.send return size %d does not match the expectation %d\n", s_idx, sent, pkt_s);
             TEST_FAIL();
             break;
         }
@@ -89,7 +89,7 @@ void TLSSOCKET_ECHOTEST()
         while (bytes2recv) {
             recvd = sock->recv(&(tls_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", x, recvd);
+                printf("[Round#%02d] network error %d\n", s_idx, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
                 return;
@@ -146,7 +146,7 @@ void TLSSOCKET_ECHOTEST_NONBLOCK()
 
     int bytes2send;
     int sent;
-    int s_idx = 0;
+    ;
     receive_error = false;
     unsigned char *stack_mem = (unsigned char *)malloc(tls_global::TLS_OS_STACK_SIZE);
     TEST_ASSERT_NOT_NULL(stack_mem);
@@ -158,8 +158,8 @@ void TLSSOCKET_ECHOTEST_NONBLOCK()
     event_queue = &queue;
     TEST_ASSERT_EQUAL(osOK, receiver_thread->start(callback(&queue, &EventQueue::dispatch_forever)));
 
-    for (int pkt_s = pkt_sizes[s_idx]; s_idx < PKTS; ++s_idx) {
-        pkt_s = pkt_sizes[s_idx];
+    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
+        int pkt_s = pkt_sizes[s_idx];
         bytes2recv = pkt_s;
         bytes2recv_total = pkt_s;
 

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -68,11 +68,10 @@ void UDPSOCKET_ECHOTEST()
 
     int recvd;
     int sent;
-    int s_idx = 0;
     int packets_sent = 0;
     int packets_recv = 0;
-    for (int pkt_s = pkt_sizes[s_idx]; s_idx < PKTS; pkt_s = ++s_idx) {
-        pkt_s = pkt_sizes[s_idx];
+    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
+        int pkt_s = pkt_sizes[s_idx];
 
         fill_tx_buffer_ascii(tx_buffer, BUFF_SIZE);
 
@@ -147,15 +146,14 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
     sock.sigio(callback(_sigio_handler));
 
     int sent;
-    int s_idx = 0;
     int packets_sent = 0;
     int packets_recv = 0;
     Thread *thread;
     unsigned char *stack_mem = (unsigned char *)malloc(OS_STACK_SIZE);
     TEST_ASSERT_NOT_NULL(stack_mem);
 
-    for (int pkt_s = pkt_sizes[s_idx]; s_idx < PKTS; ++s_idx) {
-        pkt_s = pkt_sizes[s_idx];
+    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
+        int pkt_s = pkt_sizes[s_idx];
 
         thread = new Thread(osPriorityNormal,
                             OS_STACK_SIZE,


### PR DESCRIPTION
### Description

The loop was wrongly incrementing the index of the array after assigning
the value. Thus the first array element was used twice and the last one
was never user. The issue is fixed and the loops are refactored and
simplified to avoid such confusion in the future.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@blind-owl 