### PR TITLE
PSA: Pass TFM_LVL macro to linker files

### DIFF
--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -918,6 +918,7 @@ class mbedToolchain:
             pass
 
     STACK_PARAM = "target.boot-stack-size"
+    TFM_LVL_PARAM = "tfm.level"
 
     def add_linker_defines(self):
         params, _ = self.config_data
@@ -926,6 +927,15 @@ class mbedToolchain:
             define_string = self.make_ld_define(
                 "MBED_BOOT_STACK_SIZE",
                 int(params[self.STACK_PARAM].value, 0)
+            )
+            self.ld.append(define_string)
+            self.flags["ld"].append(define_string)
+
+        # Pass TFM_LVL to linker files, so single linker file can support different TFM security levels.
+        if self.TFM_LVL_PARAM in params:
+            define_string = self.make_ld_define(
+                "TFM_LVL",
+                params[self.TFM_LVL_PARAM].value
             )
             self.ld.append(define_string)
             self.flags["ld"].append(define_string)


### PR DESCRIPTION
### Description

`TFM_LVL` is defined in **mbed-os/components/TARGET_PSA/TARGET_TFM/mbed_lib.json**. But it just passes to C/C++ files. This PR tries to pass `TFM_LVL` to also linker files. With this, single linker file can support different TFM security levels.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
