### PR TITLE
Cellular: fix unit test valgrind warnings

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -62,9 +62,6 @@ protected:
         ATHandler_stub::read_string_table[kRead_string_table_size];
         ATHandler_stub::resp_stop_success_count = kResp_stop_count_default;
         CellularDevice_stub::connect_counter = 2;
-        for (int i=0; i < kATHandler_urc_table_max_size; i++) {
-            ATHandler_stub::callback[i] = NULL;
-        }
     }
 
     void TearDown()

--- a/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
+++ b/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
@@ -567,6 +567,9 @@ TEST_F(Test_LoRaMac, clear_tx_pipe)
     conn.connection_u.otaa.nb_trials = 2;
     object->prepare_join(&conn, true);
 
+    channel_params_t params[] = {868300000, 0, { ((DR_5 << 4) | DR_0) }, 1};
+    LoRaPHY_stub::channel_params_ptr = params;
+    LoRaWANTimer_stub::call_cb_immediately = true;
     EXPECT_TRUE(LORAWAN_STATUS_OK == object->initialize(NULL, my_cb));
     EventQueue_stub::int_value = 0;
     EXPECT_EQ(LORAWAN_STATUS_BUSY, object->clear_tx_pipe());

--- a/UNITTESTS/stubs/ATHandler_stub.h
+++ b/UNITTESTS/stubs/ATHandler_stub.h
@@ -56,7 +56,6 @@ extern uint8_t info_elem_true_counter;
 extern uint8_t uint8_value;
 extern mbed::FileHandle_stub *fh_value;
 extern mbed::device_err_t device_err_value;
-extern mbed::Callback<void()> callback[kATHandler_urc_table_max_size];
 extern bool call_immediately;
 extern const char *read_string_table[kRead_string_table_size];
 extern int read_string_index;
@@ -64,8 +63,6 @@ extern int int_valid_count_table[kRead_int_table_size];
 extern int int_count;
 extern int resp_stop_success_count;
 extern bool process_oob_urc;
-extern int urc_amount;
-extern char *urc_string_table[kATHandler_urc_table_max_size];
 
 extern bool get_debug_flag;
 bool is_get_debug_run();

--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -38,7 +38,7 @@ AT_CellularDevice::AT_CellularDevice(FileHandle *fh) : CellularDevice(fh), _netw
 
 AT_CellularDevice::~AT_CellularDevice()
 {
-    delete _network;
+    close_network();
 }
 
 ATHandler *AT_CellularDevice::get_at_handler(FileHandle *fileHandle)
@@ -75,6 +75,9 @@ void delete_context(CellularContext *context)
 
 CellularNetwork *AT_CellularDevice::open_network(FileHandle *fh)
 {
+    if (_network) {
+        return _network;
+    }
     _network = new AT_CellularNetwork(*ATHandler::get_instance(fh,
                                                                _queue,
                                                                _default_timeout,
@@ -96,9 +99,12 @@ CellularInformation *AT_CellularDevice::open_information(FileHandle *fh)
 
 void AT_CellularDevice::close_network()
 {
-    delete _network;
-
-    _network = NULL;
+    if (_network) {
+        ATHandler *atHandler = &_network->get_at_handler();
+        delete _network;
+        _network = NULL;
+        release_at_handler(atHandler);
+    }
 }
 
 void AT_CellularDevice::close_sms()


### PR DESCRIPTION
### Description

Fix unit test Valgrind warnings.
Stub files did have some memory leaks and using uninitialized variables.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers


### Release Notes