### PR TITLE
Fix bug Operator new[] out of memory

### DIFF
--- a/targets/TARGET_TT/TARGET_TT_M4G9/device/TOOLCHAIN_GCC_ARM/tmpm4g9f15fg.ld
+++ b/targets/TARGET_TT/TARGET_TT_M4G9/device/TOOLCHAIN_GCC_ARM/tmpm4g9f15fg.ld
@@ -10,6 +10,12 @@
   #define MBED_APP_SIZE 0x180000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
+STACK_SIZE = MBED_BOOT_STACK_SIZE;
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
@@ -185,6 +191,7 @@ SECTIONS
 		__end__ = .;
 		end = __end__;
 		KEEP(*(.heap*))
+		. = ORIGIN(RAM) + LENGTH(RAM) - STACK_SIZE;
 		__HeapLimit = .;
 	} > RAM
 
@@ -199,7 +206,7 @@ SECTIONS
 	/* Set stack top to end of RAM, and stack limit move down by
 	 * size of stack_dummy section */
 	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
-	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	__StackLimit = __StackTop - STACK_SIZE;
 	PROVIDE(__stack = __StackTop);
 
 	/* Check if data + heap + stack exceeds RAM limit */


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Modifying API gpio_init for fix bug when the NC's input value is NC, and changing stack size for fix bug which error is Operator new[] out of memory(error=0x8001011F).

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
