### PR TITLE
STM32WB: Update Flash size

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_ARM_MICRO/stm32wb55xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_ARM_MICRO/stm32wb55xx.sct
@@ -34,7 +34,7 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-; 812KB FLASH
+; 768KB FLASH
 #define MBED_APP_SIZE 0xC0000
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_ARM_MICRO/stm32wb55xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_ARM_MICRO/stm32wb55xx.sct
@@ -34,11 +34,11 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-; 512KB FLASH
-#define MBED_APP_SIZE 0x80000
+; 812KB FLASH
+#define MBED_APP_SIZE 0xC0000
 #endif
 
-; 512KB FLASH (0x80000) + 192KB SRAM (0x30000) +  Shared mem
+; 768KB FLASH (0xC0000) + 192KB SRAM (0x30000) +  Shared mem
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
   ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_ARM_STD/stm32wb55xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_ARM_STD/stm32wb55xx.sct
@@ -34,8 +34,8 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-; 512KB FLASH
-#define MBED_APP_SIZE 0x80000
+; 768KB FLASH
+#define MBED_APP_SIZE 0xC0000
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
@@ -44,7 +44,7 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-; 512KB FLASH (0x80000) + 192KB SRAM (0x30000) +  Shared mem
+; 768KB FLASH (0xC0000) + 192KB SRAM (0x30000) +  Shared mem
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
   ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_GCC_ARM/stm32wb55xx.ld
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_GCC_ARM/stm32wb55xx.ld
@@ -3,7 +3,7 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-#define MBED_APP_SIZE 512K
+#define MBED_APP_SIZE 768K
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_IAR/stm32wb55xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/TOOLCHAIN_IAR/stm32wb55xx.icf
@@ -17,9 +17,9 @@
  */
 
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x80000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0xC0000; }
 
-/* [ROM = 512kb = 0x80000] */
+/* [ROM = 768kb = 0xC0000] */
 define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/flash_data.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/device/flash_data.h
@@ -37,8 +37,8 @@
 #undef FLASH_SIZE
 #endif
 
-// Only the first 128 pages are accessible when security is enabled
-#define FLASH_SIZE    ((uint32_t)0x80000) // 128 pages x 4 Kbytes = 512 Kbytes
+// Only the first the application side is accessible.
+#define FLASH_SIZE    ((uint32_t)0xC0000) // 768 Kbytes
 
 #endif
 #endif


### PR DESCRIPTION
### Description
The flash is shared and split between cortex-M4 that
runs (mbed-os) application and the cortex-M0+ that
runs the BLE Low-level firmware stack.

The 512K allocated to the application was a conservative value 

EDIT: 
that can now be updated with official ; 768KB as BLE firmware is being flashed strating from @ 0x080C0000 (or further address).


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@jeromecoutant 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
