### PR TITLE
README file for wifi tests gives configuration example

### DIFF
--- a/TESTS/network/wifi/README.md
+++ b/TESTS/network/wifi/README.md
@@ -87,10 +87,12 @@ git checkout master
 cd ..
 ```
 
+Prepare an `mbed_app.json` configuration file with all the required definitions provided. See [template_mbed_app.txt](template_mbed_app.txt) file for the full list of necessary definitions.
+
 Now build test binaries:
 
 ```.sh
-mbed test --compile -t <toolchain> -m <target> -n mbed-os-tests-network-wifi
+mbed test --compile -t <toolchain> -m <target> --app-config TESTS/network/wifi/template_mbed_app.txt -n mbed-os-tests-network-wifi
 ```
 
 Running tests


### PR DESCRIPTION
### Description

Instead of copying and pasting the template file I provided a reference to it, to make the maintenance easier.
I also added it to the compile example, following the [emac tests README](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/network/emac/README.md).

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@KariHaapalehto 