### PR TITLE
Update mbed-coap to version 4.8.0

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v4.8.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.8.0) 
+- Make `sn_coap_protocol_linked_list_duplication_info_remove` API to public. User might want to delete some messages from the duplicate list.
+- Enable support for unified client configuration.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.7.4...v4.8.0)
+
 ## [v4.7.4](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.4) 
 
 - Remove dependency to yotta tool

--- a/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -298,6 +298,21 @@ extern void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn
  */
 extern uint16_t sn_coap_protocol_get_configured_blockwise_size(struct coap_s *handle);
 
+/**
+ * \fn void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle, const uint8_t *src_addr_ptr, const uint16_t port, const uint16_t msg_id);
+ *
+ * \brief Removes stored Duplication info from Linked list.
+ *
+ * \param *handle Pointer to CoAP library handle
+ * \param *addr_ptr is pointer to Address key to be removed
+ * \param port is Port key to be removed
+ * \param msg_id is Message ID key to be removed
+ */
+extern void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle,
+                                                                 const uint8_t *src_addr_ptr,
+                                                                 const uint16_t port,
+                                                                 const uint16_t msg_id);
+
 #endif /* SN_COAP_PROTOCOL_H_ */
 
 #ifdef __cplusplus

--- a/features/frameworks/mbed-coap/mbed-coap/sn_config.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_config.h
@@ -21,6 +21,14 @@
 #include MBED_CLIENT_USER_CONFIG_FILE
 #endif
 
+#ifdef MBED_CLOUD_CLIENT_USER_CONFIG_FILE
+#include MBED_CLOUD_CLIENT_USER_CONFIG_FILE
+#endif
+
+#ifdef MBED_CLOUD_CLIENT_CONFIGURATION_ENABLED
+#include "mbed-cloud-client/MbedCloudClientConfig.h"
+#endif
+
 /**
 * \brief Configuration options (set of defines and values)
 *


### PR DESCRIPTION
### Description
Update mbed-coap to version 4.8.0

Make sn_coap_protocol_linked_list_duplication_info_remove API to public. User might want to delete some messages from the duplicate list.
Enable support for unified client configuration.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@yogpan01 
@teetak01 


