### PR TITLE
SysTimer should be buildable without lp ticker

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -17,10 +17,6 @@
 #error [NOT_SUPPORTED] Tickless mode not supported for this target.
 #endif
 
-#if !DEVICE_LPTICKER
-#error [NOT_SUPPORTED] Current SysTimer implementation requires lp ticker support.
-#endif
-
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/rtos/TARGET_CORTEX/SysTimer.cpp
+++ b/rtos/TARGET_CORTEX/SysTimer.cpp
@@ -21,8 +21,9 @@
  */
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
-#if DEVICE_LPTICKER
+#if MBED_TICKLESS
 
+#include "hal/us_ticker_api.h"
 #include "hal/lp_ticker_api.h"
 #include "mbed_critical.h"
 #include "mbed_assert.h"
@@ -58,7 +59,12 @@ namespace rtos {
 namespace internal {
 
 SysTimer::SysTimer() :
-    TimerEvent(get_lp_ticker_data()), _time_us(0), _tick(0)
+#if DEVICE_LPTICKER
+    TimerEvent(get_lp_ticker_data()),
+#else
+    TimerEvent(get_us_ticker_data()),
+#endif
+    _time_us(0), _tick(0)
 {
     _time_us = ticker_read_us(_ticker_data);
     _suspend_time_passed = true;
@@ -69,6 +75,8 @@ SysTimer::SysTimer(const ticker_data_t *data) :
     TimerEvent(data), _time_us(0), _tick(0)
 {
     _time_us = ticker_read_us(_ticker_data);
+    _suspend_time_passed = true;
+    _suspended = false;
 }
 
 void SysTimer::setup_irq()
@@ -194,4 +202,4 @@ void SysTimer::handler()
 }
 }
 
-#endif
+#endif // MBED_TICKLESS

--- a/rtos/TARGET_CORTEX/SysTimer.h
+++ b/rtos/TARGET_CORTEX/SysTimer.h
@@ -22,7 +22,7 @@
 #ifndef MBED_SYS_TIMER_H
 #define MBED_SYS_TIMER_H
 
-#if DEVICE_LPTICKER || defined(DOXYGEN_ONLY)
+#if MBED_TICKLESS || defined(DOXYGEN_ONLY)
 
 #include "platform/NonCopyable.h"
 #include "drivers/TimerEvent.h"

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -38,10 +38,13 @@ extern "C" {
 
 #ifdef MBED_TICKLESS
 
-    MBED_STATIC_ASSERT(!MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_USTICKER,
-                       "Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true");
-    MBED_STATIC_ASSERT(MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER || DEVICE_LPTICKER,
-                       "Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false");
+#if MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && !DEVICE_USTICKER
+#error Microsecond ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is true
+#endif
+
+#if !MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER && !DEVICE_LPTICKER
+#error Low power ticker required when MBED_CONF_TARGET_TICKLESS_FROM_US_TICKER is false
+#endif
 
 #include "rtos/TARGET_CORTEX/SysTimer.h"
 
@@ -137,7 +140,7 @@ extern "C" {
     }
 
 
-#else
+#else // MBED_TICKLESS
 
     static void default_idle_hook(void)
     {
@@ -149,7 +152,7 @@ extern "C" {
         core_util_critical_section_exit();
     }
 
-#endif // (defined(MBED_TICKLESS) && DEVICE_LPTICKER)
+#endif // MBED_TICKLESS
 
     static void (*idle_hook_fptr)(void) = &default_idle_hook;
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Tickless from us ticker is possible since #9785, but SysTimer cannot be built if lp ticker is not enabled even if the latter is not used. This PR drops such restriction and is a dependency for #10572 .

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
