### PR TITLE
PSOC6: move mbed_sdk_init to mbed_overrides.c

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_4343W/device/system_psoc6_cm4.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_4343W/device/system_psoc6_cm4.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -42,10 +38,6 @@
         #include "cy_flash.h"
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -269,41 +261,6 @@ void SystemInit(void)
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
 }
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    mailbox_init();
-#endif
-
-    /* Set up the device based on configurator selections */
-    init_cycfg_all();
-
-    /* Enable global interrupts */
-    __enable_irq();
-}
-
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/system_psoc6_cm4.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/device/system_psoc6_cm4.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -42,10 +38,6 @@
         #include "cy_flash.h"
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -269,41 +261,6 @@ void SystemInit(void)
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
 }
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    mailbox_init();
-#endif
-
-    /* Set up the device based on configurator selections */
-    init_cycfg_all();
-
-    /* Enable global interrupts */
-    __enable_irq();
-}
-
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/TARGET_MCU_PSOC6_M0/system_psoc6_cm0plus.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/TARGET_MCU_PSOC6_M0/system_psoc6_cm0plus.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -43,10 +39,6 @@
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -163,38 +155,6 @@ uint32_t cy_delay32kMs    = CY_DELAY_MS_OVERFLOW_THRESHOLD *
 #define CY_SYS_CM4_PWR_CTL_KEY_OPEN  (0x05FAUL)
 #define CY_SYS_CM4_PWR_CTL_KEY_CLOSE (0xFA05UL)
 #define CY_SYS_CM4_VECTOR_TABLE_VALID_ADDR  (0x000003FFUL)
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    /* Configure mailbox IPC interrupts */
-    mailbox_init();
-#else
-    /* Enable global interrupts */
-    __enable_irq();
-#endif
-}
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/TARGET_MCU_PSOC6_M4/system_psoc6_cm4.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/device/TARGET_MCU_PSOC6_M4/system_psoc6_cm4.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -42,10 +38,6 @@
         #include "cy_flash.h"
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -269,41 +261,6 @@ void SystemInit(void)
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
 }
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    mailbox_init();
-#endif
-
-    /* Set up the device based on configurator selections */
-    init_cycfg_all();
-
-    /* Enable global interrupts */
-    __enable_irq();
-}
-
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CMOD_062_4343W/device/system_psoc6_cm4.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CMOD_062_4343W/device/system_psoc6_cm4.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -42,10 +38,6 @@
         #include "cy_flash.h"
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -269,41 +261,6 @@ void SystemInit(void)
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
 }
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    mailbox_init();
-#endif
-
-    /* Set up the device based on configurator selections */
-    init_cycfg_all();
-
-    /* Enable global interrupts */
-    __enable_irq();
-}
-
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/device/TARGET_MCU_PSOC6_M0/system_psoc6_cm0plus.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/device/TARGET_MCU_PSOC6_M0/system_psoc6_cm0plus.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -43,10 +39,6 @@
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -163,38 +155,6 @@ uint32_t cy_delay32kMs    = CY_DELAY_MS_OVERFLOW_THRESHOLD *
 #define CY_SYS_CM4_PWR_CTL_KEY_OPEN  (0x05FAUL)
 #define CY_SYS_CM4_PWR_CTL_KEY_CLOSE (0xFA05UL)
 #define CY_SYS_CM4_VECTOR_TABLE_VALID_ADDR  (0x000003FFUL)
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    /* Configure mailbox IPC interrupts */
-    mailbox_init();
-#else
-    /* Enable global interrupts */
-    __enable_irq();
-#endif
-}
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/device/TARGET_MCU_PSOC6_M4/system_psoc6_cm4.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/device/TARGET_MCU_PSOC6_M4/system_psoc6_cm4.c
@@ -22,16 +22,12 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <stdint.h>
 #include <stdbool.h>
-#include "cy_device.h"
-#include "device.h"
 #include "system_psoc6.h"
+#include "cy_device.h"
 #include "cy_device_headers.h"
-#include "psoc6_utils.h"
 #include "cy_syslib.h"
 #include "cy_wdt.h"
-#include "cycfg.h"
 
 #if !defined(CY_IPC_DEFAULT_CFG_DISABLE)
     #include "cy_ipc_sema.h"
@@ -42,10 +38,6 @@
         #include "cy_flash.h"
     #endif /* defined(CY_DEVICE_PSOC6ABLE2) */
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
-
-#if defined(COMPONENT_SPM_MAILBOX)
-void mailbox_init(void);
-#endif
 
 
 /*******************************************************************************
@@ -269,41 +261,6 @@ void SystemInit(void)
 
 #endif /* !defined(CY_IPC_DEFAULT_CFG_DISABLE) */
 }
-
-
-/*******************************************************************************
-* Function Name: mbed_sdk_init
-****************************************************************************//**
-*
-* Mbed's post-memory-initialization function.
-* Used here to initialize common parts of the Cypress libraries.
-*
-*******************************************************************************/
-void mbed_sdk_init(void)
-{
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
-    /* Initialize shared resource manager */
-    cy_srm_initialize();
-
-    /* Initialize system and clocks. */
-    /* Placed here as it must be done after proper LIBC initialization. */
-    SystemInit();
-
-#if defined(COMPONENT_SPM_MAILBOX)
-    mailbox_init();
-#endif
-
-    /* Set up the device based on configurator selections */
-    init_cycfg_all();
-
-    /* Enable global interrupts */
-    __enable_irq();
-}
-
 
 
 /*******************************************************************************

--- a/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
@@ -34,11 +34,6 @@ void mailbox_init(void);
 *******************************************************************************/
 void mbed_sdk_init(void)
 {
-#if !defined(COMPONENT_SPM_MAILBOX)
-    /* Disable global interrupts */
-    __disable_irq();
-#endif
-
     /* Initialize shared resource manager */
     cy_srm_initialize();
 
@@ -50,16 +45,11 @@ void mbed_sdk_init(void)
     mailbox_init();
 #endif
 
-#if (CY_CPU_CORTEX_M0P)
-    #if !defined(COMPONENT_SPM_MAILBOX)
-        /* Enable global interrupts */
-        __enable_irq();
-    #endif
-#else
+#if (!CY_CPU_CORTEX_M0P)
     /* Set up the device based on configurator selections */
     init_cycfg_all();
 
-    /* Enable global interrupts */
+    /* Enable global interrupts (disabled in CM4 startup assembly) */
     __enable_irq();
 #endif
 }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/mbed_overrides.c
@@ -1,0 +1,65 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2018-2019 Cypress Semiconductor Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "device.h"
+#include "psoc6_utils.h"
+#include "cycfg.h"
+
+#if defined(COMPONENT_SPM_MAILBOX)
+void mailbox_init(void);
+#endif
+
+/*******************************************************************************
+* Function Name: mbed_sdk_init
+****************************************************************************//**
+*
+* Mbed's post-memory-initialization function.
+* Used here to initialize common parts of the Cypress libraries.
+*
+*******************************************************************************/
+void mbed_sdk_init(void)
+{
+#if !defined(COMPONENT_SPM_MAILBOX)
+    /* Disable global interrupts */
+    __disable_irq();
+#endif
+
+    /* Initialize shared resource manager */
+    cy_srm_initialize();
+
+    /* Initialize system and clocks. */
+    /* Placed here as it must be done after proper LIBC initialization. */
+    SystemInit();
+
+#if defined(COMPONENT_SPM_MAILBOX)
+    mailbox_init();
+#endif
+
+#if (CY_CPU_CORTEX_M0P)
+    #if !defined(COMPONENT_SPM_MAILBOX)
+        /* Enable global interrupts */
+        __enable_irq();
+    #endif
+#else
+    /* Set up the device based on configurator selections */
+    init_cycfg_all();
+
+    /* Enable global interrupts */
+    __enable_irq();
+#endif
+}


### PR DESCRIPTION
Purposes:
* Remove MbedOS-specific code from system_psoc6_{cm4,cm0plus}.c
  to simplify updates to new PDL version (startup code is part of PDL).
* Unify mbed_sdk_init initialization sequence for both CPU cores.
  This change is non-functional, sequence itself is not changed for any
  of the PSoC 6 M4/M0 PSA/non-PSA targets.
* Do not disable global interrupts during init_cycfg_all, this function is safe to execute with interrupts enabled.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
