### PR TITLE
BLE: deprecate UARTService and suppress compiler warnings

### DIFF
--- a/features/FEATURE_BLE/ble/services/UARTService.h
+++ b/features/FEATURE_BLE/ble/services/UARTService.h
@@ -41,9 +41,15 @@ extern const uint8_t  UARTServiceTXCharacteristicUUID[UUID::LENGTH_OF_LONG_UUID]
 extern const uint8_t  UARTServiceRXCharacteristicUUID[UUID::LENGTH_OF_LONG_UUID];
 
 /**
-* @class UARTService.
-* @brief BLE Service to enable UART over BLE.
-*/
+ * @class UARTService.
+ * @brief BLE Service to enable UART over BLE.
+ *
+ * @deprecated This service is deprecated, and no replacement is currently available.
+ */
+MBED_DEPRECATED_SINCE(
+    "mbed-os-5.13",
+    "This service is deprecated, and no replacement is currently available."
+)
 class UARTService {
 public:
     /** Maximum length of data (in bytes) that the UART service module can transmit to the peer. */

--- a/features/FEATURE_BLE/ble/services/UARTService.h
+++ b/features/FEATURE_BLE/ble/services/UARTService.h
@@ -26,8 +26,11 @@
 
 #include "ble/UUID.h"
 #include "ble/BLE.h"
+#include "ble/pal/Deprecated.h"
 
 #if BLE_FEATURE_GATT_SERVER
+
+BLE_DEPRECATED_API_USE_BEGIN()
 
 extern const uint8_t  UARTServiceBaseUUID[UUID::LENGTH_OF_LONG_UUID];
 extern const uint16_t UARTServiceShortUUID;
@@ -222,6 +225,8 @@ protected:
                                            *   they'd read from in order to receive the bytes transmitted by this
                                            *   application. */
 };
+
+BLE_DEPRECATED_API_USE_END()
 
 #endif // BLE_FEATURE_GATT_SERVER
 

--- a/features/FEATURE_BLE/ble/services/URIBeaconConfigService.h
+++ b/features/FEATURE_BLE/ble/services/URIBeaconConfigService.h
@@ -18,6 +18,7 @@
 #define SERVICES_URIBEACONCONFIGSERVICE_H_
 
 #include "ble/BLE.h"
+#include "ble/pal/Deprecated.h"
 
 #ifdef YOTTA_CFG_MBED_OS
 #include "mbed-drivers/mbed.h"
@@ -27,6 +28,8 @@
 
 #if BLE_FEATURE_GATT_SERVER
 #if BLE_ROLE_BROADCASTER
+
+BLE_DEPRECATED_API_USE_BEGIN()
 
 extern const uint8_t UUID_URI_BEACON_SERVICE[UUID::LENGTH_OF_LONG_UUID];
 extern const uint8_t UUID_LOCK_STATE_CHAR[UUID::LENGTH_OF_LONG_UUID];
@@ -482,6 +485,8 @@ public:
         }
     }
 };
+
+BLE_DEPRECATED_API_USE_END()
 
 #endif // BLE_ROLE_BROADCASTER
 #endif // BLE_FEATURE_GATT_SERVER

--- a/features/FEATURE_BLE/ble/services/iBeacon.h
+++ b/features/FEATURE_BLE/ble/services/iBeacon.h
@@ -18,8 +18,11 @@
 
 #include "cmsis_compiler.h"
 #include "ble/BLE.h"
+#include "ble/pal/Deprecated.h"
 
 #if BLE_FEATURE_GATT_SERVER
+
+BLE_DEPRECATED_API_USE_BEGIN()
 
 /**
  * iBeacon Service.
@@ -252,6 +255,8 @@ protected:
  * future release.
  */
 typedef iBeacon iBeaconService;
+
+BLE_DEPRECATED_API_USE_END()
 
 #endif // BLE_FEATURE_GATT_SERVER
 


### PR DESCRIPTION
### Description

#### Deprecated BLE APIs called by deprecated services
We have already marked a few services (e.g. ones for Beacon) as deprecated, thus their uses of deprecated API should not lead to more compiler warnings.

#### UARTService
UARTService uses the old GAP advertising API which is now deprecated in favour of AdvertisingDataBuilder.
After discussing with @pan- @paul-szczepanek-arm, we consider deprecating UARTService.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan- @paul-szczepanek-arm 