### PR TITLE
Cellular: Fix socket connect on UBLOX_AT driver

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -161,7 +161,7 @@ nsapi_error_t UBLOX_AT_CellularStack::socket_connect(nsapi_socket_t handle, cons
     CellularSocket *socket = (CellularSocket *)handle;
 
     if (socket) {
-        if (socket->id != SOCKET_UNUSED) {
+        if (socket->id == SOCKET_UNUSED) {
             nsapi_error_t err = create_socket_impl(socket);
             if (err != NSAPI_ERROR_OK) {
                 return err;
@@ -177,9 +177,10 @@ nsapi_error_t UBLOX_AT_CellularStack::socket_connect(nsapi_socket_t handle, cons
     _at.write_string(addr.get_ip_address());
     _at.write_int(addr.get_port());
     _at.cmd_stop_read_resp();
+    nsapi_error_t err = _at.get_last_error();
     _at.unlock();
 
-    if (_at.get_last_error() == NSAPI_ERROR_OK) {
+    if (err == NSAPI_ERROR_OK) {
         socket->remoteAddress = addr;
         socket->connected = true;
         return NSAPI_ERROR_OK;


### PR DESCRIPTION
### Description

Fix `socket_connect` to create a new socket when trying to connect with an id SOCKET_UNUSED.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarvte 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
