### PR TITLE
Cellular: fixed compile warnings from cellular

### DIFF
--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -77,7 +77,7 @@ void CellularContext::do_connect_with_retry()
 {
     if (_cb_data.final_try) {
         _cb_data.final_try = false;
-        _cb_data.error == NSAPI_ERROR_NO_CONNECTION;
+        _cb_data.error = NSAPI_ERROR_NO_CONNECTION;
         call_network_cb(NSAPI_STATUS_DISCONNECTED);
         return;
     }

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -181,14 +181,14 @@ void CellularDevice::stm_callback(nsapi_event_t ev, intptr_t ptr)
 void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx)
 {
     if (ev >= NSAPI_EVENT_CELLULAR_STATUS_BASE && ev <= NSAPI_EVENT_CELLULAR_STATUS_END) {
-        cell_callback_data_t *ptr_data = (cell_callback_data_t *)ptr;
         cellular_connection_status_t cell_ev = (cellular_connection_status_t)ev;
+        cell_callback_data_t *ptr_data = (cell_callback_data_t *)ptr;
+        (void)ptr_data; // avoid compile warning, used only for debugging
         if (cell_ev == CellularStateRetryEvent) {
             tr_debug("callback: CellularStateRetryEvent, err: %d, data: %d, retrycount: %d", ptr_data->error, ptr_data->status_data, *(const int *)ptr_data->data);
         } else {
             tr_debug("callback: %d, err: %d, data: %d", ev, ptr_data->error, ptr_data->status_data);
         }
-
         if (cell_ev == CellularRegistrationStatusChanged && _state_machine) {
             // broadcast only network registration changes to state machine
             _state_machine->cellular_event_changed(ev, ptr);

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -118,7 +118,7 @@ void QUECTEL_BG96_CellularStack::urc_qiurc()
 {
     char urc_string[MAX_QIURC_LENGTH + 1];
     _at.lock();
-    const int urc_string_length = _at.read_string(urc_string, sizeof(urc_string));
+    (void)_at.read_string(urc_string, sizeof(urc_string));
     const int sock_id = _at.read_int();
     const nsapi_error_t err = _at.unlock_return_error();
 

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -490,6 +490,7 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
         _at.resp_start("+QISACK:");
         sent_len_after = _at.read_int();
         sent_acked = _at.read_int();
+        (void)sent_acked; // avoid compile warning, used only for debugging
         sent_nacked = _at.read_int();
         _at.resp_stop();
 
@@ -526,7 +527,7 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_recvfrom_impl(CellularSo
     uint64_t start_time = rtos::Kernel::get_ms_count();
     nsapi_size_t len = 0;
     for (; len < size;) {
-        int read_len = (size - len > M26_RECV_BYTE_MAX) ? M26_RECV_BYTE_MAX : size - len;
+        unsigned int read_len = (size - len > M26_RECV_BYTE_MAX) ? M26_RECV_BYTE_MAX : size - len;
         _at.cmd_start("AT+QIRD=");
         _at.write_int(0); /* at+qifgcnt 0-1 */
         _at.write_int(1); /* 1-Client, 2-Server */


### PR DESCRIPTION
### Description

Removed compile warnings from cellular to clean up the compile.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica 

### Release Notes
