### PR TITLE
Fix AdvertisingDataBuilder UUID Insertion Bug

### DIFF
--- a/features/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp
+++ b/features/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp
@@ -498,7 +498,7 @@ ble_error_t AdvertisingDataBuilder::setUUIDData(
     size_t old_size = getFieldSize(shortType) + getFieldSize(longType);
 
     /* if we can't fit the new data do not proceed */
-    if (new_size > data.size() - (_payload_length - old_size)) {
+    if (new_size > _buffer.size() - (_payload_length - old_size)) {
         return BLE_ERROR_BUFFER_OVERFLOW;
     }
 


### PR DESCRIPTION
### Description

Fixed a bug that checked the wrong buffer size when inserting UUID information into an advertisement payload.

When calling `AdvertisingDataBuilder::setLocalServiceList()` (or other UUID related builder functions), they would subsequently call `AdvertisingDataBuilder::setUUIDData` to insert UUID fields into the advertisement/scan response payload.

An advertising payload field consists of a 2-byte header that details:

1. Type of the field
2. Size of the field data

As well as the field data. The check in `setUUIDData` here:

https://github.com/ARMmbed/mbed-os/blob/1dbb478bbb1b9cde70dffe699d720a49e7b30e9b/features/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp#L500-L503

Was erroneously checking the `data + header` size against the original size of the `data` passed into the function. It should have been checking the `data + header` size against the underlying `_buffer` (minus already occupied space).

I discovered this issue when attempting to advertise a 16-byte custom service UUID in the advertising scan response. If using the `AdvertisingDataSimpleBuilder` convenience class in debug build configuration, this bug would always cause an assert.

I verified I was able to send and view the custom UUID in the scan response over BLE after applying this patch. I used nRF Connect to sniff the BLE advertising data.

(Very descriptive picture I know):
![image](https://user-images.githubusercontent.com/350500/58205030-9b674900-7cab-11e9-9a64-5bc6f94e1e6d.png)


<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@pan- 
@paul-szczepanek-arm 