### PR TITLE
LPC55S69: Add support for UART hardware flow control

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_LPCXpresso/PeripheralPins.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_LPCXpresso/PeripheralPins.c
@@ -65,21 +65,27 @@ const PinMap PinMap_I2C_SCL[] = {
 /************UART***************/
 const PinMap PinMap_UART_TX[] = {
     {P0_30, UART_0, 1},
+    {P1_6,  UART_0, 1},
     {P0_27, UART_1, 1},
     {NC   ,  NC   , 0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {P0_29, UART_0, 1},
+    {P1_5,  UART_0, 1},
     {P1_24, UART_1, 1},
     {NC   ,  NC   , 0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
+    {P1_8,  UART_0, 1},
+    {P1_26, UART_1, 1},
     {NC   , NC    , 0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
+    {P1_7,  UART_0, 1},
+    {P1_27, UART_1, 1},
     {NC   , NC    , 0}
 };
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2088,6 +2088,7 @@
             "PORTINOUT",
             "PORTOUT",
             "SERIAL",
+            "SERIAL_FC",
             "SLEEP",
             "SPI",
             "SPISLAVE",


### PR DESCRIPTION
### Description
LPC55S69: Add support for UART hardware flow control. This is a fix for Issue https://github.com/ARMmbed/mbed-os/issues/10400


### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

