### PR TITLE
NUC472: Support crash capture for no-XRAM configuration

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
@@ -42,7 +42,10 @@ LR_IROM1 MBED_APP_START  MBED_APP_SIZE  {
    */
   ER_IRAMVEC  AlignExpr(+0, 1024)  EMPTY  VECTOR_SIZE  {  ; Reserve for vectors
   }
-  
+
+  RW_m_crash_data  AlignExpr(+0, 0x100)  EMPTY  0x100  { ; Reserve for crash data storage
+  }
+
   RW_IRAM1  AlignExpr(+0, 16)  {  ; 16 byte-aligned
    .ANY (+RW +ZI)
   }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
@@ -31,6 +31,9 @@ LR_IROM1 MBED_APP_START {
   ER_IRAMVEC AlignExpr(+0, 1024) EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
+  RW_m_crash_data AlignExpr(+0, 0x100) EMPTY 0x100 { ; Reserve for crash data storage
+  }
+
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
    .ANY (+RW +ZI)
   }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_UNSUPPORTED/NUC472.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/TARGET_NU_XRAM_UNSUPPORTED/NUC472.ld
@@ -14,6 +14,7 @@
   #define MBED_BOOT_STACK_SIZE      0x400
 #endif
 
+M_CRASH_DATA_RAM_SIZE = 0x100;
 StackSize = MBED_BOOT_STACK_SIZE;
 
 MEMORY
@@ -132,7 +133,19 @@ SECTIONS
         . += __vector_size;
         PROVIDE(__end_vector_table__ = .);
     } > RAM_INTERN
-    
+
+    .crash_data_ram :
+    {
+        . = ALIGN(8);
+        __CRASH_DATA_RAM__ = .;
+        __CRASH_DATA_RAM_START__ = .; /* Create a global symbol at data start */
+        KEEP(*(.keep.crash_data_ram))
+        *(.m_crash_data_ram)     /* This is a user defined section */
+        . += M_CRASH_DATA_RAM_SIZE;
+        . = ALIGN(8);
+        __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+    } > RAM_INTERN
+
     .data :
     {
         PROVIDE( __etext = LOADADDR(.data) );

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
@@ -10,7 +10,9 @@ define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000 - 1;
+define symbol __ICFEDIT_region_IRAM_end__   = 0x2000FF00 - 1;
+define symbol __region_CRASH_DATA_RAM_start__   = 0x2000FF00;
+define symbol __region_CRASH_DATA_RAM_end__     = 0x20010000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_heap__   = 0x8000;
@@ -18,8 +20,13 @@ define symbol __ICFEDIT_size_heap__   = 0x8000;
 
 
 define memory mem with size = 4G;
-define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
-define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
+define region ROM_region            = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
+define region IRAM_region           = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
+define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
+
+/* Define Crash Data Symbols */
+define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
+define exported symbol __CRASH_DATA_RAM_END__   = __region_CRASH_DATA_RAM_end__;
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };


### PR DESCRIPTION
### Description

This PR is supplement of #10349. In #10349, crash capture feature is added on NUMAKER_PFM_NUC472 target, but just for XRAM-enabled configuration. This PR adds support also for XRAM-disabled configuration.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
