### PR TITLE
Remove sleep lock/unlock from Silicon Labs HAL implementation

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
@@ -28,7 +28,6 @@
 #if DEVICE_I2C
 
 #include "mbed_assert.h"
-#include "mbed_power_mgmt.h"
 #include "i2c_api.h"
 #include "PeripheralPins.h"
 #include "pinmap_function.h"
@@ -466,7 +465,6 @@ void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
 #include "em_dma.h"
 #include "dma_api_HAL.h"
 #include "dma_api.h"
-#include "sleep_api.h"
 #include "buffer.h"
 
 /** Start i2c asynchronous transfer.
@@ -527,18 +525,7 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
     // Kick off the transfer
     retval = I2C_TransferInit(obj->i2c.i2c, &(obj->i2c.xfer));
 
-    if(retval == i2cTransferInProgress) {
-        sleep_manager_lock_deep_sleep();
-    } else {
-        // something happened, and the transfer did not go through
-        // So, we need to clean up
-
-        // Disable interrupt
-        i2c_enable_interrupt(obj, 0, false);
-
-        // Block until free
-        while(i2c_active(obj));
-    }
+    MBED_ASSERT(retval == i2cTransferInProgress);
 }
 
 /** The asynchronous IRQ handler
@@ -561,23 +548,17 @@ uint32_t i2c_irq_handler_asynch(i2c_t *obj)
             // Disable interrupt
             i2c_enable_interrupt(obj, 0, false);
 
-            sleep_manager_unlock_deep_sleep();
-
             return I2C_EVENT_TRANSFER_COMPLETE & obj->i2c.events;
         case i2cTransferNack:
             // A NACK has been received while an ACK was expected. This is usually because the slave did not respond to the address.
             // Disable interrupt
             i2c_enable_interrupt(obj, 0, false);
 
-            sleep_manager_unlock_deep_sleep();
-
             return I2C_EVENT_ERROR_NO_SLAVE & obj->i2c.events;
         default:
             // An error situation has arisen.
             // Disable interrupt
             i2c_enable_interrupt(obj, 0, false);
-
-            sleep_manager_unlock_deep_sleep();
 
             // return error
             return I2C_EVENT_ERROR & obj->i2c.events;
@@ -609,8 +590,6 @@ void i2c_abort_asynch(i2c_t *obj)
 
     // Block until free
     while(i2c_active(obj));
-
-    sleep_manager_unlock_deep_sleep();
 }
 
 #endif //DEVICE_I2C ASYNCH

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -26,7 +26,6 @@
 #if DEVICE_SPI
 
 #include "mbed_assert.h"
-#include "mbed_power_mgmt.h"
 #include "PeripheralPins.h"
 #include "pinmap.h"
 #include "pinmap_function.h"
@@ -39,7 +38,6 @@
 #include "em_usart.h"
 #include "em_cmu.h"
 #include "em_dma.h"
-#include "sleep_api.h"
 
 static uint16_t fill_word = SPI_FILL_WORD;
 
@@ -1185,9 +1183,6 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spi_enable_event(obj, SPI_EVENT_ALL, false);
     spi_enable_event(obj, event, true);
 
-    // Set the sleep mode
-    sleep_manager_lock_deep_sleep();
-
     /* And kick off the transfer */
     spi_master_transfer_dma(obj, tx, rx, tx_length, rx_length, (void*)handler, hint);
 }
@@ -1242,7 +1237,6 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
 
         /* Wait transmit to complete, before user code is indicated*/
         while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
-        sleep_manager_unlock_deep_sleep();
         /* return to CPP land to say we're finished */
         return SPI_EVENT_COMPLETE;
     } else {
@@ -1260,7 +1254,6 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
             /* disable interrupts */
             spi_enable_interrupt(obj, (uint32_t)NULL, false);
 
-            sleep_manager_unlock_deep_sleep();
             /* Return the event back to userland */
             return event;
         }
@@ -1368,7 +1361,6 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
 
         /* Wait for transmit to complete, before user code is indicated */
         while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
-        sleep_manager_unlock_deep_sleep();
 
         /* return to CPP land to say we're finished */
         return SPI_EVENT_COMPLETE;
@@ -1389,7 +1381,6 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
 
             /* Wait for transmit to complete, before user code is indicated */
             while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
-            sleep_manager_unlock_deep_sleep();
 
             /* Return the event back to userland */
             return event;
@@ -1429,9 +1420,6 @@ void spi_abort_asynch(spi_t *obj)
         // Interrupt implementation: switch off interrupts
         spi_enable_interrupt(obj, (uint32_t)NULL, false);
     }
-
-    // Release sleep mode block
-    sleep_manager_unlock_deep_sleep();
 }
 
 const PinMap *spi_master_mosi_pinmap()


### PR DESCRIPTION
The sleep locking/unlocking is taken care of by the layer above (driver).

### Description

Removing the sleep locking/unlocking calls from I2C and SPI, since they are taken care of by the layer above (driver).


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
