### PR TITLE
Implement nanostack eventloop tick timer

### DIFF
--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_hal_init.c
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_hal_init.c
@@ -43,7 +43,9 @@ void ns_hal_init(void *heap, size_t h_size, void (*passed_fptr)(heap_fail_t), me
     }
     platform_critical_init();
     ns_dyn_mem_init(heap, h_size, passed_fptr, info_ptr);
+#ifndef NS_EXCLUDE_HIGHRES_TIMER
     platform_timer_enable();
+#endif
     eventOS_scheduler_init();
 
     // We do not initialise randlib, as it should be done after


### PR DESCRIPTION

### Description

Nanostack eventloop tick timer can be used in case high resolution
platform timer is not needed. One usecase for that is Pelion
Cloud client when using for example cellular connectivity. This enables
PDMC application to enter deep sleep state by setting following settings in `mbed_app.json`:
```
"nanostack-eventloop.use_platform_tick_timer": true,
"nanostack-eventloop.exclude_highres_timer": true
```

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@kjbracey-arm , @juhoeskeli 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
