### PR TITLE
USBHost: Wait for device to implement SET ADDRESS

### DIFF
--- a/features/unsupported/USBHost/USBHost/USBHost.cpp
+++ b/features/unsupported/USBHost/USBHost/USBHost.cpp
@@ -163,6 +163,13 @@ void USBHost::usb_process()
                             devices[i].activeAddress(true);
                             USB_DBG("Address of %p: %d", &devices[i], devices[i].getAddress());
 
+                            // Wait for the device to actually set the address. The Status stage
+                            // of SET ADDRESS happens before the device implements the request.
+                            // According to Universal Serial Bus Specification Revision 2.0 chapter
+                            // 9.2.6.3 Set Address Processing, the device is allowed SetAddress()
+                            // recovery interval of 2 ms.
+                            ThisThread::sleep_for(2);
+
                             // try to read again the device descriptor to check if the device
                             // answers to its new address
                             res = getDeviceDescriptor(&devices[i], buf, 8);


### PR DESCRIPTION
The USB Device must change the address 2 ms after completing SET ADDRESS
status stage.

Wait 2 ms before issuing GET DESCRIPTOR under the new address. In my
case, this completely resolves the timeout issues.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Prior to this change the enumeration did fail every time. The output looked like this:

> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1163]----- CONTROL READ [dev: 0x200295ec - hub: 0 - port: 1] ------
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1177]Control transfer on device: 0
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1181]SETUP PACKET:
> 80 6 0 1 0 0 8 0
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1208]CONTROL setup stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1237]CONTROL READ stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1245]CONTROL READ SUCCESS [8 bytes transferred]
> 12 01 10 02 00 00 00 40
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1278]CONTROL ack stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1163]----- CONTROL WRITE [dev: 0x200295ec - hub: 0 - port: 1] ------
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1177]Control transfer on device: 0
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1181]SETUP PACKET:
> 0 5 1 0 0 0 0 0
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1208]CONTROL setup stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1278]CONTROL ack stage USB_TYPE_IDLE
> [USB_DBG: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:164]Address of 0x200295ec: 1
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1163]----- CONTROL READ [dev: 0x200295ec - hub: 0 - port: 1] ------
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1177]Control transfer on device: 1
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1181]SETUP PACKET:
> 80 6 0 1 0 0 8 0
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1208]CONTROL setup stage USB_TYPE_ERROR
> [USB_DBG: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:601]Resetting hub 0, port 1


After this change, the enumeration consistently succeeds in first try. The log looks like this:

> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1169]----- CONTROL READ [dev: 0x200295ec - hub: 0 - port: 1] ------
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1183]Control transfer on device: 0
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1187]SETUP PACKET:
> 80 6 0 1 0 0 8 0
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1214]CONTROL setup stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1243]CONTROL READ stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1251]CONTROL READ SUCCESS [8 bytes transferred]
> 12 01 10 02 00 00 00 40
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1284]CONTROL ack stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1169]----- CONTROL WRITE [dev: 0x200295ec - hub: 0 - port: 1] ------
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1183]Control transfer on device: 0
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1187]SETUP PACKET:
> 0 5 1 0 0 0 0 0
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1214]CONTROL setup stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1284]CONTROL ack stage USB_TYPE_IDLE
> [USB_DBG: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:164]Address of 0x200295ec: 1
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1169]----- CONTROL READ [dev: 0x200295ec - hub: 0 - port: 1] ------
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1183]Control transfer on device: 1
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1187]SETUP PACKET:
> 80 6 0 1 0 0 8 0
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1214]CONTROL setup stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1243]CONTROL READ stage USB_TYPE_IDLE
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1251]CONTROL READ SUCCESS [8 bytes transferred]
> 12 01 10 02 00 00 00 40
> 
> [USB_TRANSFER: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:1284]CONTROL ack stage USB_TYPE_IDLE
> [USB_INFO: .\mbed-os\features\unsupported\USBHost\USBHost\USBHost.cpp:183]New device connected: 0x200295ec [hub: 0 - port: 1]

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
