### PR TITLE
Toshiba: Cortex-M4 -> Cortex-M4F

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7912,7 +7912,7 @@
     },
     "TMPM46B": {
         "inherits": ["Target"],
-        "core": "Cortex-M4",
+        "core": "Cortex-M4F",
         "is_disk_virtual": true,
         "extra_labels": ["TOSHIBA"],
         "macros": ["__TMPM46B__"],
@@ -8105,7 +8105,7 @@
     },
     "TMPM4G9": {
         "inherits": ["Target"],
-        "core": "Cortex-M4",
+        "core": "Cortex-M4F",
         "is_disk_virtual": true,
         "extra_labels": ["TOSHIBA"],
         "macros": ["__TMPM4G9__"],
@@ -8617,7 +8617,7 @@
 	},
     "TT_M4G9": {
 		"inherits": ["Target"],
-		"core": "Cortex-M4",
+		"core": "Cortex-M4F",
 		"is_disk_virtual": true,
 		"extra_labels": ["TT"],
 		"macros": ["__TT_M4G9__"],


### PR DESCRIPTION
### Description

Toshiba parts have FPU - change core in targets.json to use it.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
