### PR TITLE
Allow application to override LWIP_RAW

### DIFF
--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -83,7 +83,9 @@
 
 #define SYS_LIGHTWEIGHT_PROT        1
 
+#ifndef LWIP_RAW
 #define LWIP_RAW                    0
+#endif
 
 #define TCPIP_MBOX_SIZE             8
 #define DEFAULT_TCP_RECVMBOX_SIZE   8


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Allow application to override LWIP_RAW. Current implementation does not allow application to override LWIP_RAW setting. This is needed for Mbed-OS ping to work without changing Mbed-OS directly.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
