### PR TITLE
GR_LYCHEE,RZ_A1H,VK_RZ_A1H: Fix greentea test failure with ARMC6

### DIFF
--- a/cmsis/TARGET_CORTEX_A/cmsis_armcc.h
+++ b/cmsis/TARGET_CORTEX_A/cmsis_armcc.h
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     cmsis_armcc.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.0.2
- * @date     10. January 2018
+ * @version  V1.0.3
+ * @date     15. May 2019
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -533,10 +533,10 @@ __STATIC_INLINE __ASM void __FPU_Enable(void)
   ENDIF
 
         //Initialise FPSCR to a known state
-        VMRS    R2,FPSCR
-        LDR     R3,=0x00086060 //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
-        AND     R2,R2,R3
-        VMSR    FPSCR,R2
+        VMRS    R1,FPSCR
+        LDR     R2,=0x00086060 //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
+        AND     R1,R1,R2
+        VMSR    FPSCR,R1
 
         BX      LR
 }

--- a/cmsis/TARGET_CORTEX_A/cmsis_armclang.h
+++ b/cmsis/TARGET_CORTEX_A/cmsis_armclang.h
@@ -1,8 +1,8 @@
 /**************************************************************************//**
  * @file     cmsis_armclang.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.1.0
- * @date     18. March 2019
+ * @version  V1.1.1
+ * @date     15. May 2019
  ******************************************************************************/
 /*
  * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
@@ -509,10 +509,11 @@ __STATIC_INLINE void __FPU_Enable(void)
 #endif
 
     //Initialise FPSCR to a known state
-    "        VMRS    R2,FPSCR          \n"
-    "        LDR     R3,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
-    "        AND     R2,R2,R3          \n"
-    "        VMSR    FPSCR,R2            "
+    "        VMRS    R1,FPSCR          \n"
+    "        LDR     R2,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
+    "        AND     R1,R1,R2          \n"
+    "        VMSR    FPSCR,R1            "
+    : : : "cc", "r1", "r2"
   );
 }
 

--- a/cmsis/TARGET_CORTEX_A/cmsis_gcc.h
+++ b/cmsis/TARGET_CORTEX_A/cmsis_gcc.h
@@ -1,11 +1,11 @@
 /**************************************************************************//**
  * @file     cmsis_gcc.h
  * @brief    CMSIS compiler specific macros, functions, instructions
- * @version  V1.1.0
- * @date     20. December 2018
+ * @version  V1.1.1
+ * @date     15. May 2019
  ******************************************************************************/
 /*
- * Copyright (c) 2009-2018 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2019 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -683,10 +683,11 @@ __STATIC_INLINE void __FPU_Enable(void)
 #endif
 
     //Initialise FPSCR to a known state
-    "        VMRS    R2,FPSCR          \n"
-    "        LDR     R3,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
-    "        AND     R2,R2,R3          \n"
-    "        VMSR    FPSCR,R2            "
+    "        VMRS    R1,FPSCR          \n"
+    "        LDR     R2,=0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
+    "        AND     R1,R1,R2          \n"
+    "        VMSR    FPSCR,R1            "
+    : : : "cc", "r1", "r2"
   );
 }
 

--- a/cmsis/TARGET_CORTEX_A/cmsis_iccarm.h
+++ b/cmsis/TARGET_CORTEX_A/cmsis_iccarm.h
@@ -2,12 +2,13 @@
  * @file     cmsis_iccarm.h
  * @brief    CMSIS compiler ICCARM (IAR Compiler for Arm) header file
  * @version  V5.0.7
- * @date     04. Semptember 2018
+ * @date     15. May 2019
  ******************************************************************************/
 
 //------------------------------------------------------------------------------
 //
 // Copyright (c) 2017-2018 IAR Systems
+// Copyright (c) 2018-2019 Arm Limited 
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
@@ -547,10 +548,12 @@ void __FPU_Enable(void)
 #endif
 
     //Initialise FPSCR to a known state
-    "        VMRS    R2,FPSCR          \n"
-    "        MOV32   R3,#0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
-    "        AND     R2,R2,R3          \n"
-    "        VMSR    FPSCR,R2          \n");
+    "        VMRS    R1,FPSCR          \n"
+    "        MOV32   R2,#0x00086060    \n" //Mask off all bits that do not have to be preserved. Non-preserved bits can/should be zero.
+    "        AND     R1,R1,R2          \n"
+    "        VMSR    FPSCR,R1          \n"
+    : : : "cc", "r1", "r2"
+  );
 }
 
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/system_RZ_A1LU.c
@@ -91,7 +91,12 @@ void SystemInit (void)
 {
 /*       do not use global variables because this function is called before
          reaching pre-main. RW section may be overwritten afterwards.          */
-  
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
   // Enable SRAM write access
   CPG.SYSCR3 = 0x0F;
 
@@ -128,11 +133,6 @@ void SystemInit (void)
   L2C_InvAllByWay();
   // Enable L2C
   L2C_Enable();
-#endif
-
-#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
-  // Enable FPU
-  __FPU_Enable();
 #endif
 
   // IRQ Initialize

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/system_RZ_A1H.c
@@ -91,7 +91,12 @@ void SystemInit (void)
 {
 /*       do not use global variables because this function is called before
          reaching pre-main. RW section may be overwritten afterwards.          */
-  
+
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
   // Enable SRAM write access
   CPG.SYSCR3 = 0x0F;
 
@@ -128,11 +133,6 @@ void SystemInit (void)
   L2C_InvAllByWay();
   // Enable L2C
   L2C_Enable();
-#endif
-
-#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
-  // Enable FPU
-  __FPU_Enable();
 #endif
 
   // IRQ Initialize

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/system_VK_RZ_A1H.c
@@ -92,6 +92,11 @@ void SystemInit (void)
 /*       do not use global variables because this function is called before
          reaching pre-main. RW section maybe overwritten afterwards.          */
 
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  // Enable FPU
+  __FPU_Enable();
+#endif
+
   // Enable SRAM write access
   CPG.SYSCR3 = 0x0F;
 
@@ -128,11 +133,6 @@ void SystemInit (void)
   L2C_InvAllByWay();
   // Enable L2C
   L2C_Enable();
-#endif
-
-#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
-  // Enable FPU
-  __FPU_Enable();
 #endif
 
   // IRQ Initialize


### PR DESCRIPTION
### Description
Fix for issue https://github.com/ARMmbed/mbed-os/issues/10356

The FPU register was used before __FPU_Enable() was called in SystemInit(). So I fixed the call timing of __ FPU_Enable().

To resolve this issue, in addition to this change, the following changes need to be merged: https://github.com/ARM-software/CMSIS_5/commit/3f3b67fd5dfe67d06c47f93bbac1c5d8086faf6b

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@toyowata 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
