### PR TITLE
PSA: mbedSPM correct SPM initialization order

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtos_rtx.c
+++ b/rtos/TARGET_CORTEX/mbed_rtos_rtx.c
@@ -91,8 +91,8 @@ MBED_NORETURN void mbed_rtos_start()
 
 #if defined(COMPONENT_SPE)
     // At this point, the mailbox is already initialized
-    spm_hal_start_nspe();
     psa_spm_init();
+    spm_hal_start_nspe();
 #endif // defined(COMPONENT_SPE)
 
 #if defined(COMPONENT_NSPE) && defined(COMPONENT_SPM_MAILBOX)


### PR DESCRIPTION
### Description
psa_spm_init() was being called after starting the non-secure core,
resulting in a possible situation where the non-secure core can run without memory protection turned on.

Tested on PSOC6_PSA with GCC_ARM
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@maclobdell @alzix @ARMmbed/mbed-os-maintainers 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
