### PR TITLE
Nanostack: release connect_semaphore only when it is pending

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -120,8 +120,9 @@ nsapi_error_t MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
 void Nanostack::Interface::network_handler(mesh_connection_status_t status)
 {
     if (_blocking) {
-        if (status == MESH_CONNECTED || status == MESH_CONNECTED_LOCAL ||
-                status == MESH_CONNECTED_GLOBAL) {
+        if (_connect_status == NSAPI_STATUS_CONNECTING
+                && (status == MESH_CONNECTED || status == MESH_CONNECTED_LOCAL
+                    || status == MESH_CONNECTED_GLOBAL)) {
             connect_semaphore.release();
         } else if (status == MESH_DISCONNECTED) {
             disconnect_semaphore.release();


### PR DESCRIPTION
### Description

The rationale behind this PR is the following. It often happens that a Thread device gets local connectivity before the global connectivity. In such case the network handler is called twice and [each time releases the _connect_semaphore](https://github.com/ARMmbed/mbed-os/blob/46603f831e13705d5aab4f73d52f00611e1f4d7d/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp#L125). If the device disconnects and then connects again, the previously released (incremented) semaphore [will be available for immediate decrementation](https://github.com/ARMmbed/mbed-os/blob/46603f831e13705d5aab4f73d52f00611e1f4d7d/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp#L151) and the connect will not really block. 
This fixes failures in NETWORKINTERFACE_CONN_DISC_REPEAT test for Thread protocol. 

I also noticed some detailed guidelines about [when to consider a Thread device connected](https://github.com/ARMmbed/mbed-os/blob/46603f831e13705d5aab4f73d52f00611e1f4d7d/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp#L145), but those are Thread-specific, and should not be implemented in general Nanostack network_handler. It made me wonder however if the semaphore should perhaps be released in the lower layer, so a Thread device unblocks at a different point than a LOWPAN device, perhaps?

@0xc0170 , does the CI for PRs run any Nanostack tests? I assumed not and hacked our CI to run this commit for me on multiple platforms to check that nothing gets broken, but I wonder if I should have relied on CI?

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@KariHaapalehto 
@VeijoPesonen 
