### PR TITLE
PSA: Exclude mbed-hal-spm test for M23 target

### DIFF
--- a/TESTS/mbed_hal/spm/main.cpp
+++ b/TESTS/mbed_hal/spm/main.cpp
@@ -23,8 +23,8 @@
 #error [NOT_SUPPORTED] this test is supported on GCC only
 #endif
 
-#if defined(__CORTEX_M33)
-#error [NOT_SUPPORTED] Cannot run on M33 core as SecureFault is implemented in secure-side and cant be remapped
+#if DOMAIN_NS == 1
+#error [NOT_SUPPORTED] Cannot run on M23/M33 core as SecureFault is implemented in secure-side and cant be remapped
 #endif
 
 #include "utest/utest.h"


### PR DESCRIPTION
### Description

The test code `mbed-hal-spm` is for `MBED_SPM`, not for `TFM`. Same as M33, add M23 in the exclude list.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
