### PR TITLE
BLE: fix deprecated API calls in battery and thermometer services

### DIFF
--- a/features/FEATURE_BLE/ble/services/BatteryService.h
+++ b/features/FEATURE_BLE/ble/services/BatteryService.h
@@ -84,7 +84,7 @@ public:
             sizeof(charTable) / sizeof(GattCharacteristic *)
         );
 
-        ble.addService(batteryService);
+        ble.gattServer().addService(batteryService);
     }
 
     /**

--- a/features/FEATURE_BLE/ble/services/HealthThermometerService.h
+++ b/features/FEATURE_BLE/ble/services/HealthThermometerService.h
@@ -61,7 +61,7 @@ public:
         GattCharacteristic *hrmChars[] = {&tempMeasurement, &tempLocation, };
         GattService         hrmService(GattService::UUID_HEALTH_THERMOMETER_SERVICE, hrmChars, sizeof(hrmChars) / sizeof(GattCharacteristic *));
 
-        ble.addService(hrmService);
+        ble.gattServer().addService(hrmService);
     }
 
     /**
@@ -72,10 +72,8 @@ public:
     *
     */
     void updateTemperature(float temperature) {
-        if (ble.getGapState().connected) {
-            valueBytes.updateTemperature(temperature);
-            ble.gattServer().write(tempMeasurement.getValueHandle(), valueBytes.getPointer(), sizeof(TemperatureValueBytes));
-        }
+        valueBytes.updateTemperature(temperature);
+        ble.gattServer().write(tempMeasurement.getValueHandle(), valueBytes.getPointer(), sizeof(TemperatureValueBytes));
     }
 
     /**


### PR DESCRIPTION
### Description

Fix deprecated API warnings reported by https://github.com/ARMmbed/mbed-os-example-ble/issues/180 (and a bit more)

Note: There're more warnings from URIBeanconConfig (deprecated) and UART (to be deprecated) services, but those should be simply suppressed instead. Will create a separate/independent PR for that.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan- @paul-szczepanek-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
