### PR TITLE
pass on asm flags for uVision project

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -175,7 +175,7 @@ class Uvision(Exporter):
             '--cpreproc --cpreproc_opts=-D__ASSERT_MSG,' +
             ",".join("-D{}".format(s) for s in
                      self.toolchain.get_symbols(for_asm=True)))
-        flags['asm_flags'] = asm_flag_string
+        flags['asm_flags'] = "{} {}".format(" ".join(self.toolchain.flags['asm']), asm_flag_string)
 
         config_header = self.config_header_ref
         config_option = self.toolchain.get_config_option(config_header.name)


### PR DESCRIPTION
### Description

This should fix Keil uVision + armc6 build failure issue https://github.com/ARMmbed/mbed-os/issues/10423 with PR https://github.com/ARMmbed/mbed-os/pull/10390/ .

Currently, asm flags are not passed on Uvision exporter 
https://github.com/ARMmbed/mbed-os/blob/0b7d9af4dd104e57907f526ff963aa09e7018ffa/tools/toolchains/arm.py#L593-L594
### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@bridadan @SenRamakri @kjbracey-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
