### PR TITLE
Atmel SAMG55: Cortex-M4 -> Cortex-M4F

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6771,7 +6771,7 @@
     },
     "SAMG55J19": {
         "inherits": ["Target"],
-        "core": "Cortex-M4",
+        "core": "Cortex-M4F",
         "extra_labels": ["Atmel", "SAM_CortexM4", "SAMG55"],
         "macros": [
             "__SAMG55J19__",


### PR DESCRIPTION
### Description

SAMG55 has FPU - change core in targets.json to use it.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

