### PR TITLE
Include mbed-greentea==1.7.1 for mbed-os-tools==0.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Jinja2>=2.10.1,<2.11
 intelhex>=1.3,<=2.2.1
 mbed-ls>=1.5.1,<1.8
 mbed-host-tests>=1.4.4,<1.6
-mbed-greentea>=0.2.24,<1.7
+mbed-greentea>=0.2.24,<1.8
 beautifulsoup4>=4,<=4.6.3
 pyelftools>=0.24,<=0.25
 manifest-tool==1.4.8


### PR DESCRIPTION
mbed-greentea<1.7 depends on mbed-os-tools<0.0.8, while the other
dependent packages require mbed-os-tools=0.0.8. Fixing this
inconsistency.

### Description

Current `requirements.txt` doesn't work as:

```
$ pip install -r requirements.txt
...
$ pip check
mbed-greentea 1.6.5 has requirement mbed-os-tools==0.0.6, but you have mbed-os-tools 0.0.8.
```

This PR fixes the issue.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
