### PR TITLE
TFM: Fix compile error with casting

### DIFF
--- a/components/TARGET_PSA/TARGET_TFM/COMPONENT_SPE/secure_fw/core/tfm_secure_api.h
+++ b/components/TARGET_PSA/TARGET_TFM/COMPONENT_SPE/secure_fw/core/tfm_secure_api.h
@@ -104,7 +104,7 @@ int32_t tfm_core_partition_request(uint32_t id, void *fn, int32_t iovec_api,
     struct tfm_sfn_req_s desc, *desc_ptr = &desc;
 
     desc.sp_id = id;
-    desc.sfn = fn;
+    desc.sfn = (sfn_t) fn;
     desc.args = args;
     desc.ns_caller = cmse_nonsecure_caller();
     desc.iovec_api = iovec_api;


### PR DESCRIPTION
### Description

This PR fixes compile error on casting `void *` to `sfn_t` implicitly in TFM code.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
