### PR TITLE
TFM: Allow tfm_ns_lock_dispatch() can dispatch in some interrupt-disable condition

### DIFF
--- a/components/TARGET_PSA/TARGET_TFM/COMPONENT_NSPE/interface/src/tfm_ns_lock_rtx.c
+++ b/components/TARGET_PSA/TARGET_TFM/COMPONENT_NSPE/interface/src/tfm_ns_lock_rtx.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include "cmsis.h"
 #include "rtx_os.h"
+#include "rtx_lib.h"
 #include "cmsis_os2.h"
 #include "tfm_api.h"
 #include "tfm_ns_lock.h"
@@ -87,3 +88,12 @@ bool tfm_ns_lock_get_init_state()
     return ns_lock.init;
 }
 
+bool tfm_ns_lock_get_lock_state()
+{
+    if (ns_lock.init) {
+        os_mutex_t *mutex = osRtxMutexId(ns_lock.id);
+        return (mutex->lock != 0U);
+    } else {
+        return false;
+    }
+}

--- a/components/TARGET_PSA/TARGET_TFM/interface/include/tfm_ns_lock.h
+++ b/components/TARGET_PSA/TARGET_TFM/interface/include/tfm_ns_lock.h
@@ -44,6 +44,15 @@ enum tfm_status_e tfm_ns_lock_init();
  */
 bool tfm_ns_lock_get_init_state();
 
+/**
+ * \brief NS world, NS lock locked
+ *
+ * \details Check if NS lock has locked. If not and also interrupt disabled, the
+ *          current thread can regard as having acquired NS lock and can call into
+ *          secure world straight.
+ */
+bool tfm_ns_lock_get_lock_state();
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/TARGET_PSA/TARGET_TFM/interface/include/tfm_ns_lock.h
+++ b/components/TARGET_PSA/TARGET_TFM/interface/include/tfm_ns_lock.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "tfm_api.h"
 
 typedef int32_t (*veneer_fn) (uint32_t arg0, uint32_t arg1,
@@ -34,6 +35,14 @@ uint32_t tfm_ns_lock_dispatch(veneer_fn fn,
  *          to initialize the TFM NS lock object
  */
 enum tfm_status_e tfm_ns_lock_init();
+
+/**
+ * \brief NS world, NS lock initialized
+ *
+ * \details Check if NS lock has initialized. If not, NS world can call into
+ *          secure world straight because now is in pre-rtos stage.
+ */
+bool tfm_ns_lock_get_init_state();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

In TFM, to call secure function from non-secure world, we must go via `tfm_ns_lock_dispatch()` to guarantee thread-safe in secure world. Original implementation of `tfm_ns_lock_dispatch()` doesn't  allow this call in interrupt-disabled context for mutex acquire/release. This PR tries to relieve this limitation when:
1. Not in IRQ mode
1. IRQ masked
1. NS lock not owned by any thread

In this condition, NS lock can be seen as acquired by current thread and other threads cannot try to acquire it due to interrupt disabled, so the call to secure function would be safe.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
