### PR TITLE
tools: Fix build output warning message

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -25,7 +25,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+        "ld": ["--verbose", "--remove", "--show_full_path", "--keep=os_cb_sections"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -23,7 +23,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -23,7 +23,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
### Description
The linker command line option `--legacyalign` is deprecated in Arm
Compiler 6 and there is no replacement to minimize the amount of padding
inserted to the image between memory regions by the compiler.

This changes removes the option from all build profile configuration
files as its presence for the `ARMC6` attribute causes a `L3912W`
warning to be displayed in the build output when building using `ARM`
or `ARMC6` toolchain.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@BartSX @evedon 
<!--
    Optional
    Request additional reviewers with @username
-->