### PR TITLE
Add support for getting ringbuf size

### DIFF
--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -233,19 +233,19 @@ public:
      *  @param stop_bits The number of stop bits (1 or 2; default = 1)
      */
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
-    
+
     /** get the available characters in the RX ringbuffer*/
-    uint32_t getRxBufferSize()
+    uint32_t get_rx_buffer_Size()
     {
         return this->_rxbuf.size();
     }
-    
+
     /** get the available characters in the TX ringbuffer*/
-    uint32_t getTxBufferSize()
+    uint32_t get_tx_buffer_Size()
     {
         return this->_txbuf.size();
     }
-    
+
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options
     // such as XON/XOFF or manual GPIO RTSCTS.

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -233,7 +233,12 @@ public:
      *  @param stop_bits The number of stop bits (1 or 2; default = 1)
      */
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
-
+    
+    /** get the available characters in the RX ringbuffer*/
+    uint32_t getRxBufferSize(){return this->_rxbuf.size();}
+    /** get the available characters in the TX ringbuffer*/
+    uint32_t getTxBufferSize(){return this->_txbuf.size();}
+    
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options
     // such as XON/XOFF or manual GPIO RTSCTS.

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -234,13 +234,14 @@ public:
      */
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
     
-     /** get the available characters in the RX ringbuffer*/
+    /** get the available characters in the RX ringbuffer*/
     uint32_t getRxBufferSize()
     {
         return this->_rxbuf.size();
     }
-     /** get the available characters in the TX ringbuffer*/
-   uint32_t getTxBufferSize()
+    
+    /** get the available characters in the TX ringbuffer*/
+    uint32_t getTxBufferSize()
     {
         return this->_txbuf.size();
     }

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -31,15 +31,14 @@
 #include "platform/NonCopyable.h"
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE
-#define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE 256
+#define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE  256
 #endif
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE
-#define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE 256
+#define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE  256
 #endif
 
-namespace mbed
-{
+namespace mbed {
 
 /** \addtogroup drivers */
 
@@ -48,10 +47,10 @@ namespace mbed
  * @ingroup drivers
  */
 
-class UARTSerial : private SerialBase, public FileHandle, private NonCopyable<UARTSerial>
-{
+class UARTSerial : private SerialBase, public FileHandle, private NonCopyable<UARTSerial> {
 
 public:
+
     /** Create a UARTSerial port, connected to the specified transmit and receive pins, with a particular baud rate.
      *  @param tx Transmit pin
      *  @param rx Receive pin
@@ -221,11 +220,11 @@ public:
     // Expose private SerialBase::Parity as UARTSerial::Parity
     using SerialBase::Parity;
     // In C++11, we wouldn't need to also have using directives for each value
-    using SerialBase::Even;
-    using SerialBase::Forced0;
-    using SerialBase::Forced1;
     using SerialBase::None;
     using SerialBase::Odd;
+    using SerialBase::Even;
+    using SerialBase::Forced1;
+    using SerialBase::Forced0;
 
     /** Set the transmission format used by the serial port
      *
@@ -234,26 +233,26 @@ public:
      *  @param stop_bits The number of stop bits (1 or 2; default = 1)
      */
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
-
-    /** get the available characters in the RX ringbuffer*/
+    
+     /** get the available characters in the RX ringbuffer*/
     uint32_t getRxBufferSize()
     {
         return this->_rxbuf.size();
     }
-    /** get the available characters in the TX ringbuffer*/
-    uint32_t getTxBufferSize()
+     /** get the available characters in the TX ringbuffer*/
+   uint32_t getTxBufferSize()
     {
         return this->_txbuf.size();
     }
-
+    
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options
     // such as XON/XOFF or manual GPIO RTSCTS.
     using SerialBase::Flow;
     // In C++11, we wouldn't need to also have using directives for each value
-    using SerialBase::CTS;
     using SerialBase::Disabled;
     using SerialBase::RTS;
+    using SerialBase::CTS;
     using SerialBase::RTSCTS;
 
     /** Set the flow control type on the serial port
@@ -266,6 +265,7 @@ public:
 #endif
 
 private:
+
     void wait_ms(uint32_t millisec);
 
     /** SerialBase lock override */
@@ -323,6 +323,7 @@ private:
     void wake(void);
 
     void dcd_irq(void);
+
 };
 } //namespace mbed
 

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -31,14 +31,15 @@
 #include "platform/NonCopyable.h"
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE
-#define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE  256
+#define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE 256
 #endif
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE
-#define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE  256
+#define MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE 256
 #endif
 
-namespace mbed {
+namespace mbed
+{
 
 /** \addtogroup drivers */
 
@@ -47,10 +48,10 @@ namespace mbed {
  * @ingroup drivers
  */
 
-class UARTSerial : private SerialBase, public FileHandle, private NonCopyable<UARTSerial> {
+class UARTSerial : private SerialBase, public FileHandle, private NonCopyable<UARTSerial>
+{
 
 public:
-
     /** Create a UARTSerial port, connected to the specified transmit and receive pins, with a particular baud rate.
      *  @param tx Transmit pin
      *  @param rx Receive pin
@@ -220,11 +221,11 @@ public:
     // Expose private SerialBase::Parity as UARTSerial::Parity
     using SerialBase::Parity;
     // In C++11, we wouldn't need to also have using directives for each value
+    using SerialBase::Even;
+    using SerialBase::Forced0;
+    using SerialBase::Forced1;
     using SerialBase::None;
     using SerialBase::Odd;
-    using SerialBase::Even;
-    using SerialBase::Forced1;
-    using SerialBase::Forced0;
 
     /** Set the transmission format used by the serial port
      *
@@ -233,20 +234,26 @@ public:
      *  @param stop_bits The number of stop bits (1 or 2; default = 1)
      */
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
-    
+
     /** get the available characters in the RX ringbuffer*/
-    uint32_t getRxBufferSize(){return this->_rxbuf.size();}
+    uint32_t getRxBufferSize()
+    {
+        return this->_rxbuf.size();
+    }
     /** get the available characters in the TX ringbuffer*/
-    uint32_t getTxBufferSize(){return this->_txbuf.size();}
-    
+    uint32_t getTxBufferSize()
+    {
+        return this->_txbuf.size();
+    }
+
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options
     // such as XON/XOFF or manual GPIO RTSCTS.
     using SerialBase::Flow;
     // In C++11, we wouldn't need to also have using directives for each value
+    using SerialBase::CTS;
     using SerialBase::Disabled;
     using SerialBase::RTS;
-    using SerialBase::CTS;
     using SerialBase::RTSCTS;
 
     /** Set the flow control type on the serial port
@@ -259,7 +266,6 @@ public:
 #endif
 
 private:
-
     void wait_ms(uint32_t millisec);
 
     /** SerialBase lock override */
@@ -317,7 +323,6 @@ private:
     void wake(void);
 
     void dcd_irq(void);
-
 };
 } //namespace mbed
 

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -235,13 +235,13 @@ public:
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
 
     /** get the available characters in the RX ringbuffer*/
-    uint32_t get_rx_buffer_size()
+    const uint32_t get_rx_buffer_size()
     {
         return this->_rxbuf.size();
     }
 
     /** get the available characters in the TX ringbuffer*/
-    uint32_t get_tx_buffer_size()
+    const uint32_t get_tx_buffer_size()
     {
         return this->_txbuf.size();
     }

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -235,13 +235,13 @@ public:
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
 
     /** get the available characters in the RX ringbuffer*/
-    uint32_t get_rx_buffer_Size()
+    uint32_t get_rx_buffer_size()
     {
         return this->_rxbuf.size();
     }
 
     /** get the available characters in the TX ringbuffer*/
-    uint32_t get_tx_buffer_Size()
+    uint32_t get_tx_buffer_size()
     {
         return this->_txbuf.size();
     }

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -126,6 +126,14 @@ public:
      */
     virtual off_t seek(off_t offset, int whence);
 
+    /*get the available characters in the rx buffer
+     * @return  bytes available in RX buffer
+     */
+    virtual off_t size()
+    {
+        return this->_rxbuf.size();
+    }
+    
     /** Flush any buffers associated with the file
      *
      *  @return         0 on success, negative error code on failure
@@ -233,18 +241,6 @@ public:
      *  @param stop_bits The number of stop bits (1 or 2; default = 1)
      */
     void set_format(int bits = 8, Parity parity = UARTSerial::None, int stop_bits = 1);
-
-    /** get the available characters in the RX ringbuffer*/
-    const uint32_t get_rx_buffer_size()
-    {
-        return this->_rxbuf.size();
-    }
-
-    /** get the available characters in the TX ringbuffer*/
-    const uint32_t get_tx_buffer_size()
-    {
-        return this->_txbuf.size();
-    }
 
 #if DEVICE_SERIAL_FC
     // For now use the base enum - but in future we may have extra options


### PR DESCRIPTION
by getting the ringbuffer size, one can detect ringbuffer overflows and display a status for debugging purposes. also maybe one could read the whole buffer at a time instead of the usual read 1 char after another.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
