### PR TITLE
M2351: Fix serial sync error in SPDMC test

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8104,6 +8104,7 @@
         "device_name": "M2351KIAAEES",
         "bootloader_supported": true,
         "tickless-from-us-ticker": true,
+        "forced_reset_timeout": 3,
         "mbed_rom_start"    : "0x10040000",
         "mbed_rom_size"     : "0x40000",
         "mbed_ram_start"    : "0x30008000",


### PR DESCRIPTION
### Description

In M2351 SPDMC (SMCC) test, it boots from secure code to non-secure bootloader, and finally to non-secure test code itself. The boot sequence will takes longer than usual. In test initiation, host will send sync signal 1s after reset device. But due to the longer boot sequence, test code in device can miss the signal. We enlarge the reset idle time to fix the issue.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
