### PR TITLE
Enable "FlashIAP" for Nucleo F303RE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2407,6 +2407,7 @@
         "supported_form_factors": ["ARDUINO", "MORPHO"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32F3", "STM32F303xE", "STM32F303RE"],
+        "components_add": ["FLASHIAP"],
         "config": {
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",


### PR DESCRIPTION
Add the component FlashIAP to Nucleo F303RE to
enable Pelion Device Management client.

Ref: mbed-os-issue #10486 

Kudos to @LMESTM for testing it.

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@LMESTM  @ARMmbed/team-st-mcd  @adbridge 

### Release Notes

Enable FlashIAP on Nucleo F303RE
