### PR TITLE
Fix warnings on PSA secure builds

### DIFF
--- a/TESTS/psa/spm_client/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_client/COMPONENT_NSPE/main.cpp
@@ -27,8 +27,8 @@
 #include "psa_manifest/sid.h"
 
 #if defined(TARGET_TFM)
-#include "psa/service.h"
 #define MBED_CONF_SPM_IPC_MAX_NUM_OF_CHANNELS TFM_CONN_HANDLE_MAX_NUM
+#define PSA_MAX_IOVEC 4
 #endif
 
 using namespace utest::v1;

--- a/TESTS/psa/spm_server/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_server/COMPONENT_NSPE/main.cpp
@@ -28,7 +28,7 @@
 #include "psa_manifest/sid.h"
 
 #if defined(TARGET_TFM)
-#include "psa/service.h"
+#define PSA_MAX_IOVEC 4
 #endif
 
 using namespace utest::v1;

--- a/TESTS/psa/spm_smoke/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/spm_smoke/COMPONENT_NSPE/main.cpp
@@ -29,7 +29,7 @@
 #include "psa_manifest/sid.h"
 
 #if defined(TARGET_TFM)
-#include "psa/service.h"
+#define PSA_MAX_IOVEC 4
 #endif
 
 using namespace utest::v1;

--- a/components/TARGET_PSA/inc/psa/service.h
+++ b/components/TARGET_PSA/inc/psa/service.h
@@ -18,6 +18,7 @@
 #if defined(TARGET_TFM)
 
 #include "interface/include/psa_service.h"
+#include "secure_fw/core/ipc/include/tfm_utils.h"
 #define SPM_PANIC(format, ...) tfm_panic()
 
 #elif defined(TARGET_MBED_SPM)

--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/attest_iat_claims_loader.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/attest_iat_claims_loader.c
@@ -17,6 +17,7 @@
 */
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
 #include "tfm_plat_boot_seed.h"
@@ -154,7 +155,7 @@ enum psa_attest_err_t attest_get_caller_client_id(int32_t *caller_id)
 /* Boot seed data is part of bootloader status*/
 enum tfm_plat_err_t tfm_plat_get_boot_seed(uint32_t size, uint8_t *buf)
 {
-    return PSA_ATTEST_ERR_CLAIM_UNAVAILABLE;
+    return (enum tfm_plat_err_t)PSA_ATTEST_ERR_CLAIM_UNAVAILABLE;
 }
 
 /**
@@ -181,13 +182,13 @@ enum tfm_plat_err_t tfm_plat_get_instance_id(uint32_t *size, uint8_t *buf)
 /* HW version data is part of bootloader status*/
 enum tfm_plat_err_t tfm_plat_get_hw_version(uint32_t *size, uint8_t *buf)
 {
-    return PSA_ATTEST_ERR_CLAIM_UNAVAILABLE;
+    return (enum tfm_plat_err_t)PSA_ATTEST_ERR_CLAIM_UNAVAILABLE;
 }
 
 enum tfm_plat_err_t tfm_plat_get_implementation_id(uint32_t *size, uint8_t *buf)
 {
     memcpy(buf, impl_id_data, *size);
-    return PSA_ATTEST_ERR_SUCCESS;
+    return (enum tfm_plat_err_t)PSA_ATTEST_ERR_SUCCESS;
 }
 
 /* Temporary Implementation of security lifecycle data: mandatory claim.

--- a/components/TARGET_PSA/services/attestation/COMPONENT_SPE/psa_attestation_partition.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_SPE/psa_attestation_partition.c
@@ -25,6 +25,7 @@
 #include "psa_attest_inject_key.h"
 #include "psa_inject_attestation_key_impl.h"
 #include "attestation.h"
+#include <stdlib.h>
 #include <string.h>
 #include "psa/crypto.h"
 

--- a/components/TARGET_PSA/services/storage/its/COMPONENT_SPE/its_partition.c
+++ b/components/TARGET_PSA/services/storage/its/COMPONENT_SPE/its_partition.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include "psa/client.h"
 #include "psa/service.h"
@@ -25,6 +26,8 @@
 
 #if defined(TARGET_MBED_SPM)
 #include "kv_config.h"
+#else
+int kv_init_storage_config();
 #endif
 
 #ifdef   __cplusplus


### PR DESCRIPTION
### Description

* Add `#include` where needed 
* Cast where needed
* Remove `#include psa/service.h` from NSPE in PSA tests

Fix most of the warnings from #10396
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@0xc0170 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
