### PR TITLE
Networking: Fix some ARMC6 warnings

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -15,8 +15,12 @@
  */
 
 #if DEVICE_SERIAL && DEVICE_INTERRUPTIN && defined(MBED_CONF_EVENTS_PRESENT) && defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_PRESENT)
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+
 #include <string.h>
-#include <stdint.h>
 #include <stdlib.h>
 
 #include "ESP8266.h"
@@ -601,7 +605,7 @@ nsapi_error_t ESP8266::send(int id, const void *data, uint32_t amount)
     set_timeout(ESP8266_SEND_TIMEOUT);
     _busy = false;
     _error = false;
-    if (!_parser.send("AT+CIPSEND=%d,%lu", id, amount)) {
+    if (!_parser.send("AT+CIPSEND=%d,%" PRIu32, id, amount)) {
         tr_debug("ESP8266::send(): AT+CIPSEND failed");
         goto END;
     }
@@ -734,7 +738,7 @@ int32_t ESP8266::_recv_tcp_passive(int id, void *data, uint32_t amount, uint32_t
         amount = amount > 2048 ? 2048 : amount;
 
         // NOTE: documentation v3.0 says '+CIPRECVDATA:<data_len>,' but it's not how the FW responds...
-        bool done = _parser.send("AT+CIPRECVDATA=%d,%lu", id, amount)
+        bool done = _parser.send("AT+CIPRECVDATA=%d,%" PRIu32, id, amount)
                     && _parser.recv("OK\n");
 
         _sock_i[id].tcp_data = NULL;
@@ -1056,7 +1060,7 @@ void ESP8266::_oob_tcp_data_hdlr()
 
     MBED_ASSERT(_sock_active_id >= 0 && _sock_active_id < 5);
 
-    if (!_parser.recv("%ld:", &len)) {
+    if (!_parser.recv("%" SCNd32 ":", &len)) {
         return;
     }
 

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -126,7 +126,7 @@ public:
         virtual char *get_gateway(char *buf, nsapi_size_t buflen);
 
     private:
-        friend LWIP;
+        friend class LWIP;
 
         Interface();
 

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
@@ -30,7 +30,7 @@ public:
     virtual nsapi_error_t bringdown();
 
 private:
-    friend Nanostack;
+    friend class Nanostack;
     friend class NanostackEthernetInterface;
     EthernetInterface(NanostackEthernetPhy &phy) : Interface(phy) {}
     nsapi_error_t initialize();

--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -33,7 +33,7 @@ public:
     virtual nsapi_error_t bringdown();
     virtual char *get_gateway(char *buf, nsapi_size_t buflen);
 
-    friend Nanostack;
+    friend class Nanostack;
     friend class ::LoWPANNDInterface;
 private:
     LoWPANNDInterface(NanostackRfPhy &phy) : MeshInterface(phy) { }

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -30,7 +30,7 @@ public:
                                   nsapi_ip_stack_t stack = IPV6_STACK,
                                   bool blocking = true);
     virtual nsapi_error_t bringdown();
-    friend Nanostack;
+    friend class Nanostack;
     friend class ::ThreadInterface;
 private:
     ThreadInterface(NanostackRfPhy &phy) : MeshInterface(phy), eui64_set(false) { }

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -33,7 +33,7 @@ public:
     virtual nsapi_error_t bringdown();
     virtual char *get_gateway(char *buf, nsapi_size_t buflen);
 
-    friend Nanostack;
+    friend class Nanostack;
     friend class ::WisunInterface;
 private:
     WisunInterface(NanostackRfPhy &phy) : MeshInterface(phy) { }

--- a/features/nanostack/mbed-mesh-api/source/nd_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/nd_tasklet.c
@@ -103,9 +103,9 @@ static void initialize_channel_list(void)
 
     arm_nwk_set_channel_list(tasklet_data_ptr->network_interface_id, &tasklet_data_ptr->channel_list);
 
-    tr_debug("Channel: %ld", channel);
+    tr_debug("Channel: %" PRIu32, channel);
     tr_debug("Channel page: %d", tasklet_data_ptr->channel_list.channel_page);
-    tr_debug("Channel mask: 0x%.8lx", tasklet_data_ptr->channel_list.channel_mask[word_index]);
+    tr_debug("Channel mask: 0x%.8" PRIx32, tasklet_data_ptr->channel_list.channel_mask[word_index]);
 }
 
 /*

--- a/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
@@ -319,7 +319,7 @@ void thread_tasklet_configure_and_connect_to_network(void)
     thread_tasklet_data_ptr->channel_list.channel_mask[0] = MBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL_MASK;
 
     TRACE_DETAIL("channel page: %d", thread_tasklet_data_ptr->channel_list.channel_page);
-    TRACE_DETAIL("channel mask: 0x%.8lx", thread_tasklet_data_ptr->channel_list.channel_mask[0]);
+    TRACE_DETAIL("channel mask: 0x%.8" PRIx32, thread_tasklet_data_ptr->channel_list.channel_mask[0]);
 
     // PSKd
     const char PSKd[] = MBED_CONF_MBED_MESH_API_THREAD_PSKD;


### PR DESCRIPTION
### Description

Some int-versus-long and signed-versus-unsigned format string mismatches, and missing `class` keyword.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
