### PR TITLE
K66F: Update SAI and SAI EDMA driver to SDK 2.5

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai.c
@@ -1,34 +1,17 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
  * Copyright 2016-2017 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_sai.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.sai"
+#endif
 
 /*******************************************************************************
  * Definitations
@@ -69,36 +52,52 @@ static void SAI_SetMasterClockDivider(I2S_Type *base, uint32_t mclk_Hz, uint32_t
  *
  * @param base SAI base pointer.
  */
-uint32_t SAI_GetInstance(I2S_Type *base);
+static uint32_t SAI_GetInstance(I2S_Type *base);
 
 /*!
  * @brief sends a piece of data in non-blocking way.
  *
  * @param base SAI base pointer
- * @param channel Data channel used.
+ * @param channel start channel number.
+ * @param channelMask enabled channels mask.
+ * @param endChannel end channel numbers.
  * @param bitWidth How many bits in a audio word, usually 8/16/24/32 bits.
  * @param buffer Pointer to the data to be written.
  * @param size Bytes to be written.
  */
-static void SAI_WriteNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+static void SAI_WriteNonBlocking(I2S_Type *base,
+                                 uint32_t channel,
+                                 uint32_t channelMask,
+                                 uint32_t endChannel,
+                                 uint32_t bitWidth,
+                                 uint8_t *buffer,
+                                 uint32_t size);
 
 /*!
  * @brief Receive a piece of data in non-blocking way.
  *
  * @param base SAI base pointer
- * @param channel Data channel used.
+ * @param channel start channel number.
+ * @param channelMask enabled channels mask.
+ * @param endChannel end channel numbers.
  * @param bitWidth How many bits in a audio word, usually 8/16/24/32 bits.
  * @param buffer Pointer to the data to be read.
  * @param size Bytes to be read.
  */
-static void SAI_ReadNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+static void SAI_ReadNonBlocking(I2S_Type *base,
+                                uint32_t channel,
+                                uint32_t channelMask,
+                                uint32_t endChannel,
+                                uint32_t bitWidth,
+                                uint8_t *buffer,
+                                uint32_t size);
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 /* Base pointer array */
 static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
 /*!@brief SAI handle pointer */
-sai_handle_t *s_saiHandle[ARRAY_SIZE(s_saiBases)][2];
+static sai_handle_t *s_saiHandle[ARRAY_SIZE(s_saiBases)][2];
 /* IRQ number array */
 static const IRQn_Type s_saiTxIRQ[] = I2S_TX_IRQS;
 static const IRQn_Type s_saiRxIRQ[] = I2S_RX_IRQS;
@@ -178,7 +177,7 @@ static void SAI_SetMasterClockDivider(I2S_Type *base, uint32_t mclk_Hz, uint32_t
 }
 #endif /* FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER */
 
-uint32_t SAI_GetInstance(I2S_Type *base)
+static uint32_t SAI_GetInstance(I2S_Type *base)
 {
     uint32_t instance;
 
@@ -196,45 +195,83 @@ uint32_t SAI_GetInstance(I2S_Type *base)
     return instance;
 }
 
-static void SAI_WriteNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+static void SAI_WriteNonBlocking(I2S_Type *base,
+                                 uint32_t channel,
+                                 uint32_t channelMask,
+                                 uint32_t endChannel,
+                                 uint32_t bitWidth,
+                                 uint8_t *buffer,
+                                 uint32_t size)
 {
     uint32_t i = 0;
-    uint8_t j = 0;
+    uint8_t j = 0, m = 0;
     uint8_t bytesPerWord = bitWidth / 8U;
     uint32_t data = 0;
     uint32_t temp = 0;
 
     for (i = 0; i < size / bytesPerWord; i++)
     {
-        for (j = 0; j < bytesPerWord; j++)
+        for (j = channel; j <= endChannel; j++)
         {
-            temp = (uint32_t)(*buffer);
-            data |= (temp << (8U * j));
-            buffer++;
+            if ((1U << j) & channelMask)
+            {
+                for (m = 0; m < bytesPerWord; m++)
+                {
+                    temp = (uint32_t)(*buffer);
+                    data |= (temp << (8U * m));
+                    buffer++;
+                }
+                base->TDR[j] = data;
+                data = 0;
+            }
         }
-        base->TDR[channel] = data;
-        data = 0;
     }
 }
 
-static void SAI_ReadNonBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+static void SAI_ReadNonBlocking(I2S_Type *base,
+                                uint32_t channel,
+                                uint32_t channelMask,
+                                uint32_t endChannel,
+                                uint32_t bitWidth,
+                                uint8_t *buffer,
+                                uint32_t size)
 {
     uint32_t i = 0;
-    uint8_t j = 0;
+    uint8_t j = 0, m = 0;
     uint8_t bytesPerWord = bitWidth / 8U;
     uint32_t data = 0;
 
     for (i = 0; i < size / bytesPerWord; i++)
     {
-        data = base->RDR[channel];
-        for (j = 0; j < bytesPerWord; j++)
+        for (j = channel; j <= endChannel; j++)
         {
-            *buffer = (data >> (8U * j)) & 0xFF;
-            buffer++;
+            if ((1U << j) & channelMask)
+            {
+                data = base->RDR[j];
+                for (m = 0; m < bytesPerWord; m++)
+                {
+                    *buffer = (data >> (8U * m)) & 0xFF;
+                    buffer++;
+                }
+            }
         }
     }
 }
 
+/*!
+ * brief Initializes the SAI Tx peripheral.
+ *
+ * Ungates the SAI clock, resets the module, and configures SAI Tx with a configuration structure.
+ * The configuration structure can be custom filled or set with default values by
+ * SAI_TxGetDefaultConfig().
+ *
+ * note  This API should be called at the beginning of the application to use
+ * the SAI driver. Otherwise, accessing the SAIM module can cause a hard fault
+ * because the clock is not enabled.
+ *
+ * param base SAI base pointer
+ * param config SAI configuration structure.
+*/
 void SAI_TxInit(I2S_Type *base, const sai_config_t *config)
 {
     uint32_t val = 0;
@@ -245,14 +282,18 @@ void SAI_TxInit(I2S_Type *base, const sai_config_t *config)
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 #if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+#if !(defined(FSL_FEATURE_SAI_HAS_NO_MCR_MICS) && (FSL_FEATURE_SAI_HAS_NO_MCR_MICS))
     /* Master clock source setting */
     val = (base->MCR & ~I2S_MCR_MICS_MASK);
     base->MCR = (val | I2S_MCR_MICS(config->mclkSource));
+#endif
 
     /* Configure Master clock output enable */
     val = (base->MCR & ~I2S_MCR_MOE_MASK);
     base->MCR = (val | I2S_MCR_MOE(config->mclkOutputEnable));
 #endif /* FSL_FEATURE_SAI_HAS_MCR */
+
+    SAI_TxReset(base);
 
     /* Configure audio protocol */
     switch (config->protocol)
@@ -337,8 +378,26 @@ void SAI_TxInit(I2S_Type *base, const sai_config_t *config)
         default:
             break;
     }
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR) && FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR
+    SAI_TxSetFIFOErrorContinue(base, true);
+#endif /* FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR */
 }
 
+/*!
+ * brief Initializes the SAI Rx peripheral.
+ *
+ * Ungates the SAI clock, resets the module, and configures the SAI Rx with a configuration structure.
+ * The configuration structure can be custom filled or set with default values by
+ * SAI_RxGetDefaultConfig().
+ *
+ * note  This API should be called at the beginning of the application to use
+ * the SAI driver. Otherwise, accessing the SAI module can cause a hard fault
+ * because the clock is not enabled.
+ *
+ * param base SAI base pointer
+ * param config SAI configuration structure.
+ */
 void SAI_RxInit(I2S_Type *base, const sai_config_t *config)
 {
     uint32_t val = 0;
@@ -349,14 +408,18 @@ void SAI_RxInit(I2S_Type *base, const sai_config_t *config)
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 #if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
+#if !(defined(FSL_FEATURE_SAI_HAS_NO_MCR_MICS) && (FSL_FEATURE_SAI_HAS_NO_MCR_MICS))
     /* Master clock source setting */
     val = (base->MCR & ~I2S_MCR_MICS_MASK);
     base->MCR = (val | I2S_MCR_MICS(config->mclkSource));
+#endif
 
     /* Configure Master clock output enable */
     val = (base->MCR & ~I2S_MCR_MOE_MASK);
     base->MCR = (val | I2S_MCR_MOE(config->mclkOutputEnable));
 #endif /* FSL_FEATURE_SAI_HAS_MCR */
+
+    SAI_RxReset(base);
 
     /* Configure audio protocol */
     switch (config->protocol)
@@ -441,8 +504,20 @@ void SAI_RxInit(I2S_Type *base, const sai_config_t *config)
         default:
             break;
     }
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR) && FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR
+    SAI_RxSetFIFOErrorContinue(base, true);
+#endif /* FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR */
 }
 
+/*!
+ * brief De-initializes the SAI peripheral.
+ *
+ * This API gates the SAI clock. The SAI module can't operate unless SAI_TxInit
+ * or SAI_RxInit is called to enable the clock.
+ *
+ * param base SAI base pointer
+*/
 void SAI_Deinit(I2S_Type *base)
 {
     SAI_TxEnable(base, false);
@@ -452,30 +527,75 @@ void SAI_Deinit(I2S_Type *base)
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
+/*!
+ * brief  Sets the SAI Tx configuration structure to default values.
+ *
+ * This API initializes the configuration structure for use in SAI_TxConfig().
+ * The initialized structure can remain unchanged in SAI_TxConfig(), or it can be modified
+ *  before calling SAI_TxConfig().
+ * This is an example.
+   code
+   sai_config_t config;
+   SAI_TxGetDefaultConfig(&config);
+   endcode
+ *
+ * param config pointer to master configuration structure
+ */
 void SAI_TxGetDefaultConfig(sai_config_t *config)
 {
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
     config->bclkSource = kSAI_BclkSourceMclkDiv;
     config->masterSlave = kSAI_Master;
-    config->mclkSource = kSAI_MclkSourceSysclk;
-    config->protocol = kSAI_BusLeftJustified;
-    config->syncMode = kSAI_ModeAsync;
 #if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
     config->mclkOutputEnable = true;
+#if !(defined(FSL_FEATURE_SAI_HAS_NO_MCR_MICS) && (FSL_FEATURE_SAI_HAS_NO_MCR_MICS))
+    config->mclkSource = kSAI_MclkSourceSysclk;
+#endif
 #endif /* FSL_FEATURE_SAI_HAS_MCR */
+    config->protocol = kSAI_BusI2S;
+    config->syncMode = kSAI_ModeAsync;
 }
 
+/*!
+ * brief  Sets the SAI Rx configuration structure to default values.
+ *
+ * This API initializes the configuration structure for use in SAI_RxConfig().
+ * The initialized structure can remain unchanged in SAI_RxConfig() or it can be modified
+ *  before calling SAI_RxConfig().
+ * This is an example.
+   code
+   sai_config_t config;
+   SAI_RxGetDefaultConfig(&config);
+   endcode
+ *
+ * param config pointer to master configuration structure
+ */
 void SAI_RxGetDefaultConfig(sai_config_t *config)
 {
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
     config->bclkSource = kSAI_BclkSourceMclkDiv;
     config->masterSlave = kSAI_Master;
-    config->mclkSource = kSAI_MclkSourceSysclk;
-    config->protocol = kSAI_BusLeftJustified;
-    config->syncMode = kSAI_ModeSync;
 #if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
     config->mclkOutputEnable = true;
+#if !(defined(FSL_FEATURE_SAI_HAS_NO_MCR_MICS) && (FSL_FEATURE_SAI_HAS_NO_MCR_MICS))
+    config->mclkSource = kSAI_MclkSourceSysclk;
+#endif
 #endif /* FSL_FEATURE_SAI_HAS_MCR */
+    config->protocol = kSAI_BusI2S;
+    config->syncMode = kSAI_ModeSync;
 }
 
+/*!
+ * brief Resets the SAI Tx.
+ *
+ * This function enables the software reset and FIFO reset of SAI Tx. After reset, clear the reset bit.
+ *
+ * param base SAI base pointer
+ */
 void SAI_TxReset(I2S_Type *base)
 {
     /* Set the software reset and FIFO reset to clear internal state */
@@ -492,6 +612,13 @@ void SAI_TxReset(I2S_Type *base)
     base->TMR = 0;
 }
 
+/*!
+ * brief Resets the SAI Rx.
+ *
+ * This function enables the software reset and FIFO reset of SAI Rx. After reset, clear the reset bit.
+ *
+ * param base SAI base pointer
+ */
 void SAI_RxReset(I2S_Type *base)
 {
     /* Set the software reset and FIFO reset to clear internal state */
@@ -508,6 +635,12 @@ void SAI_RxReset(I2S_Type *base)
     base->RMR = 0;
 }
 
+/*!
+ * brief Enables/disables the SAI Tx.
+ *
+ * param base SAI base pointer
+ * param enable True means enable SAI Tx, false means disable.
+ */
 void SAI_TxEnable(I2S_Type *base, bool enable)
 {
     if (enable)
@@ -518,14 +651,26 @@ void SAI_TxEnable(I2S_Type *base, bool enable)
             base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | I2S_RCSR_RE_MASK);
         }
         base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | I2S_TCSR_TE_MASK);
+        /* Also need to clear the FIFO error flag before start */
+        SAI_TxClearStatusFlags(base, kSAI_FIFOErrorFlag);
     }
     else
     {
-        /* Should not close RE even sync with Rx */
-        base->TCSR = ((base->TCSR & 0xFFE3FFFFU) & (~I2S_TCSR_TE_MASK));
+        /* If RE not sync with TE, than disable TE, otherwise, shall not disable TE */
+        if (((base->RCR2 & I2S_RCR2_SYNC_MASK) >> I2S_RCR2_SYNC_SHIFT) != 0x1U)
+        {
+            /* Should not close RE even sync with Rx */
+            base->TCSR = ((base->TCSR & 0xFFE3FFFFU) & (~I2S_TCSR_TE_MASK));
+        }
     }
 }
 
+/*!
+ * brief Enables/disables the SAI Rx.
+ *
+ * param base SAI base pointer
+ * param enable True means enable SAI Rx, false means disable.
+ */
 void SAI_RxEnable(I2S_Type *base, bool enable)
 {
     if (enable)
@@ -536,19 +681,232 @@ void SAI_RxEnable(I2S_Type *base, bool enable)
             base->TCSR = ((base->TCSR & 0xFFE3FFFFU) | I2S_TCSR_TE_MASK);
         }
         base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | I2S_RCSR_RE_MASK);
+        /* Also need to clear the FIFO error flag before start */
+        SAI_RxClearStatusFlags(base, kSAI_FIFOErrorFlag);
     }
     else
     {
-        base->RCSR = ((base->RCSR & 0xFFE3FFFFU) & (~I2S_RCSR_RE_MASK));
+        /* While TX is not sync with RX, close RX */
+        if (((base->TCR2 & I2S_TCR2_SYNC_MASK) >> I2S_TCR2_SYNC_SHIFT) != 0x1U)
+        {
+            base->RCSR = ((base->RCSR & 0xFFE3FFFFU) & (~I2S_RCSR_RE_MASK));
+        }
     }
 }
 
+/*!
+ * brief Do software reset or FIFO reset .
+ *
+ * FIFO reset means clear all the data in the FIFO, and make the FIFO pointer both to 0.
+ * Software reset means claer the Tx internal logic, including the bit clock, frame count etc. But software
+ * reset will not clear any configuration registers like TCR1~TCR5.
+ * This function will also clear all the error flags such as FIFO error, sync error etc.
+ *
+ * param base SAI base pointer
+ * param type Reset type, FIFO reset or software reset
+ */
+void SAI_TxSoftwareReset(I2S_Type *base, sai_reset_type_t type)
+{
+    base->TCSR |= (uint32_t)type;
+
+    /* Clear the software reset */
+    base->TCSR &= ~I2S_TCSR_SR_MASK;
+}
+
+/*!
+ * brief Do software reset or FIFO reset .
+ *
+ * FIFO reset means clear all the data in the FIFO, and make the FIFO pointer both to 0.
+ * Software reset means claer the Rx internal logic, including the bit clock, frame count etc. But software
+ * reset will not clear any configuration registers like RCR1~RCR5.
+ * This function will also clear all the error flags such as FIFO error, sync error etc.
+ *
+ * param base SAI base pointer
+ * param type Reset type, FIFO reset or software reset
+ */
+void SAI_RxSoftwareReset(I2S_Type *base, sai_reset_type_t type)
+{
+    base->RCSR |= (uint32_t)type;
+
+    /* Clear the software reset */
+    base->RCSR &= ~I2S_RCSR_SR_MASK;
+}
+
+/*!
+ * brief Set the Tx channel FIFO enable mask.
+ *
+ * param base SAI base pointer
+ * param mask Channel enable mask, 0 means all channel FIFO disabled, 1 means channel 0 enabled,
+ * 3 means both channel 0 and channel 1 enabled.
+ */
+void SAI_TxSetChannelFIFOMask(I2S_Type *base, uint8_t mask)
+{
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
+    base->TCR3 |= I2S_TCR3_TCE(mask);
+}
+
+/*!
+ * brief Set the Rx channel FIFO enable mask.
+ *
+ * param base SAI base pointer
+ * param mask Channel enable mask, 0 means all channel FIFO disabled, 1 means channel 0 enabled,
+ * 3 means both channel 0 and channel 1 enabled.
+ */
+void SAI_RxSetChannelFIFOMask(I2S_Type *base, uint8_t mask)
+{
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
+    base->RCR3 |= I2S_RCR3_RCE(mask);
+}
+
+/*!
+ * brief Set the Tx data order.
+ *
+ * param base SAI base pointer
+ * param order Data order MSB or LSB
+ */
+void SAI_TxSetDataOrder(I2S_Type *base, sai_data_order_t order)
+{
+    uint32_t val = (base->TCR4) & (~I2S_TCR4_MF_MASK);
+
+    val |= I2S_TCR4_MF(order);
+    base->TCR4 = val;
+}
+
+/*!
+ * brief Set the Rx data order.
+ *
+ * param base SAI base pointer
+ * param order Data order MSB or LSB
+ */
+void SAI_RxSetDataOrder(I2S_Type *base, sai_data_order_t order)
+{
+    uint32_t val = (base->RCR4) & (~I2S_RCR4_MF_MASK);
+
+    val |= I2S_RCR4_MF(order);
+    base->RCR4 = val;
+}
+
+/*!
+ * brief Set the Tx data order.
+ *
+ * param base SAI base pointer
+ * param order Data order MSB or LSB
+ */
+void SAI_TxSetBitClockPolarity(I2S_Type *base, sai_clock_polarity_t polarity)
+{
+    uint32_t val = (base->TCR2) & (~I2S_TCR2_BCP_MASK);
+
+    val |= I2S_TCR2_BCP(polarity);
+    base->TCR2 = val;
+}
+
+/*!
+ * brief Set the Rx data order.
+ *
+ * param base SAI base pointer
+ * param order Data order MSB or LSB
+ */
+void SAI_RxSetBitClockPolarity(I2S_Type *base, sai_clock_polarity_t polarity)
+{
+    uint32_t val = (base->RCR2) & (~I2S_RCR2_BCP_MASK);
+
+    val |= I2S_RCR2_BCP(polarity);
+    base->RCR2 = val;
+}
+
+/*!
+ * brief Set the Tx data order.
+ *
+ * param base SAI base pointer
+ * param order Data order MSB or LSB
+ */
+void SAI_TxSetFrameSyncPolarity(I2S_Type *base, sai_clock_polarity_t polarity)
+{
+    uint32_t val = (base->TCR4) & (~I2S_TCR4_FSP_MASK);
+
+    val |= I2S_TCR4_FSP(polarity);
+    base->TCR4 = val;
+}
+
+/*!
+ * brief Set the Rx data order.
+ *
+ * param base SAI base pointer
+ * param order Data order MSB or LSB
+ */
+void SAI_RxSetFrameSyncPolarity(I2S_Type *base, sai_clock_polarity_t polarity)
+{
+    uint32_t val = (base->RCR4) & (~I2S_RCR4_FSP_MASK);
+
+    val |= I2S_RCR4_FSP(polarity);
+    base->RCR4 = val;
+}
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_PACKING) && FSL_FEATURE_SAI_HAS_FIFO_PACKING
+/*!
+ * brief Set Tx FIFO packing feature.
+ *
+ * param base SAI base pointer.
+ * param pack FIFO pack type. It is element of sai_fifo_packing_t.
+ */
+void SAI_TxSetFIFOPacking(I2S_Type *base, sai_fifo_packing_t pack)
+{
+    uint32_t val = base->TCR4;
+
+    val &= ~I2S_TCR4_FPACK_MASK;
+    val |= I2S_TCR4_FPACK(pack);
+    base->TCR4 = val;
+}
+
+/*!
+* brief Set Rx FIFO packing feature.
+*
+* param base SAI base pointer.
+* param pack FIFO pack type. It is element of sai_fifo_packing_t.
+*/
+void SAI_RxSetFIFOPacking(I2S_Type *base, sai_fifo_packing_t pack)
+{
+    uint32_t val = base->RCR4;
+
+    val &= ~I2S_RCR4_FPACK_MASK;
+    val |= I2S_RCR4_FPACK(pack);
+    base->RCR4 = val;
+}
+#endif /* FSL_FEATURE_SAI_HAS_FIFO_PACKING */
+
+/*!
+ * brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * param base SAI base pointer.
+ * param format Pointer to the SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If the bit clock source is a master
+ * clock, this value should equal the masterClockHz.
+*/
 void SAI_TxSetFormat(I2S_Type *base,
                      sai_transfer_format_t *format,
                      uint32_t mclkSourceClockHz,
                      uint32_t bclkSourceClockHz)
 {
-    uint32_t bclk = format->sampleRate_Hz * 32U * 2U;
+    uint32_t bclk = 0;
+    uint32_t val = 0;
+    uint32_t i = 0U;
+    uint32_t divider = 0U, channelNums = 0U;
+
+    if (format->isFrameSyncCompact)
+    {
+        bclk = format->sampleRate_Hz * format->bitWidth * (format->stereo == kSAI_Stereo ? 2U : 1U);
+        val = (base->TCR4 & (~I2S_TCR4_SYWD_MASK));
+        val |= I2S_TCR4_SYWD(format->bitWidth - 1U);
+        base->TCR4 = val;
+    }
+    else
+    {
+        bclk = format->sampleRate_Hz * 32U * 2U;
+    }
 
 /* Compute the mclk */
 #if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
@@ -563,25 +921,88 @@ void SAI_TxSetFormat(I2S_Type *base,
     if (base->TCR2 & I2S_TCR2_BCD_MASK)
     {
         base->TCR2 &= ~I2S_TCR2_DIV_MASK;
-        base->TCR2 |= I2S_TCR2_DIV((bclkSourceClockHz / bclk) / 2U - 1U);
+        /* need to check the divided bclk, if bigger than target, then divider need to re-calculate. */
+        divider = bclkSourceClockHz / bclk;
+        /* for the condition where the source clock is smaller than target bclk */
+        if (divider == 0U)
+        {
+            divider++;
+        }
+        /* recheck the divider if properly or not, to make sure output blck not bigger than target*/
+        if ((bclkSourceClockHz / divider) > bclk)
+        {
+            divider++;
+        }
+
+#if defined(FSL_FEATURE_SAI_HAS_BCLK_BYPASS) && (FSL_FEATURE_SAI_HAS_BCLK_BYPASS)
+        /* if bclk same with MCLK, bypass the divider */
+        if (divider == 1U)
+        {
+            base->TCR2 |= I2S_TCR2_BYP_MASK;
+        }
+        else
+#endif
+        {
+            base->TCR2 |= I2S_TCR2_DIV(divider / 2U - 1U);
+        }
     }
 
     /* Set bitWidth */
+    val = (format->isFrameSyncCompact) ? (format->bitWidth - 1) : 31U;
     if (format->protocol == kSAI_BusRightJustified)
     {
-        base->TCR5 = I2S_TCR5_WNW(31U) | I2S_TCR5_W0W(31U) | I2S_TCR5_FBT(31U);
+        base->TCR5 = I2S_TCR5_WNW(val) | I2S_TCR5_W0W(val) | I2S_TCR5_FBT(val);
     }
     else
     {
-        base->TCR5 = I2S_TCR5_WNW(31U) | I2S_TCR5_W0W(31U) | I2S_TCR5_FBT(format->bitWidth - 1);
+        if (base->TCR4 & I2S_TCR4_MF_MASK)
+        {
+            base->TCR5 = I2S_TCR5_WNW(val) | I2S_TCR5_W0W(val) | I2S_TCR5_FBT(format->bitWidth - 1);
+        }
+        else
+        {
+            base->TCR5 = I2S_TCR5_WNW(val) | I2S_TCR5_W0W(val) | I2S_TCR5_FBT(0);
+        }
     }
 
     /* Set mono or stereo */
     base->TMR = (uint32_t)format->stereo;
 
+    /* if channel mask is not set, then format->channel must be set,
+     use it to get channel mask value */
+    if (format->channelMask == 0U)
+    {
+        format->channelMask = 1U << format->channel;
+    }
+
+    /* if channel nums is not set, calculate it here according to channelMask*/
+    for (i = 0U; i < FSL_FEATURE_SAI_CHANNEL_COUNT; i++)
+    {
+        if (((uint32_t)1 << i) & format->channelMask)
+        {
+            /* geet start channel number when channelNums = 0 only */
+            if (channelNums == 0U)
+            {
+                format->channel = i;
+            }
+            channelNums++;
+            format->endChannel = i;
+        }
+    }
+    format->channelNums = channelNums;
+    assert(format->channelNums <= FSL_FEATURE_SAI_CHANNEL_COUNT);
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && (FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE)
+    /* make sure combine mode disabled while multipe channel is used */
+    if (format->channelNums > 1U)
+    {
+        base->TCR4 &= ~I2S_TCR4_FCOMB_MASK;
+    }
+#endif
+
     /* Set data channel */
     base->TCR3 &= ~I2S_TCR3_TCE_MASK;
-    base->TCR3 |= I2S_TCR3_TCE(1U << format->channel);
+    base->TCR3 |= I2S_TCR3_TCE(format->channelMask);
 
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     /* Set watermark */
@@ -589,12 +1010,39 @@ void SAI_TxSetFormat(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT  */
 }
 
+/*!
+ * brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * param base SAI base pointer.
+ * param format Pointer to the SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If the bit clock source is a master
+ * clock, this value should equal the masterClockHz.
+*/
 void SAI_RxSetFormat(I2S_Type *base,
                      sai_transfer_format_t *format,
                      uint32_t mclkSourceClockHz,
                      uint32_t bclkSourceClockHz)
 {
-    uint32_t bclk = format->sampleRate_Hz * 32U * 2U;
+    uint32_t bclk = 0;
+    uint32_t val = 0;
+    uint32_t i = 0U;
+    uint32_t divider = 0U, channelNums = 0U;
+
+    if (format->isFrameSyncCompact)
+    {
+        bclk = format->sampleRate_Hz * format->bitWidth * (format->stereo == kSAI_Stereo ? 2U : 1U);
+        val = (base->RCR4 & (~I2S_RCR4_SYWD_MASK));
+        val |= I2S_RCR4_SYWD(format->bitWidth - 1U);
+        base->RCR4 = val;
+    }
+    else
+    {
+        bclk = format->sampleRate_Hz * 32U * 2U;
+    }
 
 /* Compute the mclk */
 #if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
@@ -609,25 +1057,88 @@ void SAI_RxSetFormat(I2S_Type *base,
     if (base->RCR2 & I2S_RCR2_BCD_MASK)
     {
         base->RCR2 &= ~I2S_RCR2_DIV_MASK;
-        base->RCR2 |= I2S_RCR2_DIV((bclkSourceClockHz / bclk) / 2U - 1U);
+        /* need to check the divided bclk, if bigger than target, then divider need to re-calculate. */
+        divider = bclkSourceClockHz / bclk;
+        /* for the condition where the source clock is smaller than target bclk */
+        if (divider == 0U)
+        {
+            divider++;
+        }
+        /* recheck the divider if properly or not, to make sure output blck not bigger than target*/
+        if ((bclkSourceClockHz / divider) > bclk)
+        {
+            divider++;
+        }
+#if defined(FSL_FEATURE_SAI_HAS_BCLK_BYPASS) && (FSL_FEATURE_SAI_HAS_BCLK_BYPASS)
+        /* if bclk same with MCLK, bypass the divider */
+        if (divider == 1U)
+        {
+            base->RCR2 |= I2S_RCR2_BYP_MASK;
+        }
+        else
+#endif
+        {
+            base->RCR2 |= I2S_RCR2_DIV(divider / 2U - 1U);
+        }
     }
 
     /* Set bitWidth */
+    val = (format->isFrameSyncCompact) ? (format->bitWidth - 1) : 31U;
     if (format->protocol == kSAI_BusRightJustified)
     {
-        base->RCR5 = I2S_RCR5_WNW(31U) | I2S_RCR5_W0W(31U) | I2S_RCR5_FBT(31U);
+        base->RCR5 = I2S_RCR5_WNW(val) | I2S_RCR5_W0W(val) | I2S_RCR5_FBT(val);
     }
     else
     {
-        base->RCR5 = I2S_RCR5_WNW(31U) | I2S_RCR5_W0W(31U) | I2S_RCR5_FBT(format->bitWidth - 1);
+        if (base->RCR4 & I2S_RCR4_MF_MASK)
+        {
+            base->RCR5 = I2S_RCR5_WNW(val) | I2S_RCR5_W0W(val) | I2S_RCR5_FBT(format->bitWidth - 1);
+        }
+        else
+        {
+            base->RCR5 = I2S_RCR5_WNW(val) | I2S_RCR5_W0W(val) | I2S_RCR5_FBT(0);
+        }
     }
 
     /* Set mono or stereo */
     base->RMR = (uint32_t)format->stereo;
 
+    /* if channel mask is not set, then format->channel must be set,
+     use it to get channel mask value */
+    if (format->channelMask == 0U)
+    {
+        format->channelMask = 1U << format->channel;
+    }
+
+    /* if channel nums is not set, calculate it here according to channelMask*/
+    for (i = 0U; i < FSL_FEATURE_SAI_CHANNEL_COUNT; i++)
+    {
+        if (((uint32_t)1 << i) & format->channelMask)
+        {
+            /* geet start channel number when channelNums = 0 only */
+            if (channelNums == 0U)
+            {
+                format->channel = i;
+            }
+            channelNums++;
+            format->endChannel = i;
+        }
+    }
+    format->channelNums = channelNums;
+    assert(format->channelNums <= FSL_FEATURE_SAI_CHANNEL_COUNT);
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && (FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE)
+    /* make sure combine mode disabled while multipe channel is used */
+    if (format->channelNums > 1U)
+    {
+        base->RCR4 &= ~I2S_RCR4_FCOMB_MASK;
+    }
+#endif
+
     /* Set data channel */
     base->RCR3 &= ~I2S_RCR3_RCE_MASK;
-    base->RCR3 |= I2S_RCR3_RCE(1U << format->channel);
+    /* enable all the channel */
+    base->RCR3 |= I2S_RCR3_RCE(format->channelMask);
 
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     /* Set watermark */
@@ -635,10 +1146,24 @@ void SAI_RxSetFormat(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT  */
 }
 
+/*!
+ * brief Sends data using a blocking method.
+ *
+ * note This function blocks by polling until data is ready to be sent.
+ *
+ * param base SAI base pointer.
+ * param channel Data channel used.
+ * param bitWidth How many bits in an audio word; usually 8/16/24/32 bits.
+ * param buffer Pointer to the data to be written.
+ * param size Bytes to be written.
+ */
 void SAI_WriteBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
 {
     uint32_t i = 0;
     uint8_t bytesPerWord = bitWidth / 8U;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    bytesPerWord = (size_t)((FSL_FEATURE_SAI_FIFO_COUNT - base->TCR1) * bytesPerWord);
+#endif
 
     while (i < size)
     {
@@ -647,7 +1172,7 @@ void SAI_WriteBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint
         {
         }
 
-        SAI_WriteNonBlocking(base, channel, bitWidth, buffer, bytesPerWord);
+        SAI_WriteNonBlocking(base, channel, 1U << channel, channel, bitWidth, buffer, bytesPerWord);
         buffer += bytesPerWord;
         i += bytesPerWord;
     }
@@ -658,10 +1183,123 @@ void SAI_WriteBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint
     }
 }
 
+/*!
+ * brief Sends data to multi channel using a blocking method.
+ *
+ * note This function blocks by polling until data is ready to be sent.
+ *
+ * param base SAI base pointer.
+ * param channel Data channel used.
+ * param channelMask channel mask.
+ * param bitWidth How many bits in an audio word; usually 8/16/24/32 bits.
+ * param buffer Pointer to the data to be written.
+ * param size Bytes to be written.
+ */
+void SAI_WriteMultiChannelBlocking(
+    I2S_Type *base, uint32_t channel, uint32_t channelMask, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+{
+    uint32_t i = 0, j = 0;
+    uint8_t bytesPerWord = bitWidth / 8U;
+    uint32_t channelNums = 0U, endChannel = 0U;
+
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    bytesPerWord = (size_t)((FSL_FEATURE_SAI_FIFO_COUNT - base->TCR1) * bytesPerWord);
+#endif
+
+    for (i = 0U; (i < FSL_FEATURE_SAI_CHANNEL_COUNT); i++)
+    {
+        if ((1U << i) & (channelMask))
+        {
+            channelNums++;
+            endChannel = i;
+        }
+    }
+
+    assert(channelNums <= FSL_FEATURE_SAI_CHANNEL_COUNT);
+    bytesPerWord *= channelNums;
+
+    while (j < size)
+    {
+        /* Wait until it can write data */
+        while (!(base->TCSR & I2S_TCSR_FWF_MASK))
+        {
+        }
+
+        SAI_WriteNonBlocking(base, channel, channelMask, endChannel, bitWidth, buffer, bytesPerWord);
+        buffer += bytesPerWord;
+        j += bytesPerWord;
+    }
+
+    /* Wait until the last data is sent */
+    while (!(base->TCSR & I2S_TCSR_FWF_MASK))
+    {
+    }
+}
+
+/*!
+ * brief Receives multi channel data using a blocking method.
+ *
+ * note This function blocks by polling until data is ready to be sent.
+ *
+ * param base SAI base pointer.
+ * param channel Data channel used.
+ * param channelMask channel mask.
+ * param bitWidth How many bits in an audio word; usually 8/16/24/32 bits.
+ * param buffer Pointer to the data to be read.
+ * param size Bytes to be read.
+ */
+void SAI_ReadMultiChannelBlocking(
+    I2S_Type *base, uint32_t channel, uint32_t channelMask, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
+{
+    uint32_t i = 0, j = 0;
+    uint8_t bytesPerWord = bitWidth / 8U;
+    uint32_t channelNums = 0U, endChannel = 0U;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    bytesPerWord = (size_t)(base->RCR1 * bytesPerWord);
+#endif
+    for (i = 0U; (i < FSL_FEATURE_SAI_CHANNEL_COUNT); i++)
+    {
+        if ((1U << i) & (channelMask))
+        {
+            channelNums++;
+            endChannel = i;
+        }
+    }
+
+    assert(channelNums <= FSL_FEATURE_SAI_CHANNEL_COUNT);
+    bytesPerWord *= channelNums;
+
+    while (j < size)
+    {
+        /* Wait until data is received */
+        while (!(base->RCSR & I2S_RCSR_FWF_MASK))
+        {
+        }
+
+        SAI_ReadNonBlocking(base, channel, channelMask, endChannel, bitWidth, buffer, bytesPerWord);
+        buffer += bytesPerWord;
+        j += bytesPerWord;
+    }
+}
+
+/*!
+ * brief Receives data using a blocking method.
+ *
+ * note This function blocks by polling until data is ready to be sent.
+ *
+ * param base SAI base pointer.
+ * param channel Data channel used.
+ * param bitWidth How many bits in an audio word; usually 8/16/24/32 bits.
+ * param buffer Pointer to the data to be read.
+ * param size Bytes to be read.
+ */
 void SAI_ReadBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size)
 {
     uint32_t i = 0;
     uint8_t bytesPerWord = bitWidth / 8U;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    bytesPerWord = (size_t)(base->RCR1 * bytesPerWord);
+#endif
 
     while (i < size)
     {
@@ -670,12 +1308,23 @@ void SAI_ReadBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8
         {
         }
 
-        SAI_ReadNonBlocking(base, channel, bitWidth, buffer, bytesPerWord);
+        SAI_ReadNonBlocking(base, channel, 1U << channel, channel, bitWidth, buffer, bytesPerWord);
         buffer += bytesPerWord;
         i += bytesPerWord;
     }
 }
 
+/*!
+ * brief Initializes the SAI Tx handle.
+ *
+ * This function initializes the Tx handle for the SAI Tx transactional APIs. Call
+ * this function once to get the handle initialized.
+ *
+ * param base SAI base pointer
+ * param handle SAI handle pointer.
+ * param callback Pointer to the user callback function.
+ * param userData User parameter passed to the callback function
+ */
 void SAI_TransferTxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transfer_callback_t callback, void *userData)
 {
     assert(handle);
@@ -687,6 +1336,7 @@ void SAI_TransferTxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transf
 
     handle->callback = callback;
     handle->userData = userData;
+    handle->base = base;
 
     /* Set the isr pointer */
     s_saiTxIsr = SAI_TransferTxHandleIRQ;
@@ -695,6 +1345,17 @@ void SAI_TransferTxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transf
     EnableIRQ(s_saiTxIRQ[SAI_GetInstance(base)]);
 }
 
+/*!
+ * brief Initializes the SAI Rx handle.
+ *
+ * This function initializes the Rx handle for the SAI Rx transactional APIs. Call
+ * this function once to get the handle initialized.
+ *
+ * param base SAI base pointer.
+ * param handle SAI handle pointer.
+ * param callback Pointer to the user callback function.
+ * param userData User parameter passed to the callback function.
+ */
 void SAI_TransferRxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transfer_callback_t callback, void *userData)
 {
     assert(handle);
@@ -706,6 +1367,7 @@ void SAI_TransferRxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transf
 
     handle->callback = callback;
     handle->userData = userData;
+    handle->base = base;
 
     /* Set the isr pointer */
     s_saiRxIsr = SAI_TransferRxHandleIRQ;
@@ -714,6 +1376,20 @@ void SAI_TransferRxCreateHandle(I2S_Type *base, sai_handle_t *handle, sai_transf
     EnableIRQ(s_saiRxIRQ[SAI_GetInstance(base)]);
 }
 
+/*!
+ * brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * param base SAI base pointer.
+ * param handle SAI handle pointer.
+ * param format Pointer to the SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is a master
+ * clock, this value should equal the masterClockHz in format.
+ * return Status of this function. Return value is the status_t.
+*/
 status_t SAI_TransferTxSetFormat(I2S_Type *base,
                                  sai_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -722,7 +1398,11 @@ status_t SAI_TransferTxSetFormat(I2S_Type *base,
 {
     assert(handle);
 
-    if ((mclkSourceClockHz < format->sampleRate_Hz) || (bclkSourceClockHz < format->sampleRate_Hz))
+    if ((bclkSourceClockHz < format->sampleRate_Hz)
+#if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
+        || (mclkSourceClockHz < format->sampleRate_Hz)
+#endif
+            )
     {
         return kStatus_InvalidArgument;
     }
@@ -732,13 +1412,32 @@ status_t SAI_TransferTxSetFormat(I2S_Type *base,
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->watermark = format->watermark;
 #endif
-    handle->channel = format->channel;
 
     SAI_TxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
+
+    handle->channel = format->channel;
+    /* used for multi channel */
+    handle->channelMask = format->channelMask;
+    handle->channelNums = format->channelNums;
+    handle->endChannel = format->endChannel;
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred.
+ *
+ * param base SAI base pointer.
+ * param handle SAI handle pointer.
+ * param format Pointer to the SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is a master
+ * clock, this value should equal the masterClockHz in format.
+ * return Status of this function. Return value is one of status_t.
+*/
 status_t SAI_TransferRxSetFormat(I2S_Type *base,
                                  sai_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -747,7 +1446,11 @@ status_t SAI_TransferRxSetFormat(I2S_Type *base,
 {
     assert(handle);
 
-    if ((mclkSourceClockHz < format->sampleRate_Hz) || (bclkSourceClockHz < format->sampleRate_Hz))
+    if ((bclkSourceClockHz < format->sampleRate_Hz)
+#if defined(FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER) && (FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER)
+        || (mclkSourceClockHz < format->sampleRate_Hz)
+#endif
+            )
     {
         return kStatus_InvalidArgument;
     }
@@ -757,13 +1460,33 @@ status_t SAI_TransferRxSetFormat(I2S_Type *base,
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->watermark = format->watermark;
 #endif
-    handle->channel = format->channel;
 
     SAI_RxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
+
+    handle->channel = format->channel;
+    /* used for multi channel */
+    handle->channelMask = format->channelMask;
+    handle->channelNums = format->channelNums;
+    handle->endChannel = format->endChannel;
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Performs an interrupt non-blocking send transfer on SAI.
+ *
+ * note This API returns immediately after the transfer initiates.
+ * Call the SAI_TxGetTransferStatusIRQ to poll the transfer status and check whether
+ * the transfer is finished. If the return status is not kStatus_SAI_Busy, the transfer
+ * is finished.
+ *
+ * param base SAI base pointer.
+ * param handle Pointer to the sai_handle_t structure which stores the transfer state.
+ * param xfer Pointer to the sai_transfer_t structure.
+ * retval kStatus_Success Successfully started the data receive.
+ * retval kStatus_SAI_TxBusy Previous receive still not finished.
+ * retval kStatus_InvalidArgument The input parameter is invalid.
+ */
 status_t SAI_TransferSendNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle);
@@ -797,6 +1520,21 @@ status_t SAI_TransferSendNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_t
     return kStatus_Success;
 }
 
+/*!
+ * brief Performs an interrupt non-blocking receive transfer on SAI.
+ *
+ * note This API returns immediately after the transfer initiates.
+ * Call the SAI_RxGetTransferStatusIRQ to poll the transfer status and check whether
+ * the transfer is finished. If the return status is not kStatus_SAI_Busy, the transfer
+ * is finished.
+ *
+ * param base SAI base pointer
+ * param handle Pointer to the sai_handle_t structure which stores the transfer state.
+ * param xfer Pointer to the sai_transfer_t structure.
+ * retval kStatus_Success Successfully started the data receive.
+ * retval kStatus_SAI_RxBusy Previous receive still not finished.
+ * retval kStatus_InvalidArgument The input parameter is invalid.
+ */
 status_t SAI_TransferReceiveNonBlocking(I2S_Type *base, sai_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle);
@@ -830,6 +1568,15 @@ status_t SAI_TransferReceiveNonBlocking(I2S_Type *base, sai_handle_t *handle, sa
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets a set byte count.
+ *
+ * param base SAI base pointer.
+ * param handle Pointer to the sai_handle_t structure which stores the transfer state.
+ * param count Bytes count sent.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is not a non-blocking transaction currently in progress.
+ */
 status_t SAI_TransferGetSendCount(I2S_Type *base, sai_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -848,6 +1595,15 @@ status_t SAI_TransferGetSendCount(I2S_Type *base, sai_handle_t *handle, size_t *
     return status;
 }
 
+/*!
+ * brief Gets a received byte count.
+ *
+ * param base SAI base pointer.
+ * param handle Pointer to the sai_handle_t structure which stores the transfer state.
+ * param count Bytes count received.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is not a non-blocking transaction currently in progress.
+ */
 status_t SAI_TransferGetReceiveCount(I2S_Type *base, sai_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -866,6 +1622,15 @@ status_t SAI_TransferGetReceiveCount(I2S_Type *base, sai_handle_t *handle, size_
     return status;
 }
 
+/*!
+ * brief Aborts the current send.
+ *
+ * note This API can be called any time when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * param base SAI base pointer.
+ * param handle Pointer to the sai_handle_t structure which stores the transfer state.
+ */
 void SAI_TransferAbortSend(I2S_Type *base, sai_handle_t *handle)
 {
     assert(handle);
@@ -887,6 +1652,15 @@ void SAI_TransferAbortSend(I2S_Type *base, sai_handle_t *handle)
     handle->queueUser = 0;
 }
 
+/*!
+ * brief Aborts the current IRQ receive.
+ *
+ * note This API can be called when an interrupt non-blocking transfer initiates
+ * to abort the transfer early.
+ *
+ * param base SAI base pointer
+ * param handle Pointer to the sai_handle_t structure which stores the transfer state.
+ */
 void SAI_TransferAbortReceive(I2S_Type *base, sai_handle_t *handle)
 {
     assert(handle);
@@ -908,18 +1682,73 @@ void SAI_TransferAbortReceive(I2S_Type *base, sai_handle_t *handle)
     handle->queueUser = 0;
 }
 
+/*!
+ * brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSend.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSend(I2S_Type *base, sai_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortSend(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceive.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceive(I2S_Type *base, sai_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortReceive(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Tx interrupt handler.
+ *
+ * param base SAI base pointer.
+ * param handle Pointer to the sai_handle_t structure.
+ */
 void SAI_TransferTxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
 {
     assert(handle);
 
     uint8_t *buffer = handle->saiQueue[handle->queueDriver].data;
-    uint8_t dataSize = handle->bitWidth / 8U;
+    uint8_t dataSize = (handle->bitWidth / 8U) * handle->channelNums;
 
     /* Handle Error */
     if (base->TCSR & I2S_TCSR_FEF_MASK)
     {
         /* Clear FIFO error flag to continue transfer */
         SAI_TxClearStatusFlags(base, kSAI_FIFOErrorFlag);
+
+        /* Reset FIFO for safety */
+        SAI_TxSoftwareReset(base, kSAI_ResetTypeFIFO);
 
         /* Call the callback */
         if (handle->callback)
@@ -937,7 +1766,8 @@ void SAI_TransferTxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
                            (size_t)((FSL_FEATURE_SAI_FIFO_COUNT - handle->watermark) * dataSize));
 
         /* Copy the data from sai buffer to FIFO */
-        SAI_WriteNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+        SAI_WriteNonBlocking(base, handle->channel, handle->channelMask, handle->endChannel, handle->bitWidth, buffer,
+                             size);
 
         /* Update the internal counter */
         handle->saiQueue[handle->queueDriver].dataSize -= size;
@@ -948,7 +1778,8 @@ void SAI_TransferTxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
     {
         uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize), dataSize);
 
-        SAI_WriteNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+        SAI_WriteNonBlocking(base, handle->channel, handle->channelMask, handle->endChannel, handle->bitWidth, buffer,
+                             size);
 
         /* Update internal counter */
         handle->saiQueue[handle->queueDriver].dataSize -= size;
@@ -974,18 +1805,27 @@ void SAI_TransferTxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
     }
 }
 
+/*!
+ * brief Tx interrupt handler.
+ *
+ * param base SAI base pointer.
+ * param handle Pointer to the sai_handle_t structure.
+ */
 void SAI_TransferRxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
 {
     assert(handle);
 
     uint8_t *buffer = handle->saiQueue[handle->queueDriver].data;
-    uint8_t dataSize = handle->bitWidth / 8U;
+    uint8_t dataSize = (handle->bitWidth / 8U) * handle->channelNums;
 
     /* Handle Error */
     if (base->RCSR & I2S_RCSR_FEF_MASK)
     {
         /* Clear FIFO error flag to continue transfer */
         SAI_RxClearStatusFlags(base, kSAI_FIFOErrorFlag);
+
+        /* Reset FIFO for safety */
+        SAI_RxSoftwareReset(base, kSAI_ResetTypeFIFO);
 
         /* Call the callback */
         if (handle->callback)
@@ -1002,7 +1842,8 @@ void SAI_TransferRxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
         uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize), (handle->watermark * dataSize));
 
         /* Copy the data from sai buffer to FIFO */
-        SAI_ReadNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+        SAI_ReadNonBlocking(base, handle->channel, handle->channelMask, handle->endChannel, handle->bitWidth, buffer,
+                            size);
 
         /* Update the internal counter */
         handle->saiQueue[handle->queueDriver].dataSize -= size;
@@ -1013,7 +1854,8 @@ void SAI_TransferRxHandleIRQ(I2S_Type *base, sai_handle_t *handle)
     {
         uint8_t size = MIN((handle->saiQueue[handle->queueDriver].dataSize), dataSize);
 
-        SAI_ReadNonBlocking(base, handle->channel, handle->bitWidth, buffer, size);
+        SAI_ReadNonBlocking(base, handle->channel, handle->channelMask, handle->endChannel, handle->bitWidth, buffer,
+                            size);
 
         /* Update internal state */
         handle->saiQueue[handle->queueDriver].dataSize -= size;
@@ -1044,36 +1886,51 @@ void I2S0_DriverIRQHandler(void)
 {
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[0][1]) && ((I2S0->RCSR & kSAI_FIFORequestFlag) || (I2S0->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S0->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S0->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S0->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[0][1]) && ((I2S0->RCSR & kSAI_FIFOWarningFlag) || (I2S0->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S0->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S0->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S0->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiRxIsr(I2S0, s_saiHandle[0][1]);
     }
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[0][0]) && ((I2S0->TCSR & kSAI_FIFORequestFlag) || (I2S0->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S0->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S0->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S0->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[0][0]) && ((I2S0->TCSR & kSAI_FIFOWarningFlag) || (I2S0->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S0->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S0->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S0->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiTxIsr(I2S0, s_saiHandle[0][0]);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S0_Tx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[0][0]);
     s_saiTxIsr(I2S0, s_saiHandle[0][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S0_Rx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[0][1]);
     s_saiRxIsr(I2S0, s_saiHandle[0][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 #endif /* I2S0*/
 
@@ -1082,36 +1939,51 @@ void I2S1_DriverIRQHandler(void)
 {
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[1][1]) && ((I2S1->RCSR & kSAI_FIFORequestFlag) || (I2S1->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S1->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S1->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S1->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[1][1]) && ((I2S1->RCSR & kSAI_FIFOWarningFlag) || (I2S1->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S1->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S1->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S1->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiRxIsr(I2S1, s_saiHandle[1][1]);
     }
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[1][0]) && ((I2S1->TCSR & kSAI_FIFORequestFlag) || (I2S1->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S1->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S1->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S1->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[1][0]) && ((I2S1->TCSR & kSAI_FIFOWarningFlag) || (I2S1->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S1->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S1->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S1->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiTxIsr(I2S1, s_saiHandle[1][0]);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S1_Tx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[1][0]);
     s_saiTxIsr(I2S1, s_saiHandle[1][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S1_Rx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[1][1]);
     s_saiRxIsr(I2S1, s_saiHandle[1][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 #endif /* I2S1*/
 
@@ -1120,36 +1992,51 @@ void I2S2_DriverIRQHandler(void)
 {
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[2][1]) && ((I2S2->RCSR & kSAI_FIFORequestFlag) || (I2S2->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S2->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S2->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S2->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[2][1]) && ((I2S2->RCSR & kSAI_FIFOWarningFlag) || (I2S2->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S2->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S2->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S2->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiRxIsr(I2S2, s_saiHandle[2][1]);
     }
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[2][0]) && ((I2S2->TCSR & kSAI_FIFORequestFlag) || (I2S2->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S2->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S2->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S2->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[2][0]) && ((I2S2->TCSR & kSAI_FIFOWarningFlag) || (I2S2->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S2->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S2->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S2->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiTxIsr(I2S2, s_saiHandle[2][0]);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S2_Tx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[2][0]);
     s_saiTxIsr(I2S2, s_saiHandle[2][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S2_Rx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[2][1]);
     s_saiRxIsr(I2S2, s_saiHandle[2][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 #endif /* I2S2*/
 
@@ -1158,35 +2045,905 @@ void I2S3_DriverIRQHandler(void)
 {
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[3][1]) && ((I2S3->RCSR & kSAI_FIFORequestFlag) || (I2S3->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S3->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S3->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S3->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[3][1]) && ((I2S3->RCSR & kSAI_FIFOWarningFlag) || (I2S3->RCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S3->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S3->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S3->RCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiRxIsr(I2S3, s_saiHandle[3][1]);
     }
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     if ((s_saiHandle[3][0]) && ((I2S3->TCSR & kSAI_FIFORequestFlag) || (I2S3->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S3->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S3->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S3->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #else
     if ((s_saiHandle[3][0]) && ((I2S3->TCSR & kSAI_FIFOWarningFlag) || (I2S3->TCSR & kSAI_FIFOErrorFlag)) &&
-                               ((I2S3->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+        ((I2S3->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S3->TCSR & kSAI_FIFOErrorInterruptEnable)))
 #endif
     {
         s_saiTxIsr(I2S3, s_saiHandle[3][0]);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S3_Tx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[3][0]);
     s_saiTxIsr(I2S3, s_saiHandle[3][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 void I2S3_Rx_DriverIRQHandler(void)
 {
     assert(s_saiHandle[3][1]);
     s_saiRxIsr(I2S3, s_saiHandle[3][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 #endif /* I2S3*/
+
+#if defined(I2S4)
+void I2S4_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[4][1]) && ((I2S4->RCSR & kSAI_FIFORequestFlag) || (I2S4->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S4->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S4->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[4][1]) && ((I2S4->RCSR & kSAI_FIFOWarningFlag) || (I2S4->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S4->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S4->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(I2S4, s_saiHandle[4][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[4][0]) && ((I2S4->TCSR & kSAI_FIFORequestFlag) || (I2S4->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S4->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S4->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[4][0]) && ((I2S4->TCSR & kSAI_FIFOWarningFlag) || (I2S4->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S4->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S4->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(I2S4, s_saiHandle[4][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S4_Tx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[4][0]);
+    s_saiTxIsr(I2S4, s_saiHandle[4][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S4_Rx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[4][1]);
+    s_saiRxIsr(I2S4, s_saiHandle[4][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif
+
+#if defined(FSL_FEATURE_SAI5_SAI6_SHARE_IRQ) && (FSL_FEATURE_SAI5_SAI6_SHARE_IRQ) && defined(I2S5) && defined(I2S6)
+void I2S56_DriverIRQHandler(void)
+{
+    /* use index 5 to get handle when I2S5 & I2S6 share IRQ NUMBER */
+    I2S_Type *base = s_saiHandle[5][1]->base;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[5][1]) && base && ((base->RCSR & kSAI_FIFORequestFlag) || (base->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((base->RCSR & kSAI_FIFORequestInterruptEnable) || (base->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[5][1]) && base && ((base->RCSR & kSAI_FIFOWarningFlag) || (base->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((base->RCSR & kSAI_FIFOWarningInterruptEnable) || (base->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(base, s_saiHandle[5][1]);
+    }
+
+    base = s_saiHandle[5][0]->base;
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[5][0]) && base && ((base->TCSR & kSAI_FIFORequestFlag) || (base->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((base->TCSR & kSAI_FIFORequestInterruptEnable) || (base->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[5][0]) && base && ((base->TCSR & kSAI_FIFOWarningFlag) || (base->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((base->TCSR & kSAI_FIFOWarningInterruptEnable) || (base->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(base, s_saiHandle[5][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S56_Tx_DriverIRQHandler(void)
+{
+    /* use index 5 to get handle when I2S5 & I2S6 share IRQ NUMBER */
+    assert(s_saiHandle[5][0]);
+    s_saiTxIsr(s_saiHandle[5][0]->base, s_saiHandle[5][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S56_Rx_DriverIRQHandler(void)
+{
+    /* use index 5 to get handle when I2S5 & I2S6 share IRQ NUMBER */
+    assert(s_saiHandle[5][1]);
+    s_saiRxIsr(s_saiHandle[5][1]->base, s_saiHandle[5][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+#else
+
+#if defined(I2S5)
+void I2S5_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[5][1]) && ((I2S5->RCSR & kSAI_FIFORequestFlag) || (I2S5->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S5->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S5->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[5][1]) && ((I2S5->RCSR & kSAI_FIFOWarningFlag) || (I2S5->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S5->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S5->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(I2S5, s_saiHandle[5][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[5][0]) && ((I2S5->TCSR & kSAI_FIFORequestFlag) || (I2S5->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S5->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S5->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[5][0]) && ((I2S5->TCSR & kSAI_FIFOWarningFlag) || (I2S5->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S5->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S5->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(I2S5, s_saiHandle[5][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S5_Tx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[5][0]);
+    s_saiTxIsr(I2S5, s_saiHandle[5][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S5_Rx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[5][1]);
+    s_saiRxIsr(I2S5, s_saiHandle[5][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif
+
+#if defined(I2S6)
+void I2S6_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[6][1]) && ((I2S6->RCSR & kSAI_FIFORequestFlag) || (I2S6->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S6->RCSR & kSAI_FIFORequestInterruptEnable) || (I2S6->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[6][1]) && ((I2S6->RCSR & kSAI_FIFOWarningFlag) || (I2S6->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S6->RCSR & kSAI_FIFOWarningInterruptEnable) || (I2S6->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(I2S6, s_saiHandle[6][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[6][0]) && ((I2S6->TCSR & kSAI_FIFORequestFlag) || (I2S6->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S6->TCSR & kSAI_FIFORequestInterruptEnable) || (I2S6->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[6][0]) && ((I2S6->TCSR & kSAI_FIFOWarningFlag) || (I2S6->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((I2S6->TCSR & kSAI_FIFOWarningInterruptEnable) || (I2S6->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(I2S6, s_saiHandle[6][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S6_Tx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[6][0]);
+    s_saiTxIsr(I2S6, s_saiHandle[6][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void I2S6_Rx_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[6][1]);
+    s_saiRxIsr(I2S6, s_saiHandle[6][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif
+#endif
+
+#if defined(AUDIO__SAI0)
+void AUDIO_SAI0_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[0][1]) &&
+        ((AUDIO__SAI0->RCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI0->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI0->RCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[0][1]) &&
+        ((AUDIO__SAI0->RCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI0->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI0->RCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(AUDIO__SAI0, s_saiHandle[0][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[0][0]) &&
+        ((AUDIO__SAI0->TCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI0->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI0->TCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[0][0]) &&
+        ((AUDIO__SAI0->TCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI0->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI0->TCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI0, s_saiHandle[0][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* AUDIO__SAI0 */
+
+#if defined(AUDIO__SAI1)
+void AUDIO_SAI1_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) &&
+        ((AUDIO__SAI1->RCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI1->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI1->RCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) &&
+        ((AUDIO__SAI1->RCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI1->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI1->RCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(AUDIO__SAI1, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) &&
+        ((AUDIO__SAI1->TCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI1->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI1->TCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) &&
+        ((AUDIO__SAI1->TCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI1->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI1->TCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI1, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* AUDIO__SAI1 */
+
+#if defined(AUDIO__SAI2)
+void AUDIO_SAI2_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[2][1]) &&
+        ((AUDIO__SAI2->RCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI2->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI2->RCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[2][1]) &&
+        ((AUDIO__SAI2->RCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI2->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI2->RCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(AUDIO__SAI2, s_saiHandle[2][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[2][0]) &&
+        ((AUDIO__SAI2->TCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI2->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI2->TCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[2][0]) &&
+        ((AUDIO__SAI2->TCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI2->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI2->TCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI2, s_saiHandle[2][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* AUDIO__SAI2 */
+
+#if defined(AUDIO__SAI3)
+void AUDIO_SAI3_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[3][1]) &&
+        ((AUDIO__SAI3->RCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI3->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI3->RCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[3][1]) &&
+        ((AUDIO__SAI3->RCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI3->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI3->RCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(AUDIO__SAI3, s_saiHandle[3][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[3][0]) &&
+        ((AUDIO__SAI3->TCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI3->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI3->TCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[3][0]) &&
+        ((AUDIO__SAI3->TCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI3->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI3->TCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI3, s_saiHandle[3][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif
+
+#if defined(AUDIO__SAI6)
+void AUDIO_SAI6_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[6][1]) &&
+        ((AUDIO__SAI6->RCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI6->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI6->RCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI6->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[6][1]) &&
+        ((AUDIO__SAI6->RCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI6->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI6->RCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI6->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(AUDIO__SAI6, s_saiHandle[6][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[6][0]) &&
+        ((AUDIO__SAI6->TCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI6->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI6->TCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI6->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[6][0]) &&
+        ((AUDIO__SAI6->TCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI6->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI6->TCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI6->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI6, s_saiHandle[6][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* AUDIO__SAI6 */
+
+#if defined(AUDIO__SAI7)
+void AUDIO_SAI7_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[7][1]) &&
+        ((AUDIO__SAI7->RCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI7->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI7->RCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI7->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[7][1]) &&
+        ((AUDIO__SAI7->RCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI7->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI7->RCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI7->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(AUDIO__SAI7, s_saiHandle[7][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[7][0]) &&
+        ((AUDIO__SAI7->TCSR & kSAI_FIFORequestFlag) || (AUDIO__SAI7->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI7->TCSR & kSAI_FIFORequestInterruptEnable) || (AUDIO__SAI7->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[7][0]) &&
+        ((AUDIO__SAI7->TCSR & kSAI_FIFOWarningFlag) || (AUDIO__SAI7->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((AUDIO__SAI7->TCSR & kSAI_FIFOWarningInterruptEnable) || (AUDIO__SAI7->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI7, s_saiHandle[7][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* AUDIO__SAI7 */
+
+#if defined(ADMA__SAI0)
+void ADMA_SAI0_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI0->RCSR & kSAI_FIFORequestFlag) || (ADMA__SAI0->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI0->RCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI0->RCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI0->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI0->RCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(ADMA__SAI0, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI0->TCSR & kSAI_FIFORequestFlag) || (ADMA__SAI0->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI0->TCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI0->TCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI0->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI0->TCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(ADMA__SAI0, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* ADMA__SAI0 */
+
+#if defined(ADMA__SAI1)
+void ADMA_SAI1_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI1->RCSR & kSAI_FIFORequestFlag) || (ADMA__SAI1->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI1->RCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI1->RCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI1->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI1->RCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(ADMA__SAI1, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI1->TCSR & kSAI_FIFORequestFlag) || (ADMA__SAI1->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI1->TCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI1->TCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI1->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI1->TCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(ADMA__SAI1, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* ADMA__SAI1 */
+
+#if defined(ADMA__SAI2)
+void ADMA_SAI2_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI2->RCSR & kSAI_FIFORequestFlag) || (ADMA__SAI2->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI2->RCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI2->RCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI2->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI2->RCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(ADMA__SAI2, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI2->TCSR & kSAI_FIFORequestFlag) || (ADMA__SAI2->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI2->TCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI2->TCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI2->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI2->TCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(ADMA__SAI2, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* ADMA__SAI2 */
+
+#if defined(ADMA__SAI3)
+void ADMA_SAI3_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI3->RCSR & kSAI_FIFORequestFlag) || (ADMA__SAI3->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI3->RCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI3->RCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI3->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI3->RCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(ADMA__SAI3, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI3->TCSR & kSAI_FIFORequestFlag) || (ADMA__SAI3->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI3->TCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI3->TCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI3->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI3->TCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(ADMA__SAI3, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* ADMA__SAI3 */
+
+#if defined(ADMA__SAI4)
+void ADMA_SAI4_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI4->RCSR & kSAI_FIFORequestFlag) || (ADMA__SAI4->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI4->RCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI4->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI4->RCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI4->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI4->RCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI4->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(ADMA__SAI4, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI4->TCSR & kSAI_FIFORequestFlag) || (ADMA__SAI4->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI4->TCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI4->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI4->TCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI4->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI4->TCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI4->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(ADMA__SAI4, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* ADMA__SAI4 */
+
+#if defined(ADMA__SAI5)
+void ADMA_SAI5_INT_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI5->RCSR & kSAI_FIFORequestFlag) || (ADMA__SAI5->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI5->RCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI5->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((ADMA__SAI5->RCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI5->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI5->RCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI5->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(ADMA__SAI5, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI5->TCSR & kSAI_FIFORequestFlag) || (ADMA__SAI5->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI5->TCSR & kSAI_FIFORequestInterruptEnable) || (ADMA__SAI5->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((ADMA__SAI5->TCSR & kSAI_FIFOWarningFlag) || (ADMA__SAI5->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((ADMA__SAI5->TCSR & kSAI_FIFOWarningInterruptEnable) || (ADMA__SAI5->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(ADMA__SAI5, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* ADMA__SAI5 */
+
+#if defined(SAI0)
+void SAI0_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[0][1]) && ((SAI0->RCSR & kSAI_FIFORequestFlag) || (SAI0->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI0->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[0][1]) && ((SAI0->RCSR & kSAI_FIFOWarningFlag) || (SAI0->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI0->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI0->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI0, s_saiHandle[0][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[0][0]) && ((SAI0->TCSR & kSAI_FIFORequestFlag) || (SAI0->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI0->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[0][0]) && ((SAI0->TCSR & kSAI_FIFOWarningFlag) || (SAI0->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI0->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI0->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(AUDIO__SAI0, s_saiHandle[0][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI0 */
+
+#if defined(SAI1)
+void SAI1_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][1]) && ((SAI1->RCSR & kSAI_FIFORequestFlag) || (SAI1->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI1->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][1]) && ((SAI1->RCSR & kSAI_FIFOWarningFlag) || (SAI1->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI1->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI1->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI1, s_saiHandle[1][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[1][0]) && ((SAI1->TCSR & kSAI_FIFORequestFlag) || (SAI1->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI1->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[1][0]) && ((SAI1->TCSR & kSAI_FIFOWarningFlag) || (SAI1->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI1->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI1->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(SAI1, s_saiHandle[1][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI1 */
+
+#if defined(SAI2)
+void SAI2_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[2][1]) && ((SAI2->RCSR & kSAI_FIFORequestFlag) || (SAI2->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI2->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[2][1]) && ((SAI2->RCSR & kSAI_FIFOWarningFlag) || (SAI2->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI2->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI2->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI2, s_saiHandle[2][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[2][0]) && ((SAI2->TCSR & kSAI_FIFORequestFlag) || (SAI2->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI2->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[2][0]) && ((SAI2->TCSR & kSAI_FIFOWarningFlag) || (SAI2->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI2->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI2->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(SAI2, s_saiHandle[2][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI2 */
+
+#if defined(SAI3)
+void SAI3_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[3][1]) && ((SAI3->RCSR & kSAI_FIFORequestFlag) || (SAI3->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI3->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[3][1]) && ((SAI3->RCSR & kSAI_FIFOWarningFlag) || (SAI3->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI3->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI3->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI3, s_saiHandle[3][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[3][0]) && ((SAI3->TCSR & kSAI_FIFORequestFlag) || (SAI3->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI3->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[3][0]) && ((SAI3->TCSR & kSAI_FIFOWarningFlag) || (SAI3->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI3->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI3->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(SAI3, s_saiHandle[3][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void SAI3_TX_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[3][0]);
+    s_saiTxIsr(SAI3, s_saiHandle[3][0]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
+void SAI3_RX_DriverIRQHandler(void)
+{
+    assert(s_saiHandle[3][1]);
+    s_saiRxIsr(SAI3, s_saiHandle[3][1]);
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI3 */
+
+#if defined(SAI4)
+void SAI4_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[4][1]) && ((SAI4->RCSR & kSAI_FIFORequestFlag) || (SAI4->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI4->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI4->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[4][1]) && ((SAI4->RCSR & kSAI_FIFOWarningFlag) || (SAI4->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI4->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI4->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI4, s_saiHandle[4][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[4][0]) && ((SAI4->TCSR & kSAI_FIFORequestFlag) || (SAI4->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI4->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI4->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[4][0]) && ((SAI4->TCSR & kSAI_FIFOWarningFlag) || (SAI4->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI4->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI4->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(SAI4, s_saiHandle[4][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI4 */
+
+#if defined(SAI5)
+void SAI5_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[5][1]) && ((SAI5->RCSR & kSAI_FIFORequestFlag) || (SAI5->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI5->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI5->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[5][1]) && ((SAI5->RCSR & kSAI_FIFOWarningFlag) || (SAI5->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI5->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI5->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI5, s_saiHandle[5][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[5][0]) && ((SAI5->TCSR & kSAI_FIFORequestFlag) || (SAI5->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI5->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI5->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[5][0]) && ((SAI5->TCSR & kSAI_FIFOWarningFlag) || (SAI5->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI5->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI5->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(SAI5, s_saiHandle[5][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI5 */
+
+#if defined(SAI6)
+void SAI6_DriverIRQHandler(void)
+{
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[6][1]) && ((SAI6->RCSR & kSAI_FIFORequestFlag) || (SAI6->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI6->RCSR & kSAI_FIFORequestInterruptEnable) || (SAI6->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[6][1]) && ((SAI6->RCSR & kSAI_FIFOWarningFlag) || (SAI6->RCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI6->RCSR & kSAI_FIFOWarningInterruptEnable) || (SAI6->RCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiRxIsr(SAI6, s_saiHandle[6][1]);
+    }
+#if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
+    if ((s_saiHandle[6][0]) && ((SAI6->TCSR & kSAI_FIFORequestFlag) || (SAI6->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI6->TCSR & kSAI_FIFORequestInterruptEnable) || (SAI6->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#else
+    if ((s_saiHandle[6][0]) && ((SAI6->TCSR & kSAI_FIFOWarningFlag) || (SAI6->TCSR & kSAI_FIFOErrorFlag)) &&
+        ((SAI6->TCSR & kSAI_FIFOWarningInterruptEnable) || (SAI6->TCSR & kSAI_FIFOErrorInterruptEnable)))
+#endif
+    {
+        s_saiTxIsr(SAI6, s_saiHandle[6][0]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+#endif /* SAI6 */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
  * Copyright 2016-2017 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _FSL_SAI_H_
@@ -44,7 +22,7 @@
 
 /*! @name Driver version */
 /*@{*/
-#define FSL_SAI_DRIVER_VERSION (MAKE_VERSION(2, 1, 2)) /*!< Version 2.1.2 */
+#define FSL_SAI_DRIVER_VERSION (MAKE_VERSION(2, 1, 7)) /*!< Version 2.1.7 */
 /*@}*/
 
 /*! @brief SAI return status*/
@@ -57,6 +35,19 @@ enum _sai_status_t
     kStatus_SAI_QueueFull = MAKE_STATUS(kStatusGroup_SAI, 4), /*!< SAI transfer queue is full. */
     kStatus_SAI_TxIdle = MAKE_STATUS(kStatusGroup_SAI, 5),    /*!< SAI Tx is idle */
     kStatus_SAI_RxIdle = MAKE_STATUS(kStatusGroup_SAI, 6)     /*!< SAI Rx is idle */
+};
+
+/*< sai channel mask value, actual channel numbers is depend soc specific */
+enum _sai_channel_mask
+{
+    kSAI_Channel0Mask = 1 << 0U, /*!< channel 0 mask value */
+    kSAI_Channel1Mask = 1 << 1U, /*!< channel 1 mask value */
+    kSAI_Channel2Mask = 1 << 2U, /*!< channel 2 mask value */
+    kSAI_Channel3Mask = 1 << 3U, /*!< channel 3 mask value */
+    kSAI_Channel4Mask = 1 << 4U, /*!< channel 4 mask value */
+    kSAI_Channel5Mask = 1 << 5U, /*!< channel 5 mask value */
+    kSAI_Channel6Mask = 1 << 6U, /*!< channel 6 mask value */
+    kSAI_Channel7Mask = 1 << 7U, /*!< channel 7 mask value */
 };
 
 /*! @brief Define the SAI bus type */
@@ -80,9 +71,23 @@ typedef enum _sai_master_slave
 typedef enum _sai_mono_stereo
 {
     kSAI_Stereo = 0x0U, /*!< Stereo sound. */
-    kSAI_MonoLeft,      /*!< Only left channel have sound. */
-    kSAI_MonoRight      /*!< Only Right channel have sound. */
+    kSAI_MonoRight,     /*!< Only Right channel have sound. */
+    kSAI_MonoLeft       /*!< Only left channel have sound. */
 } sai_mono_stereo_t;
+
+/*! @brief SAI data order, MSB or LSB */
+typedef enum _sai_data_order
+{
+    kSAI_DataLSB = 0x0U, /*!< LSB bit transferred first */
+    kSAI_DataMSB         /*!< MSB bit transferred first */
+} sai_data_order_t;
+
+/*! @brief SAI clock polarity, active high or low */
+typedef enum _sai_clock_polarity
+{
+    kSAI_PolarityActiveHigh = 0x0U, /*!< Clock active high */
+    kSAI_PolarityActiveLow          /*!< Clock active low */
+} sai_clock_polarity_t;
 
 /*! @brief Synchronous or asynchronous mode */
 typedef enum _sai_sync_mode
@@ -93,6 +98,7 @@ typedef enum _sai_sync_mode
     kSAI_ModeSyncWithOtherRx  /*!< Synchronous with another SAI receiver */
 } sai_sync_mode_t;
 
+#if !(defined(FSL_FEATURE_SAI_HAS_NO_MCR_MICS) && (FSL_FEATURE_SAI_HAS_NO_MCR_MICS))
 /*! @brief Mater clock source */
 typedef enum _sai_mclk_source
 {
@@ -101,14 +107,20 @@ typedef enum _sai_mclk_source
     kSAI_MclkSourceSelect2,       /*!< Master clock from source 2 */
     kSAI_MclkSourceSelect3        /*!< Master clock from source 3 */
 } sai_mclk_source_t;
+#endif
 
 /*! @brief Bit clock source */
 typedef enum _sai_bclk_source
 {
     kSAI_BclkSourceBusclk = 0x0U, /*!< Bit clock using bus clock */
-    kSAI_BclkSourceMclkDiv,       /*!< Bit clock using master clock divider */
-    kSAI_BclkSourceOtherSai0,     /*!< Bit clock from other SAI device  */
-    kSAI_BclkSourceOtherSai1      /*!< Bit clock from other SAI device */
+    /* General device bit source definition */
+    kSAI_BclkSourceMclkOption1 = 0x1U, /*!< Bit clock MCLK option 1 */
+    kSAI_BclkSourceMclkOption2 = 0x2U, /*!< Bit clock MCLK option2  */
+    kSAI_BclkSourceMclkOption3 = 0x3U, /*!< Bit clock MCLK option3 */
+    /* Kinetis device bit clock source definition */
+    kSAI_BclkSourceMclkDiv = 0x1U,   /*!< Bit clock using master clock divider */
+    kSAI_BclkSourceOtherSai0 = 0x2U, /*!< Bit clock from other SAI device  */
+    kSAI_BclkSourceOtherSai1 = 0x3U  /*!< Bit clock from other SAI device */
 } sai_bclk_source_t;
 
 /*! @brief The SAI interrupt enable flag */
@@ -172,9 +184,11 @@ typedef struct _sai_config
     sai_protocol_t protocol;  /*!< Audio bus protocol in SAI */
     sai_sync_mode_t syncMode; /*!< SAI sync mode, control Tx/Rx clock sync */
 #if defined(FSL_FEATURE_SAI_HAS_MCR) && (FSL_FEATURE_SAI_HAS_MCR)
-    bool mclkOutputEnable;          /*!< Master clock output enable, true means master clock divider enabled */
-#endif                              /* FSL_FEATURE_SAI_HAS_MCR */
-    sai_mclk_source_t mclkSource;   /*!< Master Clock source */
+    bool mclkOutputEnable; /*!< Master clock output enable, true means master clock divider enabled */
+#if !(defined(FSL_FEATURE_SAI_HAS_NO_MCR_MICS) && (FSL_FEATURE_SAI_HAS_NO_MCR_MICS))
+    sai_mclk_source_t mclkSource; /*!< Master Clock source */
+#endif                            /* FSL_FEATURE_SAI_HAS_MCR */
+#endif
     sai_bclk_source_t bclkSource;   /*!< Bit Clock source */
     sai_master_slave_t masterSlave; /*!< Master or slave */
 } sai_config_t;
@@ -194,7 +208,9 @@ typedef enum _sai_sample_rate
     kSAI_SampleRate32KHz = 32000U,   /*!< Sample rate 32000 Hz */
     kSAI_SampleRate44100Hz = 44100U, /*!< Sample rate 44100 Hz */
     kSAI_SampleRate48KHz = 48000U,   /*!< Sample rate 48000 Hz */
-    kSAI_SampleRate96KHz = 96000U    /*!< Sample rate 96000 Hz */
+    kSAI_SampleRate96KHz = 96000U,   /*!< Sample rate 96000 Hz */
+    kSAI_SampleRate192KHz = 192000U, /*!< Sample rate 192000 Hz */
+    kSAI_SampleRate384KHz = 384000U, /*!< Sample rate 384000 Hz */
 } sai_sample_rate_t;
 
 /*! @brief Audio word width */
@@ -214,10 +230,24 @@ typedef struct _sai_transfer_format
     sai_mono_stereo_t stereo; /*!< Mono or stereo */
     uint32_t masterClockHz;   /*!< Master clock frequency in Hz */
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
-    uint8_t watermark;       /*!< Watermark value */
-#endif                       /* FSL_FEATURE_SAI_FIFO_COUNT */
-    uint8_t channel;         /*!< Data channel used in transfer.*/
+    uint8_t watermark; /*!< Watermark value */
+#endif                 /* FSL_FEATURE_SAI_FIFO_COUNT */
+
+    /* for the multi channel usage, user can provide channelMask Oonly, then sai driver will handle
+    * other parameter carefully, such as
+    * channelMask = kSAI_Channel0Mask | kSAI_Channel1Mask | kSAI_Channel4Mask
+    * then in SAI_RxSetFormat/SAI_TxSetFormat function, channel/endChannel/channelNums will be calculated.
+    * for the single channel usage, user can provide channel or channel mask only, such as,
+    * channel = 0 or channelMask = kSAI_Channel0Mask.
+    */
+    uint8_t channel;     /*!< Transfer start channel */
+    uint8_t channelMask; /*!< enabled channel mask value, reference _sai_channel_mask */
+    uint8_t endChannel;  /*!< end channel number */
+    uint8_t channelNums; /*!< Total enabled channel numbers */
+
     sai_protocol_t protocol; /*!< Which audio protocol used */
+    bool isFrameSyncCompact; /*!< True means Frame sync length is configurable according to bitWidth, false means frame
+                                sync length is 64 times of bit clock. */
 } sai_transfer_format_t;
 
 /*! @brief SAI transfer structure */
@@ -235,11 +265,25 @@ typedef void (*sai_transfer_callback_t)(I2S_Type *base, sai_handle_t *handle, st
 /*! @brief SAI handle structure */
 struct _sai_handle
 {
-    uint32_t state;                               /*!< Transfer status */
-    sai_transfer_callback_t callback;             /*!< Callback function called at transfer event*/
-    void *userData;                               /*!< Callback parameter passed to callback function*/
-    uint8_t bitWidth;                             /*!< Bit width for transfer, 8/16/24/32 bits */
-    uint8_t channel;                              /*!< Transfer channel */
+    I2S_Type *base; /*!< base address */
+
+    uint32_t state;                   /*!< Transfer status */
+    sai_transfer_callback_t callback; /*!< Callback function called at transfer event*/
+    void *userData;                   /*!< Callback parameter passed to callback function*/
+    uint8_t bitWidth;                 /*!< Bit width for transfer, 8/16/24/32 bits */
+
+    /* for the multi channel usage, user can provide channelMask Oonly, then sai driver will handle
+    * other parameter carefully, such as
+    * channelMask = kSAI_Channel0Mask | kSAI_Channel1Mask | kSAI_Channel4Mask
+    * then in SAI_RxSetFormat/SAI_TxSetFormat function, channel/endChannel/channelNums will be calculated.
+    * for the single channel usage, user can provide channel or channel mask only, such as,
+    * channel = 0 or channelMask = kSAI_Channel0Mask.
+    */
+    uint8_t channel;     /*!< Transfer start channel */
+    uint8_t channelMask; /*!< enabled channel mask value, refernece _sai_channel_mask */
+    uint8_t endChannel;  /*!< end channel number */
+    uint8_t channelNums; /*!< Total enabled channel numbers */
+
     sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE]; /*!< Transfer queue storing queued transfer */
     size_t transferSize[SAI_XFER_QUEUE_SIZE];     /*!< Data bytes need to transfer */
     volatile uint8_t queueUser;                   /*!< Index for user to queue transfer */
@@ -279,7 +323,7 @@ extern "C" {
 void SAI_TxInit(I2S_Type *base, const sai_config_t *config);
 
 /*!
- * @brief Initializes the the SAI Rx peripheral.
+ * @brief Initializes the SAI Rx peripheral.
  *
  * Ungates the SAI clock, resets the module, and configures the SAI Rx with a configuration structure.
  * The configuration structure can be custom filled or set with default values by
@@ -427,6 +471,159 @@ static inline void SAI_RxClearStatusFlags(I2S_Type *base, uint32_t mask)
     base->RCSR = ((base->RCSR & 0xFFE3FFFFU) | mask);
 }
 
+/*!
+ * @brief Do software reset or FIFO reset .
+ *
+ * FIFO reset means clear all the data in the FIFO, and make the FIFO pointer both to 0.
+ * Software reset means claer the Tx internal logic, including the bit clock, frame count etc. But software
+ * reset will not clear any configuration registers like TCR1~TCR5.
+ * This function will also clear all the error flags such as FIFO error, sync error etc.
+ *
+ * @param base SAI base pointer
+ * @param type Reset type, FIFO reset or software reset
+ */
+void SAI_TxSoftwareReset(I2S_Type *base, sai_reset_type_t type);
+
+/*!
+ * @brief Do software reset or FIFO reset .
+ *
+ * FIFO reset means clear all the data in the FIFO, and make the FIFO pointer both to 0.
+ * Software reset means claer the Rx internal logic, including the bit clock, frame count etc. But software
+ * reset will not clear any configuration registers like RCR1~RCR5.
+ * This function will also clear all the error flags such as FIFO error, sync error etc.
+ *
+ * @param base SAI base pointer
+ * @param type Reset type, FIFO reset or software reset
+ */
+void SAI_RxSoftwareReset(I2S_Type *base, sai_reset_type_t type);
+
+/*!
+ * @brief Set the Tx channel FIFO enable mask.
+ *
+ * @param base SAI base pointer
+ * @param mask Channel enable mask, 0 means all channel FIFO disabled, 1 means channel 0 enabled,
+ * 3 means both channel 0 and channel 1 enabled.
+ */
+void SAI_TxSetChannelFIFOMask(I2S_Type *base, uint8_t mask);
+
+/*!
+ * @brief Set the Rx channel FIFO enable mask.
+ *
+ * @param base SAI base pointer
+ * @param mask Channel enable mask, 0 means all channel FIFO disabled, 1 means channel 0 enabled,
+ * 3 means both channel 0 and channel 1 enabled.
+ */
+void SAI_RxSetChannelFIFOMask(I2S_Type *base, uint8_t mask);
+
+/*!
+ * @brief Set the Tx data order.
+ *
+ * @param base SAI base pointer
+ * @param order Data order MSB or LSB
+ */
+void SAI_TxSetDataOrder(I2S_Type *base, sai_data_order_t order);
+
+/*!
+ * @brief Set the Rx data order.
+ *
+ * @param base SAI base pointer
+ * @param order Data order MSB or LSB
+ */
+void SAI_RxSetDataOrder(I2S_Type *base, sai_data_order_t order);
+
+/*!
+ * @brief Set the Tx data order.
+ *
+ * @param base SAI base pointer
+ * @param order Data order MSB or LSB
+ */
+void SAI_TxSetBitClockPolarity(I2S_Type *base, sai_clock_polarity_t polarity);
+
+/*!
+ * @brief Set the Rx data order.
+ *
+ * @param base SAI base pointer
+ * @param order Data order MSB or LSB
+ */
+void SAI_RxSetBitClockPolarity(I2S_Type *base, sai_clock_polarity_t polarity);
+
+/*!
+ * @brief Set the Tx data order.
+ *
+ * @param base SAI base pointer
+ * @param order Data order MSB or LSB
+ */
+void SAI_TxSetFrameSyncPolarity(I2S_Type *base, sai_clock_polarity_t polarity);
+
+/*!
+ * @brief Set the Rx data order.
+ *
+ * @param base SAI base pointer
+ * @param order Data order MSB or LSB
+ */
+void SAI_RxSetFrameSyncPolarity(I2S_Type *base, sai_clock_polarity_t polarity);
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_PACKING) && FSL_FEATURE_SAI_HAS_FIFO_PACKING
+/*!
+ * @brief Set Tx FIFO packing feature.
+ *
+ * @param base SAI base pointer.
+ * @param pack FIFO pack type. It is element of sai_fifo_packing_t.
+ */
+void SAI_TxSetFIFOPacking(I2S_Type *base, sai_fifo_packing_t pack);
+
+/*!
+* @brief Set Rx FIFO packing feature.
+*
+* @param base SAI base pointer.
+* @param pack FIFO pack type. It is element of sai_fifo_packing_t.
+*/
+void SAI_RxSetFIFOPacking(I2S_Type *base, sai_fifo_packing_t pack);
+#endif /* FSL_FEATURE_SAI_HAS_FIFO_PACKING */
+
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR) && FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR
+/*!
+* @brief Set Tx FIFO error continue.
+*
+* FIFO error continue mode means SAI will keep running while FIFO error occured. If this feature
+* not enabled, SAI will hang and users need to clear FEF flag in TCSR register.
+*
+* @param base SAI base pointer.
+* @param isEnabled Is FIFO error continue enabled, true means enable, false means disable.
+*/
+static inline void SAI_TxSetFIFOErrorContinue(I2S_Type *base, bool isEnabled)
+{
+    if (isEnabled)
+    {
+        base->TCR4 |= I2S_TCR4_FCONT_MASK;
+    }
+    else
+    {
+        base->TCR4 &= ~I2S_TCR4_FCONT_MASK;
+    }
+}
+
+/*!
+* @brief Set Rx FIFO error continue.
+*
+* FIFO error continue mode means SAI will keep running while FIFO error occured. If this feature
+* not enabled, SAI will hang and users need to clear FEF flag in RCSR register.
+*
+* @param base SAI base pointer.
+* @param isEnabled Is FIFO error continue enabled, true means enable, false means disable.
+*/
+static inline void SAI_RxSetFIFOErrorContinue(I2S_Type *base, bool isEnabled)
+{
+    if (isEnabled)
+    {
+        base->RCR4 |= I2S_RCR4_FCONT_MASK;
+    }
+    else
+    {
+        base->RCR4 &= ~I2S_RCR4_FCONT_MASK;
+    }
+}
+#endif
 /*! @} */
 
 /*!
@@ -634,6 +831,21 @@ void SAI_RxSetFormat(I2S_Type *base,
 void SAI_WriteBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
 
 /*!
+ * @brief Sends data to multi channel using a blocking method.
+ *
+ * @note This function blocks by polling until data is ready to be sent.
+ *
+ * @param base SAI base pointer.
+ * @param channel Data channel used.
+ * @param channelMask channel mask.
+ * @param bitWidth How many bits in an audio word; usually 8/16/24/32 bits.
+ * @param buffer Pointer to the data to be written.
+ * @param size Bytes to be written.
+ */
+void SAI_WriteMultiChannelBlocking(
+    I2S_Type *base, uint32_t channel, uint32_t channelMask, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+
+/*!
  * @brief Writes data into SAI FIFO.
  *
  * @param base SAI base pointer.
@@ -657,6 +869,21 @@ static inline void SAI_WriteData(I2S_Type *base, uint32_t channel, uint32_t data
  * @param size Bytes to be read.
  */
 void SAI_ReadBlocking(I2S_Type *base, uint32_t channel, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
+
+/*!
+ * @brief Receives multi channel data using a blocking method.
+ *
+ * @note This function blocks by polling until data is ready to be sent.
+ *
+ * @param base SAI base pointer.
+ * @param channel Data channel used.
+ * @param channelMask channel mask.
+ * @param bitWidth How many bits in an audio word; usually 8/16/24/32 bits.
+ * @param buffer Pointer to the data to be read.
+ * @param size Bytes to be read.
+ */
+void SAI_ReadMultiChannelBlocking(
+    I2S_Type *base, uint32_t channel, uint32_t channelMask, uint32_t bitWidth, uint8_t *buffer, uint32_t size);
 
 /*!
  * @brief Reads data from the SAI FIFO.
@@ -811,7 +1038,7 @@ status_t SAI_TransferGetReceiveCount(I2S_Type *base, sai_handle_t *handle, size_
 void SAI_TransferAbortSend(I2S_Type *base, sai_handle_t *handle);
 
 /*!
- * @brief Aborts the the current IRQ receive.
+ * @brief Aborts the current IRQ receive.
  *
  * @note This API can be called when an interrupt non-blocking transfer initiates
  * to abort the transfer early.
@@ -820,6 +1047,28 @@ void SAI_TransferAbortSend(I2S_Type *base, sai_handle_t *handle);
  * @param handle Pointer to the sai_handle_t structure which stores the transfer state.
  */
 void SAI_TransferAbortReceive(I2S_Type *base, sai_handle_t *handle);
+
+/*!
+ * @brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSend.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSend(I2S_Type *base, sai_handle_t *handle);
+
+/*!
+ * @brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceive.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceive(I2S_Type *base, sai_handle_t *handle);
 
 /*!
  * @brief Tx interrupt handler.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai_edma.c
@@ -1,40 +1,25 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
  * Copyright 2016-2017 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_sai_edma.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.sai_edma"
+#endif
 
 /*******************************************************************************
  * Definitations
  ******************************************************************************/
 /* Used for 32byte aligned */
-#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)address + 32) & ~0x1FU)
+#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)(address) + 32) & ~0x1FU)
+
+static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
 
 /*<! Structure definition for uart_edma_private_handle_t. The structure is private. */
 typedef struct _sai_edma_private_handle
@@ -50,7 +35,7 @@ enum _sai_edma_transfer_state
 };
 
 /*<! Private handle only used for internally. */
-static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][2];
+static sai_edma_private_handle_t s_edmaPrivateHandle[ARRAY_SIZE(s_saiBases)][2];
 
 /*******************************************************************************
  * Prototypes
@@ -60,7 +45,7 @@ static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][
  *
  * @param base SAI base pointer.
  */
-extern uint32_t SAI_GetInstance(I2S_Type *base);
+static uint32_t SAI_GetInstance(I2S_Type *base);
 
 /*!
  * @brief SAI EDMA callback for send.
@@ -85,6 +70,24 @@ static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done,
 /*******************************************************************************
 * Code
 ******************************************************************************/
+static uint32_t SAI_GetInstance(I2S_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_saiBases); instance++)
+    {
+        if (s_saiBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_saiBases));
+
+    return instance;
+}
+
 static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds)
 {
     sai_edma_private_handle_t *privHandle = (sai_edma_private_handle_t *)userData;
@@ -101,7 +104,9 @@ static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done,
     /* If all data finished, just stop the transfer */
     if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
     {
-        SAI_TransferAbortSendEDMA(privHandle->base, saiHandle);
+        /* Disable DMA enable bit */
+        SAI_TxEnableDMA(privHandle->base, kSAI_FIFORequestDMAEnable, false);
+        EDMA_AbortTransfer(handle);
     }
 }
 
@@ -121,10 +126,25 @@ static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done,
     /* If all data finished, just stop the transfer */
     if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
     {
-        SAI_TransferAbortReceiveEDMA(privHandle->base, saiHandle);
+        /* Disable DMA enable bit */
+        SAI_RxEnableDMA(privHandle->base, kSAI_FIFORequestDMAEnable, false);
+        EDMA_AbortTransfer(handle);
     }
 }
 
+/*!
+ * brief Initializes the SAI eDMA handle.
+ *
+ * This function initializes the SAI master DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param base SAI peripheral base address.
+ * param callback Pointer to user callback function.
+ * param userData User parameter passed to the callback function.
+ * param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
 void SAI_TransferTxCreateHandleEDMA(
     I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
 {
@@ -147,12 +167,25 @@ void SAI_TransferTxCreateHandleEDMA(
     s_edmaPrivateHandle[instance][0].handle = handle;
 
     /* Need to use scatter gather */
-    EDMA_InstallTCDMemory(dmaHandle, STCD_ADDR(handle->tcd), SAI_XFER_QUEUE_SIZE);
+    EDMA_InstallTCDMemory(dmaHandle, (edma_tcd_t *)(STCD_ADDR(handle->tcd)), SAI_XFER_QUEUE_SIZE);
 
     /* Install callback for Tx dma channel */
     EDMA_SetCallback(dmaHandle, SAI_TxEDMACallback, &s_edmaPrivateHandle[instance][0]);
 }
 
+/*!
+ * brief Initializes the SAI Rx eDMA handle.
+ *
+ * This function initializes the SAI slave DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param base SAI peripheral base address.
+ * param callback Pointer to user callback function.
+ * param userData User parameter passed to the callback function.
+ * param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
 void SAI_TransferRxCreateHandleEDMA(
     I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
 {
@@ -181,6 +214,21 @@ void SAI_TransferRxCreateHandleEDMA(
     EDMA_SetCallback(dmaHandle, SAI_RxEDMACallback, &s_edmaPrivateHandle[instance][1]);
 }
 
+/*!
+ * brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param format Pointer to SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+ * retval kStatus_Success Audio format set successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+*/
 void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
                                  sai_edma_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -204,6 +252,9 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
 
     /* Update the data channel SAI used */
     handle->channel = format->channel;
+
+    /* Clear the channel enable bits unitl do a send/receive */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->count = FSL_FEATURE_SAI_FIFO_COUNT - format->watermark;
 #else
@@ -211,6 +262,21 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT */
 }
 
+/*!
+ * brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param format Pointer to SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is the master
+ * clock, this value should equal to masterClockHz in format.
+ * retval kStatus_Success Audio format set successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+*/
 void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
                                  sai_edma_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -235,6 +301,8 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
     /* Update the data channel SAI used */
     handle->channel = format->channel;
 
+    /* Clear the channel enable bits unitl do a send/receive */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->count = format->watermark;
 #else
@@ -242,6 +310,19 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT */
 }
 
+/*!
+ * brief Performs a non-blocking SAI transfer using DMA.
+ *
+ * note This interface returns immediately after the transfer initiates. Call
+ * SAI_GetTransferStatus to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param xfer Pointer to the DMA transfer structure.
+ * retval kStatus_Success Start a SAI eDMA send successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+ * retval kStatus_TxBusy SAI is busy sending data.
+ */
 status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -287,9 +368,25 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
     /* Enable SAI Tx clock */
     SAI_TxEnable(base, true);
 
+    /* Enable the channel FIFO */
+    base->TCR3 |= I2S_TCR3_TCE(1U << handle->channel);
+
     return kStatus_Success;
 }
 
+/*!
+ * brief Performs a non-blocking SAI receive using eDMA.
+ *
+ * note This interface returns immediately after the transfer initiates. Call
+ * the SAI_GetReceiveRemainingBytes to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ * param xfer Pointer to DMA transfer structure.
+ * retval kStatus_Success Start a SAI eDMA receive successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+ * retval kStatus_RxBusy SAI is busy receiving data.
+ */
 status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -332,12 +429,24 @@ status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     /* Enable DMA enable bit */
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
 
+    /* Enable the channel FIFO */
+    base->RCR3 |= I2S_RCR3_RCE(1U << handle->channel);
+
     /* Enable SAI Rx clock */
     SAI_RxEnable(base, true);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Aborts a SAI transfer using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateSendEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
 void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
 {
     assert(handle);
@@ -345,16 +454,36 @@ void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
     /* Disable dma */
     EDMA_AbortTransfer(handle->dmaHandle);
 
+    /* Disable the channel FIFO */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
+
     /* Disable DMA enable bit */
     SAI_TxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
 
     /* Disable Tx */
     SAI_TxEnable(base, false);
 
+    /* Reset the FIFO pointer, at the same time clear all error flags if set */
+    base->TCSR |= (I2S_TCSR_FR_MASK | I2S_TCSR_SR_MASK);
+    base->TCSR &= ~I2S_TCSR_SR_MASK;
+
+    /* Handle the queue index */
+    memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+    handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
+
     /* Set the handle state */
     handle->state = kSAI_Idle;
 }
 
+/*!
+ * brief Aborts a SAI receive using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateReceiveEDMA.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ */
 void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
 {
     assert(handle);
@@ -362,16 +491,84 @@ void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
     /* Disable dma */
     EDMA_AbortTransfer(handle->dmaHandle);
 
+    /* Disable the channel FIFO */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
+
     /* Disable DMA enable bit */
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
 
     /* Disable Rx */
     SAI_RxEnable(base, false);
 
+    /* Reset the FIFO pointer, at the same time clear all error flags if set */
+    base->RCSR |= (I2S_RCSR_FR_MASK | I2S_RCSR_SR_MASK);
+    base->RCSR &= ~I2S_RCSR_SR_MASK;
+
+    /* Handle the queue index */
+    memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+    handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
+
     /* Set the handle state */
     handle->state = kSAI_Idle;
 }
 
+/*!
+ * brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSendEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortSendEDMA(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->tcd, 0U, sizeof(handle->tcd));
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceiveEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortReceiveEDMA(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->tcd, 0U, sizeof(handle->tcd));
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Gets byte count sent by SAI.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param count Bytes count sent by SAI.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
 status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -392,6 +589,15 @@ status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle,
     return status;
 }
 
+/*!
+ * brief Gets byte count received by SAI.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ * param count Bytes count received by SAI.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
 status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
 {
     assert(handle);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_sai_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
  * Copyright 2016-2017 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SAI_EDMA_H_
 #define _FSL_SAI_EDMA_H_
@@ -42,6 +20,11 @@
  * Definitions
  ******************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+#define FSL_SAI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 5)) /*!< Version 2.1.5 */
+/*@}*/
+
 typedef struct _sai_edma_handle sai_edma_handle_t;
 
 /*! @brief SAI eDMA transfer callback function for finish and error */
@@ -50,19 +33,19 @@ typedef void (*sai_edma_callback_t)(I2S_Type *base, sai_edma_handle_t *handle, s
 /*! @brief SAI DMA transfer handle, users should not touch the content of the handle.*/
 struct _sai_edma_handle
 {
-    edma_handle_t *dmaHandle;                     /*!< DMA handler for SAI send */
-    uint8_t nbytes;                               /*!< eDMA minor byte transfer count initially configured. */
-    uint8_t bytesPerFrame;                        /*!< Bytes in a frame */
-    uint8_t channel;                              /*!< Which data channel */
-    uint8_t count;                                /*!< The transfer data count in a DMA request */
-    uint32_t state;                               /*!< Internal state for SAI eDMA transfer */
-    sai_edma_callback_t callback;                 /*!< Callback for users while transfer finish or error occurs */
-    void *userData;                               /*!< User callback parameter */
-    edma_tcd_t tcd[SAI_XFER_QUEUE_SIZE + 1U];     /*!< TCD pool for eDMA transfer. */
-    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE]; /*!< Transfer queue storing queued transfer. */
-    size_t transferSize[SAI_XFER_QUEUE_SIZE];     /*!< Data bytes need to transfer */
-    volatile uint8_t queueUser;                   /*!< Index for user to queue transfer. */
-    volatile uint8_t queueDriver;                 /*!< Index for driver to get the transfer data and size */
+    edma_handle_t *dmaHandle;     /*!< DMA handler for SAI send */
+    uint8_t nbytes;               /*!< eDMA minor byte transfer count initially configured. */
+    uint8_t bytesPerFrame;        /*!< Bytes in a frame */
+    uint8_t channel;              /*!< Which data channel */
+    uint8_t count;                /*!< The transfer data count in a DMA request */
+    uint32_t state;               /*!< Internal state for SAI eDMA transfer */
+    sai_edma_callback_t callback; /*!< Callback for users while transfer finish or error occurs */
+    void *userData;               /*!< User callback parameter */
+    uint8_t tcd[(SAI_XFER_QUEUE_SIZE + 1U) * sizeof(edma_tcd_t)]; /*!< TCD pool for eDMA transfer. */
+    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE];                 /*!< Transfer queue storing queued transfer. */
+    size_t transferSize[SAI_XFER_QUEUE_SIZE];                     /*!< Data bytes need to transfer */
+    volatile uint8_t queueUser;                                   /*!< Index for user to queue transfer. */
+    volatile uint8_t queueDriver; /*!< Index for driver to get the transfer data and size */
 };
 
 /*******************************************************************************
@@ -182,7 +165,32 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
 status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer);
 
 /*!
+ * @brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSendEDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
+ * @brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceiveEDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
  * @brief Aborts a SAI transfer using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateSendEDMA.
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.
@@ -191,6 +199,9 @@ void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
 
 /*!
  * @brief Aborts a SAI receive using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateReceiveEDMA.
  *
  * @param base SAI base pointer
  * @param handle SAI eDMA handle pointer.


### PR DESCRIPTION
### Description

SAI and SAI EDMA drivers in SDK 2.2 does not work with demo EDMA based audio loopback code from SDK 2.5. Tested the changes locally to confirm that updating SAI and SAI EDMA driver to SDK 2.5 fixes the issue.  Driver code for SDK 2.5 was downloaded from https://mcuxpresso.nxp.com


### Pull request type

    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@mmahadevan108  