### PR TITLE
STM32F303RE: Activate FLASHIAP

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2413,6 +2413,7 @@
                 "macro_name": "CLOCK_SOURCE"
             }
         },
+        "components_add": ["FLASHIAP"],
         "detect_code": ["0745"],
         "device_has_add": [
             "ANALOGOUT",


### PR DESCRIPTION
### Description

As suggested in #10486 by @JanneKiiskila, we may activate FLASHIAP for F303RE.
Flash driver is already in place. 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
```
Tests results:
+-----------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target                | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+-----------------------------+--------+--------------------+-------------+
| NUCLEO_F303RE-GCC_ARM | NUCLEO_F303RE | tests-mbed_drivers-flashiap | OK     | 18.39              | default     |
+-----------------------+---------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+-----------------------+---------------+-----------------------------+-----------------------------------+--------+--------+--------+--------                                                       ------------+
| target                | platform_name | test suite                  | test case                         | passed | failed | result | elapsed                                                       _time (sec) |
+-----------------------+---------------+-----------------------------+-----------------------------------+--------+--------+--------+--------                                                       ------------+
| NUCLEO_F303RE-GCC_ARM | NUCLEO_F303RE | tests-mbed_drivers-flashiap | FlashIAP - init                   | 1      | 0      | OK     | 0.09                                                                      |
| NUCLEO_F303RE-GCC_ARM | NUCLEO_F303RE | tests-mbed_drivers-flashiap | FlashIAP - program                | 1      | 0      | OK     | 0.22                                                                      |
| NUCLEO_F303RE-GCC_ARM | NUCLEO_F303RE | tests-mbed_drivers-flashiap | FlashIAP - program across sectors | 1      | 0      | OK     | 0.16                                                                      |
| NUCLEO_F303RE-GCC_ARM | NUCLEO_F303RE | tests-mbed_drivers-flashiap | FlashIAP - program errors         | 1      | 0      | OK     | 0.1                                                                       |
| NUCLEO_F303RE-GCC_ARM | NUCLEO_F303RE | tests-mbed_drivers-flashiap | FlashIAP - timing                 | 1      | 0      | OK     | 1.01                                                                      |
+-----------------------+---------------+-----------------------------+-----------------------------------+--------+--------+--------+--------                                                       ------------+
mbedgt: test case results: 5 OK
mbedgt: completed in 30.58 sec
```
