### PR TITLE
Fastmodel: enable flashIAP and kvstore

### DIFF
--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/mbed_lib.json
@@ -14,6 +14,10 @@
         "REALTEK_RTL8195AM": {
             "base-address": "0x1C0000",
             "size": "0x40000"
+        },
+        "FVP_MPS2_M3": {
+            "base-address": "0x00200000",
+            "size": "0x200000"
         }
     }
 }

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/mbed_lib.json
@@ -15,7 +15,7 @@
             "base-address": "0x1C0000",
             "size": "0x40000"
         },
-        "FVP_MPS2_M3": {
+        "FVP_MPS2": {
             "base-address": "0x00200000",
             "size": "0x200000"
         }

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -27,8 +27,8 @@
 #include "utest.h"
 #include <stdlib.h>
 
-#if !defined(TARGET_K64F)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
 #endif
 
 #define FSST_TEST_NUM_OF_THREADS 5

--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -29,8 +29,8 @@
 using namespace utest::v1;
 using namespace mbed;
 
-#if !defined(TARGET_K64F)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
 #endif
 
 static const char   data[] = "data";

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -29,8 +29,8 @@
 using namespace utest::v1;
 using namespace mbed;
 
-#if !defined(TARGET_K64F)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
 #endif
 
 static const char   data[] = "data";

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -34,8 +34,8 @@
 #include <stdio.h>
 #include <algorithm>
 
-#if !defined(TARGET_K64F)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
 #endif
 
 #if !SECURESTORE_ENABLED

--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -22,6 +22,10 @@
        "ARM_MUSCA_A1_S": {
             "internal_size": "0x8000",
             "internal_base_address": "0x00420000"
+        },
+        "FVP_MPS2": {
+            "internal_size": "0x200000",
+            "internal_base_address": "0x00200000"
         }
     }
 }

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_ARM_STD/MPS2.sct
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_ARM_STD/MPS2.sct
@@ -1,8 +1,9 @@
 #! armcc -E
 ;* MPS2 CMSIS Library
 ;*
-;* Copyright (c) 2006-2018 ARM Limited
+;* Copyright (c) 2006-2019 ARM Limited
 ;* All rights reserved.
+;* SPDX-License-Identifier: Apache-2.0
 ;*
 ;* Redistribution and use in source and binary forms, with or without
 ;* modification, are permitted provided that the following conditions are met:
@@ -37,26 +38,25 @@
 #include "../memory_zones.h"
 #include "../cmsis_nvic.h"
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
 #if (defined(__stack_size__))
     #define STACK_SIZE  __stack_size__
 #else  
-    #define STACK_SIZE  0x0400
+    #define STACK_SIZE  MBED_BOOT_STACK_SIZE
 #endif
 
 ; The vector table is loaded at address 0x00000000 in Flash memory region.
-LR_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
-  ER_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
+LR_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
+  ER_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
-  }
-}
-
-LR_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
-  ER_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *(InRoot$$Sections)
    *(+RO)
   }
   ; NVIC_VECTORS_SIZE Total: 64 vectors = 256 bytes (0x100) to be reserved in RAM
-  RW_IRAM1 (ZBT_SRAM2_START + NVIC_VECTORS_SIZE) (ZBT_SRAM2_SIZE - NVIC_VECTORS_SIZE)  {  ; RW data
+  RW_IRAM1 (ZBT_SRAM2_START + NVIC_VECTORS_SIZE) (ZBT_SRAM2_SIZE - NVIC_VECTORS_SIZE - STACK_SIZE)  {  ; RW data
    *(+RW +ZI)
   }
   ARM_LIB_STACK (ZBT_SRAM2_START + ZBT_SRAM2_SIZE) EMPTY - STACK_SIZE { ; Stack region growing down

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,7 +21,7 @@
 /*
  * This file is derivative of CMSIS V5.00 gcc_arm.ld
  */
-/* Linker script for mbed FVP Cortex-M0 on MPS2 */
+/* Linker script for mbed FVP Cortex-M on MPS2 */
 
 /* Linker script to configure memory regions. */
 /* The length of the VECTORS region is a bit larger than
@@ -37,7 +37,6 @@
 
 MEMORY
 {
-  VECTORS (rx)          : ORIGIN = MAPPABLE_START, LENGTH = MAPPABLE_SIZE
   FLASH (rx)            : ORIGIN = ZBT_SRAM1_START, LENGTH = ZBT_SRAM1_SIZE
   RAM (rwx)             : ORIGIN = ZBT_SRAM2_START, LENGTH = ZBT_SRAM2_SIZE
 }
@@ -82,7 +81,7 @@ SECTIONS
         __vector_table = .;
         KEEP(*(.vector_table))
          . = ALIGN(8);
-    } > VECTORS
+    } > FLASH
 
     .text :
     {

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_IAR/MPS2.icf
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,21 +24,19 @@
  * can not be included here. Please make sure that the two definitions match.
  */
 /* Code memory zones */
-define symbol MAPPABLE_START   = 0x00000000;
-define symbol MAPPABLE_SIZE    = 0x00004000; /* 16 KiB */
-define symbol ZBT_SRAM1_START  = (0x00000000 + 0x00004000);
-define symbol ZBT_SRAM1_SIZE   = (0x00400000 - 0x00004000); /* 4 MiB - 16 KiB */
+define symbol ZBT_SRAM1_START = 0x00000000;
+define symbol ZBT_SRAM1_SIZE  = 0x00400000; /* 4 MiB */
 
 /* Data memory zones */
 define symbol ZBT_SRAM2_START = 0x20000000;
-define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MB */
+define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MiB */
 
 /* NVIC vector numbers and size. */
 define symbol NVIC_NUM_VECTORS        = (16 + 48);
 define symbol NVIC_VECTORS_SIZE       = (NVIC_NUM_VECTORS * 4);
 
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = MAPPABLE_START;
+define symbol __ICFEDIT_intvec_start__ = ZBT_SRAM1_START;
 
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__    = ZBT_SRAM1_START;

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/memory_zones.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/memory_zones.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017-2018 ARM Limited
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +38,8 @@
  * only to keep the same name than in the CMSDK RTL and Fast Models Reference
  * Guide.
  */
-#define MAPPABLE_START   0x00000000
-#define MAPPABLE_SIZE    0x00004000  /* 16 KiB */
-#define ZBT_SRAM1_START  (0x00000000 + 0x00004000)
-#define ZBT_SRAM1_SIZE   (0x00400000 - 0x00004000) /* 4 MiB - 16 KiB*/
+#define ZBT_SRAM1_START  0x00000000
+#define ZBT_SRAM1_SIZE   0x00400000 /* 4 MiB */
 
 /* Data memory zones */
 #define ZBT_SRAM2_START  0x20000000

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_ARM_STD/MPS2.sct
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_ARM_STD/MPS2.sct
@@ -1,8 +1,9 @@
 #! armcc -E
 ;* MPS2 CMSIS Library
 ;*
-;* Copyright (c) 2006-2018 ARM Limited
+;* Copyright (c) 2006-2019 ARM Limited
 ;* All rights reserved.
+;* SPDX-License-Identifier: Apache-2.0
 ;*
 ;* Redistribution and use in source and binary forms, with or without
 ;* modification, are permitted provided that the following conditions are met:
@@ -48,14 +49,9 @@
 #endif
 
 ; The vector table is loaded at address 0x00000000 in Flash memory region.
-LR_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
-  ER_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
+LR_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
+  ER_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
-  }
-}
-
-LR_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
-  ER_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *(InRoot$$Sections)
    *(+RO)
   }

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,7 +21,7 @@
 /*
  * This file is derivative of CMSIS V5.00 gcc_arm.ld
  */
-/* Linker script for mbed FVP Cortex-M0-Plus on MPS2 */
+/* Linker script for mbed FVP Cortex-M on MPS2 */
 
 /* Linker script to configure memory regions. */
 /* The length of the VECTORS region is a bit larger than
@@ -31,9 +31,12 @@
 #include "../memory_zones.h"
 #include "../cmsis_nvic.h"
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
 MEMORY
 {
-  VECTORS (rx)          : ORIGIN = MAPPABLE_START, LENGTH = MAPPABLE_SIZE
   FLASH (rx)            : ORIGIN = ZBT_SRAM1_START, LENGTH = ZBT_SRAM1_SIZE
   RAM (rwx)             : ORIGIN = ZBT_SRAM2_START, LENGTH = ZBT_SRAM2_SIZE
 }
@@ -66,10 +69,6 @@ MEMORY
  */
 ENTRY(Reset_Handler)
 
-#if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
-#endif
-
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
 /* Size of the vector table in SRAM */
@@ -82,7 +81,7 @@ SECTIONS
         __vector_table = .;
         KEEP(*(.vector_table))
          . = ALIGN(8);
-    } > VECTORS
+    } > FLASH
 
     .text :
     {

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_IAR/MPS2.icf
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,21 +24,19 @@
  * can not be included here. Please make sure that the two definitions match.
  */
 /* Code memory zones */
-define symbol MAPPABLE_START   = 0x00000000;
-define symbol MAPPABLE_SIZE    = 0x00004000; /* 16 KiB */
-define symbol ZBT_SRAM1_START  = (0x00000000 + 0x00004000);
-define symbol ZBT_SRAM1_SIZE   = (0x00400000 - 0x00004000); /* 4 MiB - 16 KiB */
+define symbol ZBT_SRAM1_START = 0x00000000;
+define symbol ZBT_SRAM1_SIZE  = 0x00400000; /* 4 MiB */
 
 /* Data memory zones */
 define symbol ZBT_SRAM2_START = 0x20000000;
-define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MB */
+define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MiB */
 
 /* NVIC vector numbers and size. */
 define symbol NVIC_NUM_VECTORS        = (16 + 48);
 define symbol NVIC_VECTORS_SIZE       = (NVIC_NUM_VECTORS * 4);
 
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = MAPPABLE_START;
+define symbol __ICFEDIT_intvec_start__ = ZBT_SRAM1_START;
 
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__    = ZBT_SRAM1_START;

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/memory_zones.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/memory_zones.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017-2018 ARM Limited
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +38,8 @@
  * only to keep the same name than in the CMSDK RTL and Fast Models Reference
  * Guide.
  */
-#define MAPPABLE_START   0x00000000
-#define MAPPABLE_SIZE    0x00004000  /* 16 KiB */
-#define ZBT_SRAM1_START  (0x00000000 + 0x00004000)
-#define ZBT_SRAM1_SIZE   (0x00400000 - 0x00004000) /* 4 MiB - 16 KiB*/
+#define ZBT_SRAM1_START  0x00000000
+#define ZBT_SRAM1_SIZE   0x00400000 /* 4 MiB */
 
 /* Data memory zones */
 #define ZBT_SRAM2_START  0x20000000

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_ARM_STD/MPS2.sct
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_ARM_STD/MPS2.sct
@@ -1,8 +1,9 @@
 #! armcc -E
 ;* MPS2 CMSIS Library
 ;*
-;* Copyright (c) 2006-2018 ARM Limited
+;* Copyright (c) 2006-2019 ARM Limited
 ;* All rights reserved.
+;* SPDX-License-Identifier: Apache-2.0
 ;*
 ;* Redistribution and use in source and binary forms, with or without
 ;* modification, are permitted provided that the following conditions are met:
@@ -48,14 +49,9 @@
 #endif
 
 ; The vector table is loaded at address 0x00000000 in Flash memory region.
-LR_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
-  ER_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
+LR_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
+  ER_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
-  }
-}
-
-LR_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
-  ER_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *(InRoot$$Sections)
    *(+RO)
   }

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,19 +21,22 @@
 /*
  * This file is derivative of CMSIS V5.00 gcc_arm.ld
  */
-/* Linker script for mbed FVP Cortex-M3 on MPS2 */
+/* Linker script for mbed FVP Cortex-M on MPS2 */
 
 /* Linker script to configure memory regions. */
 /* The length of the VECTORS region is a bit larger than
  * is necessary based on the number of exception handlers.
  */
- 
+
 #include "../memory_zones.h"
 #include "../cmsis_nvic.h"
- 
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
 MEMORY
 {
-  VECTORS (rx)          : ORIGIN = MAPPABLE_START, LENGTH = MAPPABLE_SIZE
   FLASH (rx)            : ORIGIN = ZBT_SRAM1_START, LENGTH = ZBT_SRAM1_SIZE
   RAM (rwx)             : ORIGIN = ZBT_SRAM2_START, LENGTH = ZBT_SRAM2_SIZE
 }
@@ -66,10 +69,6 @@ MEMORY
  */
 ENTRY(Reset_Handler)
 
-#if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
-#endif
-
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
 /* Size of the vector table in SRAM */
@@ -82,7 +81,7 @@ SECTIONS
         __vector_table = .;
         KEEP(*(.vector_table))
          . = ALIGN(8);
-    } > VECTORS
+    } > FLASH
 
     .text :
     {

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_IAR/MPS2.icf
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,21 +24,19 @@
  * can not be included here. Please make sure that the two definitions match.
  */
 /* Code memory zones */
-define symbol MAPPABLE_START   = 0x00000000;
-define symbol MAPPABLE_SIZE    = 0x00004000; /* 16 KiB */
-define symbol ZBT_SRAM1_START  = (0x00000000 + 0x00004000);
-define symbol ZBT_SRAM1_SIZE   = (0x00400000 - 0x00004000); /* 4 MiB - 16 KiB */
+define symbol ZBT_SRAM1_START = 0x00000000;
+define symbol ZBT_SRAM1_SIZE  = 0x00400000; /* 4 MiB */
 
 /* Data memory zones */
 define symbol ZBT_SRAM2_START = 0x20000000;
-define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MB */
+define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MiB */
 
 /* NVIC vector numbers and size. */
 define symbol NVIC_NUM_VECTORS        = (16 + 48);
 define symbol NVIC_VECTORS_SIZE       = (NVIC_NUM_VECTORS * 4);
 
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = MAPPABLE_START;
+define symbol __ICFEDIT_intvec_start__ = ZBT_SRAM1_START;
 
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__    = ZBT_SRAM1_START;

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/memory_zones.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/memory_zones.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017-2018 ARM Limited
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +38,8 @@
  * only to keep the same name than in the CMSDK RTL and Fast Models Reference
  * Guide.
  */
-#define MAPPABLE_START   0x00000000
-#define MAPPABLE_SIZE    0x00004000  /* 16 KiB */
-#define ZBT_SRAM1_START  (0x00000000 + 0x00004000)
-#define ZBT_SRAM1_SIZE   (0x00400000 - 0x00004000) /* 4 MiB - 16 KiB*/
+#define ZBT_SRAM1_START  0x00000000
+#define ZBT_SRAM1_SIZE   0x00400000 /* 4 MiB */
 
 /* Data memory zones */
 #define ZBT_SRAM2_START  0x20000000

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_ARM_STD/MPS2.sct
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_ARM_STD/MPS2.sct
@@ -1,8 +1,9 @@
 #! armcc -E
 ;* MPS2 CMSIS Library
 ;*
-;* Copyright (c) 2006-2018 ARM Limited
+;* Copyright (c) 2006-2019 ARM Limited
 ;* All rights reserved.
+;* SPDX-License-Identifier: Apache-2.0
 ;*
 ;* Redistribution and use in source and binary forms, with or without
 ;* modification, are permitted provided that the following conditions are met:
@@ -48,14 +49,9 @@
 #endif
 
 ; The vector table is loaded at address 0x00000000 in Flash memory region.
-LR_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
-  ER_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
+LR_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
+  ER_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
-  }
-}
-
-LR_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
-  ER_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *(InRoot$$Sections)
    *(+RO)
   }

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,7 +21,7 @@
 /*
  * This file is derivative of CMSIS V5.00 gcc_arm.ld
  */
-/* Linker script for mbed FVP Cortex-M4 on MPS2 */
+/* Linker script for mbed FVP Cortex-M on MPS2 */
 
 /* Linker script to configure memory regions. */
 /* The length of the VECTORS region is a bit larger than
@@ -37,7 +37,6 @@
 
 MEMORY
 {
-  VECTORS (rx)          : ORIGIN = MAPPABLE_START, LENGTH = MAPPABLE_SIZE
   FLASH (rx)            : ORIGIN = ZBT_SRAM1_START, LENGTH = ZBT_SRAM1_SIZE
   RAM (rwx)             : ORIGIN = ZBT_SRAM2_START, LENGTH = ZBT_SRAM2_SIZE
 }
@@ -82,7 +81,7 @@ SECTIONS
         __vector_table = .;
         KEEP(*(.vector_table))
          . = ALIGN(8);
-    } > VECTORS
+    } > FLASH
 
     .text :
     {

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_IAR/MPS2.icf
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,21 +24,19 @@
  * can not be included here. Please make sure that the two definitions match.
  */
 /* Code memory zones */
-define symbol MAPPABLE_START   = 0x00000000;
-define symbol MAPPABLE_SIZE    = 0x00004000; /* 16 KiB */
-define symbol ZBT_SRAM1_START  = (0x00000000 + 0x00004000);
-define symbol ZBT_SRAM1_SIZE   = (0x00400000 - 0x00004000); /* 4 MiB - 16 KiB */
+define symbol ZBT_SRAM1_START = 0x00000000;
+define symbol ZBT_SRAM1_SIZE  = 0x00400000; /* 4 MiB */
 
 /* Data memory zones */
 define symbol ZBT_SRAM2_START = 0x20000000;
-define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MB */
+define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MiB */
 
 /* NVIC vector numbers and size. */
 define symbol NVIC_NUM_VECTORS        = (16 + 48);
 define symbol NVIC_VECTORS_SIZE       = (NVIC_NUM_VECTORS * 4);
 
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = MAPPABLE_START;
+define symbol __ICFEDIT_intvec_start__ = ZBT_SRAM1_START;
 
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__    = ZBT_SRAM1_START;

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/memory_zones.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/memory_zones.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017-2018 ARM Limited
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +38,8 @@
  * only to keep the same name than in the CMSDK RTL and Fast Models Reference
  * Guide.
  */
-#define MAPPABLE_START   0x00000000
-#define MAPPABLE_SIZE    0x00004000  /* 16 KiB */
-#define ZBT_SRAM1_START  (0x00000000 + 0x00004000)
-#define ZBT_SRAM1_SIZE   (0x00400000 - 0x00004000) /* 4 MiB - 16 KiB*/
+#define ZBT_SRAM1_START  0x00000000
+#define ZBT_SRAM1_SIZE   0x00400000 /* 4 MiB */
 
 /* Data memory zones */
 #define ZBT_SRAM2_START  0x20000000

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_ARM_STD/MPS2.sct
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_ARM_STD/MPS2.sct
@@ -1,34 +1,35 @@
 #! armcc -E
 ;* MPS2 CMSIS Library
 ;*
-;* Copyright (c) 2006-2018 ARM Limited
+;* Copyright (c) 2006-2019 ARM Limited
 ;* All rights reserved.
-;* 
-;* Redistribution and use in source and binary forms, with or without 
+;* SPDX-License-Identifier: Apache-2.0
+;*
+;* Redistribution and use in source and binary forms, with or without
 ;* modification, are permitted provided that the following conditions are met:
-;* 
-;* 1. Redistributions of source code must retain the above copyright notice, 
+;*
+;* 1. Redistributions of source code must retain the above copyright notice,
 ;* this list of conditions and the following disclaimer.
-;* 
-;* 2. Redistributions in binary form must reproduce the above copyright notice, 
-;* this list of conditions and the following disclaimer in the documentation 
+;*
+;* 2. Redistributions in binary form must reproduce the above copyright notice,
+;* this list of conditions and the following disclaimer in the documentation
 ;* and/or other materials provided with the distribution.
-;* 
-;* 3. Neither the name of the copyright holder nor the names of its contributors 
-;* may be used to endorse or promote products derived from this software without 
+;*
+;* 3. Neither the name of the copyright holder nor the names of its contributors
+;* may be used to endorse or promote products derived from this software without
 ;* specific prior written permission.
-;* 
-;* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-;* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-;* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-;* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-;* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-;* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-;* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-;* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-;* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-;* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-;* POSSIBILITY OF SUCH DAMAGE. 
+;*
+;* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+;* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;* POSSIBILITY OF SUCH DAMAGE.
 ;*
 ; *************************************************************
 ; *** Scatter-Loading Description File                      ***
@@ -48,14 +49,9 @@
 #endif
 
 ; The vector table is loaded at address 0x00000000 in Flash memory region.
-LR_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
-  ER_IROM1 MAPPABLE_START MAPPABLE_SIZE  {
+LR_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
+  ER_IROM1 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
-  }
-}
-
-LR_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {    ; load region size_region
-  ER_IROM2 ZBT_SRAM1_START ZBT_SRAM1_SIZE  {  ; load address = execution address
    *(InRoot$$Sections)
    *(+RO)
   }

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -21,7 +21,7 @@
 /*
  * This file is derivative of CMSIS V5.00 gcc_arm.ld
  */
-/* Linker script for mbed FVP Cortex-M7 on MPS2 */
+/* Linker script for mbed FVP Cortex-M on MPS2 */
 
 /* Linker script to configure memory regions. */
 /* The length of the VECTORS region is a bit larger than
@@ -31,9 +31,12 @@
 #include "../memory_zones.h"
 #include "../cmsis_nvic.h"
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
 MEMORY
 {
-  VECTORS (rx)          : ORIGIN = MAPPABLE_START, LENGTH = MAPPABLE_SIZE
   FLASH (rx)            : ORIGIN = ZBT_SRAM1_START, LENGTH = ZBT_SRAM1_SIZE
   RAM (rwx)             : ORIGIN = ZBT_SRAM2_START, LENGTH = ZBT_SRAM2_SIZE
 }
@@ -66,10 +69,6 @@ MEMORY
  */
 ENTRY(Reset_Handler)
 
-#if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
-#endif
-
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
 /* Size of the vector table in SRAM */
@@ -82,7 +81,7 @@ SECTIONS
         __vector_table = .;
         KEEP(*(.vector_table))
          . = ALIGN(8);
-    } > VECTORS
+    } > FLASH
 
     .text :
     {

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_IAR/MPS2.icf
@@ -2,7 +2,7 @@
  * MPS2 CMSIS Library
  */
 /*
- * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2019 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,21 +24,19 @@
  * can not be included here. Please make sure that the two definitions match.
  */
 /* Code memory zones */
-define symbol MAPPABLE_START   = 0x00000000;
-define symbol MAPPABLE_SIZE    = 0x00004000; /* 16 KiB */
-define symbol ZBT_SRAM1_START  = (0x00000000 + 0x00004000);
-define symbol ZBT_SRAM1_SIZE   = (0x00400000 - 0x00004000); /* 4 MiB - 16 KiB */
+define symbol ZBT_SRAM1_START = 0x00000000;
+define symbol ZBT_SRAM1_SIZE  = 0x00400000; /* 4 MiB */
 
 /* Data memory zones */
 define symbol ZBT_SRAM2_START = 0x20000000;
-define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MB */
+define symbol ZBT_SRAM2_SIZE  = 0x00400000; /* 4 MiB */
 
 /* NVIC vector numbers and size. */
 define symbol NVIC_NUM_VECTORS        = (16 + 48);
 define symbol NVIC_VECTORS_SIZE       = (NVIC_NUM_VECTORS * 4);
 
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = MAPPABLE_START;
+define symbol __ICFEDIT_intvec_start__ = ZBT_SRAM1_START;
 
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__    = ZBT_SRAM1_START;

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/memory_zones.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/memory_zones.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017-2018 ARM Limited
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +38,8 @@
  * only to keep the same name than in the CMSDK RTL and Fast Models Reference
  * Guide.
  */
-#define MAPPABLE_START   0x00000000
-#define MAPPABLE_SIZE    0x00004000  /* 16 KiB */
-#define ZBT_SRAM1_START  (0x00000000 + 0x00004000)
-#define ZBT_SRAM1_SIZE   (0x00400000 - 0x00004000) /* 4 MiB - 16 KiB*/
+#define ZBT_SRAM1_START  0x00000000
+#define ZBT_SRAM1_SIZE   0x00400000 /* 4 MiB */
 
 /* Data memory zones */
 #define ZBT_SRAM2_START  0x20000000

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8058,7 +8058,7 @@
             "USTICKER"
         ],
         "release_versions": ["5"],
-        "components_add": ["LAN91C111"],
+        "components_add": ["LAN91C111", "FLASHIAP"],
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         }


### PR DESCRIPTION
### Description

Enable flashIAP and KVStore by setting the base address and size of the flash region

 
### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

