### PR TITLE
Cellular: Initialize CellularContext member variables in correct class

### DIFF
--- a/UNITTESTS/stubs/CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/CellularContext_stub.cpp
@@ -19,6 +19,15 @@
 
 namespace mbed {
 
+CellularContext::CellularContext() : _next(0), _stack(0), _pdp_type(DEFAULT_PDP_TYPE),
+    _authentication_type(CellularContext::CHAP), _connect_status(NSAPI_STATUS_DISCONNECTED), _status_cb(0),
+    _cid(-1), _new_context_set(false), _is_context_active(false), _is_context_activated(false),
+    _apn(0), _uname(0), _pwd(0), _dcd_pin(NC), _active_high(false), _cp_netif(0), _retry_array_length(0),
+    _retry_count(0), _device(0), _nw(0), _is_blocking(true)
+{
+    memset(_retry_timeout_array, 0, CELLULAR_RETRY_ARRAY_SIZE);
+}
+
 void CellularContext::cp_data_received()
 {
     _cp_netif->data_received();

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -122,6 +122,7 @@ public:
 protected:
     // friend of CellularDevice, so it's the only way to close or delete this class.
     friend class CellularDevice;
+    CellularContext();
     virtual ~CellularContext() {}
 public: // from NetworkInterface
     virtual nsapi_error_t set_blocking(bool blocking) = 0;

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -51,28 +51,8 @@ AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, co
     _nonip_req(nonip_req), _cp_in_use(false)
 {
     tr_info("New CellularContext %s (%p)", apn ? apn : "", this);
-    _stack = NULL;
-    _pdp_type = DEFAULT_PDP_TYPE;
-    _authentication_type = CellularContext::CHAP;
-    _connect_status = NSAPI_STATUS_DISCONNECTED;
-    _is_context_active = false;
-    _is_context_activated = false;
     _apn = apn;
-    _uname = NULL;
-    _pwd = NULL;
-    _status_cb = NULL;
-    _cid = -1;
-    _new_context_set = false;
-    _next = NULL;
-    _dcd_pin = NC;
-    _active_high = false;
-    _cp_netif = NULL;
-    memset(_retry_timeout_array, 0, CELLULAR_RETRY_ARRAY_SIZE);
-    _retry_array_length = 0;
-    _retry_count = 0;
-    _is_blocking = true;
     _device = device;
-    _nw = NULL;
 }
 
 AT_CellularContext::~AT_CellularContext()

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -58,6 +58,15 @@ MBED_WEAK CellularContext *CellularContext::get_default_nonip_instance()
     return context;
 }
 
+CellularContext::CellularContext() : _next(0), _stack(0), _pdp_type(DEFAULT_PDP_TYPE),
+    _authentication_type(CellularContext::CHAP), _connect_status(NSAPI_STATUS_DISCONNECTED), _status_cb(0),
+    _cid(-1), _new_context_set(false), _is_context_active(false), _is_context_activated(false),
+    _apn(0), _uname(0), _pwd(0), _dcd_pin(NC), _active_high(false), _cp_netif(0), _retry_array_length(0),
+    _retry_count(0), _device(0), _nw(0), _is_blocking(true)
+{
+    memset(_retry_timeout_array, 0, CELLULAR_RETRY_ARRAY_SIZE);
+}
+
 void CellularContext::cp_data_received()
 {
     _cp_netif->data_received();


### PR DESCRIPTION
### Description

CellularContext member variables were initialized in inheriting class.
Now in base class where they should be initialized so that every inheriting
class don't have to init them.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 

### Release Notes
