### PR TITLE
BLE HealthThermometerService: correct GATT characteristics

### DIFF
--- a/features/FEATURE_BLE/ble/services/HealthThermometerService.h
+++ b/features/FEATURE_BLE/ble/services/HealthThermometerService.h
@@ -55,7 +55,7 @@ public:
     HealthThermometerService(BLE &_ble, float initialTemp, uint8_t _location) :
         ble(_ble),
         valueBytes(initialTemp),
-        tempMeasurement(GattCharacteristic::UUID_TEMPERATURE_MEASUREMENT_CHAR, (TemperatureValueBytes *)valueBytes.getPointer(), GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY),
+        tempMeasurement(GattCharacteristic::UUID_TEMPERATURE_MEASUREMENT_CHAR, (TemperatureValueBytes *)valueBytes.getPointer(), GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE),
         tempLocation(GattCharacteristic::UUID_TEMPERATURE_TYPE_CHAR, &_location) {
 
         GattCharacteristic *hrmChars[] = {&tempMeasurement, &tempLocation, };


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
(Issue https://github.com/ARMmbed/mbed-os-example-ble/issues/53)

As per official specification (https://www.bluetooth.org/docman/handlers/downloaddoc.ashx?doc_id=238688), temperature measurement requires
the GATT characteristic "INDICATE" instead of "NOTIFY".

Full credits to Jean-Marc Jobin (@jmjobin on GitHub) for
identifying the issue and proposing this fix.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@donatieng @pan- @paul-szczepanek-arm 
