### PR TITLE
ARM MPS2: Cortex-M4 -> M4F & M7 -> M7FD

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5314,7 +5314,7 @@
     },
     "ARM_MPS2_M7": {
         "inherits": ["ARM_MPS2_Target"],
-        "core": "Cortex-M7",
+        "core": "Cortex-M7FD",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M7"],
         "macros": ["CMSDK_CM7"],
@@ -8011,13 +8011,13 @@
     },
     "FVP_MPS2_M4": {
         "inherits": ["FVP_MPS2"],
-        "core": "Cortex-M4",
+        "core": "Cortex-M4F",
         "macros_add": ["CMSDK_CM4"],
         "device_has_add": ["MPU"]
     },
     "FVP_MPS2_M7": {
         "inherits": ["FVP_MPS2"],
-        "core": "Cortex-M7",
+        "core": "Cortex-M7FD",
         "macros_add": ["CMSDK_CM7"],
         "device_has_add": ["MPU"]
     },


### PR DESCRIPTION
### Description

According to their cmsis.h, FPU is present, so change targets.json to use it.

* ARM_MPS2_M4: already was Cortex-M4F
* ARM_MPS2_M7: Cortex-M7 -> M7FD
* FVP_MPS2_M4: Cortex-M4 -> M4F
* FVP_MPS2_M7: Cortex-M7 -> M7FD

If they do not in fact have FPU, then cmsis.h should be modified to set `__FPU_PRESENT` to 0. This will currently cause compilation problems with ARMC6, but I'll be submitting a fix for that.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

