### PR TITLE
Cellular: fix calls to ATHandler::read_string(...) give correct size

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -394,9 +394,9 @@ bool AT_CellularContext::get_context()
             cid_max = cid;
         }
         char pdp_type_from_context[10];
-        int pdp_type_len = _at.read_string(pdp_type_from_context, sizeof(pdp_type_from_context) - 1);
+        int pdp_type_len = _at.read_string(pdp_type_from_context, sizeof(pdp_type_from_context));
         if (pdp_type_len > 0) {
-            apn_len = _at.read_string(apn, sizeof(apn) - 1);
+            apn_len = _at.read_string(apn, sizeof(apn));
             if (apn_len >= 0) {
                 if (_apn && (strcmp(apn, _apn) != 0)) {
                     continue;

--- a/features/cellular/framework/AT/AT_CellularInformation.cpp
+++ b/features/cellular/framework/AT/AT_CellularInformation.cpp
@@ -78,7 +78,7 @@ nsapi_error_t AT_CellularInformation::get_info(const char *cmd, char *buf, size_
     _at.cmd_stop();
     _at.set_delimiter(0);
     _at.resp_start();
-    _at.read_string(buf, buf_size - 1);
+    _at.read_string(buf, buf_size);
     _at.resp_stop();
     _at.set_default_delimiter();
     return _at.unlock_return_error();
@@ -93,10 +93,7 @@ nsapi_error_t AT_CellularInformation::get_imsi(char *imsi, size_t buf_size)
     _at.cmd_start("AT+CIMI");
     _at.cmd_stop();
     _at.resp_start();
-    int len = _at.read_string(imsi, MAX_IMSI_LENGTH);
-    if (len > 0) {
-        imsi[len] = '\0';
-    }
+    _at.read_string(imsi, MAX_IMSI_LENGTH + 1);
     _at.resp_stop();
     return _at.unlock_return_error();
 }

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -70,7 +70,7 @@ const char *AT_CellularStack::get_ip_address()
 
         _at.skip_param();
 
-        int len = _at.read_string(_ip, NSAPI_IPv4_SIZE - 1);
+        int len = _at.read_string(_ip, NSAPI_IPv4_SIZE);
         if (len == -1) {
             _ip[0] = '\0';
             _at.resp_stop();
@@ -81,7 +81,7 @@ const char *AT_CellularStack::get_ip_address()
 
         // in case stack type is not IPV4 only, try to look also for IPV6 address
         if (_stack_type != IPV4_STACK) {
-            (void)_at.read_string(_ip, PDP_IPV6_SIZE - 1);
+            (void)_at.read_string(_ip, PDP_IPV6_SIZE);
         }
     }
 

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -444,7 +444,7 @@ const char *UBLOX_AT_CellularStack::get_ip_address()
     if (_at.info_resp()) {
         _at.skip_param();
         _at.skip_param();
-        int len = _at.read_string(_ip, NSAPI_IPv4_SIZE - 1);
+        int len = _at.read_string(_ip, NSAPI_IPv4_SIZE);
         if (len == -1) {
             _ip[0] = '\0';
             _at.unlock();
@@ -454,7 +454,7 @@ const char *UBLOX_AT_CellularStack::get_ip_address()
 
         // in case stack type is not IPV4 only, try to look also for IPV6 address
         if (_stack_type != IPV4_STACK) {
-            len = _at.read_string(_ip, PDP_IPV6_SIZE - 1);
+            len = _at.read_string(_ip, PDP_IPV6_SIZE);
         }
     }
     _at.resp_stop();


### PR DESCRIPTION
### Description

ATHandler::read_string(...) buffer size param was changed a long time ago to include also NULL. Some calls still gave wrong size after this change.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AriParkkila @mirelachirica 

### Release Notes
