### PR TITLE
MbedCRC: make buffers const void *

### DIFF
--- a/drivers/MbedCRC.h
+++ b/drivers/MbedCRC.h
@@ -146,7 +146,7 @@ public:
      *  @param  crc  CRC is the output value
      *  @return  0 on success, negative error code on failure
      */
-    int32_t compute(void *buffer, crc_data_size_t size, uint32_t *crc)
+    int32_t compute(const void *buffer, crc_data_size_t size, uint32_t *crc)
     {
         MBED_ASSERT(crc != NULL);
         int32_t status = 0;
@@ -193,7 +193,7 @@ public:
      *  @note: CRC as output in compute_partial is not final CRC value, call `compute_partial_stop`
      *         to get final correct CRC value.
      */
-    int32_t compute_partial(void *buffer, crc_data_size_t size, uint32_t *crc)
+    int32_t compute_partial(const void *buffer, crc_data_size_t size, uint32_t *crc)
     {
         int32_t status = 0;
 

--- a/drivers/MbedCRC.h
+++ b/drivers/MbedCRC.h
@@ -200,7 +200,7 @@ public:
         switch (_mode) {
 #if DEVICE_CRC
             case HARDWARE:
-                hal_crc_compute_partial((uint8_t *)buffer, size);
+                hal_crc_compute_partial(static_cast<const uint8_t *>(buffer), size);
                 *crc = 0;
                 break;
 #endif


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
In MbedCRC, changing the following buffers from void * to const void *:
int32_t compute(const void *buffer, crc_data_size_t size, uint32_t *crc)
int32_t compute_partial(const void *buffer, crc_data_size_t size, uint32_t *crc)

This addresses issue #8287 (IOTCORE-556)

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->