### PR TITLE
Fix 'LICENSE' file 404 link error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Mbed OS][mbed-os-logo]][mbed-os-link]
 
-[![Build status release][mbed-travis-release-svg]][mbed-travis-release] 
-[![Build status master][mbed-travis-master-svg]][mbed-travis-master] 
-[![Tools coverage status][mbed-coveralls-tools-svg]][mbed-coveralls-tools] 
+[![Build status release][mbed-travis-release-svg]][mbed-travis-release]
+[![Build status master][mbed-travis-master-svg]][mbed-travis-master]
+[![Tools coverage status][mbed-coveralls-tools-svg]][mbed-coveralls-tools]
 
 [mbed-os-logo]: logo.png
 [mbed-os-link]: https://www.mbed.com/en/platform/mbed-os/
@@ -19,25 +19,25 @@ Mbed OS provides a platform that includes:
 
 - Security foundations.
 - Cloud management services.
-- Drivers for sensors, I/O devices and connectivity. 
+- Drivers for sensors, I/O devices and connectivity.
 
 ## Release notes
 The [release notes](https://os.mbed.com/releases) detail the current release. You can also find information about previous versions.
 
-## License and contributions 
+## License and contributions
 
 The software is provided under the [Apache-2.0 license](LICENSE-apache-2.0.txt). Contributions to this project are accepted under the same license. Please see [contributing.md](CONTRIBUTING.md) for more information.
 
 This project contains code from other projects. The original license text is included in those source files. They must comply with our [license guide](https://os.mbed.com/docs/mbed-os/latest/contributing/license.html).
 
-Folders containing files under different permissive license than Apache 2.0 are listed in the [LICENSE](LICENSE) file.
+Folders containing files under different permissive license than Apache 2.0 are listed in the [LICENSE](LICENSE.md) file.
 
 ## Getting started for developers
- 
+
 We have a [developer website](https://os.mbed.com) for asking questions, engaging with others, finding information on boards and components, using an online IDE and compiler, reading the documentation and learning about what's new and what's coming next in Mbed OS.
 
 ## Getting started for contributors
- 
+
 We also have a [contributing and publishing guide](https://os.mbed.com/contributing/) that covers licensing, contributor agreements and style guidelines.
 
 ## Documentation


### PR DESCRIPTION
### Description
Fix for the 'LICENSE' file link in the readme that currently 404s. 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@0xc0170 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
