### PR TITLE
Configure UNO_91H to support PDMC compile

### DIFF
--- a/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_ARM_STD/TARGET_UNO_91H/RDA5981C.sct
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_ARM_STD/TARGET_UNO_91H/RDA5981C.sct
@@ -31,7 +31,7 @@
 #endif /* RDA_ICACHE_DISABLE */
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 2000K
+  #define MBED_APP_SIZE (0x1F4000)
 #endif
 #define RDA_CODE_SIZE         (MBED_APP_SIZE)
 #define RDA_AHB1_BASE         (0x40100000)

--- a/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_ARM_STD/TARGET_UNO_91H/RDA5981C.sct
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_ARM_STD/TARGET_UNO_91H/RDA5981C.sct
@@ -21,9 +21,19 @@
 #if defined(RDA_ICACHE_DISABLE)
 #define RDA_CODE_BASE         (RDA_FLASH_BASE + RDA_PADDR_OFST)
 #else  /* RDA_ICACHE_DISABLE */
+
+#if !defined(MBED_APP_START) /* MBED_APP_START */
 #define RDA_CODE_BASE         (RDA_ICACHE_BASE + RDA_PADDR_OFST)
+#else /* MBED_APP_START */
+#define RDA_CODE_BASE         (MBED_APP_START)
+#endif /* MBED_APP_START */
+
 #endif /* RDA_ICACHE_DISABLE */
-#define RDA_CODE_SIZE         (0x001F4000)
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 2000K
+#endif
+#define RDA_CODE_SIZE         (MBED_APP_SIZE)
 #define RDA_AHB1_BASE         (0x40100000)
 #define RDA_MEMC_BASE         (RDA_AHB1_BASE + 0x00000)
 

--- a/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_GCC_ARM/TARGET_UNO_91H/RDA5981C.ld
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_GCC_ARM/TARGET_UNO_91H/RDA5981C.ld
@@ -6,12 +6,20 @@
 
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x18001000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 2000K
+#endif
+
 /* Linker script to configure memory regions. */
 MEMORY
 {
     /* If ICache is enable, use virtual flash base address */
     /* Use partition index: 0 */
-    FLASH (rx)      : ORIGIN = 0x18001000, LENGTH = 2000K
+    FLASH (rx)      : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
     /* Use partition index: 1 */
     /* FLASH (rx)      : ORIGIN = 0x181F5000, LENGTH = 2000K */
 

--- a/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_IAR/TARGET_UNO_91H/RDA5981C.icf
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_IAR/TARGET_UNO_91H/RDA5981C.icf
@@ -17,7 +17,12 @@ if (0 == RDA_PARTITION_INDEX) {
 if (1 == RDA_ICACHE_DISABLE) {
   define symbol RDA_CODE_BASE       = RDA_FLASH_BASE + RDA_PADDR_OFST;
 } else {
+
+/* MBED_APP_START */
+if (!isdefinedsymbol(MBED_APP_START)) { 
   define symbol RDA_CODE_BASE       = RDA_ICACHE_BASE + RDA_PADDR_OFST;
+else 
+  define symbol RDA_CODE_BASE       = MBED_APP_START;
 }
 define symbol RDA_CODE_END          = RDA_CODE_BASE + 0x1F3FFF;
 define symbol RDA_AHB1_BASE         = 0x40100000;

--- a/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_IAR/TARGET_UNO_91H/RDA5981C.icf
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/device/TOOLCHAIN_IAR/TARGET_UNO_91H/RDA5981C.icf
@@ -17,12 +17,12 @@ if (0 == RDA_PARTITION_INDEX) {
 if (1 == RDA_ICACHE_DISABLE) {
   define symbol RDA_CODE_BASE       = RDA_FLASH_BASE + RDA_PADDR_OFST;
 } else {
-
-/* MBED_APP_START */
-if (!isdefinedsymbol(MBED_APP_START)) { 
+  /* MBED_APP_START */
+  if (!isdefinedsymbol(MBED_APP_START)) { 
   define symbol RDA_CODE_BASE       = RDA_ICACHE_BASE + RDA_PADDR_OFST;
-else 
+  } else { 
   define symbol RDA_CODE_BASE       = MBED_APP_START;
+  }
 }
 define symbol RDA_CODE_END          = RDA_CODE_BASE + 0x1F3FFF;
 define symbol RDA_AHB1_BASE         = 0x40100000;

--- a/targets/TARGET_RDA/TARGET_UNO_91H/flash_api.c
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/flash_api.c
@@ -18,6 +18,14 @@
 #include "flash_data.h"
 #include "mbed_critical.h"
 
+#ifndef MBED_ROM_SIZE
+#define MBED_FLASH_SIZE 0x100000
+#else
+//there is 4K BOOTROM at beginning of the flash
+#define MBED_FLASH_SIZE (MBED_ROM_SIZE+0x1000)
+#endif
+
+
 // This file is automagically generated
 
 // This is a flash algo binary blob. It is PIC (position independent code) that should be stored in RAM
@@ -68,7 +76,7 @@ static const sector_info_t sectors_info[] = {
 static const flash_target_config_t flash_target_config = {
     .page_size  = 0x100,
     .flash_start = 0x18000000,
-    .flash_size = 0x100000,
+    .flash_size = MBED_FLASH_SIZE,
     .sectors = sectors_info,
     .sector_info_count = sizeof(sectors_info) / sizeof(sector_info_t)
 };

--- a/targets/TARGET_RDA/mbed_rtx.h
+++ b/targets/TARGET_RDA/mbed_rtx.h
@@ -42,4 +42,12 @@ extern uint32_t                 Image$$ARM_LIB_HEAP$$ZI$$Length[];
 #error "no toolchain defined"
 #endif
 
+#if defined(TARGET_UNO_91H)
+/* Stack Pointer */
+#ifndef INITIAL_SP
+#define INITIAL_SP              (0x120000UL)
+//#define INITIAL_SP              (0x1A8000UL)
+#endif
+#endif
+
 #endif  // MBED_MBED_RTX_H

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8514,7 +8514,6 @@
         "mbed_ram_size": "0x1ff80",
         "mbed_rom_start": "0x18001000",
         "mbed_rom_size": "0x1F4000",
-        "device_name": "RDA5981X",
         "sectors": [[0,4096]],
         "overrides": {
             "network-default-interface-type" : "WIFI"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8508,6 +8508,14 @@
     "UNO_91H": {
         "inherits": ["RDA5981X"],
         "detect_code": ["8001"],
+        "components_add": ["FLASHIAP"],
+        "bootloader_supported": true,
+        "mbed_ram_start": "0x00100080",
+        "mbed_ram_size": "0x1ff80",
+        "mbed_rom_start": "0x18001000",
+        "mbed_rom_size": "0x1F4000",
+        "device_name": "RDA5981X",
+        "sectors": [[0,4096]],
         "overrides": {
             "network-default-interface-type" : "WIFI"
         }


### PR DESCRIPTION
### Description

1, Change target.json by add FLASHIAP,  mbed address offsets etc.  So that PDMC compile could pass on UNO_91H platform. 
2, Add mbed APP address offset support for all 3 linker scripts. 
3, UNO_91H have multi kind of flash size, add support for that by configure mbed_rom_size.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
