### PR TITLE
Cortex M33: set DOMAIN_NS to 0 when TZ is not used

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -522,7 +522,7 @@ class ARMC6(ARM_STD):
                 self.flags['asm'].append("--library_type=microlib")
 
         core = target.core
-        if CORE_ARCH[target.core] == 8:
+        if CORE_ARCH[target.core] == 8 and (target.is_PSA_secure_target or "MBED_TZ_DEFAULT_ACCESS=1" in target.macros):
             if ((not target.core.endswith("-NS")) and
                     kwargs.get('build_dir', False)):
                 # Create Secure library

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -61,7 +61,7 @@ class GCC(mbedToolchain):
 
         core = target.core
         self.cpu = []
-        if CORE_ARCH[target.core] == 8:
+        if CORE_ARCH[target.core] == 8 and (target.is_PSA_secure_target or "MBED_TZ_DEFAULT_ACCESS=1" in target.macros):
             # Add linking time preprocessor macro DOMAIN_NS
             if target.core.endswith("-NS"):
                 self.flags["ld"].append("-DDOMAIN_NS=1")

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -55,7 +55,7 @@ class IAR(mbedToolchain):
             build_profile=build_profile
         )
         core = target.core
-        if CORE_ARCH[target.core] == 8:
+        if CORE_ARCH[target.core] == 8 and (target.is_PSA_secure_target or "MBED_TZ_DEFAULT_ACCESS=1" in target.macros):
             # Add linking time preprocessor macro DOMAIN_NS
             if target.core.endswith("-NS"):
                 define_string = self.make_ld_define("DOMAIN_NS", "0x1")


### PR DESCRIPTION
### Description

This could fix #9460 ?

If TFM is not used for a V8M target:
- cmse compilation option is not set
- DOMAIN_NS is explitely defined for non-NS targets


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-psa 
@LMESTM 
@kjbracey-arm 
