### PR TITLE
suppress coverity error

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack_adaptation/wsf_os.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack_adaptation/wsf_os.c
@@ -121,7 +121,7 @@ void WsfTaskUnlock(void)
 void WsfSetEvent(wsfHandlerId_t handlerId, wsfEventMask_t event)
 {
   WSF_CS_INIT(cs);
-
+  // coverity[CONSTANT_EXPRESSION_RESULT]
   WSF_ASSERT(WSF_HANDLER_FROM_ID(handlerId) < WSF_MAX_HANDLERS);
 
   WSF_TRACE_INFO2("WsfSetEvent handlerId:%u event:%u", handlerId, event);


### PR DESCRIPTION
### Description

This is only a comment that suppresses a coverity error. Constant may change in the future and that is what the check is for so complaining about it being a pointless comparison now is incorrect.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

no change
