### PR TITLE
Allow NC pins to be instantiated on Silicon Labs platforms

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/gpio_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/gpio_api.c
@@ -29,6 +29,8 @@
 
 void gpio_write(gpio_t *obj, int value)
 {
+    MBED_ASSERT(obj->pin != NC);
+
     if (value) {
         GPIO_PinOutSet((GPIO_Port_TypeDef)(obj->pin >> 4 & 0xF), obj->pin & 0xF); // Pin number encoded in first four bits of obj->pin
     } else {
@@ -38,6 +40,8 @@ void gpio_write(gpio_t *obj, int value)
 
 int gpio_read(gpio_t *obj)
 {
+    MBED_ASSERT(obj->pin != NC);
+
     if (obj->dir == PIN_INPUT) {
         return GPIO_PinInGet((GPIO_Port_TypeDef)(obj->pin >> 4 & 0xF), obj->pin & 0xF); // Pin number encoded in first four bits of obj->pin
     } else {
@@ -63,8 +67,6 @@ uint32_t gpio_set(PinName pin)
 
 void gpio_init(gpio_t *obj, PinName pin)
 {
-    MBED_ASSERT(pin != NC);
-
     CMU_ClockEnable(cmuClock_HFPER, true);
     CMU_ClockEnable(cmuClock_GPIO, true);
     obj->pin = pin;
@@ -72,6 +74,8 @@ void gpio_init(gpio_t *obj, PinName pin)
 
 void gpio_mode(gpio_t *obj, PinMode mode)
 {
+    MBED_ASSERT(obj->pin != NC);
+
     uint32_t pin = 1 << (obj->pin & 0xF);
     uint32_t port = (obj->pin >> 4) & 0xF;
 
@@ -129,6 +133,8 @@ void gpio_mode(gpio_t *obj, PinMode mode)
 // Used by DigitalInOut to set correct mode when direction is set
 void gpio_dir(gpio_t *obj, PinDirection direction)
 {
+    MBED_ASSERT(obj->pin != NC);
+
     obj->dir = direction;
     switch (direction) {
         case PIN_INPUT:


### PR DESCRIPTION
### Description

Allow gpio objects to be instantiated with NC on Silicon Labs targets. Although this is nowhere defined, it seems to be the de-facto standard to allow this on mbed.

Closes #7862
Closes #10191 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
