### PR TITLE
C027 Fix for modemOn flag

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.c
@@ -59,12 +59,14 @@ void ublox_mdm_powerOn(int usb)
     // turn on the mode by enabling power with power on pin low and correct USB detect level
     gpio_init_out_ex(&gpio, MDMUSBDET,  usb ? 1 : 0);  // USBDET: 0=disabled, 1=enabled
     if (!modemOn) { // enable modem
+        modemOn = true;
         gpio_init_out_ex(&gpio, MDMEN, 1);        // LDOEN:  1=on
         wait_ms(1);                   // wait until supply switched off
         // now we can safely enable the level shifters
         gpio_init_out_ex(&gpio, MDMLVLOE, 0);      // LVLEN:  0=enabled (uart/gpio)
-        if (gpsOn)
+        if (gpsOn) {
             gpio_init_out_ex(&gpio, MDMILVLOE, 1); // ILVLEN: 1=enabled (i2c)
+        }
     }
 }
 
@@ -78,13 +80,13 @@ void ublox_mdm_powerOff(void)
 {
     gpio_t gpio;
     if (modemOn) {
+        modemOn = false;
         // diable all level shifters
         gpio_init_out_ex(&gpio, MDMILVLOE, 0);  // ILVLEN: 0=disabled (i2c)
         gpio_init_out_ex(&gpio, MDMLVLOE, 1);   // LVLEN:  1=disabled (uart/gpio)
         gpio_init_out_ex(&gpio,MDMUSBDET, 0);  // USBDET: 0=disabled
         // now we can savely switch off the ldo
         gpio_init_out_ex(&gpio, MDMEN, 0);      // LDOEN:  0=off
-        modemOn = false;
     }
 }        
 
@@ -92,11 +94,13 @@ void ublox_gps_powerOn(void)
 {
     gpio_t gpio;
     if (!gpsOn) {
+        gpsOn = true;
         // switch on power supply
         gpio_init_out_ex(&gpio, GPSEN, 1);          // LDOEN: 1=on
         wait_ms(1);                     // wait until supply switched off
-        if (modemOn)
+        if (modemOn) {
             gpio_init_out_ex(&gpio, MDMILVLOE, 1);  // ILVLEN: 1=enabled (i2c)
+        }
     }
 }
 
@@ -104,6 +108,7 @@ void ublox_gps_powerOff(void)
 {
     gpio_t gpio;
     if (gpsOn) {
+        gpsOn = false;
         gpio_init_out_ex(&gpio, MDMILVLOE, 0);   // ILVLEN: 0=disabled (i2c)
         gpio_init_out_ex(&gpio, GPSEN, 0);       // LDOEN: 0=off
     }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
In C027 low level api, `modemOn` and `gpsOn` flags were not being set/clear as intended.
Fixes the issue described here #10452 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@fahim-ublox @RobMeades 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
