### PR TITLE
NANO130: Fix optimization error with NVIC_SetVector/NVIC_GetVector on ARMC6

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -19,6 +19,7 @@ define memory mem with size = 4G;
 define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
+define block ROMVEC    with alignment = 8                                   { readonly section .intvec };
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
@@ -26,7 +27,7 @@ define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
-place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
+place at address mem:__ICFEDIT_intvec_start__ { block ROMVEC };
 
 place in ROM_region   { readonly };
 place at start of IRAM_region   { block CSTACK };


### PR DESCRIPTION
### Description

On **ARMC6** with optimization level `-Os`, the two functions `NVIC_SetVector`/`NVIC_GetVector` are optimized to trapping instruction due to access to address 0. This PR fixes it by defining `NVIC_FLASH_VECTOR_ADDRESS` as a symbol instead of a direct 0 to avoid such unwanted optimization.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
