### PR TITLE
FUTURE_SEQUANA: Fix flash_api bug introduced with e16d2d81d9

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/flash_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/flash_api.c
@@ -48,7 +48,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, 
 {
     (void)(obj);
     int32_t status = 0;
-    static uint8_t prog_buf[CY_FLASH_SIZEOF_ROW];
+    static uint32_t prog_buf[CY_FLASH_SIZEOF_ROW / sizeof(uint32_t)];
     while (size) {
         uint32_t offset = address % CY_FLASH_SIZEOF_ROW;
         uint32_t chunk_size;
@@ -59,7 +59,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, 
         }
         uint32_t row_address = address / CY_FLASH_SIZEOF_ROW * CY_FLASH_SIZEOF_ROW;
         memcpy(prog_buf, (const void *)row_address, CY_FLASH_SIZEOF_ROW);
-        memcpy(prog_buf + offset, data, chunk_size);
+        memcpy((uint8_t *)prog_buf + offset, data, chunk_size);
 
         if (Cy_Flash_ProgramRow(row_address, (const uint32_t *)prog_buf) != CY_FLASH_DRV_SUCCESS) {
             status = -1;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

PDL Flash API requires that the data buffer is 32-bit aligned, otherwise
programming can hang. Buffer declared as uint8_t array is not always
properly aligned, e.g. with gcc 6 when -Os option is used.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
