### PR TITLE
Add hardcoded Echo server defaults for Greentea socket tests.

### DIFF
--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -20,9 +20,6 @@
     (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI && !defined(MBED_CONF_NSAPI_DEFAULT_WIFI_SSID))
 #error [NOT_SUPPORTED] No network configuration found for this target.
 #endif
-#ifndef MBED_CONF_APP_ECHO_SERVER_ADDR
-#error [NOT_SUPPORTED] Requires parameters from mbed_app.json
-#endif
 
 #include "mbed.h"
 #include "greentea-client/test_env.h"
@@ -30,6 +27,10 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "tcp_tests.h"
+
+#ifndef ECHO_SERVER_ADDR
+#error [NOT_SUPPORTED] Requires parameters for echo server
+#endif
 
 using namespace utest::v1;
 
@@ -84,7 +85,7 @@ nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
 {
     SocketAddress tcp_addr;
 
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(port);
 
     printf("MBED: Server '%s', port %d\n", tcp_addr.get_ip_address(), tcp_addr.get_port());
@@ -106,12 +107,12 @@ nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
 
 nsapi_error_t tcpsocket_connect_to_echo_srv(TCPSocket &sock)
 {
-    return tcpsocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_PORT);
+    return tcpsocket_connect_to_srv(sock, ECHO_SERVER_PORT);
 }
 
 nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock)
 {
-    return tcpsocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT);
+    return tcpsocket_connect_to_srv(sock, ECHO_SERVER_DISCARD_PORT);
 }
 
 bool is_tcp_supported()

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -18,6 +18,8 @@
 #ifndef TCP_TESTS_H
 #define TCP_TESTS_H
 
+#include "../test_params.h"
+
 NetworkInterface *get_interface();
 void drop_bad_packets(TCPSocket &sock, int orig_timeout);
 nsapi_version_t get_ip_version();

--- a/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
@@ -33,7 +33,7 @@ void TCPSOCKET_CONNECT_INVALID()
     TEST_ASSERT(sock.connect(NULL, 9) < 0);
     TEST_ASSERT(sock.connect("", 9) < 0);
     TEST_ASSERT(sock.connect("", 0) < 0);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, 9));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(ECHO_SERVER_ADDR, ECHO_SERVER_DISCARD_PORT));
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }

--- a/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -38,7 +38,7 @@ static nsapi_error_t _tcpsocket_connect_to_daytime_srv(TCPSocket &sock)
 {
     SocketAddress tcp_addr;
 
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(13);
 
     nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -33,7 +33,7 @@ static nsapi_error_t _tcpsocket_connect_to_chargen_srv(TCPSocket &sock)
 {
     SocketAddress tcp_addr;
 
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tcp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(19);
 
     nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());

--- a/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_setsockopt_keepalive_valid.cpp
@@ -40,7 +40,7 @@ void TCPSOCKET_SETSOCKOPT_KEEPALIVE_VALID()
     }
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, ret);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, 9));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(ECHO_SERVER_ADDR, 9));
     // LWIP stack does not support getsockopt so the part below is commented out
     //    int32_t optval;
     //    unsigned int optlen;

--- a/TESTS/netsocket/test_params.h
+++ b/TESTS/netsocket/test_params.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TEST_PARAMS_H
+#define TEST_PARAMS_H
+
+#ifndef MBED_CONF_APP_ECHO_SERVER_ADDR
+#define ECHO_SERVER_ADDR "echo.mbedcloudtesting.com"
+#else
+#define ECHO_SERVER_ADDR MBED_CONF_APP_ECHO_SERVER_ADDR
+#endif
+
+#ifndef MBED_CONF_APP_ECHO_SERVER_PORT
+#define ECHO_SERVER_PORT 7
+#else
+#define ECHO_SERVER_PORT MBED_CONF_APP_ECHO_SERVER_PORT
+#endif
+
+#ifndef MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT
+#define ECHO_SERVER_DISCARD_PORT 9
+#else
+#define ECHO_SERVER_DISCARD_PORT MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT
+#endif
+
+#ifndef MBED_CONF_APP_ECHO_SERVER_PORT_TLS
+#define ECHO_SERVER_PORT_TLS 2007
+#else
+#define ECHO_SERVER_PORT_TLS MBED_CONF_APP_ECHO_SERVER_PORT_TLS
+#endif
+
+#ifndef MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS
+#define ECHO_SERVER_DISCARD_PORT_TLS 2009
+#else
+#define ECHO_SERVER_DISCARD_PORT_TLS MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS
+#endif
+
+#endif //TEST_PARAMS_H

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -20,9 +20,6 @@
     (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI && !defined(MBED_CONF_NSAPI_DEFAULT_WIFI_SSID))
 #error [NOT_SUPPORTED] No network configuration found for this target.
 #endif
-#ifndef MBED_CONF_APP_ECHO_SERVER_ADDR
-#error [NOT_SUPPORTED] Requires echo-server-discard-port parameter from mbed_app.json
-#endif
 
 #include "mbed.h"
 #include "greentea-client/test_env.h"
@@ -30,6 +27,10 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "tls_tests.h"
+
+#ifndef ECHO_SERVER_ADDR
+#error [NOT_SUPPORTED] Requires parameters for echo server
+#endif
 
 #if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 
@@ -106,7 +107,7 @@ nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
 {
     SocketAddress tls_addr;
 
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tls_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tls_addr);
     tls_addr.set_port(port);
 
     printf("MBED: Server '%s', port %d\n", tls_addr.get_ip_address(), tls_addr.get_port());
@@ -134,12 +135,12 @@ nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
 
 nsapi_error_t tlssocket_connect_to_echo_srv(TLSSocket &sock)
 {
-    return tlssocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_PORT_TLS);
+    return tlssocket_connect_to_srv(sock, ECHO_SERVER_PORT_TLS);
 }
 
 nsapi_error_t tlssocket_connect_to_discard_srv(TLSSocket &sock)
 {
-    return tlssocket_connect_to_srv(sock, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS);
+    return tlssocket_connect_to_srv(sock, ECHO_SERVER_DISCARD_PORT_TLS);
 }
 
 bool is_tcp_supported()

--- a/TESTS/netsocket/tls/tls_tests.h
+++ b/TESTS/netsocket/tls/tls_tests.h
@@ -18,6 +18,7 @@
 #ifndef TLS_TESTS_H
 #define TLS_TESTS_H
 
+#include "../test_params.h"
 #include "TLSSocket.h"
 
 #if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)

--- a/TESTS/netsocket/tls/tlssocket_connect_invalid.cpp
+++ b/TESTS/netsocket/tls/tlssocket_connect_invalid.cpp
@@ -33,12 +33,12 @@ void TLSSOCKET_CONNECT_INVALID()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));
 
-    TEST_ASSERT(sock.connect(NULL, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS) < 0);
-    TEST_ASSERT(sock.connect("", MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS) < 0);
+    TEST_ASSERT(sock.connect(NULL, ECHO_SERVER_DISCARD_PORT_TLS) < 0);
+    TEST_ASSERT(sock.connect("", ECHO_SERVER_DISCARD_PORT_TLS) < 0);
     TEST_ASSERT(sock.connect("", 0) < 0);
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK,
-                      sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, MBED_CONF_APP_ECHO_SERVER_DISCARD_PORT_TLS));
+                      sock.connect(ECHO_SERVER_ADDR, ECHO_SERVER_DISCARD_PORT_TLS));
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }

--- a/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
@@ -40,7 +40,7 @@ static nsapi_error_t _tlssocket_connect_to_daytime_srv(TLSSocket &sock)
 {
     SocketAddress tls_addr;
 
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &tls_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tls_addr);
     tls_addr.set_port(2013);
 
     nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());

--- a/TESTS/netsocket/tls/tlssocket_no_cert.cpp
+++ b/TESTS/netsocket/tls/tlssocket_no_cert.cpp
@@ -32,7 +32,7 @@ void TLSSOCKET_NO_CERT()
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE,
-                      sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, MBED_CONF_APP_ECHO_SERVER_PORT_TLS));
+                      sock.connect(ECHO_SERVER_ADDR, ECHO_SERVER_PORT_TLS));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }
 

--- a/TESTS/netsocket/tls/tlssocket_send_closed.cpp
+++ b/TESTS/netsocket/tls/tlssocket_send_closed.cpp
@@ -33,7 +33,7 @@ void TLSSOCKET_SEND_CLOSED()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK,
-                      sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, MBED_CONF_APP_ECHO_SERVER_PORT_TLS));
+                      sock.connect(ECHO_SERVER_ADDR, ECHO_SERVER_PORT_TLS));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
     TEST_ASSERT_EQUAL(NSAPI_ERROR_NO_SOCKET, sock.send("12345", 5));
 }

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -20,9 +20,6 @@
     (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI && !defined(MBED_CONF_NSAPI_DEFAULT_WIFI_SSID))
 #error [NOT_SUPPORTED] No network configuration found for this target.
 #endif
-#ifndef MBED_CONF_APP_ECHO_SERVER_ADDR
-#error [NOT_SUPPORTED] Requires parameters from mbed_app.json
-#endif
 
 #include "mbed.h"
 #include "greentea-client/test_env.h"
@@ -30,6 +27,10 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "udp_tests.h"
+
+#ifndef ECHO_SERVER_ADDR
+#error [NOT_SUPPORTED] Requires parameters for echo server
+#endif
 
 using namespace utest::v1;
 

--- a/TESTS/netsocket/udp/udp_tests.h
+++ b/TESTS/netsocket/udp/udp_tests.h
@@ -18,6 +18,8 @@
 #ifndef UDP_TESTS_H
 #define UDP_TESTS_H
 
+#include "../test_params.h"
+
 NetworkInterface *get_interface();
 void drop_bad_packets(UDPSocket &sock, int orig_timeout);
 nsapi_version_t get_ip_version();

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -60,8 +60,8 @@ static void _sigio_handler()
 void UDPSOCKET_ECHOTEST()
 {
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
-    udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
+    udp_addr.set_port(ECHO_SERVER_PORT);
 
     UDPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
@@ -143,8 +143,8 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
     time_allotted = split2half_rmng_udp_test_time(); // [s]
 
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
-    udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
+    udp_addr.set_port(ECHO_SERVER_PORT);
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     sock.set_blocking(false);

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -71,8 +71,8 @@ static void _sigio_handler(osThreadId id)
 void UDPSOCKET_ECHOTEST_BURST()
 {
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
-    udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
+    udp_addr.set_port(ECHO_SERVER_PORT);
 
     UDPSocket sock;
     const int TIMEOUT = 5000; // [ms]
@@ -154,8 +154,8 @@ void UDPSOCKET_ECHOTEST_BURST()
 void UDPSOCKET_ECHOTEST_BURST_NONBLOCK()
 {
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
-    udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
+    udp_addr.set_port(ECHO_SERVER_PORT);
 
     UDPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -38,8 +38,8 @@ static void _sigio_handler(osThreadId id)
 void UDPSOCKET_RECV_TIMEOUT()
 {
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
-    udp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
+    udp_addr.set_port(ECHO_SERVER_PORT);
 
     static const int DATA_LEN = 100;
     char buff[DATA_LEN] = {0};

--- a/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
@@ -33,12 +33,12 @@ void UDPSOCKET_SENDTO_INVALID()
     TEST_ASSERT(sock.sendto("", 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 0, NULL, 0) < 0);
 
-    nsapi_error_t result = sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, NULL, 0);
+    nsapi_error_t result = sock.sendto(ECHO_SERVER_ADDR, 9, NULL, 0);
     if (result != NSAPI_ERROR_UNSUPPORTED) {
         TEST_ASSERT_EQUAL(0, result);
     }
 
-    TEST_ASSERT_EQUAL(5, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, "hello", 5));
+    TEST_ASSERT_EQUAL(5, sock.sendto(ECHO_SERVER_ADDR, 9, "hello", 5));
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }

--- a/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_repeat.cpp
@@ -30,7 +30,7 @@ void UDPSOCKET_SENDTO_REPEAT()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(9);
 
     int sent;

--- a/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
@@ -33,7 +33,7 @@ void UDPSOCKET_SENDTO_TIMEOUT()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
 
     SocketAddress udp_addr;
-    NetworkInterface::get_default_instance()->gethostbyname(MBED_CONF_APP_ECHO_SERVER_ADDR, &udp_addr);
+    NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(9);
 
     Timer timer;


### PR DESCRIPTION
### Description
Default  setings for Greentea Echo server are now  moved to separate header file. 
Now  socket tests can be built without  echo server settings in app JSON configuration file .

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

 @SeppoTakalo 
@kjbracey-arm 

### Release Notes

 
