### PR TITLE
FUTURE_SEQUANA: Clean up "unused variable" compiler warnings

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_ctdac.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_ctdac.h
@@ -928,6 +928,7 @@ __STATIC_INLINE void Cy_CTDAC_ClearInterrupt(CTDAC_Type *base)
 
     /* Dummy read for buffered writes. */
     unused = base->INTR;
+    (void)unused;
 }
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_gpio.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_gpio.h
@@ -1577,6 +1577,7 @@ __STATIC_INLINE void Cy_GPIO_ClearInterrupt(GPIO_PRT_Type* base, uint32_t pinNum
 
     /* This read ensures that the initial write has been flushed out to the hardware */
     unused = base->INTR;
+    (void)unused;
 }
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_ipc_drv.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_ipc_drv.h
@@ -622,6 +622,7 @@ __STATIC_INLINE void  Cy_IPC_Drv_ClearInterrupt(IPC_INTR_STRUCT_Type* base, uint
     base->INTR =  _VAL2FLD(IPC_INTR_STRUCT_INTR_NOTIFY,  ipcNotifyMask) |
                   _VAL2FLD(IPC_INTR_STRUCT_INTR_RELEASE, ipcReleaseMask);
     unused = base->INTR;  /* Read the register to flush the cache */
+    (void)unused;
 }
 
 /** \} group_ipc_functions */

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_sar.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_sar.h
@@ -1564,6 +1564,7 @@ __STATIC_INLINE void Cy_SAR_ClearInterrupt(SAR_Type *base, uint32_t intrMask)
 
     /* Dummy read for buffered writes. */
     unused = base->INTR;
+    (void)unused;
 }
 
 /*******************************************************************************
@@ -1720,6 +1721,7 @@ __STATIC_INLINE void Cy_SAR_ClearRangeInterrupt(SAR_Type *base, uint32_t chanMas
 
     /* Dummy read for buffered writes. */
     unused = base->RANGE_INTR;
+    (void)unused;
 }
 
 /*******************************************************************************
@@ -1863,6 +1865,7 @@ __STATIC_INLINE void Cy_SAR_ClearSatInterrupt(SAR_Type *base, uint32_t chanMask)
 
     /* Dummy read for buffered writes. */
     unused = base->SATURATE_INTR;
+    (void)unused;
 }
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_scb_common.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_scb_common.h
@@ -666,6 +666,7 @@ __STATIC_INLINE void Cy_SCB_ClearRxFifo(CySCB_Type* base)
     base->RX_FIFO_CTRL &= (uint32_t) ~SCB_RX_FIFO_CTRL_CLEAR_Msk;
 
     unused = base->RX_FIFO_CTRL;
+    (void)unused;
 }
 
 
@@ -793,6 +794,7 @@ __STATIC_INLINE void Cy_SCB_ClearTxFifo(CySCB_Type *base)
     base->TX_FIFO_CTRL &= (uint32_t) ~SCB_TX_FIFO_CTRL_CLEAR_Msk;
 
     unused = base->TX_FIFO_CTRL;
+    (void)unused;
 }
 
 
@@ -968,6 +970,7 @@ __STATIC_INLINE void Cy_SCB_ClearRxInterrupt(CySCB_Type *base, uint32_t interrup
 
     base->INTR_RX = interruptMask;
     unused = base->INTR_RX;
+    (void)unused;
 }
 
 
@@ -1116,6 +1119,7 @@ __STATIC_INLINE void Cy_SCB_ClearTxInterrupt(CySCB_Type *base, uint32_t interrup
 
     base->INTR_TX = interruptMask;
     unused = base->INTR_TX;
+    (void)unused;
 }
 
 
@@ -1255,6 +1259,7 @@ __STATIC_INLINE void Cy_SCB_ClearMasterInterrupt(CySCB_Type *base, uint32_t inte
 
     base->INTR_M = interruptMask;
     unused = base->INTR_M;
+    (void)unused;
 }
 
 
@@ -1396,6 +1401,7 @@ __STATIC_INLINE void Cy_SCB_ClearSlaveInterrupt(CySCB_Type *base, uint32_t inter
 
     base->INTR_S = interruptMask;
     unused = base->INTR_S;
+    (void)unused;
 }
 
 
@@ -1534,6 +1540,7 @@ __STATIC_INLINE void Cy_SCB_ClearI2CInterrupt(CySCB_Type *base, uint32_t interru
 
     base->INTR_I2C_EC = interruptMask;
     unused = base->INTR_I2C_EC;
+    (void)unused;
 }
 
 
@@ -1649,6 +1656,7 @@ __STATIC_INLINE void Cy_SCB_ClearSpiInterrupt(CySCB_Type *base, uint32_t interru
 
     base->INTR_SPI_EC = interruptMask;
     unused = base->INTR_SPI_EC;
+    (void)unused;
 }
 
 /** \cond INTERNAL */
@@ -1734,6 +1742,7 @@ __STATIC_INLINE void Cy_SCB_FwBlockReset(CySCB_Type *base)
     base->CTRL |= (uint32_t)  SCB_CTRL_ENABLED_Msk;
 
     unused = base->CTRL;
+    (void)unused;
 }
 
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_sysclk.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_sysclk.h
@@ -2085,6 +2085,7 @@ __STATIC_INLINE cy_en_sysclk_status_t
                             _VAL2FLD(PERI_DIV_CMD_TYPE_SEL, dividerType) |
                             _VAL2FLD(PERI_DIV_CMD_DIV_SEL,  dividerNum);
             unused = PERI->DIV_CMD; /* dummy read to handle buffered writes */
+            (void)unused;
             retval = CY_SYSCLK_SUCCESS;
         }
     }

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_tcpwm.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/device/drivers/include/cy_tcpwm.h
@@ -539,6 +539,7 @@ __STATIC_INLINE void Cy_TCPWM_ClearInterrupt(TCPWM_Type *base, uint32_t cntNum, 
 
     base->CNT[cntNum].INTR = source;
     unused = base->CNT[cntNum].INTR;
+    (void)unused;
 }
 
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Clean up compiler warnings coming from PDL read-out of peripheral interrupt status registers.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
