### PR TITLE
Cellular: Minor doc update for CellualrSocket object

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -105,7 +105,8 @@ protected:
             pending_bytes(0)
         {
         }
-        // Socket id from cellular device
+        // Socket identifier, generally it will be the socket ID assigned by the
+        // modem. In a few special cases, modems may take that as an input argument.
         int id;
         // Being connected means remote ip address and port are set
         bool connected;


### PR DESCRIPTION


### Description

Socket ID is usually spitted out by the modem, however there are cases
when the modem is actully taken in as an input argument, e.g., in the
case of QUECTEL M26 modem. This minor knit clarifies that the
CellularSocket::id can be an input argument.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@blind-owl @AriParkkila @mirelachirica @AnttiKauppila 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
