### PR TITLE
Clean up ARM toolchains from get_mbed_official_release()

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -26,6 +26,7 @@ from shutil import rmtree
 from os.path import join, exists, dirname, basename, abspath, normpath, splitext
 from os.path import relpath
 from os import linesep, remove, makedirs
+from copy import copy
 from time import time
 from json import load, dump
 from jinja2 import FileSystemLoader
@@ -365,17 +366,13 @@ def transform_release_toolchains(target, version):
     """
     if int(target.build_tools_metadata["version"]) > 0:
         if version == '5':
-            non_arm_toolchains = set(["IAR", "GCC_ARM"])
-            if 'ARMC5' in target.supported_toolchains:
-                result = ["ARMC5"]
-            else:
-                result = ["ARM", "ARMC6"]
-            result.extend(
-                set(target.supported_toolchains).intersection(
-                    non_arm_toolchains
-                )
-            )
-            return result
+            toolchains = copy(target.supported_toolchains)
+
+            if "ARM" in toolchains:
+                toolchains.remove("ARM")
+                toolchains.extend(["ARMC5", "ARMC6"])
+
+            return toolchains
         return target.supported_toolchains
     else:
         if version == '5':


### PR DESCRIPTION
Previously it would return `ARM` for `ARMC5`, which was quite confusing, since supplying `-t ARM` will select either `ARMC5` or `ARMC6` internally. Now it will return `ARMC5` if the targets only supports `ARMC5`, `ARMC5` and `ARMC6` if it supports both, or just `ARMC6` if it only supports `ARMC6`.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@OPpuolitaival - I'd like to double check with you that this won't cause issues or break assumptions in the CI

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
