### PR TITLE
STM32H7: WATCHDOG and RESET_REASON support

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/device/stm32h7xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/device/stm32h7xx_hal_conf.h
@@ -122,6 +122,15 @@
 #endif /* HSI_VALUE */
 
 /**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE)
+ #define LSI_VALUE  32000U                  /*!< LSI Typical Value in Hz*/
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
+
+/**
   * @brief External Low Speed oscillator (LSE) value.
   *        This value is used by the UART, RTC HAL module to compute the system frequency
   */

--- a/targets/TARGET_STM/TARGET_STM32H7/device/stm32h7xx_hal_iwdg.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/device/stm32h7xx_hal_iwdg.c
@@ -109,10 +109,8 @@
 /** @defgroup IWDG_Private_Defines IWDG Private Defines
   * @{
   */
-/* Status register need 5 RC LSI divided by prescaler clock to be updated. With
-   higher prescaler (256), and according to LSI variation, we need to wait at
-   least 6 cycles so 48 ms. */
-#define HAL_IWDG_DEFAULT_TIMEOUT            48u
+/* MBED */
+#define HAL_IWDG_DEFAULT_TIMEOUT            96u
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -170,6 +170,9 @@ struct can_s {
 #define RCC_LPUART1CLKSOURCE_PCLK1  RCC_LPUART1CLKSOURCE_PLL2
 #define RCC_LPUART1CLKSOURCE_SYSCLK RCC_LPUART1CLKSOURCE_D3PCLK1
 
+/* watchdog_api.c */
+#define IWDG IWDG1
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/reset_reason.c
+++ b/targets/TARGET_STM/reset_reason.c
@@ -27,14 +27,32 @@ reset_reason_t hal_reset_reason_get(void)
     }
 #endif
 
+#ifdef RCC_FLAG_LPWR1RST
+    if ((__HAL_RCC_GET_FLAG(RCC_FLAG_LPWR1RST))||(__HAL_RCC_GET_FLAG(RCC_FLAG_LPWR2RST))) {
+        return RESET_REASON_WAKE_LOW_POWER;
+    }
+#endif
+
 #ifdef RCC_FLAG_WWDGRST
     if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
         return RESET_REASON_WATCHDOG;
     }
 #endif
 
+#ifdef RCC_FLAG_WWDG1RST
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDG1RST)) {
+        return RESET_REASON_WATCHDOG;
+    }
+#endif
+
 #ifdef RCC_FLAG_IWDGRST
     if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        return RESET_REASON_WATCHDOG;
+    }
+#endif
+
+#ifdef RCC_FLAG_IWDG1RST
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDG1RST)) {
         return RESET_REASON_WATCHDOG;
     }
 #endif
@@ -69,7 +87,11 @@ reset_reason_t hal_reset_reason_get(void)
 
 uint32_t hal_reset_reason_get_raw(void)
 {
+#if TARGET_STM32H7
+    return RCC->RSR;
+#else /* TARGET_STM32H7 */
     return RCC->CSR;
+#endif /* TARGET_STM32H7 */
 }
 
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3227,8 +3227,7 @@
         ],
         "release_versions": ["2", "5"],
         "device_name": "STM32H743ZI",
-        "bootloader_supported": true,
-        "device_has_remove": ["WATCHDOG"]
+        "bootloader_supported": true
     },
     "NUCLEO_H743ZI2": {
         "inherits": ["NUCLEO_H743ZI"],


### PR DESCRIPTION
### Description

This PR enables the WATCHDOG and RESET_REASON feature support for STM32H7.

| target              | platform_name | test suite                        | result | elapsed_time (sec) | copy_method |
|---------------------|---------------|-----------------------------------|--------|--------------------|-------------|
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_drivers-reset_reason   | OK     | 19.81              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_drivers-watchdog       | OK     | 20.21              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_drivers-watchdog_reset | OK     | 21.99              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_hal-reset_reason       | OK     | 19.87              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_hal-watchdog           | OK     | 20.28              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_hal-watchdog_reset     | OK     | 22.36              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-mbed_hal-watchdog_timing    | OK     | 35.82              | default     |


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
