### PR TITLE
STM USBHALHost: Fix NULL pointer dereference

### DIFF
--- a/features/unsupported/USBHost/targets/TARGET_STM/USBHALHost_STM.h
+++ b/features/unsupported/USBHost/targets/TARGET_STM/USBHALHost_STM.h
@@ -122,10 +122,17 @@ static gpio_t gpio_powerpin;
 
 void usb_vbus(uint8_t state)
 {
-    if (state == 0) {
-        gpio_write(&gpio_powerpin, USB_POWER_OFF);
-    } else {
-        gpio_write(&gpio_powerpin, USB_POWER_ON);
+    if (gpio_powerpin.reg_set && gpio_powerpin.reg_clr)
+    {
+        if (state == 0) {
+            gpio_write(&gpio_powerpin, USB_POWER_OFF);
+        } else {
+            gpio_write(&gpio_powerpin, USB_POWER_ON);
+        }
+    }
+    else
+    {
+        /* The board does not have GPIO pin to control usb supply */
     }
     wait(0.2);
 }

--- a/features/unsupported/USBHost/targets/TARGET_STM/USBHALHost_STM.h
+++ b/features/unsupported/USBHost/targets/TARGET_STM/USBHALHost_STM.h
@@ -122,16 +122,13 @@ static gpio_t gpio_powerpin;
 
 void usb_vbus(uint8_t state)
 {
-    if (gpio_powerpin.reg_set && gpio_powerpin.reg_clr)
-    {
+    if (gpio_powerpin.reg_set && gpio_powerpin.reg_clr) {
         if (state == 0) {
             gpio_write(&gpio_powerpin, USB_POWER_OFF);
         } else {
             gpio_write(&gpio_powerpin, USB_POWER_ON);
         }
-    }
-    else
-    {
+    } else {
         /* The board does not have GPIO pin to control usb supply */
     }
     wait(0.2);


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
On STM32F746G Discovery boards, the USB OTG HS port does not have a
dedicated GPIO for controlling the USB VBUS.

This change fixes HardFault (NULL pointer dereference) that triggered
when such USB host port was used.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
