### PR TITLE
STM32 LP ticker workaround

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -226,8 +226,15 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
     /* Any successive write before the CMPOK flag be set, will lead to unpredictable results */
     /* LPTICKER_DELAY_TICKS value prevents OS to call this set interrupt function before CMPOK */
     MBED_ASSERT(__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == SET);
-    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-    __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
+
+    if(timestamp < lp_ticker_read()) {
+        /*  Workaround, because limitation */
+        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+        __HAL_LPTIM_COMPARE_SET(&LptimHandle, ~0);
+    } else {
+        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+        __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
+    }
 
     lp_ticker_clear_interrupt();
 


### PR DESCRIPTION
There is an errata in LPTIM specification that explains that CMP Flag
condition is not an exact match (COUNTER = MATCH) but rather a
comparison (COUNTER >= MATCH).

As a consequence the interrupt is firing early than expected when
programing a timestamp after the 0xFFFF wrap-around.

In order to
work-around this issue, we implement the below work-around.
In case timestamp is after the work-around, let's decide to program the
CMP value to 0xFFFF, which is the wrap-around value. There would anyway be
a wake-up at the time of wrap-around to let the OS update the system time.
When the wrap-around interrupt happen, OS will check the current time and
program again the timestamp to the proper value.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
