### PR TITLE
BLE - Management of Tx path on Cordio. 

### DIFF
--- a/features/FEATURE_BLE/ble/GattServer.h
+++ b/features/FEATURE_BLE/ble/GattServer.h
@@ -693,6 +693,12 @@ protected:
                     confirmationReceivedCallback(attributeHandle);
                 }
                 break;
+
+            case GattServerEvents::GATT_EVENT_DATA_SENT:
+                // Called every time a notification or indication has been sent
+                handleDataSentEvent(1);
+                break;
+
             default:
                 break;
         }

--- a/features/FEATURE_BLE/ble/generic/GenericGattClient.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGattClient.h
@@ -147,6 +147,15 @@ public:
         uint16_t att_mtu_size
     );
 
+    /**
+     * @see pal::GattClient::EventHandler::on_write_command_sent
+     */
+    void on_write_command_sent_(
+        ble::connection_handle_t connection_handle,
+        ble::attribute_handle_t attribute_handle,
+        uint8_t status
+    );
+
 private:
     struct ProcedureControlBlock;
     struct DiscoveryControlBlock;

--- a/features/FEATURE_BLE/ble/pal/PalGattClient.h
+++ b/features/FEATURE_BLE/ble/pal/PalGattClient.h
@@ -52,6 +52,18 @@ struct GattClientEventHandler : StaticInterface<Impl, GattClientEventHandler> {
     ) { 
         impl()->on_att_mtu_change_(connection_handle, att_mtu_size);
     }
+
+    void on_write_command_sent(
+        ble::connection_handle_t connection_handle,
+        ble::attribute_handle_t attribute_handle,
+        uint8_t status
+    ) {
+        impl()->on_write_command_sent_(
+            connection_handle,
+            attribute_handle,
+            status
+        );
+    }
 };
 
 

--- a/features/FEATURE_BLE/ble/pal/PalGattClient.h
+++ b/features/FEATURE_BLE/ble/pal/PalGattClient.h
@@ -53,6 +53,14 @@ struct GattClientEventHandler : StaticInterface<Impl, GattClientEventHandler> {
         impl()->on_att_mtu_change_(connection_handle, att_mtu_size);
     }
 
+    /**
+     * Function invoked when a write command has been sent out of the stack
+     * (either to the controller or over the air).
+     *
+     * @param connection_handle Connection targeted by the write command
+     * @param attribute_handle Attribute written
+     * @param status HCI status of the operation.
+     */
     void on_write_command_sent(
         ble::connection_handle_t connection_handle,
         ble::attribute_handle_t attribute_handle,

--- a/features/FEATURE_BLE/source/generic/GenericGattClient.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGattClient.tpp
@@ -1340,6 +1340,24 @@ void GenericGattClient<TPalGattClient, SigningMonitorEventHandler>::on_att_mtu_c
 }
 
 template<template<class> class TPalGattClient, class SigningMonitorEventHandler>
+void GenericGattClient<TPalGattClient, SigningMonitorEventHandler>::on_write_command_sent_(
+    ble::connection_handle_t connection_handle,
+    ble::attribute_handle_t attribute_handle,
+    uint8_t status
+) {
+    GattWriteCallbackParams response = {
+        connection_handle,
+        attribute_handle,
+        GattWriteCallbackParams::OP_WRITE_CMD,
+        BLE_ERROR_NONE,
+        status
+    };
+
+    this->processWriteResponse(&response);
+}
+
+
+template<template<class> class TPalGattClient, class SigningMonitorEventHandler>
 void GenericGattClient<TPalGattClient, SigningMonitorEventHandler>::on_termination(connection_handle_t connection_handle) {
 	if (_termination_callback) {
 		_termination_callback(connection_handle);

--- a/features/FEATURE_BLE/source/generic/GenericGattClient.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGattClient.tpp
@@ -966,6 +966,7 @@ GenericGattClient<TPalGattClient, SigningMonitorEventHandler>::GenericGattClient
 	_pal_client->when_transaction_timeout(
 		mbed::callback(this, &GenericGattClient::on_transaction_timeout)
 	);
+	_pal_client->set_event_handler(this);
 }
 
 template<template<class> class TPalGattClient, class SigningMonitorEventHandler>

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -695,10 +695,6 @@ ble_error_t GattServer::write_(
     }
 #endif // BLE_FEATURE_SECURITY
 
-    if (updates_sent) {
-        handleDataSentEvent(updates_sent);
-    }
-
     return BLE_ERROR_NONE;
 }
 
@@ -748,10 +744,6 @@ ble_error_t GattServer::write_(
         }
     }
 #endif // BLE_FEATURE_SECURITY
-
-    if (updates_sent) {
-        handleDataSentEvent(updates_sent);
-    }
 
     return BLE_ERROR_NONE;
 }

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalAttClient.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalAttClient.cpp
@@ -32,6 +32,16 @@ void CordioAttClient::att_client_handler(const attEvt_t* event)
         if (handler) {
             handler->on_att_mtu_change(event->hdr.param, event->mtu);
         }
+    } else if (event->hdr.event == ATTC_WRITE_CMD_RSP) {
+        ble::vendor::cordio::BLE& ble = ble::vendor::cordio::BLE::deviceInstance();
+        impl::PalGattClientImpl::EventHandler *handler = ble.getPalGattClient().get_event_handler();
+        if (handler) {
+            handler->on_write_command_sent(
+                event->hdr.param,
+                event->handle,
+                event->hdr.status
+            );
+        }
     } else {
         // all handlers are stored in a static array
         static const event_handler_t handlers[] = {


### PR DESCRIPTION
### Description

This PR allows an application to track when a write without response or an indication has been sent to the controller. Using this information allows efficient queueing of non reliable data. In itself it is not a new feature as this was already present but the old implementation was inefficient.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@donatieng @paul-szczepanek-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->