### PR TITLE
BLE: put the acl buffer size in config

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -48,7 +48,7 @@
             "macro_name": "SMP_DB_MAX_DEVICES"
         },
         "desired-att-mtu": {
-            "help": "Desired ATT_MTU, this needs to be between 23 and 517 (inclusive).",
+            "help": "Desired ATT_MTU, this needs to be between 23 and 517 (inclusive). The effective ATT_MTU is limited by rx-acl-buffer-size (minus 4 bytes for the header).",
             "value": 23
         },
         "rx-acl-buffer-size": {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -51,6 +51,10 @@
             "help": "Desired ATT_MTU, this needs to be between 23 and 517 (inclusive).",
             "value": 23
         },
+        "rx-acl-buffer-size": {
+            "help": "Size of the buffer holding the ACL packet. This will limit the effective ATT_MTU (to its value minus 4 bytes for the header). The size of the buffer must be small enough to be allocated from the existing cordio pool. If this value is increased you may need to adjust the memory pool.",
+            "value": 100
+        },
         "max-prepared-writes": {
             "help": "Number of queued prepare writes supported by server.",
             "value": 4

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -52,7 +52,7 @@
             "value": 23
         },
         "rx-acl-buffer-size": {
-            "help": "Size of the buffer holding the ACL packet. This will limit the effective ATT_MTU (to its value minus 4 bytes for the header). The size of the buffer must be small enough to be allocated from the existing cordio pool. If this value is increased you may need to adjust the memory pool.",
+            "help": "Size of the buffer holding the reassembled complete ACL packet. This will limit the effective ATT_MTU (to its value minus 4 bytes for the header). The size of the buffer must be small enough to be allocated from the existing cordio pool. If this value is increased you may need to adjust the memory pool.",
             "value": 100
         },
         "max-prepared-writes": {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -510,7 +510,7 @@ void BLE::stack_setup()
 
     stack_handler_id = WsfOsSetNextHandler(&BLE::stack_handler);
 
-    HciSetMaxRxAclLen(100);
+    HciSetMaxRxAclLen(MBED_CONF_CORDIO_RX_ACL_BUFFER_SIZE);
 
     DmRegister(BLE::device_manager_cb);
 #if BLE_FEATURE_CONNECTABLE


### PR DESCRIPTION
### Description

This is completely non-functional change - this simply puts the acl buffer size in a config file. Comprehensive fix that integrates with the memory pool will be scheduled later.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
