### PR TITLE
CordioGattServer: reset settings variable before ANDing the properties to it

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -321,8 +321,10 @@ ble_error_t GattServer::insert_characteristic_value_attribute(
     memset(attribute_it->pValue + *attribute_it->pLen, 0, attribute_it->maxLen - *attribute_it->pLen);
 
     // Set value attribute settings
+    attribute_it->settings = 0;
+
     if (properties & READ_PROPERTY) {
-        attribute_it->settings = ATTS_SET_READ_CBACK;
+        attribute_it->settings |= ATTS_SET_READ_CBACK;
     }
     if (properties & WRITABLE_PROPERTIES) {
         attribute_it->settings |= ATTS_SET_WRITE_CBACK;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

We had some strange behaviour with a characteristic that would sometimes work correctly and sometimes it would not work at all. After a lot of debugging I found out that a variable would not be reset before use, hence the PR.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change


