### PR TITLE
This removes many const char* warnings related with LWIP_ASSERT()

### DIFF
--- a/features/lwipstack/lwip-sys/arch/cc.h
+++ b/features/lwipstack/lwip-sys/arch/cc.h
@@ -110,7 +110,7 @@ MBED_NORETURN void lwip_mbed_assert_fail(const char *msg, const char *func, cons
 #else // MBED_CONF_LWIP_USE_MBED_TRACE
 #include <stdio.h>
 
-MBED_NORETURN void assert_printf(char *msg, int line, char *file);
+MBED_NORETURN void assert_printf(const char *msg, int line, const char *file);
 
 /* Plaform specific diagnostic output */
 #define LWIP_PLATFORM_DIAG(vars) printf vars

--- a/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
@@ -611,7 +611,7 @@ MBED_NORETURN void lwip_mbed_assert_fail(const char *msg, const char *func, cons
     \param[in]    line  Line number in file with error
     \param[in]    file  Filename with error
  */
-MBED_NORETURN void assert_printf(char *msg, int line, char *file) {
+MBED_NORETURN void assert_printf(const char *msg, int line, const char *file) {
     if (msg)
         error("%s:%d in file %s\n", msg, line, file);
     else


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

If we enable LWIP debugging option like `"lwip.debug-enabled": true,`, we get many warnings related with LWIP_ASSERT like following.
```
[Warning] cc.h@117,78: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
[Warning] cc.h@117,78: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
[Warning] cc.h@117,78: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
```
For more information, please refer to the attached build_log.txt file.
[build_log.txt](https://github.com/ARMmbed/mbed-os/files/3137744/build_log.txt)

The code change removes duplicate warnings.
This problem was reproduced in GCC_ARM and fixed in GCC_ARM. Other toolchains are not tested.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
