### PR TITLE
Size should be calculate after confirm the final start address

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -980,7 +980,6 @@ class Config(object):
                 yield region._replace(filename=self.target.header_format)
 
         if self.target.restrict_size is not None:
-
             if self.target.app_offset:
                 start = self._assign_new_offset(
                     rom_start,

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -980,10 +980,6 @@ class Config(object):
                 yield region._replace(filename=self.target.header_format)
 
         if self.target.restrict_size is not None:
-            new_size = int(self.target.restrict_size, 0)
-            new_size = Config._align_floor(
-                start + new_size, self.sectors
-            ) - start
 
             if self.target.app_offset:
                 start = self._assign_new_offset(
@@ -992,6 +988,10 @@ class Config(object):
                     "application",
                     regions
                 )
+            new_size = int(self.target.restrict_size, 0)
+            new_size = Config._align_floor(
+                start + new_size, self.sectors
+            ) - start
 
             yield Region("application", start, new_size, True, None)
             start += new_size


### PR DESCRIPTION
### Description

The final size maybe wrong if we caculate the size before start address.  
Since the start address may shift after align operation,  then the final size/post address should shift as well. 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
