### PR TITLE
 LWIP 2.1.2 tcpip thread stack overflow fix. 

### DIFF
--- a/features/lwipstack/lwip/src/netif/ppp/lwip_utils.c
+++ b/features/lwipstack/lwip/src/netif/ppp/lwip_utils.c
@@ -603,7 +603,7 @@ void ppp_print_string(const u_char *p, int len, void (*printer) (void *, const c
  * ppp_logit - does the hard work for fatal et al.
  */
 static void ppp_logit(int level, const char *fmt, va_list args) {
-    char buf[1024];
+    char buf[256];
 
     ppp_vslprintf(buf, sizeof(buf), fmt, args);
     ppp_log_write(level, buf);


### PR DESCRIPTION
### Description
Applied missing LWIP patch to PPP/utils.c
"Major Refactoring & extensions" commited on May 23, 201 by hasnainvirk
According to this patch  PPP logger module member  "ppp_logit"  consumes only 256 byte buffer on stack instead of 1024  like original LWIP code from Savanah repo does. 

LWIP 2.1.2 tcpip thread stack is restored to 1200 bytes.
   
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@mikaleppanen 
@kjbracey-arm 
@AriParkkila 
@kimlep01
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
