### PR TITLE
Cellular: Added BG96 handling for socket closing URC

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -20,6 +20,12 @@
 
 using namespace mbed;
 
+const char *QIURC_RECV = "recv";
+const uint8_t QIURC_RECV_LENGTH = 4;
+const char *QIURC_CLOSED = "closed";
+const uint8_t QIURC_CLOSED_LENGTH = 6;
+const uint8_t MAX_QIURC_LENGTH = QIURC_CLOSED_LENGTH;
+
 QUECTEL_BG96_CellularStack::QUECTEL_BG96_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type) : AT_CellularStack(atHandler, cid, stack_type)
 {
     _at.set_urc_handler("+QIURC:", mbed::Callback<void()>(this, &QUECTEL_BG96_CellularStack::urc_qiurc));
@@ -110,20 +116,30 @@ nsapi_error_t QUECTEL_BG96_CellularStack::socket_connect(nsapi_socket_t handle, 
 
 void QUECTEL_BG96_CellularStack::urc_qiurc()
 {
-    int sock_id = 0;
-
+    char urc_string[MAX_QIURC_LENGTH + 1];
     _at.lock();
-    (void) _at.skip_param();
-    sock_id = _at.read_int();
-    _at.unlock();
+    const int urc_string_length = _at.read_string(urc_string, sizeof(urc_string));
+    const int sock_id = _at.read_int();
+    const nsapi_error_t err = _at.unlock_return_error();
 
-    for (int i = 0; i < get_max_socket_count(); i++) {
-        CellularSocket *sock = _socket[i];
-        if (sock && sock->id == sock_id) {
+    if (err != NSAPI_ERROR_OK) {
+        return;
+    }
+
+    bool recv = strcmp(urc_string, "recv") == 0;
+    bool closed = strcmp(urc_string, "closed") == 0;
+
+    CellularSocket *sock = find_socket(sock_id);
+    if (sock) {
+        if (closed) {
+            tr_error("Socket closed %d", sock_id);
+            sock->closed = true;
+        }
+
+        if (recv || closed) {
             if (sock->_cb) {
                 sock->_cb(sock->_data);
             }
-            break;
         }
     }
 }


### PR DESCRIPTION
### Description
BG96 wasn't handling URC for socket closing at all. Now socket closed flag is set on the arriving of such URC. Also, if the socket was closed but closed flag not yet set at the moment a socket sending/receiving was issued, the socket would get stuck waiting for data. To prevent this, socket event is called also when socket close URC arrives.

### Pull request type
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change