### PR TITLE
Disable LPTICKER on L073RZ

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -17,10 +17,6 @@
 #error [NOT_SUPPORTED] Tickless mode not supported for this target.
 #endif
 
-#if !DEVICE_LPTICKER
-#error [NOT_SUPPORTED] Current SysTimer implementation requires lp ticker support.
-#endif
-
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"
@@ -53,7 +49,7 @@ private:
 
 public:
     SysTimerTest() :
-        SysTimer(), _sem(0, 1)
+        SysTimer(get_lp_ticker_data()), _sem(0, 1)
     {
     }
 

--- a/rtos/TARGET_CORTEX/SysTimer.cpp
+++ b/rtos/TARGET_CORTEX/SysTimer.cpp
@@ -21,9 +21,6 @@
  */
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
-#if DEVICE_LPTICKER
-
-#include "hal/lp_ticker_api.h"
 #include "mbed_critical.h"
 #include "mbed_assert.h"
 #if defined(TARGET_CORTEX_A)
@@ -56,14 +53,6 @@ extern "C" IRQn_ID_t mbed_get_a9_tick_irqn(void);
 
 namespace rtos {
 namespace internal {
-
-SysTimer::SysTimer() :
-    TimerEvent(get_lp_ticker_data()), _time_us(0), _tick(0)
-{
-    _time_us = ticker_read_us(_ticker_data);
-    _suspend_time_passed = true;
-    _suspended = false;
-}
 
 SysTimer::SysTimer(const ticker_data_t *data) :
     TimerEvent(data), _time_us(0), _tick(0)
@@ -193,5 +182,3 @@ void SysTimer::handler()
 
 }
 }
-
-#endif

--- a/rtos/TARGET_CORTEX/SysTimer.h
+++ b/rtos/TARGET_CORTEX/SysTimer.h
@@ -22,7 +22,7 @@
 #ifndef MBED_SYS_TIMER_H
 #define MBED_SYS_TIMER_H
 
-#if DEVICE_LPTICKER || defined(DOXYGEN_ONLY)
+#if MBED_TICKLESS || defined(DOXYGEN_ONLY)
 
 #include "platform/NonCopyable.h"
 #include "drivers/TimerEvent.h"
@@ -48,7 +48,6 @@ namespace internal {
 class SysTimer: private mbed::TimerEvent, private mbed::NonCopyable<SysTimer> {
 public:
 
-    SysTimer();
     SysTimer(const ticker_data_t *data);
     virtual ~SysTimer();
 

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -38,10 +38,13 @@ extern "C" {
 
 #ifdef MBED_TICKLESS
 
-    MBED_STATIC_ASSERT(!MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_USTICKER,
-                       "Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true");
-    MBED_STATIC_ASSERT(MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_LPTICKER,
-                       "Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false");
+#if MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && !DEVICE_USTICKER
+#error Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true
+#endif
+
+#if !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && !DEVICE_LPTICKER
+#error Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false
+#endif
 
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
@@ -137,7 +140,7 @@ extern "C" {
     }
 
 
-#else
+#else // MBED_TICKLESS
 
     static void default_idle_hook(void)
     {
@@ -149,7 +152,7 @@ extern "C" {
         core_util_critical_section_exit();
     }
 
-#endif // (defined(MBED_TICKLESS) && DEVICE_LPTICKER)
+#endif // MBED_TICKLESS
 
     static void (*idle_hook_fptr)(void) = &default_idle_hook;
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3352,6 +3352,7 @@
             "FLASH",
             "MPU"
         ],
+        "device_has_remove": ["LPTICKER"],
         "release_versions": ["2", "5"],
         "bootloader_supported": true,
         "device_name": "STM32L073RZ"


### PR DESCRIPTION
### Description

**(Depends on #10597)**

LPTIM is currently disabled on L073RZ due to a hardware bug (see #10537). As an alternative, RTC is used for lp ticker. This brings a new problem that RTC-based lp ticker appears to have a high latency (of a few hundred microseconds. See #9962 for more details.

After discussing with @c1728p9, we disable lp ticker feature on L073RZ for now. This also implies tests in TESTS/mbed_drivers/lp_* will not apply to this target until we re-enable LPTIM-based lp ticker once it's fixed.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
