### PR TITLE
Cellular: Preventing Socket ID assignment until actual socket creation at the modem 

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -97,7 +97,6 @@ protected:
             localAddress("", 0),
             _cb(NULL),
             _data(NULL),
-            created(false),
             closed(false),
             started(false),
             tx_ready(false),
@@ -114,7 +113,6 @@ protected:
         SocketAddress localAddress;
         void (*_cb)(void *);
         void *_data;
-        bool created; // socket has been created on modem stack
         bool closed; // socket has been closed by a peer
         bool started; // socket has been opened on modem stack
         bool tx_ready; // socket is ready for sending on modem stack
@@ -175,12 +173,22 @@ protected:
                                                        void *buffer, nsapi_size_t size) = 0;
 
     /**
-     *  Find the socket handle based on socket identifier
+     *  Find the socket handle based on the index of the socket construct
+     *  in the socket container. Please note that this index may or may not be
+     *  the socket id. The actual meaning of this index depends upon the modem
+     *  being used.
      *
-     *  @param sock_id  Socket identifier
+     *  @param index    Index of the socket construct in the container
      *  @return         Socket handle, NULL on error
      */
-    CellularSocket *find_socket(int sock_id);
+    CellularSocket *find_socket(int index);
+
+    /**
+     *  Find the index of the given CellularSocket handle. This index may or may
+     *  not be the socket id. The actual meaning of this index depends upon the modem
+     *  being used.
+     */
+    int find_socket_index(nsapi_socket_t handle);
 
     // socket container
     CellularSocket **_socket;
@@ -198,7 +206,6 @@ protected:
     nsapi_ip_stack_t _stack_type;
 
 private:
-    int find_socket_index(nsapi_socket_t handle);
 
     int get_socket_index_by_port(uint16_t port);
 

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -48,7 +48,7 @@ nsapi_error_t QUECTEL_BC95_CellularStack::socket_connect(nsapi_socket_t handle, 
     CellularSocket *socket = (CellularSocket *)handle;
 
     _at.lock();
-    if (!socket->created) {
+    if (socket->id == -1) {
         const nsapi_error_t error_create = create_socket_impl(socket);
         if (error_create != NSAPI_ERROR_OK) {
             return error_create;
@@ -157,8 +157,8 @@ nsapi_error_t QUECTEL_BC95_CellularStack::create_socket_impl(CellularSocket *soc
     // Check for duplicate socket id delivered by modem
     for (int i = 0; i < BC95_SOCKET_MAX; i++) {
         CellularSocket *sock = _socket[i];
-        if (sock && sock->created && sock->id == sock_id) {
-            tr_error("Duplicate socket index: %d created:%d, sock_id: %d", i, sock->created, sock_id);
+        if (sock && sock->id != -1 && sock->id == sock_id) {
+            tr_error("Duplicate socket index: %d, sock_id: %d", i, sock_id);
             return NSAPI_ERROR_NO_SOCKET;
         }
     }
@@ -166,7 +166,6 @@ nsapi_error_t QUECTEL_BC95_CellularStack::create_socket_impl(CellularSocket *soc
     tr_info("Socket create id: %d", sock_id);
 
     socket->id = sock_id;
-    socket->created = true;
 
     return NSAPI_ERROR_OK;
 }
@@ -174,6 +173,10 @@ nsapi_error_t QUECTEL_BC95_CellularStack::create_socket_impl(CellularSocket *soc
 nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSocket *socket, const SocketAddress &address,
                                                                      const void *data, nsapi_size_t size)
 {
+    //AT_CellularStack::socket_sendto(...) will create a socket on modem if it wasn't
+    // open already.
+    MBED_ASSERT(socket->id != -1);
+
     int sent_len = 0;
 
     if (size > PACKET_SIZE_MAX) {
@@ -220,6 +223,10 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSoc
 nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_recvfrom_impl(CellularSocket *socket, SocketAddress *address,
                                                                        void *buffer, nsapi_size_t size)
 {
+    //AT_CellularStack::socket_recvfrom(...) will create a socket on modem if it wasn't
+    // open already.
+    MBED_ASSERT(socket->id != -1);
+
     nsapi_size_or_error_t recv_len = 0;
     int port;
     char ip_address[NSAPI_IP_SIZE];

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -63,7 +63,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::socket_connect(nsapi_socket_t handle, 
 
         if ((_at.get_last_error() == NSAPI_ERROR_OK) && err) {
             if (err == BG96_SOCKET_BIND_FAIL) {
-                socket->created = false;
+                socket->id = -1;
                 return NSAPI_ERROR_PARAMETER;
             }
             _at.cmd_start("AT+QICLOSE=");
@@ -99,7 +99,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::socket_connect(nsapi_socket_t handle, 
     _at.unlock();
 
     if ((ret_val == NSAPI_ERROR_OK) && (modem_connect_id == request_connect_id)) {
-        socket->created = true;
+        socket->id = request_connect_id;
         socket->remoteAddress = address;
         socket->connected = true;
         return NSAPI_ERROR_OK;
@@ -164,9 +164,13 @@ void QUECTEL_BG96_CellularStack::handle_open_socket_response(int &modem_connect_
 nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *socket)
 {
     int modem_connect_id = -1;
-    int request_connect_id = socket->id;
     int remote_port = 0;
     int err = -1;
+
+    int request_connect_id = find_socket_index(socket);
+    // assert here as its a programming error if the socket container doesn't contain
+    // specified handle
+    MBED_ASSERT(request_connect_id != -1);
 
     if (socket->proto == NSAPI_UDP && !socket->connected) {
         _at.cmd_start("AT+QIOPEN=");
@@ -183,7 +187,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *soc
 
         if ((_at.get_last_error() == NSAPI_ERROR_OK) && err) {
             if (err == BG96_SOCKET_BIND_FAIL) {
-                socket->created = false;
+                socket->id = -1;
                 return NSAPI_ERROR_PARAMETER;
             }
             _at.cmd_start("AT+QICLOSE=");
@@ -215,7 +219,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *soc
 
         if ((_at.get_last_error() == NSAPI_ERROR_OK) && err) {
             if (err == BG96_SOCKET_BIND_FAIL) {
-                socket->created = false;
+                socket->id = -1;
                 return NSAPI_ERROR_PARAMETER;
             }
             _at.cmd_start("AT+QICLOSE=");
@@ -243,7 +247,9 @@ nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *soc
 
     nsapi_error_t ret_val = _at.get_last_error();
 
-    socket->created = ((ret_val == NSAPI_ERROR_OK) && (modem_connect_id == request_connect_id));
+    if (ret_val == NSAPI_ERROR_OK && (modem_connect_id == request_connect_id)) {
+        socket->id = request_connect_id;
+    }
 
     return ret_val;
 }

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -302,6 +302,8 @@ nsapi_error_t QUECTEL_M26_CellularStack::socket_connect(nsapi_socket_t handle, c
 {
     CellularSocket *socket = (CellularSocket *)handle;
 
+    MBED_ASSERT(socket->id != -1);
+
     int modem_connect_id = -1;
     int request_connect_id = socket->id;
     int err = -1;
@@ -348,7 +350,6 @@ nsapi_error_t QUECTEL_M26_CellularStack::socket_connect(nsapi_socket_t handle, c
     _at.unlock();
 
     if ((ret_val == NSAPI_ERROR_OK) && (modem_connect_id == request_connect_id)) {
-        socket->created = true;
         socket->remoteAddress = address;
         socket->connected = true;
         return NSAPI_ERROR_OK;
@@ -359,7 +360,29 @@ nsapi_error_t QUECTEL_M26_CellularStack::socket_connect(nsapi_socket_t handle, c
 
 nsapi_error_t QUECTEL_M26_CellularStack::create_socket_impl(CellularSocket *socket)
 {
-    int request_connect_id = socket->id;
+    // This modem is a special case. It takes in the socket ID rather than spitting
+    // it out. So we will first try to use the index of the socket construct as the id
+    // but if another opened socket is already opened with that id we will pick the next
+    // id which is not in use
+    bool duplicate = false;
+    int potential_sid = -1;
+    int index = find_socket_index(socket);
+
+    for (int i = 0; i < get_max_socket_count(); i++) {
+        CellularSocket *sock = _socket[i];
+        if (sock && sock != socket && sock->id == index) {
+            duplicate = true;
+        } else if (duplicate && !sock) {
+            potential_sid = i;
+            break;
+        }
+    }
+
+    if (duplicate) {
+        index = potential_sid;
+    }
+
+    int request_connect_id = index;
     int modem_connect_id = request_connect_id;
     int err = -1;
     nsapi_error_t ret_val;
@@ -403,13 +426,15 @@ nsapi_error_t QUECTEL_M26_CellularStack::create_socket_impl(CellularSocket *sock
         }
 
         ret_val = _at.get_last_error();
-        socket->created = ((ret_val == NSAPI_ERROR_OK) && (modem_connect_id == request_connect_id));
+        if ((ret_val == NSAPI_ERROR_OK) && (modem_connect_id == request_connect_id)) {
+            socket->id = request_connect_id;
+        }
         return ret_val;
     } else {
         ret_val = NSAPI_ERROR_OK;
     }
 
-    tr_debug("QUECTEL_M26_CellularStack:%s:%u: END [%d,%d]", __FUNCTION__, __LINE__, socket->created, ret_val);
+    tr_debug("QUECTEL_M26_CellularStack:%s:%u: END [%d]", __FUNCTION__, __LINE__, ret_val);
     return ret_val;
 }
 
@@ -431,11 +456,11 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
         return NSAPI_ERROR_PARAMETER;
     }
 
-    if (!socket->created) {
+    if (socket->id == -1) {
         socket->remoteAddress = address;
         socket->connected = true;
         nsapi_error_t ret_val = create_socket_impl(socket);
-        if ((ret_val != NSAPI_ERROR_OK) || (!socket->created)) {
+        if ((ret_val != NSAPI_ERROR_OK) || (socket->id == -1)) {
             tr_error("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_NO_SOCKET]", __FUNCTION__, __LINE__);
             return NSAPI_ERROR_NO_SOCKET;
         }


### PR DESCRIPTION
### Description

Local modem ip stacks vary in their implementations and the way of
    working. Some of the modems may not open a socket until an IP context is
    assigned. That's why we came up with a container that stores addresses of
    any CellularSocket instances created on-demand by the application. When
    the application requests opening a socket we allocate and store the
    primitive in the container however actual socket creation at the modem
    may happen at a later stage, e.g., a call to send_to() may result in
    actual opening of a socket.
    
That's why we must not assign socket ids in the CellularSocket object
    during construction. It must happen when actual socket is opened and is
    alive.
  
Another implication of the previous model is that we may have multiple
    sockets created in our container but the actual socket ids are not
    assigned yet, so we cannot directly map the socket id to the container
    indices which has been happening previously.
    
To solve this issue we have promoted the AT_CellularStack::find_socket_index(...) method
    to be a protected method rather than being private so that the children
    can use the method to determine if the given index in the container
    corresponds to the assigned socket id or not.
    
We have given up on the socket->created flag and the whole decision
    making to actually open a socket on the modem happens on the basis of a
    valid socket id being assigned or not.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AnttiKauppila @kjbracey-arm @AriParkkila @blind-owl @mirelachirica @jarvte 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
