### PR TITLE
Nuvoton: Add COMPONENT_FLASHIAP support

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7425,6 +7425,7 @@
             "FLASH",
             "MPU"
         ],
+        "components_add": ["FLASHIAP"],
         "release_versions": ["2", "5"],
         "device_name": "M453VG6AE",
         "bootloader_supported": true,
@@ -8091,6 +8092,7 @@
             "FLASH",
             "MPU"
         ],
+        "components_add": ["FLASHIAP"],
         "detect_code": ["1305"],
         "release_versions": ["5"],
         "device_name": "M2351KIAAEES",


### PR DESCRIPTION
### Description

Some Nuvoton targets support `DEVICE_FLASH` but its related `COMPONENT_FLASHIAP` support is not enabled. This PR enables it on these targets:

- NUMAKER_PFM_M453
- NUMAKER_PFM_M2351

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
