### PR TITLE
Adding NetworkInterface::get_dns_server() virtual method.

### DIFF
--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -86,6 +86,11 @@ nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address, con
     return get_stack()->add_dns_server(address, interface_name);
 }
 
+nsapi_error_t NetworkInterface::get_dns_server(int index, SocketAddress *address, const char *interface_name)
+{
+    return get_stack()->get_dns_server(index, address, interface_name);
+}
+
 void NetworkInterface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
     // Dummy, that needs to be overwritten when inherited, but cannot be removed

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -260,6 +260,18 @@ public:
      */
     virtual nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name);
 
+    /** Get a domain name server from a list of servers to query
+     *
+     *  Returns a DNS server address for a index. If returns error no more
+     *  DNS servers to read.
+     *
+     *  @param index    Index of the DNS server, starts from zero
+     *  @param address  Destination for the host address
+     *  @param interface_name  Network interface name
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure
+     */
+    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address, const char *interface_name = NULL);
+
     /** Register callback for status reporting.
      *
      *  The specified status callback function will be called on status changes


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

`NetworkInterface` class is very useful for Mbed-OS application. However, it lacks `get_dns_server()` method which can be enabled by `protected NetworkStack::get_dns_server` method. 
From the application, there is definite need to know DNS server list. This PR fulfills the need with minimal code change.

Verified compiling well without any warnings in GCC_ARM toolchain.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
