### PR TITLE
Fix ARMC6 fpu detection for M33 core

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -547,6 +547,7 @@ class ARMC6(ARM_STD):
             "Cortex-M7FD": "cortex-m7",
             "Cortex-M33": "cortex-m33+nodsp",
             "Cortex-M33F": "cortex-m33+nodsp",
+            "Cortex-M33E": "cortex-m33",
             "Cortex-M33FE": "cortex-m33"}.get(core, core)
 
         cpu = cpu.lower()

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -554,7 +554,7 @@ class ARMC6(ARM_STD):
         self.SHEBANG += " -mcpu=%s" % cpu
 
         # FPU handling
-        if core == "Cortex-M4" or core == "Cortex-M7" or core == "Cortex-M33":
+        if core in ["Cortex-M4", "Cortex-M7", "Cortex-M33", "Cortex-M33E"]:
             self.flags['common'].append("-mfpu=none")
         elif core == "Cortex-M4F":
             self.flags['common'].append("-mfpu=fpv4-sp-d16")

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -554,7 +554,7 @@ class ARMC6(ARM_STD):
         self.SHEBANG += " -mcpu=%s" % cpu
 
         # FPU handling
-        if core == "Cortex-M4" or core == "Cortex-M7" or "core" == "Cortex-M33":
+        if core == "Cortex-M4" or core == "Cortex-M7" or core == "Cortex-M33":
             self.flags['common'].append("-mfpu=none")
         elif core == "Cortex-M4F":
             self.flags['common'].append("-mfpu=fpv4-sp-d16")


### PR DESCRIPTION
### Description
normal Coretex-M33 was not adding `-mfpu=none` to the build command
this issue was caused by #10390

This fix is needed for #9221 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kjbracey-arm @ARMmbed/mbed-os-maintainers 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
