### PR TITLE
MAX32630.sct fix

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32630/device/TOOLCHAIN_ARM_STD/MAX3263x.sct
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/device/TOOLCHAIN_ARM_STD/MAX3263x.sct
@@ -4,7 +4,7 @@
 ; 512KB RAM (0x80000) @ 0x20000000
 
 #if !defined(MBED_BOOT_STACK_SIZE)
-  #define MBED_BOOT_STACK_SIZE 0x800
+  #define MBED_BOOT_STACK_SIZE 0x400
 #endif
 
 #define Stack_Size MBED_BOOT_STACK_SIZE


### PR DESCRIPTION
### Description

Fixed error that stop the compiling for the MAX32630 in the releases from 2019/01/9.

Corrected a miswriting error in the STD toolchain that blocks the compiling to the MAX32630.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
