### PR TITLE
Cellular: Increase receiving timeout for UDP echo non-blocking test

### DIFF
--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -29,7 +29,7 @@ namespace {
 static const int SIGNAL_SIGIO_RX = 0x1;
 static const int SIGNAL_SIGIO_TX = 0x2;
 static const int SIGIO_TIMEOUT = 5000; //[ms]
-static const int WAIT2RECV_TIMEOUT = 2000; //[ms]
+static const int WAIT2RECV_TIMEOUT = 5000; //[ms]
 static const int RETRIES = 2;
 
 static const double EXPECTED_LOSS_RATIO = 0.0;


### PR DESCRIPTION
### Description

This is similar to PR https://github.com/ARMmbed/mbed-os/pull/10184 that incresed the timeout from 1s to 2s. The 2 seconds timeout still seems unstable -> increased to 5 seconds

WISE-1570 is passing the UDPSOCKET_ECHOTEST_NONBLOCK only with a greater receiving timeout.

Note: UDPSOCKET_ECHOTEST_BURST_NONBLOCK on the other hand would pass even with a receiving timeout of 1 sec. I think the UDPSOCKET_ECHOTEST_NONBLOCK can be improved so that receiving timeout of 1 sec would be enough for this test too. I will create an issue about this to the test responsable team.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change