### PR TITLE
32 Byte key derivation may fail with a 16 Byte ROT key

### DIFF
--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -169,7 +169,7 @@ int DeviceKey::read_key_from_kvstore(uint32_t *output, size_t &size)
         return DEVICEKEY_NOT_FOUND;
     }
 
-    int kvStatus = ((TDBStore *)inner_store)->reserved_data_get(output, size);
+    int kvStatus = ((TDBStore *)inner_store)->reserved_data_get(output, size, &size);
     if (MBED_ERROR_ITEM_NOT_FOUND == kvStatus) {
         return DEVICEKEY_NOT_FOUND;
     }


### PR DESCRIPTION
### Description
When trying to derive 32 bytes key with a 16 bytes ROT key the process may fail cause the ROT returned buffer size from kvstore has been ignored. 


This bug fix is influencing PR #10493 (STM32F303RE: Activate FLASHIAP)  because the device key test is failing on that PR.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@JanneKiiskila, @jeromecoutant 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
