### PR TITLE
timeout_tests: do not call sleep from test thread

### DIFF
--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -264,9 +264,7 @@ void test_sleep(void)
 
     bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_FALSE_MESSAGE(deep_sleep_allowed, "Deep sleep should be disallowed");
-    while (!sem.try_acquire()) {
-        sleep();
-    }
+    sem.acquire();
     timer.stop();
 
     sleep_manager_unlock_deep_sleep();
@@ -323,9 +321,7 @@ void test_deepsleep(void)
 
     bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
-    while (!sem.try_acquire()) {
-        sleep();
-    }
+    sem.acquire();
     timer.stop();
 
     TEST_ASSERT_UINT64_WITHIN(delta_us, delay_us, timer.read_high_resolution_us());


### PR DESCRIPTION

### Description

This is up to scheduler to call sleep when threads are inactive.
So the thread should simply wait for the semaphore for ever (or test timeout).

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x ] Test update
    [ ] Breaking change

### Reviewers
@jeromecoutant @mprse 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
