### PR TITLE
Cellular: AT_CellularContext disconnect in non-blocking mode

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -603,15 +603,22 @@ TEST_F(TestAT_CellularContext, connect_disconnect_async)
     ASSERT_EQ(network_cb_count, 5);
     ASSERT_EQ(ctx1.connect(), NSAPI_ERROR_IS_CONNECTED);
     EXPECT_TRUE(ctx1.is_connected() == true);
+    ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_NO_MEMORY);
+    EXPECT_TRUE(ctx1.is_connected() == true);
+
+    struct equeue_event ptr;
+    equeue_stub.void_ptr = &ptr;
+    equeue_stub.call_cb_immediately = true;
     ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
     EXPECT_TRUE(ctx1.is_connected() == false);
 
     // sdet CellularDevice_stub::connect_counter = 0 so device is already attached and will return NSAPI_ERROR_ALREADY to context when calling connect
+    equeue_stub.void_ptr = &ptr;
+    equeue_stub.call_cb_immediately = false;
     CellularDevice_stub::connect_counter = 0;
     // queue can't allocate so return NSAPI_ERROR_NO_MEMORY
     ASSERT_EQ(ctx1.connect(), NSAPI_ERROR_NO_MEMORY);
 
-    struct equeue_event ptr;
     equeue_stub.void_ptr = &ptr;
     equeue_stub.call_cb_immediately = true;
     ASSERT_EQ(ctx1.connect(), NSAPI_ERROR_OK);

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -118,6 +118,7 @@ private:
     AT_CellularBase::CellularProperty pdp_type_t_to_cellular_property(pdp_type_t pdp_type);
     void ciot_opt_cb(mbed::CellularNetwork::CIoT_Supported_Opt ciot_opt);
     virtual void do_connect_with_retry();
+    void do_disconnect();
 private:
     bool _is_connected;
     ContextOperation  _current_op;


### PR DESCRIPTION
### Description

Disconnect was supporting only blocking mode.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica 

### Release Notes
