### PR TITLE
+UPSND sent to poll activation status

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -89,8 +89,7 @@ nsapi_error_t UBLOX_AT_CellularContext::open_data_channel()
     _at.cmd_start("AT+UPSND=" PROFILE ",8");
     _at.cmd_stop();
     _at.resp_start("+UPSND:");
-    _at.read_int();
-    _at.read_int();
+    _at.skip_param(2);
     active = _at.read_int();
     _at.resp_stop();
 
@@ -133,7 +132,7 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
     // Set up the APN
     if (apn) {
         success = false;
-        _at.cmd_start("AT+UPSD=0,1,");
+        _at.cmd_start("AT+UPSD=" PROFILE ",1,");
         _at.write_string(apn);
         _at.cmd_stop();
         _at.resp_start();
@@ -192,14 +191,27 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
                 if (_at.get_last_error() == NSAPI_ERROR_OK) {
                     // Activate, wait upto 30 seconds for the connection to be made
                     _at.set_at_timeout(30000);
-                    _at.cmd_start("AT+UPSDA=0,3");
+                    _at.cmd_start("AT+UPSD=" PROFILE ",6,");
                     _at.cmd_stop();
                     _at.resp_start();
                     _at.resp_stop();
                     _at.restore_at_timeout();
 
                     if (_at.get_last_error() == NSAPI_ERROR_OK) {
-                        activated = true;
+                        Timer t1;
+                        t1.start();
+                        while (!(t1.read() >= 180)){
+                            _at.cmd_start("AT+UPSND=" PROFILE ",8");
+                            _at.cmd_stop();
+                            _at.resp_start("+UPSND:");
+                            _at.skip_param(2);
+                            _at.read_int() ? activated = true : activated = false;
+                            _at.resp_stop();
+
+                            if (activated)    //If context is activated, exit while loop and return status
+                                break;
+                            wait_ms(5000);    //Wait for 5 seconds and then try again
+                        }
                     }
                 }
             }

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -182,7 +182,7 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
         for (int protocol = nsapi_security_to_modem_security(NSAPI_SECURITY_NONE);
                 success && (protocol <= nsapi_security_to_modem_security(NSAPI_SECURITY_CHAP)); protocol++) {
             if ((_auth == NSAPI_SECURITY_UNKNOWN) || (nsapi_security_to_modem_security(_auth) == protocol)) {
-                _at.cmd_start("AT+UPSD=0,6,");
+                _at.cmd_start("AT+UPSD=" PROFILE ",6,");
                 _at.write_int(protocol);
                 _at.cmd_stop();
                 _at.resp_start();
@@ -191,7 +191,7 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
                 if (_at.get_last_error() == NSAPI_ERROR_OK) {
                     // Activate, wait upto 30 seconds for the connection to be made
                     _at.set_at_timeout(30000);
-                    _at.cmd_start("AT+UPSD=" PROFILE ",6,");
+                    _at.cmd_start("AT+UPSDA=" PROFILE ",3");
                     _at.cmd_stop();
                     _at.resp_start();
                     _at.resp_stop();

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -212,6 +212,7 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
                                 break;
                             wait_ms(5000);    //Wait for 5 seconds and then try again
                         }
+                        t1.stop();
                     }
                 }
             }

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -200,7 +200,7 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
                     if (_at.get_last_error() == NSAPI_ERROR_OK) {
                         Timer t1;
                         t1.start();
-                        while (!(t1.read() >= 180)){
+                        while (!(t1.read() >= 180)) {
                             _at.cmd_start("AT+UPSND=" PROFILE ",8");
                             _at.cmd_stop();
                             _at.resp_start("+UPSND:");
@@ -208,8 +208,9 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
                             _at.read_int() ? activated = true : activated = false;
                             _at.resp_stop();
 
-                            if (activated)    //If context is activated, exit while loop and return status
+                            if (activated) {  //If context is activated, exit while loop and return status
                                 break;
+                            }
                             wait_ms(5000);    //Wait for 5 seconds and then try again
                         }
                         t1.stop();

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ONBOARD_UBLOX.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ONBOARD_UBLOX.cpp
@@ -31,7 +31,15 @@ CellularDevice *CellularDevice::get_target_default_instance()
 #elif defined(TARGET_UBLOX_C030_N211)
     static UARTSerial serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
     static ONBOARD_UBLOX_N2XX device(&serial);
-#else
+#elif defined(TARGET_UBLOX_C030_U201)
+    #if (NSAPI_PPP_AVAILABLE)
+        static UARTSerial serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
+        static ONBOARD_UBLOX_PPP device(&serial);
+    #else
+        static UARTSerial serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
+        static ONBOARD_UBLOX_AT device(&serial);
+    #endif
+#else //UBLOX_C027
     static UARTSerial serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
     static ONBOARD_UBLOX_PPP device(&serial);
 #endif


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This pull request updates the context activation using the +UPSND AT command. Previously, the context status was updated immediately after activating the context (without verifying if it was activated successfully).

+UPSND command responds with the status of the context activation. The status is polled every 5s with a max timeout of 180s.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
