### PR TITLE
Explicit CCC added descriptor does not send notification/indication t…

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/att/atts_write.c
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/stack/ble-host/sources/stack/att/atts_write.c
@@ -157,17 +157,17 @@ void attsProcWrite(attCcb_t *pCcb, uint16_t len, uint8_t *pPacket)
     }
     else
     {
+	   /*  check if CCC */
+      if ((pAttr->settings & ATTS_SET_CCC) && (attsCb.cccCback != NULL))
+      {
+        err = (*attsCb.cccCback)(pCcb->connId, ATT_METHOD_WRITE, handle, pPacket);
+      }
       /* if write callback is desired */
       if ((pAttr->settings & ATTS_SET_WRITE_CBACK) &&
           (pGroup->writeCback != NULL))
       {
         err = (*pGroup->writeCback)(pCcb->connId, handle, opcode, 0, writeLen,
                                     pPacket, pAttr);
-      }
-      /* else check if CCC */
-      else if ((pAttr->settings & ATTS_SET_CCC) && (attsCb.cccCback != NULL))
-      {
-        err = (*attsCb.cccCback)(pCcb->connId, ATT_METHOD_WRITE, handle, pPacket);
       }
       else
       {


### PR DESCRIPTION
…o client

### Description

<!--
When the CCC descriptor is added explicitly from application then the indication or notification packets are not sent out from server device.
We found this issue is in attsProcWrite () function in atts_write.c file.
We had to move out the cccCback from else if condition.
#10316 
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
