### PR TITLE
Changes required by the ST low power ticker wrapper.

### DIFF
--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -196,13 +196,14 @@ void test_multiple(void)
 template<typename T>
 void test_no_wait(void)
 {
-    Semaphore sem(0, 1);
-    T timeout;
-    timeout.attach_callback(mbed::callback(sem_callback, &sem), 0ULL);
-
-    bool acquired = sem.try_acquire();
-    TEST_ASSERT_TRUE(acquired);
-    timeout.detach();
+    for (int i = 0; i < 100; i++) {
+        Semaphore sem(0, 1);
+        T timeout;
+        timeout.attach_callback(mbed::callback(sem_callback, &sem), 0ULL);
+        int32_t sem_slots = sem.wait(0);
+        TEST_ASSERT_EQUAL(1, sem_slots);
+        timeout.detach();
+    }
 }
 
 /** Template for tests: accuracy of timeout delay

--- a/TESTS/mbed_hal/sleep/main.cpp
+++ b/TESTS/mbed_hal/sleep/main.cpp
@@ -122,7 +122,26 @@ void deepsleep_lpticker_test()
 
         lp_ticker_set_interrupt(next_match_timestamp);
 
+        /* On some targets like STM family boards with LPTIM enabled there is a required delay (~100 us) before we are able to
+           reprogram LPTIM_COMPARE register back to back. This is handled by the low level lp ticker wrapper which uses LPTIM_CMPOK interrupt.
+           CMPOK fires when LPTIM_COMPARE register can be safely reprogrammed again. During this period deep-sleep is locked.
+           This means that on these platforms we have additional interrupt (CMPOK) fired always ~100 us after programming lp ticker.
+           Since this interrupt wakes-up the board from the sleep we need to go to sleep after CMPOK is handled. */
+        TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep_test_check());
+
         sleep();
+
+        /* On some targets like STM family boards with LPTIM enabled an interrupt is triggered on counter rollover.
+           We need special handling for cases when next_match_timestamp < start_timestamp (interrupt is to be fired after rollover).
+           In such case after first wake-up we need to reset interrupt and go back to sleep waiting for the valid one.
+           NOTE: Above comment (CMPOK) applies also here.*/
+#if MBED_CONF_TARGET_LPTICKER_LPTIM
+        if ((next_match_timestamp < start_timestamp) && lp_ticker_read() < next_match_timestamp) {
+            lp_ticker_set_interrupt(next_match_timestamp);
+            wait_ns(200000);
+            sleep();
+        }
+#endif
 
         const timestamp_t wakeup_timestamp = lp_ticker_read();
 
@@ -154,10 +173,13 @@ void deepsleep_high_speed_clocks_turned_off_test()
 
     TEST_ASSERT_TRUE_MESSAGE(sleep_manager_can_deep_sleep(), "deep sleep should not be locked");
 
-    const unsigned int us_ticks_before_sleep = us_ticker_read();
-
     const timestamp_t wakeup_time = lp_ticker_read() + us_to_ticks(20000, lp_ticker_freq);
     lp_ticker_set_interrupt(wakeup_time);
+
+    /* Wait for CMPOK */
+    TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep_test_check());
+
+    const unsigned int us_ticks_before_sleep = us_ticker_read();
 
     sleep();
 

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -377,9 +377,12 @@ void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *o
     /* if prev is NULL we're at the head */
     if (prev == NULL) {
         ticker->queue->head = obj;
-        schedule_interrupt(ticker);
     } else {
         prev->next = obj;
+    }
+
+    if (prev == NULL || timestamp <= ticker->queue->present_time) {
+        schedule_interrupt(ticker);
     }
 
     core_util_critical_section_exit();


### PR DESCRIPTION
### Description

This PR is related to PR https://github.com/ARMmbed/mbed-os/pull/10701 (Stm lp ticker low-level wrapper).

While working on the low-level ticker wrapper the following issues have been found:

- `tests-mbed_hal-sleep`

1. When STM low-level lp ticker wrapper is in use an interrupt is triggered on counter rollover. We need special handling for cases when next_match_timestamp < start_timestamp (interrupt is to be fired after the rollover). In such case after first wake-up, we need to reset interrupt and go back to sleep waiting for the valid one.

2. On some targets like STM family boards with LPTIM enabled there is a required delay (~100 us) before we are able to reprogram LPTIM_COMPARE register back to back.
This is handled by the low-level lp ticker wrapper which uses LPTIM_CMPOK interrupt. CMPOK fires when LPTIM_COMPARE register can be safely reprogrammed again. This means that on these platforms we have additional interrupt (CMPOK) fired always ~100 us after programming lp ticker.
Since this interrupt wake-ups the board from the sleep we need to go to sleep after CMPOK is handled.

- `tests-mbed_drivers-lp_timeout`

It has been found that `Zero delay` test case sometimes fails. Test case creates `LowPowerTimeout` object and attaches callback with timeout `0` (no timeout).  This test was failing occasionally against ST low-level lp ticker wrapper. To make the test more stable, the proposition is to execute it 100 times in a loop.

- `Ticker common layer`: run interrupt reschedule if the inserted event has already expired. 

On some platforms, if low power ticker interrupt is set to very close value (e.g. timestamp < current tick + 3), then interrupt may not fire. This is one use case of lp ticker wrapper, but not all platforms use the wrapper. Some platforms cheat a bit and in this case, simply schedules interrupt a bit later. The problem has been found while working on the low-level lp ticker wrapper for ST boards which run lp ticker using LPTIM. These platforms have such limitation.

Failing test: `tests-mbed_drivers-lp_timeout (Test Case: Zero delay)`

In the test scenario, the lp ticker callback is attached with 0.0 s delay in the loop. The new events are put in the front of the lp ticker event list and interrupt reschedule is performed. Usually, the new event is already expired, interrupt fires immediately and next event from the list is then scheduled (e.g. system tick). When the next event (e.g. system tick) is very close to the current time it might be scheduled a bit later (because of lp ticker limitation). Let's assume that system tick has been delayed by 3 ticks and while inserting new zero delay event, absolute system tick time on the event list has already expired. In this case, zero delay event may be added after the expired system tick event and no reschedule is performed (because the head of the list has not changed). Interrupt also didn't fire yet since it has been delayed, so after return from attach_callback(0) we are still waiting for the delayed interrupt and zero delay callback has not been called instantly.

This may also affect other platforms which use such delays (Cypress, NORDIC, etc.).

The proposition is to add extra condition while adding an event to the event list. If the inserted event is already expired, then perform reschedule immediately.

Debug log `tests-mbed_drivers-lp_timeout (Test Case: Zero delay)` on `NUCLEO_L073RZ`:

![image](https://user-images.githubusercontent.com/30721012/58704570-d0128900-83ac-11e9-9292-7a82fdbdaff9.png)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@LMESTM 
@c1728p9 
