### PR TITLE
SPI: Prime asynch transaction buffer on construction

### DIFF
--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -83,6 +83,12 @@ void SPI::_do_construct()
         _peripheral->name = name;
     }
     core_util_critical_section_exit();
+
+#if DEVICE_SPI_ASYNCH && TRANSACTION_QUEUE_SIZE_SPI
+    // prime the SingletonPtr, so we don't have a problem trying to
+    // construct the buffer if asynch operation initiated from IRQ
+    _peripheral->transaction_buffer.get();
+#endif
     // we don't need to _acquire at this stage.
     // this will be done anyway before any operation.
 }


### PR DESCRIPTION

### Description

SPI peripherals' asynch transaction buffers are now wrapped by `SingletonPtr`, which needs to take the singleton_lock `Mutex` when first accessed. If it was first accessed by an asynch transaction started from IRQ, that would not be possible.

Add a `SingletonPtr::get()` call to the `SPI` construction process so that the peripheral's buffer is fully constructed before any `SPI` methods can be called, meaning asynch methods won't fail from IRQ.

(Other pre-existing synchronisation issues with async remain, but this  avoids a new trap in Mbed OS 5.12).

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@stevew817 