### PR TITLE
NVStore.cpp compiler warning removal (os_ret)

### DIFF
--- a/features/storage/nvstore/source/nvstore.cpp
+++ b/features/storage/nvstore/source/nvstore.cpp
@@ -811,7 +811,6 @@ int NVStore::init()
     uint32_t free_space_offset_of_area[NVSTORE_NUM_AREAS];
     uint32_t init_attempts_val;
     uint32_t next_offset;
-    int os_ret;
     int ret = NVSTORE_SUCCESS;
     int valid;
     uint16_t key;
@@ -869,8 +868,8 @@ int NVStore::init()
 
         // Find start of empty space at the end of the area. This serves for both
         // knowing whether the area is empty and for the record traversal at the end.
-        os_ret = calc_empty_space(area, free_space_offset_of_area[area]);
-        MBED_ASSERT(!os_ret);
+        ret = calc_empty_space(area, free_space_offset_of_area[area]);
+        MBED_ASSERT(!ret);
 
         if (!free_space_offset_of_area[area]) {
             area_state[area] = NVSTORE_AREA_STATE_EMPTY;
@@ -891,8 +890,8 @@ int NVStore::init()
 
         // We have a non valid master record, in a non-empty area. Just erase the area.
         if ((!valid) || (key != master_record_key)) {
-            os_ret = flash_erase_area(area);
-            MBED_ASSERT(!os_ret);
+            ret = flash_erase_area(area);
+            MBED_ASSERT(!ret);
             area_state[area] = NVSTORE_AREA_STATE_EMPTY;
             continue;
         }
@@ -939,8 +938,8 @@ int NVStore::init()
             _active_area = 1;
         }
         _active_area_version = versions[_active_area];
-        os_ret = flash_erase_area(1 - _active_area);
-        MBED_ASSERT(!os_ret);
+        ret = flash_erase_area(1 - _active_area);
+        MBED_ASSERT(!ret);
     }
 
     // Traverse area until reaching the empty space at the end or until reaching a faulty record


### PR DESCRIPTION
### Description

One gets this compiler warning from nvstore.cpp:

```
Compile [ 48.6%]: nvstore.cpp
[Warning] nvstore.cpp@814,9: variable 'os_ret' set but not used [-Wunused-but-set-variable]
```

Turns out it's caused by the fact that the variable is only used
with `MBED_ASSERT`s, which get optimized out or not, depending on your
build profile. In reality we do not need a separate variable for that
in my opinion though, so we can just use the `ret`-variable instead
and drop the `os_ret` variable completely and thus avoid this
compiler warning.


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@davidsaada  @bulislaw 

