### PR TITLE
Fix deprecation notice for ble::Gap::getState()

### DIFF
--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -1347,13 +1347,15 @@ public:
      * @return The current GAP state of the device.
      *
      * @deprecated Deprecated since addition of extended advertising support.
-     * This is not meaningful when you use extended advertising; please use
-     * isAdvertisingActive() and getConnectionCount().
+     * This is not meaningful when you use extended advertising; Please replace
+     * getState().advertising with isAdvertisingActive(), and replace
+     * getState().connected with your own record and update during callbacks.
      */
     MBED_DEPRECATED_SINCE(
         "mbed-os-5.11.0",
         "Deprecated since addition of extended advertising support. "
-        "Use isAdvertisingActive() and getConnectionCount()."
+        "Replace getState().advertising with isAdvertisingActive()."
+        "Replace getState().connected with your own record and update during callbacks."
     )
     GapState_t getState(void) const;
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
The deprecation notice suggests getConnectionCount() which did not land in the final API.

The proper replacement of getState().connected is keeping a local record in the application and updating it during connection and disconnection callbacks.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [x] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@pan- @paul-szczepanek-arm 
