### PR TITLE
BLE: fix CCC callback not being called when writing to a CCC

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -510,7 +510,7 @@ ble_error_t GattServer::insert_descriptor(
 #endif // BLE_FEATURE_SECURITY
         }
 
-        if (properties & READ_PROPERTY) {
+        if (properties & READ_PROPERTY && !(attribute_it->settings & ATTS_SET_CCC)) {
             attribute_it->settings |= ATTS_SET_READ_CBACK;
         }
     }

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -543,7 +543,7 @@ ble_error_t GattServer::insert_descriptor(
 #endif // BLE_FEATURE_SECURITY
         }
 
-        if (properties & WRITABLE_PROPERTIES) {
+        if (properties & WRITABLE_PROPERTIES && !(attribute_it->settings & ATTS_SET_CCC)) {
             attribute_it->settings |= ATTS_SET_WRITE_CBACK;
         }
     }


### PR DESCRIPTION
### Description

When creating a CCC manually the special handling of the attribute creation for CCC would set the correct CCC flag but then normal handling would also include the normal handling causing the setting for writable enabling the write callback which takes precedence. This fix removes that callback thus allowing the CCC callback to happen.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
