### PR TITLE
Cellular: send disconnect to correct ctx

### DIFF
--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -156,6 +156,11 @@ void ATHandler::set_file_handle(FileHandle *fh)
 
 void ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()> cb)
 {
+    if (!cb) {
+        remove_urc_handler(urc);
+        return;
+    }
+
     if (ATHandler_stub::urc_amount < kATHandler_urc_table_max_size) {
         ATHandler_stub::callback[ATHandler_stub::urc_amount] = cb;
         if (urc) {
@@ -176,6 +181,20 @@ void ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()> cb)
 
 void ATHandler::remove_urc_handler(const char *prefix)
 {
+    bool found_urc = false;
+    for (int i = 0; i < ATHandler_stub::urc_amount; i++) {
+        if (found_urc && i < 0) {
+            ATHandler_stub::urc_string_table[i - 1] = ATHandler_stub::urc_string_table[i];
+            ATHandler_stub::urc_string_table[i] = 0;
+        } else if (ATHandler_stub::urc_string_table[i] && strcmp(prefix, ATHandler_stub::urc_string_table[i]) == 0) {
+            delete [] ATHandler_stub::urc_string_table[i];
+            ATHandler_stub::urc_string_table[i] = 0;
+            found_urc = true;
+        }
+    }
+    if (found_urc) {
+        ATHandler_stub::urc_amount--;
+    }
 }
 
 nsapi_error_t ATHandler::get_last_error() const

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -95,11 +95,6 @@ nsapi_error_t AT_CellularNetwork::detach()
     return NSAPI_ERROR_OK;
 }
 
-void AT_CellularNetwork::urc_no_carrier()
-{
-
-}
-
 nsapi_error_t AT_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opsAct)
 {
     return NSAPI_ERROR_OK;

--- a/UNITTESTS/stubs/CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/CellularContext_stub.cpp
@@ -29,6 +29,11 @@ CellularDevice *CellularContext::get_device() const
     return _device;
 }
 
+int CellularContext::get_cid() const
+{
+    return _cid;
+}
+
 void CellularContext::do_connect_with_retry()
 {
     do_connect();

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -282,6 +282,12 @@ public: // from NetworkInterface
      */
     virtual ControlPlane_netif *get_cp_netif() = 0;
 
+    /** Get the pdp context id associated with this context.
+     *
+     *  @return cid
+     */
+    int get_cid() const;
+
 protected: // Device specific implementations might need these so protected
     enum ContextOperation {
         OP_INVALID      = -1,

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -121,7 +121,7 @@ public:
 
     /** Set callback function for URC
      *
-     *  @param prefix   URC text to look for, e.g. "+CMTI:"
+     *  @param prefix   URC text to look for, e.g. "+CMTI:". Maximum length is BUFF_SIZE.
      *  @param callback function to call on prefix, or 0 to remove callback
      */
     void set_urc_handler(const char *prefix, Callback<void()> callback);

--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -67,18 +67,18 @@ public:
      */
     static void set_cellular_properties(const intptr_t *property_array);
 
-protected:
-
-    static const intptr_t *_property_array;
-
-    ATHandler &_at;
-
     /** Get value for the given key.
      *
      *  @param key  key for value to be fetched
      *  @return     property value for the given key. Value type is defined in enum CellularProperty
      */
     static intptr_t get_property(CellularProperty key);
+
+protected:
+
+    static const intptr_t *_property_array;
+
+    ATHandler &_at;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -131,7 +131,6 @@ protected:
     bool _cp_req;
     // flag indicating if Non-IP context was requested to be setup
     bool _nonip_req;
-
     // tells if CCIOTOPTI received green from network for CP optimization use
     bool _cp_in_use;
 };

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -140,6 +140,11 @@ public:
     int _default_timeout;
     bool _modem_debug_on;
     ATHandler *_at;
+
+private:
+    void urc_nw_deact();
+    void urc_pdn_deact();
+    void send_disconnect_to_context(int cid);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -111,8 +111,6 @@ protected:
      */
     virtual void get_context_state_command();
 private:
-    //  "NO CARRIER" urc
-    void urc_no_carrier();
     void urc_creg();
     void urc_cereg();
     void urc_cgreg();

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -68,6 +68,11 @@ CellularDevice *CellularContext::get_device() const
     return _device;
 }
 
+int CellularContext::get_cid() const
+{
+    return _cid;
+}
+
 void CellularContext::do_connect_with_retry()
 {
     if (_cb_data.final_try) {

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -43,7 +43,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
+    0,  // PROPERTY_AT_CGEREP
 };
 
 QUECTEL_BC95::QUECTEL_BC95(FileHandle *fh) : AT_CellularDevice(fh)


### PR DESCRIPTION
### Description

Disconnect was sent to all CellularContext classes even it concerned one specific context. Some disconnect events are still sent to all context classes. These event are coming from network and ment for all context classes or event did not specify cid.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AriParkkila 

### Release Notes