### PR TITLE
mbed_error: Avoid negative left shift

### DIFF
--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -50,14 +50,17 @@ extern "C" {
 #endif
 
 #define MBED_ERROR_STATUS_CODE_MASK                 (0x0000FFFF)
+#define MBED_ERROR_STATUS_CODE_UNSHIFTED_MASK       (0x0000FFFF)
 #define MBED_ERROR_STATUS_CODE_POS                  (0)
 #define MBED_ERROR_STATUS_CODE_FIELD_SIZE           (16)
 
 #define MBED_ERROR_STATUS_MODULE_MASK               (0x00FF0000)
+#define MBED_ERROR_STATUS_MODULE_UNSHIFTED_MASK     (0x000000FF)
 #define MBED_ERROR_STATUS_MODULE_POS                (16)
 #define MBED_ERROR_STATUS_MODULE_FIELD_SIZE         (8)
 
 #define MBED_ERROR_STATUS_TYPE_MASK                 (0x60000000)
+#define MBED_ERROR_STATUS_TYPE_UNSHIFTED_MASK       (0x00000003)
 #define MBED_ERROR_STATUS_TYPE_POS                  (29)
 #define MBED_ERROR_STATUS_TYPE_FIELD_SIZE           (2)
 
@@ -65,11 +68,11 @@ extern "C" {
 //|31(1 bit) Always Negative|30-29(2 bits)  |28-24              | 23-16(8 bits) |  15-0(16 bits) |
 //|-1                       |TYPE           |(unused/reserved)  | MODULE TYPE   |  ERROR CODE    |
 
-#define MAKE_MBED_ERROR(type, module, error_code)   (mbed_error_status_t)                                                                   \
-                                                    ((0x80000000) |                                                                     \
-                                                    (MBED_ERROR_STATUS_CODE_MASK & (error_code << MBED_ERROR_STATUS_CODE_POS)) |        \
-                                                    (MBED_ERROR_STATUS_MODULE_MASK & (module << MBED_ERROR_STATUS_MODULE_POS)) |        \
-                                                    (MBED_ERROR_STATUS_TYPE_MASK & (type << MBED_ERROR_STATUS_TYPE_POS)))
+#define MAKE_MBED_ERROR(type, module, error_code)   (mbed_error_status_t)                                                                                           \
+                                                    ((0x80000000) |                                                                                                 \
+                                                    ((mbed_error_status_t) (error_code & MBED_ERROR_STATUS_CODE_UNSHIFTED_MASK) << MBED_ERROR_STATUS_CODE_POS) |    \
+                                                    ((mbed_error_status_t) (module & MBED_ERROR_STATUS_MODULE_UNSHIFTED_MASK) << MBED_ERROR_STATUS_MODULE_POS) |    \
+                                                    ((mbed_error_status_t) (type & MBED_ERROR_STATUS_TYPE_UNSHIFTED_MASK) << MBED_ERROR_STATUS_TYPE_POS))
 
 #define MBED_GET_ERROR_TYPE( error_status )         ((error_status & MBED_ERROR_STATUS_TYPE_MASK) >> MBED_ERROR_STATUS_TYPE_POS)
 #define MBED_GET_ERROR_MODULE( error_status )       ((error_status & MBED_ERROR_STATUS_MODULE_MASK) >> MBED_ERROR_STATUS_MODULE_POS)
@@ -83,7 +86,7 @@ extern "C" {
  *
  \verbatim
  | 31 Always Negative | 30-29(2 bits)  | 28-24              | 23-16(8 bits) | 15-0(16 bits) |
- | -1                 | TYPE           | (unused/reserved)  | MODULE TYPE    | ERROR CODE    |
+ | -1                 | TYPE           | (unused/reserved)  | MODULE TYPE   | ERROR CODE    |
  \endverbatim
  *
  * The error status value range for each error type is as follows:\n


### PR DESCRIPTION
### Description

User uses of `MBED_MAKE_ERROR` assemble a new error that gets its bottom 16 bits from an existing negative 32-bit error code. This led to undefined behaviour when `<<` was used on it - even though it was a shift by zero!

Avoid the undefined behaviour warning from Clang by masking before shifting.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@deepakvenugopal, @SenRamakri 