### PR TITLE
Correct some CPU selections in tools

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1347,7 +1347,7 @@
     "KW24D": {
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4",
-        "supported_toolchains": ["ARMC5", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM"],
         "is_disk_virtual": true,
         "macros": ["CPU_MKW24D512VHA5", "FSL_RTOS_MBED"],

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -82,16 +82,11 @@ class ARM(mbedToolchain):
             if "--library_type=microlib" not in self.flags['common']:
                 self.flags['common'].append("--library_type=microlib")
 
-        if target.core == "Cortex-M0+":
-            cpu = "Cortex-M0"
-        elif target.core == "Cortex-M4F":
-            cpu = "Cortex-M4.fp"
-        elif target.core == "Cortex-M7FD":
-            cpu = "Cortex-M7.fp.dp"
-        elif target.core == "Cortex-M7F":
-            cpu = "Cortex-M7.fp.sp"
-        else:
-            cpu = target.core
+        cpu = {
+            "Cortex-M0+": "Cortex-M0plus",
+            "Cortex-M4F": "Cortex-M4.fp.sp",
+            "Cortex-M7F": "Cortex-M7.fp.sp",
+            "Cortex-M7FD": "Cortex-M7.fp.dp"}.get(target.core, target.core)
 
         ARM_BIN = join(TOOLCHAIN_PATHS['ARM'], "bin")
 
@@ -559,38 +554,31 @@ class ARMC6(ARM_STD):
         self.SHEBANG += " -mcpu=%s" % cpu
 
         # FPU handling
-        if core == "Cortex-M4F":
+        if core == "Cortex-M4" or core == "Cortex-M7" or "core" == "Cortex-M33":
+            self.flags['common'].append("-mfpu=none")
+        elif core == "Cortex-M4F":
             self.flags['common'].append("-mfpu=fpv4-sp-d16")
             self.flags['common'].append("-mfloat-abi=hard")
-            self.flags['ld'].append("--cpu=cortex-m4")
-        elif core == "Cortex-M7F":
+        elif core == "Cortex-M7F" or core.startswith("Cortex-M33F"):
             self.flags['common'].append("-mfpu=fpv5-sp-d16")
             self.flags['common'].append("-mfloat-abi=hard")
-            self.flags['ld'].append("--cpu=cortex-m7.fp.sp")
         elif core == "Cortex-M7FD":
             self.flags['common'].append("-mfpu=fpv5-d16")
             self.flags['common'].append("-mfloat-abi=hard")
-            self.flags['ld'].append("--cpu=cortex-m7")
-        elif core == "Cortex-M33F":
-            self.flags['common'].append("-mfpu=fpv5-sp-d16")
-            self.flags['common'].append("-mfloat-abi=hard")
-            self.flags['ld'].append("--cpu=cortex-m33.no_dsp")
-        elif core == "Cortex-M33":
-            self.flags['common'].append("-mfpu=none")
-            self.flags['ld'].append("--cpu=cortex-m33.no_dsp.no_fp")
-        else:
-            self.flags['ld'].append("--cpu=%s" % cpu)
 
-        asm_cpu = {
-            "Cortex-M0+": "Cortex-M0",
-            "Cortex-M4F": "Cortex-M4.fp",
+        asm_ld_cpu = {
+            "Cortex-M0+": "Cortex-M0plus",
+            "Cortex-M4": "Cortex-M4.no_fp",
+            "Cortex-M4F": "Cortex-M4",
+            "Cortex-M7": "Cortex-M7.no_fp",
             "Cortex-M7F": "Cortex-M7.fp.sp",
-            "Cortex-M7FD": "Cortex-M7.fp.dp",
+            "Cortex-M7FD": "Cortex-M7",
             "Cortex-M33": "Cortex-M33.no_dsp.no_fp",
             "Cortex-M33F": "Cortex-M33.no_dsp",
             "Cortex-M33FE": "Cortex-M33"}.get(core, core)
 
-        self.flags['asm'].append("--cpu=%s" % asm_cpu)
+        self.flags['asm'].append("--cpu=%s" % asm_ld_cpu)
+        self.flags['ld'].append("--cpu=%s" % asm_ld_cpu)
 
         self.cc = ([join(TOOLCHAIN_PATHS["ARMC6"], "armclang")] +
                    self.flags['common'] + self.flags['c'])

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -574,6 +574,7 @@ class ARMC6(ARM_STD):
             "Cortex-M7F": "Cortex-M7.fp.sp",
             "Cortex-M7FD": "Cortex-M7",
             "Cortex-M33": "Cortex-M33.no_dsp.no_fp",
+            "Cortex-M33E": "Cortex-M33.no_fp",
             "Cortex-M33F": "Cortex-M33.no_dsp",
             "Cortex-M33FE": "Cortex-M33"}.get(core, core)
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -78,11 +78,14 @@ class GCC(mbedToolchain):
             "Cortex-M4F": "cortex-m4",
             "Cortex-M7F": "cortex-m7",
             "Cortex-M7FD": "cortex-m7",
+            "Cortex-M33": "cortex-m33+nodsp",
             "Cortex-M33F": "cortex-m33+nodsp",
             "Cortex-M33FE": "cortex-m33"}.get(core, core)
 
-        if core == "Cortex-M33":
+        if cpu == "cortex-m33+nodsp":
             self.cpu.append("-march=armv8-m.main")
+        elif cpu == "cortex-m33":
+            self.cpu.append("-march=armv8-m.main+dsp")
         else:
             self.cpu.append("-mcpu={}".format(cpu.lower()))
 
@@ -93,14 +96,11 @@ class GCC(mbedToolchain):
         if core == "Cortex-M4F":
             self.cpu.append("-mfpu=fpv4-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
-        elif core == "Cortex-M7F":
+        elif core == "Cortex-M7F" or core.startswith("Cortex-M33F"):
             self.cpu.append("-mfpu=fpv5-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
         elif core == "Cortex-M7FD":
             self.cpu.append("-mfpu=fpv5-d16")
-            self.cpu.append("-mfloat-abi=softfp")
-        elif core.startswith("Cortex-M33F"):
-            self.cpu.append("-mfpu=fpv5-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
 
         if target.core == "Cortex-A9":

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -79,6 +79,7 @@ class GCC(mbedToolchain):
             "Cortex-M7F": "cortex-m7",
             "Cortex-M7FD": "cortex-m7",
             "Cortex-M33": "cortex-m33+nodsp",
+            "Cortex-M33E": "cortex-m33",
             "Cortex-M33F": "cortex-m33+nodsp",
             "Cortex-M33FE": "cortex-m33"}.get(core, core)
 

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -69,8 +69,8 @@ class IAR(mbedToolchain):
                 self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 
         cpu = {
-            "Cortex-M7FD": "Cortex-M7.fp.dp",
             "Cortex-M7F": "Cortex-M7.fp.sp",
+            "Cortex-M7FD": "Cortex-M7.fp.dp",
             "Cortex-M33": "Cortex-M33.no_dsp",
             "Cortex-M33F": "Cortex-M33.fp.no_dsp",
             "Cortex-M33FE": "Cortex-M33.fp"}.get(core, core)

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -72,6 +72,7 @@ class IAR(mbedToolchain):
             "Cortex-M7F": "Cortex-M7.fp.sp",
             "Cortex-M7FD": "Cortex-M7.fp.dp",
             "Cortex-M33": "Cortex-M33.no_dsp",
+            "Cortex-M33E": "Cortex-M33",
             "Cortex-M33F": "Cortex-M33.fp.no_dsp",
             "Cortex-M33FE": "Cortex-M33.fp"}.get(core, core)
 


### PR DESCRIPTION
### Description

* For ARMC6, core types `Cortex-M4` and `Cortex-M7` did not explicitly add `--fpu=none`, so it defaulted to assuming FPU present. This would cause a compilation error if the target's cmsis.h had `__FPU_PRESENT` defined to 0.

* For GCC, `Cortex-M33FE` did not include `+dsp` in the architecture selection.

* For ARMC5 and ARMC6, `Cortex-M0+` did not pass `M0plus` to the non-Clang tools.

* Add missing `Cortex-M33E` DSP Extension without FP possibility.

* Switch KW24D to use ARMC6 - it was using ARMC5 because it has non-FP Cortex-M4 and hit this tool problem.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
