### PR TITLE
STM32H7: flash issue while erasing sector in Bank 1

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/flash_api.c
@@ -79,12 +79,6 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
         if (HAL_FLASHEx_Erase(&EraseInitStruct, &SectorError) != HAL_OK) {
             status =  -1;
         }
-        /* Mass erase of second bank */
-        EraseInitStruct.TypeErase = FLASH_TYPEERASE_MASSERASE;
-        EraseInitStruct.Banks = FLASH_BANK_2;
-        if (HAL_FLASHEx_Erase(&EraseInitStruct, &SectorError) != HAL_OK) {
-            status = -1;
-        }
     } else {
         EraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
         EraseInitStruct.Banks = FLASH_BANK_2;


### PR DESCRIPTION
### Description

This fix #10691 

Erasing a sector in bank one of the flash leads to a mass-erase of bank two.

@supertoast


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
