### PR TITLE
Exclude target-specific pins from GPIO tests with the FPGA shield

### DIFF
--- a/docs/design-documents/hal/0002-pinmap-extension.md
+++ b/docs/design-documents/hal/0002-pinmap-extension.md
@@ -83,3 +83,5 @@ MBED_WEAK const PinList *pinmap_restricted_pins()
     return &pin_list;
 }
 ```
+
+In addition to `pinmap_restricted_pins()`, the `pinmap_restricted_pins_gpio()` is used to skip pins during GPIO testing. By default this function returns an empty list and any target can override it to provide a list of pins that should be skipped. For example, D14 and D15 pins present in the Arduino form factor of FRDM-K64F have fixed pull-up resistors. The `PullDown` `PinMode` is impossible to test. However, other peripherals like the I2C may be successfully tested on these pins.

--- a/hal/mbed_pinmap_default.c
+++ b/hal/mbed_pinmap_default.c
@@ -77,3 +77,11 @@ MBED_WEAK const PinList *pinmap_restricted_pins()
     return &pin_list;
 }
 
+//*** Default restricted pins for the GPIO test ***
+MBED_WEAK const PinList *pinmap_restricted_pins_gpio()
+{
+    static const PinName pins[] = {};
+    static const PinList pin_list = {0, pins};
+    return &pin_list;
+}
+

--- a/hal/pinmap.h
+++ b/hal/pinmap.h
@@ -139,6 +139,25 @@ bool pinmap_list_has_pin(const PinList *list, PinName pin);
  */
 const PinList *pinmap_restricted_pins(void);
 
+/**
+ * Get the additional list of pins to avoid during GPIO testing
+ *
+ * Unlike a list returned by generic pinmap_restricted_pins(),
+ * that is used by *ALL* tests, this list is used only for GPIO tests.
+ * This list extends the one returned by pinmap_restricted_pins().
+ *
+ * For example, PTE25 & PTE24 on the FRDM-K64F have fixed pull-ups
+ * making the PullDown PinMode impossible to test. However, the I2C
+ * may be successfully tested on these pins.
+ *
+ * Targets should override the weak implementation of this
+ * function if they have additional pins which should be
+ * skipped during GPIO testing.
+ *
+ * @return Pointer to a pin list of pins to avoid
+ */
+const PinList *pinmap_restricted_pins_gpio(void);
+
 #ifdef TARGET_FF_ARDUINO
 
 /**

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/pinmap.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/pinmap.c
@@ -1,0 +1,30 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hal/pinmap.h"
+
+const PinList *pinmap_restricted_pins_gpio()
+{
+    static const PinName pins[] = {
+        PTE25, PTE24 // fixed pull-ups (for I2C)
+    };
+    static const PinList pin_list = {
+        sizeof(pins) / sizeof(pins[0]),
+        pins
+    };
+    return &pin_list;
+}


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Most of the HAL tests that use the FPGA shield only use pins present in a `PinMap` specific for given peripheral. There is no `PinMap` for GPIOs, but some board-specific pins have to be excluded from testing due to hardware limitations. This patch adds a `pinmap_restricted_pins_gpio()` function that every target can override if needed.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@c1728p9 @jamesbeyond @mprse @maciejbocianski

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
Add a weak `pinmap_restricted_pins_gpio()` that every target can override and provide a list of pins that should be skipped during the GPIO tests (in addition to `pinmap_restricted_pins()`).