### PR TITLE
Introduce Semaphore::acquire methods

### DIFF
--- a/TESTS/lorawan/loraradio/main.cpp
+++ b/TESTS/lorawan/loraradio/main.cpp
@@ -125,7 +125,7 @@ void test_set_tx_config()
 
     TEST_ASSERT_EQUAL(RF_TX_RUNNING, radio->get_status());
 
-    TEST_ASSERT_EQUAL(1, event_sem.wait(1000));
+    TEST_ASSERT_TRUE(event_sem.try_acquire_for(1000));
     TEST_ASSERT_EQUAL(EV_TX_DONE, received_event);
     received_event = EV_NONE;
 }
@@ -145,7 +145,7 @@ void test_set_rx_config()
 
     TEST_ASSERT_EQUAL(RF_RX_RUNNING, radio->get_status());
 
-    TEST_ASSERT_EQUAL(1, event_sem.wait(1000));
+    TEST_ASSERT_TRUE(event_sem.try_acquire_for(1000));
 
     // Nobody was sending to us so timeout is expected.
     TEST_ASSERT_EQUAL(EV_RX_TIMEOUT, received_event);

--- a/TESTS/mbed_drivers/lp_ticker/main.cpp
+++ b/TESTS/mbed_drivers/lp_ticker/main.cpp
@@ -141,22 +141,20 @@ void test_multi_call_time(void)
 void test_detach(void)
 {
     LowPowerTicker ticker;
-    int32_t ret;
+    bool ret;
     const float ticker_time_s = 0.1f;
     const uint32_t wait_time_ms = 500;
     Semaphore sem(0, 1);
 
     ticker.attach(callback(sem_release, &sem), ticker_time_s);
 
-    ret = sem.wait();
-    TEST_ASSERT_TRUE(ret > 0);
+    sem.acquire();
 
-    ret = sem.wait();
+    sem.acquire();
     ticker.detach(); /* cancel */
-    TEST_ASSERT_TRUE(ret > 0);
 
-    ret = sem.wait(wait_time_ms);
-    TEST_ASSERT_EQUAL(0, ret);
+    ret = sem.try_acquire_for(wait_time_ms);
+    TEST_ASSERT_FALSE(ret);
 }
 
 /** Test single callback time via attach

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -257,22 +257,20 @@ void test_multi_call_time(void)
 void test_detach(void)
 {
     Ticker ticker;
-    int32_t ret;
+    bool ret;
     const float ticker_time_s = 0.1f;
     const uint32_t wait_time_ms = 500;
     Semaphore sem(0, 1);
 
     ticker.attach(callback(sem_release, &sem), ticker_time_s);
 
-    ret = sem.wait();
-    TEST_ASSERT_TRUE(ret > 0);
+    sem.acquire();
 
-    ret = sem.wait();
+    sem.acquire();
     ticker.detach(); /* cancel */
-    TEST_ASSERT_TRUE(ret > 0);
 
-    ret = sem.wait(wait_time_ms);
-    TEST_ASSERT_EQUAL(0, ret);
+    ret = sem.try_acquire_for(wait_time_ms);
+    TEST_ASSERT_FALSE(ret);
 }
 
 /** Test single callback time via attach

--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -78,14 +78,14 @@ void test_single_call(void)
 
     timeout.attach_callback(mbed::callback(sem_callback, &sem), TEST_DELAY_US);
 
-    int32_t sem_slots = sem.wait(0);
-    TEST_ASSERT_EQUAL(0, sem_slots);
+    bool acquired = sem.try_acquire();
+    TEST_ASSERT_FALSE(acquired);
 
-    sem_slots = sem.wait(TEST_DELAY_MS + 2);
-    TEST_ASSERT_EQUAL(1, sem_slots);
+    acquired = sem.try_acquire_for(TEST_DELAY_MS + 2);
+    TEST_ASSERT_TRUE(acquired);
 
-    sem_slots = sem.wait(TEST_DELAY_MS + 2);
-    TEST_ASSERT_EQUAL(0, sem_slots);
+    acquired = sem.try_acquire_for(TEST_DELAY_MS + 2);
+    TEST_ASSERT_FALSE(acquired);
 
     timeout.detach();
 }
@@ -110,12 +110,12 @@ void test_cancel(void)
 
     timeout.attach_callback(mbed::callback(sem_callback, &sem), 2.0f * TEST_DELAY_US);
 
-    int32_t sem_slots = sem.wait(TEST_DELAY_MS);
-    TEST_ASSERT_EQUAL(0, sem_slots);
+    bool acquired = sem.try_acquire_for(TEST_DELAY_MS);
+    TEST_ASSERT_FALSE(acquired);
     timeout.detach();
 
-    sem_slots = sem.wait(TEST_DELAY_MS + 2);
-    TEST_ASSERT_EQUAL(0, sem_slots);
+    acquired = sem.try_acquire_for(TEST_DELAY_MS + 2);
+    TEST_ASSERT_FALSE(acquired);
 }
 
 /** Template for tests: callback override
@@ -143,14 +143,14 @@ void test_override(void)
 
     timeout.attach_callback(mbed::callback(sem_callback, &sem1), 2.0f * TEST_DELAY_US);
 
-    int32_t sem_slots = sem1.wait(TEST_DELAY_MS);
-    TEST_ASSERT_EQUAL(0, sem_slots);
+    bool acquired = sem1.try_acquire_for(TEST_DELAY_MS);
+    TEST_ASSERT_FALSE(acquired);
     timeout.attach_callback(mbed::callback(sem_callback, &sem2), 2.0f * TEST_DELAY_US);
 
-    sem_slots = sem2.wait(2 * TEST_DELAY_MS + 2);
-    TEST_ASSERT_EQUAL(1, sem_slots);
-    sem_slots = sem1.wait(0);
-    TEST_ASSERT_EQUAL(0, sem_slots);
+    acquired = sem2.try_acquire_for(2 * TEST_DELAY_MS + 2);
+    TEST_ASSERT_TRUE(acquired);
+    acquired = sem1.try_acquire();
+    TEST_ASSERT_FALSE(acquired);
 
     timeout.detach();
 }
@@ -200,8 +200,8 @@ void test_no_wait(void)
     T timeout;
     timeout.attach_callback(mbed::callback(sem_callback, &sem), 0ULL);
 
-    int32_t sem_slots = sem.wait(0);
-    TEST_ASSERT_EQUAL(1, sem_slots);
+    bool acquired = sem.try_acquire();
+    TEST_ASSERT_TRUE(acquired);
     timeout.detach();
 }
 
@@ -227,9 +227,8 @@ void test_delay_accuracy(void)
     timer.start();
     timeout.attach_callback(mbed::callback(sem_callback, &sem), delay_us);
 
-    int32_t sem_slots = sem.wait(osWaitForever);
+    sem.acquire();
     timer.stop();
-    TEST_ASSERT_EQUAL(1, sem_slots);
     TEST_ASSERT_UINT64_WITHIN(delta_us, delay_us, timer.read_high_resolution_us());
 
     timeout.detach();
@@ -265,7 +264,7 @@ void test_sleep(void)
 
     bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_FALSE_MESSAGE(deep_sleep_allowed, "Deep sleep should be disallowed");
-    while (sem.wait(0) != 1) {
+    while (!sem.try_acquire()) {
         sleep();
     }
     timer.stop();
@@ -324,7 +323,7 @@ void test_deepsleep(void)
 
     bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
-    while (sem.wait(0) != 1) {
+    while (!sem.try_acquire()) {
         sleep();
     }
     timer.stop();

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -261,9 +261,9 @@ void test_error_hook()
     }
 
     MBED_WARNING1(MBED_ERROR_INVALID_ARGUMENT, "Test for error hook", 1234);
-    int32_t sem_status = callback_sem.wait(5000);
+    bool acquired = callback_sem.try_acquire_for(5000);
 
-    TEST_ASSERT(sem_status > 0);
+    TEST_ASSERT(acquired);
 }
 
 #if MBED_CONF_PLATFORM_ERROR_HIST_ENABLED && defined(MBED_TEST_SIM_BLOCKDEVICE)

--- a/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
@@ -66,7 +66,7 @@ void send_thread_sync(EventFlags *ef)
     for (uint32_t i = 0; i <= MAX_FLAG_POS; i++) {
         const uint32_t flag = flags & (1 << i);
         if (flag) {
-            sync_sem.wait();
+            sync_sem.acquire();
             ef->set(flag);
             ThisThread::sleep_for(wait_ms);
         }

--- a/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
@@ -50,7 +50,7 @@ public:
 
     void start(void)
     {
-        _sem.wait(0);
+        _sem.try_acquire();
         Timer::start();
     }
 
@@ -68,7 +68,7 @@ public:
         if (!running) {
             return 1;
         }
-        return _sem.wait(millisec);
+        return _sem.try_acquire_for(millisec);
     }
 };
 
@@ -169,8 +169,8 @@ void test_start_again()
     osStatus status = rtostimer.start(DELAY_MS);
     TEST_ASSERT_EQUAL(osOK, status);
 
-    int32_t slots = sem.wait(DELAY_MS + DELTA_MS);
-    TEST_ASSERT_EQUAL(1, slots);
+    bool acquired = sem.try_acquire_for(DELAY_MS + DELTA_MS);
+    TEST_ASSERT(acquired);
 
 #if !MBED_TRAP_ERRORS_ENABLED
     status = rtostimer.stop();
@@ -180,8 +180,8 @@ void test_start_again()
     status = rtostimer.start(DELAY_MS);
     TEST_ASSERT_EQUAL(osOK, status);
 
-    slots = sem.wait(DELAY_MS + DELTA_MS);
-    TEST_ASSERT_EQUAL(1, slots);
+    acquired = sem.try_acquire_for(DELAY_MS + DELTA_MS);
+    TEST_ASSERT(acquired);
 
 #if !MBED_TRAP_ERRORS_ENABLED
     status = rtostimer.stop();
@@ -255,14 +255,14 @@ void test_stop()
     osStatus status = rtostimer.start(DELAY_MS);
     TEST_ASSERT_EQUAL(osOK, status);
 
-    int32_t slots = sem.wait(RESTART_DELAY_MS);
-    TEST_ASSERT_EQUAL(0, slots);
+    bool acquired = sem.try_acquire_for(RESTART_DELAY_MS);
+    TEST_ASSERT_FALSE(acquired);
 
     status = rtostimer.stop();
     TEST_ASSERT_EQUAL(osOK, status);
 
-    slots = sem.wait(DELAY_MS + DELTA_MS);
-    TEST_ASSERT_EQUAL(0, slots);
+    acquired = sem.try_acquire_for(DELAY_MS + DELTA_MS);
+    TEST_ASSERT_FALSE(acquired);
 
 #if !MBED_TRAP_ERRORS_ENABLED
     status = rtostimer.stop();

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -46,7 +46,7 @@ void test_thread(int const *delay)
 {
     const int thread_delay = *delay;
     while (true) {
-        two_slots.wait();
+        two_slots.acquire();
         sem_counter++;
         const bool sem_lock_failed = sem_counter > SEMAPHORE_SLOTS;
         if (sem_lock_failed) {
@@ -96,8 +96,7 @@ struct thread_data {
 
 void single_thread(struct thread_data *data)
 {
-    int32_t cnt = data->sem->wait();
-    TEST_ASSERT_EQUAL(1, cnt);
+    data->sem->acquire();
     data->data++;
 }
 
@@ -140,8 +139,8 @@ void test_single_thread()
 
 void timeout_thread(Semaphore *sem)
 {
-    int32_t cnt = sem->wait(30);
-    TEST_ASSERT_EQUAL(0, cnt);
+    bool acquired = sem->try_acquire_for(30);
+    TEST_ASSERT_FALSE(acquired);
 }
 
 /** Test timeout
@@ -188,8 +187,8 @@ void test_no_timeout()
     Timer timer;
     timer.start();
 
-    int32_t cnt = sem.wait(0);
-    TEST_ASSERT_EQUAL(T, cnt);
+    bool acquired = sem.try_acquire();
+    TEST_ASSERT_EQUAL(T > 0, acquired);
 
     TEST_ASSERT_UINT32_WITHIN(5000, 0, timer.read_us());
 }
@@ -205,8 +204,8 @@ void test_multiple_tokens_wait()
     Semaphore sem(5);
 
     for (int i = 5; i >= 0; i--) {
-        int32_t cnt = sem.wait(0);
-        TEST_ASSERT_EQUAL(i, cnt);
+        bool acquired = sem.try_acquire();
+        TEST_ASSERT_EQUAL(i > 0, acquired);
     }
 }
 

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -647,7 +647,7 @@ void test_mutex()
 
 void test_semaphore_thread(Semaphore *sem)
 {
-    sem->wait();
+    sem->acquire();
 }
 
 /** Testing thread states: wait semaphore

--- a/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
@@ -48,7 +48,7 @@ void ASYNCHRONOUS_DNS_CACHE()
                                                                  mbed::Callback<void(nsapi_error_t, SocketAddress *)>(hostbyname_cb, (void *) &data));
         TEST_ASSERT(err >= 0);
 
-        semaphore.wait();
+        semaphore.acquire();
 
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
         TEST_ASSERT(strlen(data.addr.get_ip_address()) > 1);

--- a/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
@@ -58,7 +58,7 @@ void ASYNCHRONOUS_DNS_CANCEL()
 
     // Wait for callback(s) to complete
     for (int i = 0; i < count; i++) {
-        semaphore.wait();
+        semaphore.acquire();
     }
 
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {

--- a/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -45,7 +45,7 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
         TEST_ASSERT(strlen(addr.get_ip_address()) > 1);
     }
 
-    semaphore.wait(100);
+    semaphore.try_acquire_for(100);
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
 

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -82,7 +82,7 @@ void do_asynchronous_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsign
 
     // Wait for callback(s) to complete
     for (unsigned int i = 0; i < count; i++) {
-        semaphore.wait();
+        semaphore.acquire();
     }
 
     // Print result

--- a/TESTS/netsocket/dns/synchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_cache.cpp
@@ -34,8 +34,6 @@ static void test_dns_query_ticker(void)
 
 void SYNCHRONOUS_DNS_CACHE()
 {
-    rtos::Semaphore semaphore;
-
     Ticker ticker;
     ticker.attach_us(&test_dns_query_ticker, 100);
 

--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -187,7 +187,7 @@ void TCPSOCKET_ECHOTEST_NONBLOCK()
         }
         TEST_ASSERT_EQUAL(bytes2send, tcp_stats[j].sent_bytes);
 #endif
-        tx_sem.wait(split2half_rmng_tcp_test_time() * 1000); // *1000 to convert s->ms
+        tx_sem.try_acquire_for(split2half_rmng_tcp_test_time() * 1000); // *1000 to convert s->ms
         if (receive_error) {
             break;
         }

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -192,7 +192,7 @@ void TLSSOCKET_ECHOTEST_NONBLOCK()
         }
         TEST_ASSERT_EQUAL(bytes2send, tls_stats[j].sent_bytes);
 #endif
-        tx_sem.wait();
+        tx_sem.acquire();
         if (receive_error) {
             break;
         }

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -183,7 +183,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
                 printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
                 continue;
             }
-            if (tx_sem.wait(WAIT2RECV_TIMEOUT * 2) == 0) { // RX might wait up to WAIT2RECV_TIMEOUT before recvfrom
+            if (!tx_sem.try_acquire_for(WAIT2RECV_TIMEOUT * 2)) { // RX might wait up to WAIT2RECV_TIMEOUT before recvfrom
                 continue;
             }
             break;

--- a/TESTS/network/emac/emac_util.cpp
+++ b/TESTS/network/emac/emac_util.cpp
@@ -525,9 +525,9 @@ void worker_loop_start(void (*test_step_cb_fnc)(int opt), int timeout)
     }
 
 #if MBED_CONF_APP_ECHO_SERVER
-    worker_loop_semaphore.wait();
+    worker_loop_semaphore.acquire();
 #else
-    worker_loop_semaphore.wait(600 * SECOND_TO_MS);
+    worker_loop_semaphore.try_acquire_for(600 * SECOND_TO_MS);
 #endif
 
     worker_loop_event_queue.cancel(test_step_cb_timer);
@@ -554,7 +554,7 @@ static void worker_loop_event_cb(int event)
 void worker_loop_link_up_wait(void)
 {
     if (!link_up) {
-        link_status_semaphore.wait();
+        link_status_semaphore.acquire();
     }
 }
 

--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -54,7 +54,7 @@ nsapi_connection_status_t wait_status_callback()
     nsapi_connection_status_t status;
 
     while (true) {
-        status_semaphore.wait();
+        status_semaphore.acquire();
 
         status = statuses[status_read_counter];
         status_read_counter++;

--- a/TESTS/network/multihoming/multihoming_asynchronous_dns.cpp
+++ b/TESTS/network/multihoming/multihoming_asynchronous_dns.cpp
@@ -67,7 +67,7 @@ void MULTIHOMING_ASYNCHRONOUS_DNS()
                                                                        mbed::Callback<void(nsapi_error_t, SocketAddress *)>(hostbyname_cb, (void *) &data), NSAPI_UNSPEC, interface_name[j]);
                 TEST_ASSERT(err >= 0);
 
-                semaphore.wait();
+                semaphore.acquire();
 
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
                 printf("DNS: query  interface_name %s %d \n", interface_name[j], j);

--- a/TESTS/network/multihoming/multihoming_udpsocket_echotest.cpp
+++ b/TESTS/network/multihoming/multihoming_udpsocket_echotest.cpp
@@ -179,7 +179,7 @@ void MULTIHOMING_UDPSOCKET_ECHOTEST_NONBLOCK()
                         printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
                         continue;
                     }
-                    if (tx_sem.wait(WAIT2RECV_TIMEOUT * 2) == 0) { // RX might wait up to WAIT2RECV_TIMEOUT before recvfrom
+                    if (!tx_sem.try_acquire_for(WAIT2RECV_TIMEOUT * 2)) { // RX might wait up to WAIT2RECV_TIMEOUT before recvfrom
                         continue;
                     }
                     break;

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -474,7 +474,7 @@ TEST_F(TestAT_CellularContext, connect_disconnect_sync)
 
     my_AT_CTX ctx1(at, &dev);
     ctx1.attach(&network_cb);
-    Semaphore_stub::wait_return_value = 1;
+    Semaphore_stub::acquire_return_value = true;
 
     // call callback so that network is opened which is needed in disconnect
     cell_callback_data_t data;

--- a/UNITTESTS/stubs/Semaphore_stub.cpp
+++ b/UNITTESTS/stubs/Semaphore_stub.cpp
@@ -19,6 +19,7 @@
 #include "Semaphore_stub.h"
 
 int Semaphore_stub::wait_return_value = 0;
+bool Semaphore_stub::acquire_return_value;
 
 namespace rtos {
 
@@ -45,6 +46,26 @@ int32_t Semaphore::wait(uint32_t millisec)
 int32_t Semaphore::wait_until(uint64_t millisec)
 {
     return Semaphore_stub::wait_return_value;
+}
+
+void Semaphore::acquire()
+{
+
+}
+
+bool Semaphore::try_acquire()
+{
+    return Semaphore_stub::acquire_return_value;
+}
+
+bool Semaphore::try_acquire_for(uint32_t millisec)
+{
+    return Semaphore_stub::acquire_return_value;
+}
+
+bool Semaphore::try_acquire_until(uint64_t millisec)
+{
+    return Semaphore_stub::acquire_return_value;
 }
 
 osStatus Semaphore::release(void)

--- a/UNITTESTS/stubs/Semaphore_stub.h
+++ b/UNITTESTS/stubs/Semaphore_stub.h
@@ -19,6 +19,7 @@
 
 namespace Semaphore_stub {
 extern int wait_return_value;
+extern bool acquire_return_value;
 }
 
 

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -170,8 +170,8 @@ nsapi_error_t AT_CellularContext::check_operation(nsapi_error_t err, ContextOper
     _current_op = op;
     if (err == NSAPI_ERROR_IN_PROGRESS || err == NSAPI_ERROR_OK) {
         if (_is_blocking) {
-            int sema_err = _semaphore.wait(get_timeout_for_operation(op)); // cellular network searching may take several minutes
-            if (sema_err != 1) {
+            int sema_acq = _semaphore.try_acquire_for(get_timeout_for_operation(op)); // cellular network searching may take several minutes
+            if (!sema_acq) {
                 tr_warning("No cellular connection");
                 return NSAPI_ERROR_TIMEOUT;
             }
@@ -1043,7 +1043,7 @@ nsapi_error_t AT_CellularContext::setup_control_plane_opt()
     }
 
     //wait for control plane opt call back to release semaphore
-    _cp_opt_semaphore.wait(CP_OPT_NW_REPLY_TIMEOUT);
+    _cp_opt_semaphore.try_acquire_for(CP_OPT_NW_REPLY_TIMEOUT);
 
     if (_cp_in_use) {
         return NSAPI_ERROR_OK;

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.cpp
@@ -103,7 +103,7 @@ nsapi_error_t QUECTEL_BG96_CellularContext::activate_non_ip_context()
     _at.unlock();
 
     if (ret == NSAPI_ERROR_OK) {
-        _semaphore.wait(NIDD_OPEN_URC_TIMEOUT);
+        _semaphore.try_acquire_for(NIDD_OPEN_URC_TIMEOUT);
         if (_cid == -1) {
             return NSAPI_ERROR_NO_CONNECTION;
         }

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -590,7 +590,6 @@ private:
     static void tcpip_thread_callback(void *ptr);
 
     char ip_address[40];
-    rtos::Semaphore tcpip_inited;
     Interface *default_interface;
     LWIPMemoryManager memory_manager;
     osThreadId tcpip_thread_id;

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -17,6 +17,7 @@
 #ifndef MESHINTERFACENANOSTACK_H
 #define MESHINTERFACENANOSTACK_H
 
+#include "Semaphore.h"
 #include "MeshInterface.h"
 #include "NanostackRfPhy.h"
 #include "Nanostack.h"

--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -92,11 +92,7 @@ nsapi_error_t Nanostack::LoWPANNDInterface::bringup(bool dhcp, const char *ip,
 
     if (blocking) {
         // wait connection for ever
-        int32_t count = connect_semaphore.wait(osWaitForever);
-
-        if (count <= 0) {
-            return NSAPI_ERROR_DHCP_FAILURE; // sort of...
-        }
+        connect_semaphore.acquire();
     }
     return 0;
 

--- a/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
@@ -78,9 +78,9 @@ nsapi_error_t Nanostack::EthernetInterface::bringup(bool dhcp, const char *ip,
     }
 
     if (blocking) {
-        int32_t count = connect_semaphore.wait(30000);
+        bool acquired = connect_semaphore.try_acquire_for(30000);
 
-        if (count <= 0) {
+        if (!acquired) {
             return NSAPI_ERROR_DHCP_FAILURE; // sort of...
         }
     }
@@ -112,7 +112,7 @@ nsapi_error_t Nanostack::EthernetInterface::bringdown()
     }
 
     if (_blocking) {
-        int32_t count = disconnect_semaphore.wait(30000);
+        int32_t count = disconnect_semaphore.try_acquire_for(30000);
 
         if (count <= 0) {
             return NSAPI_ERROR_TIMEOUT;

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -148,11 +148,7 @@ nsapi_error_t Nanostack::ThreadInterface::bringup(bool dhcp, const char *ip,
     // -devices without network settings gets connectivity once commissioned and attached to network
     _connect_status = NSAPI_STATUS_CONNECTING;
     if (_blocking) {
-        int32_t count = connect_semaphore.wait(osWaitForever);
-
-        if (count <= 0) {
-            return NSAPI_ERROR_DHCP_FAILURE; // sort of...
-        }
+        connect_semaphore.acquire();
     }
     return 0;
 }

--- a/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/WisunInterface.cpp
@@ -92,11 +92,7 @@ nsapi_error_t Nanostack::WisunInterface::bringup(bool dhcp, const char *ip,
 
     if (blocking) {
         // wait connection for ever
-        int32_t count = connect_semaphore.wait(osWaitForever);
-
-        if (count <= 0) {
-            return NSAPI_ERROR_DHCP_FAILURE; // sort of...
-        }
+        connect_semaphore.acquire();
     }
     return 0;
 

--- a/features/netsocket/TCPServer.h
+++ b/features/netsocket/TCPServer.h
@@ -25,7 +25,6 @@
 #include "netsocket/TCPSocket.h"
 #include "netsocket/NetworkStack.h"
 #include "netsocket/NetworkInterface.h"
-#include "rtos/Semaphore.h"
 
 
 /** TCP socket server

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
@@ -412,7 +412,7 @@ bool Kinetis_EMAC::link_out(emac_mem_buf_t *buf)
     }
 
     /* Check if a descriptor is available for the transfer (wait 10ms before dropping the buffer) */
-    if (xTXDCountSem.wait(10) == 0) {
+    if (!xTXDCountSem.try_acquire_for(10)) {
         memory_manager->free(buf);
         return false;
     }

--- a/features/netsocket/emac-drivers/TARGET_GD_EMAC/gd32xx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_GD_EMAC/gd32xx_emac.h
@@ -20,7 +20,6 @@
 #define GD32_EMAC_H_
 
 #include "EMAC.h"
-#include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 
 class GD32_EMAC : public EMAC {

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.h
@@ -18,7 +18,6 @@
 #define NUMAKER_EMAC_H_
 
 #include "EMAC.h"
-#include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 
 class NUMAKER_EMAC : public EMAC {
@@ -161,7 +160,6 @@ private:
     mbed_rtos_storage_thread_t thread_cb;
     osThreadId_t thread; /**< Processing thread */
     rtos::Mutex TXLockMutex;/**< TX critical section mutex */
-    rtos::Semaphore xTXDCountSem; /**< TX free buffer counting semaphore */
     emac_link_input_cb_t emac_link_input_cb; /**< Callback for incoming data */
     emac_link_state_change_cb_t emac_link_state_cb; /**< Link state change callback */
     EMACMemoryManager *memory_manager; /**< Memory manager */

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_IMX/imx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_IMX/imx_emac.cpp
@@ -411,7 +411,7 @@ bool Kinetis_EMAC::link_out(emac_mem_buf_t *buf)
     SCB_CleanDCache_by_Addr(static_cast<uint32_t *>(memory_manager->get_ptr(buf)), memory_manager->get_len(buf));
 
     /* Check if a descriptor is available for the transfer (wait 10ms before dropping the buffer) */
-    if (xTXDCountSem.wait(10) == 0) {
+    if (!xTXDCountSem.try_acquire_for(10)) {
         memory_manager->free(buf);
         return false;
     }

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPCTarget/lpc17_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPCTarget/lpc17_emac.cpp
@@ -541,7 +541,7 @@ bool LPC17_EMAC::link_out(emac_mem_buf_t *p)
     /* Wait until enough descriptors are available for the transfer. */
     /* THIS WILL BLOCK UNTIL THERE ARE ENOUGH DESCRIPTORS AVAILABLE */
     for (int32_t count = 0; count < dn; count++) {
-        xTXDCountSem.wait();
+        xTXDCountSem.acquire();
     }
 
     MBED_ASSERT(dn <= lpc_tx_ready());
@@ -655,7 +655,7 @@ void LPC17_EMAC::packet_tx(void* pvParameters)
 
     while (1) {
         /* Wait for transmit cleanup task to wakeup */
-        lpc17_emac->TxCleanSem.wait();
+        lpc17_emac->TxCleanSem.acquire();
 
         /* Error handling for TX underruns. This should never happen unless
            something is holding the bus or the clocks are going too slow. It

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_MCU_LPC546XX/lpc546xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_MCU_LPC546XX/lpc546xx_emac.cpp
@@ -409,7 +409,7 @@ bool LPC546XX_EMAC::link_out(emac_mem_buf_t *buf)
     }
 
     /* Check if a descriptor is available for the transfer. */
-    if (xTXDCountSem.wait(0) == 0) {
+    if (!xTXDCountSem.try_acquire()) {
         memory_manager->free(buf);
         return false;
     }

--- a/features/netsocket/emac-drivers/TARGET_RDA_EMAC/rda5981x_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_RDA_EMAC/rda5981x_emac.h
@@ -18,7 +18,6 @@
 #define STM32_EMAC_H_
 
 #include "EMAC.h"
-#include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 
 class RDA5981x_EMAC : public EMAC {

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.h
@@ -17,7 +17,6 @@
 #define STM32_EMAC_H_
 
 #include "EMAC.h"
-#include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 
 class STM32_EMAC : public EMAC {

--- a/features/netsocket/emac-drivers/TARGET_Silicon_Labs/sl_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Silicon_Labs/sl_emac.cpp
@@ -124,7 +124,7 @@ void SL_EMAC::power_down()
 
     tr_debug("Link coming down, waiting for TX to be done.");
 
-    tx_sem.wait();
+    tx_sem.acquire();
 
     NVIC_DisableIRQ(ETH_IRQn);
 
@@ -491,8 +491,7 @@ bool SL_EMAC::link_out(emac_mem_buf_t *buf)
     }
 
     /* Wait for previous packet to finish transmitting */
-    int32_t stat = tx_sem.wait(100);
-    if (stat <= 0) {
+    if (!tx_sem.try_acquire_for(100)) {
         tr_warn("TX process didn't complete within 100ms");
         memory_manager->free(buf);
         return false;

--- a/rtos/ConditionVariable.cpp
+++ b/rtos/ConditionVariable.cpp
@@ -52,8 +52,7 @@ bool ConditionVariable::wait_for(uint32_t millisec)
 
     _mutex.unlock();
 
-    int32_t sem_count = current_thread.sem.wait(millisec);
-    bool timeout = (sem_count > 0) ? false : true;
+    bool timeout = !current_thread.sem.try_acquire_for(millisec);
 
     _mutex.lock();
 

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -148,10 +148,7 @@ osStatus Thread::terminate()
 
 osStatus Thread::join()
 {
-    int32_t ret = _join_sem.wait();
-    if (ret < 0) {
-        return osError;
-    }
+    _join_sem.acquire();
 
     // The semaphore has been released so this thread is being
     // terminated or has been terminated. Once the mutex has

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/TARGET_CY8C63XX/TARGET_MCU_PSOC6_M4/ipc_rpc.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/TARGET_CY8C63XX/TARGET_MCU_PSOC6_M4/ipc_rpc.cpp
@@ -77,7 +77,7 @@ uint32_t ipcrpc_call(uint32_t call_id, uint32_t args_num, ...)
     MBED_ASSERT(status == CY_IPC_PIPE_SUCCESS);
 
     // Now wait for the response;
-    msg_semaphore->wait();
+    msg_semaphore->acquire();
 
     return message.result;
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/rtw_emac.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/rtw_emac.h
@@ -18,7 +18,6 @@
 #define RTW_EMAC_H
 
 #include "EMAC.h"
-#include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 #include "netif.h"
 #include "EMACMemoryManager.h"

--- a/targets/TARGET_WICED/wiced_interface/wiced_emac.h
+++ b/targets/TARGET_WICED/wiced_interface/wiced_emac.h
@@ -21,7 +21,6 @@
 #include "EMACInterface.h"
 #include "WiFiInterface.h"
 
-#include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 
 class WICED_EMAC : public EMAC {

--- a/usb/device/utilities/AsyncOp.cpp
+++ b/usb/device/utilities/AsyncOp.cpp
@@ -63,7 +63,7 @@ void AsyncOp::wait(rtos::Mutex *host_mutex, uint32_t milliseconds)
         return;
     }
 
-    if (sem.wait(milliseconds) == 1) {
+    if (sem.try_acquire_for(milliseconds)) {
         // Operation completion signaled semaphore
         return;
     }

--- a/usb/device/utilities/events/TaskBase.cpp
+++ b/usb/device/utilities/events/TaskBase.cpp
@@ -79,7 +79,7 @@ void TaskBase::wait()
     _flush_sem = &sem;
     core_util_critical_section_exit();
 
-    sem.wait();
+    sem.acquire();
 }
 
 bool TaskBase::ready()


### PR DESCRIPTION
Deprecate `wait()` in favour of `acquire()`, `try_acquire()`, `try_acquire_for()` and `try_acquire_until()`.

Brings `Semaphore` more into line with CMSIS-RTOS 2 (which uses "acquire"), itself (as it has "release"), and other classes having "try", "try for" and "try until".

Also steps away from vague "wait" term - the primary operation here is to acquire the semaphore, and this will of course sleep.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@bulislaw 


