### PR TITLE
Permit non-TrustZone ARMv8 build

### DIFF
--- a/components/TARGET_PSA/TARGET_TFM/tf-m-integration.md
+++ b/components/TARGET_PSA/TARGET_TFM/tf-m-integration.md
@@ -26,12 +26,12 @@ TF-M is built as bare-metal in a secure target, in order to build a secure targe
 ## Build hooks
 
 Mbed-OS testing tools are designed to work with a single image (`.bin` or `.hex`).
-When building mbed-os for ARMv8-M targets two images are created. One for normal world(NW) and one for TrustZone(TZ).
+When building mbed-os for TF-M targets two images are created. One for normal world(NW) and one for TrustZone(TZ).
 Mbed-OS build system provides `post_binary_hook` that allows executing arbitrary Python script for merging NW and TZ images. Typically `post_binary_hook` is added to NW target and assumes TZ target images as a prerequisite.
 
-## Porting ARMv8-M targets
+## Porting TF-M targets
 
-Typically firmware for ARMv8-M targets consist of 2 or more images: normal world and TrustZone image. More images can be present in case boot loaders are used.
+Typically firmware for TF-M targets consist of 2 or more images: normal world and TrustZone image. More images can be present in case boot loaders are used.
 Two images must be built and linked separately. TrustZone image must be built first.
 
 There may be code and/or header files sharing between the two targets.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1,6 +1,7 @@
 {
     "Target": {
         "core": null,
+        "trustzone": false,
         "default_toolchain": "ARM",
         "supported_toolchains": null,
         "extra_labels": [],
@@ -8042,6 +8043,7 @@
             "MBED_TZ_DEFAULT_ACCESS=1",
             "LPTICKER_DELAY_TICKS=3"
         ],
+        "trustzone": true,
         "is_disk_virtual": true,
         "supported_toolchains": ["ARMC6"],
         "config": {

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -601,10 +601,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         if into_dir:
             copy_when_different(res[0], into_dir)
             if not extra_artifacts:
-                if (
-                    CORE_ARCH[toolchain.target.core] == 8 and
-                    not toolchain.target.core.endswith("NS")
-                ):
+                if toolchain.target.is_TrustZone_secure_target:
                     cmse_lib = join(dirname(res[0]), "cmse_lib.o")
                     copy_when_different(cmse_lib, into_dir)
             else:

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -380,6 +380,32 @@ class Target(namedtuple(
         return labels
 
     @property
+    def core_without_NS(self):
+        if self.core.endswith('-NS'):
+            return self.core[:-3]
+        else:
+            return self.core
+
+    # Mechanism for specifying TrustZone is subject to change - see
+    # discussion on https://github.com/ARMmbed/mbed-os/issues/9460
+    # In the interim, we follow heuristics that support existing
+    # documentation for ARMv8-M TF-M integration (check the "TFM" label),
+    # plus an extra "trustzone" flag set by M2351, and looking at the "-NS"
+    # suffix. This now permits non-TrustZone ARMv8 builds if
+    # having trustzone = false (default), no TFM flag, and no -NS suffix.
+    @property
+    def is_TrustZone_secure_target(self):
+        return (getattr(self, 'trustzone', False) or 'TFM' in self.labels) and not self.core.endswith('-NS')
+
+    @property
+    def is_TrustZone_non_secure_target(self):
+        return self.core.endswith('-NS')
+
+    @property
+    def is_TrustZone_target(self):
+        return self.is_TrustZone_secure_target or self.is_TrustZone_non_secure_target
+
+    @property
     def is_PSA_secure_target(self):
         return 'SPE_Target' in self.labels
 


### PR DESCRIPTION
### Description

Change the heuristic for selection of CMSE in the tools python, so that a non-TrustZone ARMv8 build can happen.

Ideally we would have more direct flagging in the targets, but this refines the heuristic so the necessary behaviour can be easily achieved.

* DOMAIN_NS=1 is based purely on the `-NS` suffix on the core name.

* Enabling CMSE in the compiler and outputting a secure import library is now enabled when the core doesn't have an `-NS` suffix by either the target label `TFM` being present or the flag `trustzone` being set.

This covers the existing ARMv8-M behaviour - TF-M builds have the `TFM` label, as per its documentation; M2351 secure builds have no explicit flagging, so we ensure that the M2351_NS target has the `trustzone` flag set, and the out-of-tree secure target inherits that.

Replacement for #10514, hopefully fixes #9460

Marked it as "fix", as I think it's quite reasonable to regard not being able to make non-TrustZone builds for current ARMs as a bug, although arguably it's a functionality change.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant, @alzix, @bridadan, @bulislaw

### Release Notes

* Non-TrustZone ARMv8 targets now supported (core must be set to `Cortex-M33` rather than `Cortex-M33-NS`).

