### PR TITLE
Cellular: Fix netsocket test and BC95 driver to cope with network busy

### DIFF
--- a/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
@@ -37,18 +37,13 @@ void UDPSOCKET_SENDTO_REPEAT()
     Timer timer;
     int i;
     static const char tx_buffer[] = {'h', 'e', 'l', 'l', 'o'};
-    bool oom_earlier = false; // 2 times in a row -> time to give up
     for (i = 0; i < 100; i++) {
         sent = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
-        if (sent == NSAPI_ERROR_NO_MEMORY) {
-            if (oom_earlier) {
-                break;
-            }
-            oom_earlier = true;
+        if (sent == NSAPI_ERROR_NO_MEMORY || sent == NSAPI_ERROR_BUSY) {
             wait(1);
-            continue;
+            printf("Temporary failure %s\n", sent == NSAPI_ERROR_NO_MEMORY ? "NSAPI_ERROR_NO_MEMORY" : "NSAPI_ERROR_BUSY");
+            continue; // it may recover so keep going
         }
-        oom_earlier = false;
         TEST_ASSERT_EQUAL(sizeof(tx_buffer), sent);
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -214,6 +214,10 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSoc
         return sent_len;
     }
 
+    if (_at.get_last_device_error().errType == DeviceErrorTypeErrorCME && _at.get_last_device_error().errCode == 159) { // Uplink busy/flow control
+        return NSAPI_ERROR_BUSY;
+    }
+
     return _at.get_last_error();
 }
 


### PR DESCRIPTION
### Description

Fix netsocket test and BC95 driver to cope with network congestion.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica @VeijoPesonen 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
