### PR TITLE
Add compilation flags to rf_configuration

### DIFF
--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.c
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.c
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
+
 #include "nanostack/platform/arm_hal_phy.h"
 #include "rf_configuration.h"
 
@@ -167,3 +170,6 @@ uint32_t rf_conf_calculate_deviation(phy_modulation_index_e modulation_index, ui
     }
     return deviation;
 }
+
+#endif // MBED_CONF_NANOSTACK_CONFIGURATION && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
+


### PR DESCRIPTION
Add flags to allow compilation without nanostack.

### Description

Fix to issue https://github.com/ARMmbed/mbed-os/issues/10678
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@JarkkoPaso 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
