### PR TITLE
LWIP TCP socket close - disconnecting fix 

### DIFF
--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -587,6 +587,8 @@ private:
     LWIPMemoryManager memory_manager;
     osThreadId tcpip_thread_id;
     rtos::Mutex adaptation;
+    rtos::EventFlags _event_flag;
+    static const int TCP_CLOSED_FLAG = 0x4u;
 };
 
 #endif /* LWIPSTACK_H_ */

--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -244,6 +244,11 @@
 #define LWIP_TCP                    1
 #define TCP_OVERSIZE                0
 #define LWIP_TCP_KEEPALIVE          1
+#ifdef MBED_CONF_TCP_CLOSE_TIMEOUT
+#define TCP_CLOSE_TIMEOUT            MBED_CONF_TCP_CLOSE_TIMEOUT
+#else
+#define TCP_CLOSE_TIMEOUT            1000
+#endif
 #else
 #define LWIP_TCP                    0
 #endif

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -100,6 +100,10 @@
             "help": "Maximum number of retransmissions of SYN segments. Current default (used if null here) is set to 6 in opt.h",
             "value": null
         },
+        "tcp-close-timeout": {
+            "help": "Maximum timeout (ms) for TCP close handshaking timeout",
+            "value": 1000
+        },
         "pbuf-pool-size": {
             "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.",
             "value": null


### PR DESCRIPTION

### Description

Currently  LWIP TCP socket close doesn't care  TCP close handshaking is properly completed.
If network interface disconnect follows immediately after TCP socket_close and TCP FSM is in 
ESTABLISHED state this causes  too early eth/wifi driver stop.
In result FIN ACK sequence is being corrupted and  TCP FSM stucks in FIN_WAIT_1 state until  LWIP netif is deleted. This is a reason of failing TCP tests due to lack of memory because TCP PCB  mempool is not freed on time.

This fix check if socket is TCP and FSM is in ESTABLISHED state.
Then give extra time for connection close handshaking  until TIME_WAIT state or timeout occurs.
  
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@mikaleppanen 
@kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
