### PR TITLE
TEST: update python script to enable examples smoke test

### DIFF
--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -486,7 +486,8 @@ def update_mbedos_version(config, tag, examples):
 def fetch_output_image(output):
     """Find the build image from the last 5 lines of a given log"""
     lines = output.splitlines()
-    for index in range(-1,-6,-1):
+    last_index = -6 if len(lines)>4 else (-1 - len(lines))
+    for index in range(-1,last_index,-1):
         if lines[index].startswith("Image:"):
             image = lines[index][7:]
             if os.path.isfile(image):

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -373,6 +373,7 @@ def compile_repos(config, toolchains, targets, profile, verbose, examples):
     results = {}
     test_json = {"builds":{}}
     valid_examples = set(examples)
+    base_path = os.getcwd()
     print("\nCompiling example repos....\n")
     for example in config['examples']:
         example_names = [basename(x['repo']) for x in get_repo_list(example)]
@@ -430,7 +431,7 @@ def compile_repos(config, toolchains, targets, profile, verbose, examples):
                                     test_json['builds'][test_group] = {
                                         "platform":target ,
                                         "toolchain": toolchain ,
-                                        "base_path": os.getcwd() ,
+                                        "base_path": base_path ,
                                         "baud_rate": int(example['baud_rate']), 
                                         "tests":{} }
                                 test_json['builds'][test_group]['tests'][name]={"binaries":image_info}

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -411,6 +411,8 @@ def compile_repos(config, toolchains, targets, profile, verbose, examples):
                     
                     if test_example:
                         log = example['compare_log'].pop(0)
+                        # example['compare_log'] is a list of log file/files, which matches each examples/sub-examples from same repo. 
+                        # pop the log file out of list regardless the compilation for each example pass of fail
                         image = fetch_output_image(std_out)
                         if image:
                             image_info = [{"binary_type": "bootable","path": normpath(join(name,image)),"compare_log":log}]


### PR DESCRIPTION
### Description
The goal of this PR is to enable examples smoke test in CI
 * the new scripts will check `examples.json` if contains 'test', 'compare_log', 'baud_rate' keys
 * the new scripts will dump `test_spec.json` test in examples compiled successfully

The auto generated `test_spec.json` can be consumed by GreenTea.
This PR is related with ARMmbed/mbed-os-tools#162

`examples.json` is not required to be changed at moment. 
later on when test cases in each example are ready, corresponding example then will need to be updated. 


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers
@OPpuolitaival 

