### PR TITLE
UDPSOCKET_ECHOTEST fails if a packet of every size was not sent

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -785,9 +785,9 @@ Verify working of different packet sizes.
 
 **Expected result:**
 
-All sendto() calls should return the packet size. All recvfrom() calls
-should return the same sized packet that was send with same content.
-Calculate packet loss rate, maximum tolerated packet loss rate is 30%
+At least one sendto() call of every size should return the packet size.
+Errors returned from recvfrom() calls are tolerated. 
+Calculate packet loss rate, maximum tolerated packet loss rate is 30%.
 
 
 
@@ -819,11 +819,9 @@ mode
 
 **Expected result:**
 
-All sendto() calls should return the packet size. All recvfrom() calls
-should return the same sized packet that was send with same content or
-NSAPI_ERROR_WOULD_BLOCK.
-
-Calculate packet loss rate, maximum tolerated packet loss rate is 30%
+At least one sendto() call of every size should return the packet size.
+Errors returned from recvfrom() calls are tolerated. 
+Calculate packet loss rate, maximum tolerated packet loss rate is 30%.
 
 
 


### PR DESCRIPTION
### Description

So far the UDPSOCKET_ECHOTEST could report success if no packets were sent. The only trace of problems was visible in the logs.
It could also report pass if the device was able to send a lot of small packets, but consistently failed with larger ones.
We want to make sure that at least one packet of every size gets sent at least once, so we check if the number of sent packets increased after every loop (it can increase by 1, 2 or 3, depending on how many times the retry loop executes.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 