### PR TITLE
Cellular:  Add WISE-1570 handling for socket closing URC

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -27,10 +27,13 @@ using namespace mbed_cellular_util;
 QUECTEL_BC95_CellularStack::QUECTEL_BC95_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type) : AT_CellularStack(atHandler, cid, stack_type)
 {
     _at.set_urc_handler("+NSONMI:", mbed::Callback<void()>(this, &QUECTEL_BC95_CellularStack::urc_nsonmi));
+    _at.set_urc_handler("+NSOCLI:", mbed::Callback<void()>(this, &QUECTEL_BC95_CellularStack::urc_nsocli));
 }
 
 QUECTEL_BC95_CellularStack::~QUECTEL_BC95_CellularStack()
 {
+    _at.set_urc_handler("+NSONMI:", NULL);
+    _at.set_urc_handler("+NSOCLI:", NULL);
 }
 
 nsapi_error_t QUECTEL_BC95_CellularStack::socket_listen(nsapi_socket_t handle, int backlog)
@@ -88,6 +91,28 @@ void QUECTEL_BC95_CellularStack::urc_nsonmi()
     }
 }
 
+void QUECTEL_BC95_CellularStack::urc_nsocli()
+{
+    int sock_id = _at.read_int();
+
+    const nsapi_error_t err = _at.get_last_error();
+
+    if (err != NSAPI_ERROR_OK) {
+        return;
+    }
+
+    CellularSocket *sock = find_socket(sock_id);
+
+    if (sock) {
+        sock->closed = true;
+        if (sock->_cb) {
+            sock->_cb(sock->_data);
+        }
+        tr_info("Socket closed %d", sock_id);
+    }
+}
+
+
 int QUECTEL_BC95_CellularStack::get_max_socket_count()
 {
     return BC95_SOCKET_MAX;
@@ -100,6 +125,11 @@ bool QUECTEL_BC95_CellularStack::is_protocol_supported(nsapi_protocol_t protocol
 
 nsapi_error_t QUECTEL_BC95_CellularStack::socket_close_impl(int sock_id)
 {
+    CellularSocket *sock = find_socket(sock_id);
+
+    if (sock && sock->closed) {
+        return NSAPI_ERROR_OK;
+    }
     _at.cmd_start("AT+NSOCL=");
     _at.write_int(sock_id);
     _at.cmd_stop_read_resp();

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.h
@@ -57,6 +57,7 @@ protected: // AT_CellularStack
 private:
     // URC handlers
     void urc_nsonmi();
+    void urc_nsocli();
 };
 } // namespace mbed
 #endif /* QUECTEL_BC95_CELLULARSTACK_H_ */


### PR DESCRIPTION
### Description

WISE-1570 wasn't handling URC for socket closing at all. Now socket closed flag is set on the arriving of such URC. Also, if the socket was closed but closed flag not yet set at the moment a socket sending/receiving was issued, the socket would get stuck waiting for data. To prevent this, socket event is called also when socket close URC arrives.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change