### PR TITLE
Set compilers to C++14 and C11

### DIFF
--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/MbedTester.cpp
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/MbedTester.cpp
@@ -185,9 +185,9 @@ public:
 
         uint8_t cmd[] = {
             0x0B,                       // Fast read
-            (addr >> (2 * 8)) & 0xFF,   // Address
-            (addr >> (1 * 8)) & 0xFF,
-            (addr >> (0 * 8)) & 0xFF,
+            (uint8_t)(addr >> (2 * 8)), // Address
+            (uint8_t)(addr >> (1 * 8)),
+            (uint8_t)(addr >> (0 * 8)),
             0x00                        // Dummy
         };
         _write((char *)cmd, sizeof(cmd), NULL, 0);

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_SOFTDEVICE/TARGET_NRF52/source/nRF5xGap.cpp
@@ -746,8 +746,8 @@ ble_error_t nRF5xGap::setPhy_(
 #else
     // TODO handle coded symbol once supported by the softdevice.
     ble_gap_phys_t gap_phys = {
-        txPhys? txPhys->value() : 0,
-        rxPhys? rxPhys->value() : 0
+        txPhys? txPhys->value() : uint8_t(0),
+        rxPhys? rxPhys->value() : uint8_t(0)
     };
 
     uint32_t err = sd_ble_gap_phy_update(connection, &gap_phys);
@@ -1662,8 +1662,8 @@ void nRF5xGap::on_phy_update_request(
     const ble_gap_evt_phy_update_request_t& evt
 ) {
     ble_gap_phys_t phys = {
-        _preferred_tx_phys & evt.peer_preferred_phys.tx_phys,
-        _preferred_rx_phys & evt.peer_preferred_phys.rx_phys
+        static_cast<uint8_t>(_preferred_tx_phys & evt.peer_preferred_phys.tx_phys),
+        static_cast<uint8_t>(_preferred_rx_phys & evt.peer_preferred_phys.rx_phys)
     };
 
     if (!phys.tx_phys) {

--- a/tools/export/coide/arch_max.coproj.tmpl
+++ b/tools/export/coide/arch_max.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/arch_pro.coproj.tmpl
+++ b/tools/export/coide/arch_pro.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Includepaths>
           {% for path in include_paths %} <Includepath path="{{path}}"/> {% endfor %}
         </Includepaths>

--- a/tools/export/coide/disco_f051r8.coproj.tmpl
+++ b/tools/export/coide/disco_f051r8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -84,7 +84,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_f100rb.coproj.tmpl
+++ b/tools/export/coide/disco_f100rb.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -84,7 +84,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_f303vc.coproj.tmpl
+++ b/tools/export/coide/disco_f303vc.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_f334c8.coproj.tmpl
+++ b/tools/export/coide/disco_f334c8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_f401vc.coproj.tmpl
+++ b/tools/export/coide/disco_f401vc.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -85,7 +85,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_f407vg.coproj.tmpl
+++ b/tools/export/coide/disco_f407vg.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_f429zi.coproj.tmpl
+++ b/tools/export/coide/disco_f429zi.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/disco_l053c8.coproj.tmpl
+++ b/tools/export/coide/disco_l053c8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -84,7 +84,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/kl05z.coproj.tmpl
+++ b/tools/export/coide/kl05z.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Includepaths>
           {% for path in include_paths %} <Includepath path="{{path}}"/> {% endfor %}
         </Includepaths>

--- a/tools/export/coide/kl25z.coproj.tmpl
+++ b/tools/export/coide/kl25z.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Includepaths>
           {% for path in include_paths %} <Includepath path="{{path}}"/> {% endfor %}
         </Includepaths>

--- a/tools/export/coide/lpc1768.coproj.tmpl
+++ b/tools/export/coide/lpc1768.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Includepaths>
           {% for path in include_paths %} <Includepath path="{{path}}"/> {% endfor %}
         </Includepaths>

--- a/tools/export/coide/mote_l152rc.coproj.tmpl
+++ b/tools/export/coide/mote_l152rc.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/mts_mdot_f405rg.coproj.tmpl
+++ b/tools/export/coide/mts_mdot_f405rg.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/mts_mdot_f411re.coproj.tmpl
+++ b/tools/export/coide/mts_mdot_f411re.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f030r8.coproj.tmpl
+++ b/tools/export/coide/nucleo_f030r8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f042k6.coproj.tmpl
+++ b/tools/export/coide/nucleo_f042k6.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f070rb.coproj.tmpl
+++ b/tools/export/coide/nucleo_f070rb.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f072rb.coproj.tmpl
+++ b/tools/export/coide/nucleo_f072rb.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f091rc.coproj.tmpl
+++ b/tools/export/coide/nucleo_f091rc.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f103rb.coproj.tmpl
+++ b/tools/export/coide/nucleo_f103rb.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -84,7 +84,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f302r8.coproj.tmpl
+++ b/tools/export/coide/nucleo_f302r8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f303re.coproj.tmpl
+++ b/tools/export/coide/nucleo_f303re.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f334r8.coproj.tmpl
+++ b/tools/export/coide/nucleo_f334r8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f401re.coproj.tmpl
+++ b/tools/export/coide/nucleo_f401re.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f410rb.coproj.tmpl
+++ b/tools/export/coide/nucleo_f410rb.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f411re.coproj.tmpl
+++ b/tools/export/coide/nucleo_f411re.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_f446re.coproj.tmpl
+++ b/tools/export/coide/nucleo_f446re.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -84,7 +84,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_l053r8.coproj.tmpl
+++ b/tools/export/coide/nucleo_l053r8.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>
@@ -84,7 +84,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="0"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nucleo_l152re.coproj.tmpl
+++ b/tools/export/coide/nucleo_l152re.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/nz32_sc151.coproj.tmpl
+++ b/tools/export/coide/nz32_sc151.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Option name="FPU" value="1"/>
         <Option name="SupportCPlusplus" value="1"/>
         <Includepaths>

--- a/tools/export/coide/ublox_c027.coproj.tmpl
+++ b/tools/export/coide/ublox_c027.coproj.tmpl
@@ -6,7 +6,7 @@
       <Compile>
         <Option name="OptimizationLevel" value="4"/>
         <Option name="UseFPU" value="0"/>
-        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++98"/>
+        <Option name="UserEditCompiler" value="-fno-common; -fmessage-length=0; -Wall; -fno-strict-aliasing; -fno-rtti; -fno-exceptions; -ffunction-sections; -fdata-sections; -std=gnu++14"/>
         <Includepaths>
           {% for path in include_paths %} <Includepath path="{{path}}"/> {% endfor %}
         </Includepaths>

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -288,6 +288,34 @@ class Uvision(Exporter):
         ctx['fputype'] = self.format_fpu(ctx['device'].core)
         ctx['armc6'] = int(self.TOOLCHAIN is 'ARMC6')
         ctx['toolchain_name'] = self.TOOLCHAIN_NAME
+
+        std = [flag for flag in self.flags['c_flags'] if flag.startswith("-std=")]
+        if len(std) >= 1:
+            std = std[-1][len('-std='):]
+        else:
+            std = None
+        c_std = {
+            'c89': 1, 'gnu89': 2,
+            'c90': 1, 'gnu90': 2,
+            'c99': 3, 'gnu99': 4,
+            'c11': 5, 'gnu11': 6,
+        }
+        ctx['v6_lang'] = c_std.get(std, 0)
+
+        std = [flag for flag in self.flags['cxx_flags'] if flag.startswith("-std=")]
+        if len(std) >= 1:
+            std = std[-1][len('-std='):]
+        else:
+            std = None
+        cpp_std = {
+            'c++98': 1, 'gnu++98': 2,
+            'c++03': 5, 'gnu++03': 2, # UVision 5.27.1.0 does not support gnu++03 - fall back to gnu++98
+            'c++11': 3, 'gnu++11': 4,
+            'c++14': 6, 'gnu++14': 4, # UVision 5.27.1.0 does not support gnu++14 - should be able to get it as compiler default, but that doesn't work as documented and requests gnu++98. So fall back to gnu++11
+            'c++17': 6, 'gnu++17': 4, # UVision 5.27.1.0 does not support c++17/gnu++17 - fall back to c++14/gnu++11
+        }
+        ctx['v6_lang_p'] = cpp_std.get(std, 0)
+
         ctx.update(self.format_flags())
         self.gen_file(
             'uvision/uvision.tmpl', ctx, self.project_name + ".uvprojx"

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -183,7 +183,7 @@ class Uvision(Exporter):
             flags['c_flags'] + flags['cxx_flags'] + flags['common_flags']
         )
         in_template = set(
-            ["--no_vla", "--cpp", "--c99", "-MMD"] + config_option
+            ["--no_vla", "--cpp", "--cpp11", "--c99", "-MMD"] + config_option
         )
 
         def valid_flag(x):

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -369,8 +369,8 @@
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <useXO>0</useXO>
-            <v6Lang>4</v6Lang>
-            <v6LangP>2</v6LangP>
+            <v6Lang>{{v6_lang}}</v6Lang>
+            <v6LangP>{{v6_lang_p}}</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
             <v6Lto>0</v6Lto>

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -8,8 +8,8 @@
                    "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG",
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
-        "c": ["-std=gnu99"],
-        "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
+        "c": ["-std=gnu11"],
+        "cxx": ["-std=gnu++14", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
@@ -23,8 +23,8 @@
                    "-fshort-enums", "-fshort-wchar", "-DMBED_DEBUG",
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
-        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
-        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "c": ["-D__ASSERT_MSG", "-std=gnu11"],
+        "cxx": ["-fno-rtti", "-std=gnu++14"],
         "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
     },
     "ARM": {
@@ -34,7 +34,7 @@
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
         "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "uARM": {
@@ -45,7 +45,7 @@
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
         "ld": ["--library_type=microlib"]
     },
     "IAR": {

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -18,6 +18,7 @@
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-Wno-reserved-user-defined-literal",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DMBED_DEBUG",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -17,6 +17,7 @@
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-Wno-reserved-user-defined-literal",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DMBED_TRAP_ERRORS_ENABLED=1"],

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -7,8 +7,8 @@
                    "-MMD", "-fno-delete-null-pointer-checks",
                    "-fomit-frame-pointer", "-Os", "-g1", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
-        "c": ["-std=gnu99"],
-        "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
+        "c": ["-std=gnu11"],
+        "cxx": ["-std=gnu++14", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
@@ -21,8 +21,8 @@
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
-        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
-        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "c": ["-D__ASSERT_MSG", "-std=gnu11"],
+        "cxx": ["-fno-rtti", "-std=gnu++14"],
         "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
     },
     "ARM": {
@@ -31,7 +31,7 @@
                    "--multibyte_chars", "-O3", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
         "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "uARM": {
@@ -42,7 +42,7 @@
                     "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
         "ld": ["--library_type=microlib"]
     },
     "IAR": {

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -17,6 +17,7 @@
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-Wno-reserved-user-defined-literal",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DNDEBUG"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -7,8 +7,8 @@
                    "-MMD", "-fno-delete-null-pointer-checks",
                    "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g1"],
         "asm": ["-x", "assembler-with-cpp"],
-        "c": ["-std=gnu99"],
-        "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
+        "c": ["-std=gnu11"],
+        "cxx": ["-std=gnu++14", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
@@ -21,8 +21,8 @@
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DNDEBUG"],
         "asm": [],
-        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
-        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "c": ["-D__ASSERT_MSG", "-std=gnu11"],
+        "cxx": ["-fno-rtti", "-std=gnu++14"],
         "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
     },
     "ARM": {
@@ -31,7 +31,7 @@
                    "--multibyte_chars", "-O3", "-DNDEBUG"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
         "ld": ["--show_full_path",  "--keep=os_cb_sections"]
     },
     "uARM": {
@@ -41,7 +41,7 @@
                    "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DNDEBUG"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
         "ld": ["--library_type=microlib"]
     },
     "IAR": {


### PR DESCRIPTION
### Description

* ARMC6 and GCC are set to C++14 and C11.
* ARMC5 is set to C++11 and C99, as it's the highest it can offer.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [X] Breaking change

### Release Notes

* GCC and ARM toolchain profiles now select C++14 and C11, matching IAR, and these are the tested profiles. Codebase in this release should still work if profiles are set to C++98 and C99, although this is no longer tested.

### Migration notes

As the default profiles now select C++14 and C11 for GCC and ARM toolchains, some applications may fail to compile because they use constructs that were valid in C++98, but not in C++14.

IAR 8 has always operated in C++14/C11 mode, so there are no new changes for IAR users who switched to IAR 8 for Mbed OS 5.12, but these notes apply for users migrating from older Mbed OS versions that used IAR 7.

#### Common compatibility issues

* A space is required when a macro follows a string literal, for example in C99-style `printf` formats
```C++
    uint32_t val;
    printf("val = %"PRIu32, val); // Not valid in C++11
    printf("val = %" PRIu32, val); // OK
```
Without the space, C++11 interprets it as being a request for a user-defined "PRIu32-type" string literal.

* Initializer lists cannot have implicit narrowing conversions:
```C++
    uint32_t x;
    uint8_t array1[] = { x }; // Not valid in C++11
    uint8_t array2[] = { 0xffff }; // Not valid in C++11
    uint8_t array3[] = { x & 0xff }; // Not valid in C++11
    uint8_t array4[] = { (uint8_t) x }; // OK
    uint8_t array5[] = { static_cast<uint8_t>(x) }; // OK
    uint8_t array6[] = { 0xffff & 0xff }; // OK (because it's a compile-time constant that fits)
```
These changes should be easy to make to existing codebases. A guide to other possible breakages in C++11 can be found at https://stackoverflow.com/questions/6399615/what-breaking-changes-are-introduced-in-c11. C++14 and C11 cause few extra issues.

#### Future compatibility issues
* The `register` keyword is deprecated in C++14, and is removed in C++17. Some compilers issue warnings for `register` use in C++14, but this has been temporarily suppressed due to the prevalence of the keyword in target code. C++ code should be updated to remove the keyword as soon as possible - the warning will be reactivated once Mbed OS itself no longer triggers it.

#### Fallback

Mbed OS 5.13 releases should still work if compiled as C++98/C99, although this is not tested - if you have serious application compatibility issues, you should be able to switch the build profile back to the earlier language version as a temporary measure. This is likely to no longer be the case for Mbed OS 5.14.

#### ARM Compiler 5

Note also that ARM Compiler 5 has limited C++11 support and no C++14 or C11 support, and ARM Compiler 5 is no longer tested or officially supported. Nevertheless, ARMC5 builds have not been deliberately broken; ARMC5 build profiles select its C++11 mode in an attempt to match the other toolchains as much as possible, but the limited support may itself cause issues - attempts to check `__cplusplus >= 201103` may activate code that ARMC5 cannot actually compile. Like the other toolchains, the profile can be switched back to C++98 if necessary for now.

Continued ARM C 5 support will limit the adoption of C++11 and C++14 features in the Mbed OS codebase, so it is quite possible that ARM Compiler 5 builds may stop working altogether in an upcoming release.
