### PR TITLE
Tools: check for GCC 9, rather than 6

### DIFF
--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -155,15 +155,23 @@ def test_gcc_version_check(_run_cmd):
     toolchain = TOOLCHAIN_CLASSES["GCC_ARM"](
         TARGET_MAP["K64F"], notify=notifier)
     toolchain.version_check()
-    assert notifier.messages == []
+    assert len(notifier.messages) == 1
     _run_cmd.return_value = ("""
-    arm-none-eabi-gcc (Arch Repository) 8.1.0
-    Copyright (C) 2018 Free Software Foundation, Inc.
+    arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 9-2019-q4-major) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
+    Copyright (C) 2019 Free Software Foundation, Inc.
     This is free software; see the source for copying conditions.  There is NO
     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     """, "", 0)
     toolchain.version_check()
     assert len(notifier.messages) == 1
+    _run_cmd.return_value = ("""
+    arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 10-2020-q4-major) 10.2.1 20201025 (release) [ARM/arm-10-branch revision 377599]
+    Copyright (C) 2020 Free Software Foundation, Inc.
+    This is free software; see the source for copying conditions.  There is NO
+    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    """, "", 0)
+    toolchain.version_check()
+    assert len(notifier.messages) == 2
     _run_cmd.return_value = ("""
     arm-none-eabi-gcc (Arch Repository)
     Copyright (C) 2018 Free Software Foundation, Inc.
@@ -171,7 +179,7 @@ def test_gcc_version_check(_run_cmd):
     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     """, "", 0)
     toolchain.version_check()
-    assert len(notifier.messages) == 2
+    assert len(notifier.messages) == 3
 
 
 @given(fixed_dictionaries({

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -32,7 +32,7 @@ class GCC(mbedToolchain):
     STD_LIB_NAME = "lib%s.a"
     DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(?P<col>\d+):? (?P<severity>warning|[eE]rror|fatal error): (?P<message>.+)')
 
-    GCC_RANGE = (LooseVersion("6.0.0"), LooseVersion("7.0.0"))
+    GCC_RANGE = (LooseVersion("9.0.0"), LooseVersion("10.0.0"))
     GCC_VERSION_RE = re.compile(b"\d+\.\d+\.\d+")
 
     def __init__(self, target,  notify=None, macros=None, build_profile=None,


### PR DESCRIPTION
### Description

Planning to update to supporting GCC 9 as found in _GNU Tools for Arm Embedded Processors 9-2019q4-major_.

Newer GCC in particular supports ARMv8-M security extensions, and link-time optimisation - two areas of interest.

Should be no code changes required, but need to change the warning in the toolchain script.

Docs update: https://github.com/ARMmbed/mbed-os-5-docs/pull/1073

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@bulislaw 

### Release Notes

* GCC 9 is now the officially-supported compiler version for the GCC_ARM toolchain
