### PR TITLE
STM: replace C++ low power ticker wrapper with a low level wrapper

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -41,8 +41,11 @@
 #include "platform/mbed_critical.h"
 #include <stdbool.h>
 
-#if !defined(LPTICKER_DELAY_TICKS) || (LPTICKER_DELAY_TICKS < 3)
-#warning "lpticker_delay_ticks value should be set to 3"
+/*  lpticker delay is for using C++ Low Power Ticker wrapper,
+ *  which introduces extra delays. We rather want to use the
+ *  low level implementation from this file */
+#if defined(LPTICKER_DELAY_TICKS) && (LPTICKER_DELAY_TICKS > 0)
+#warning "lpticker_delay_ticks usage not recommended"
 #endif
 
 #define LP_TIMER_WRAP(val) (val & 0xFFFF)

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -226,8 +226,15 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
     /* Any successive write before the CMPOK flag be set, will lead to unpredictable results */
     /* LPTICKER_DELAY_TICKS value prevents OS to call this set interrupt function before CMPOK */
     MBED_ASSERT(__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == SET);
-    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-    __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
+
+    if(timestamp < lp_ticker_read()) {
+        /*  Workaround, because limitation */
+        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+        __HAL_LPTIM_COMPARE_SET(&LptimHandle, ~0);
+    } else {
+        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+        __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
+    }
 
     lp_ticker_clear_interrupt();
 

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -37,10 +37,20 @@
 
 #include "lp_ticker_api.h"
 #include "mbed_error.h"
+#include "mbed_power_mgmt.h"
+#include "platform/mbed_critical.h"
+#include <stdbool.h>
 
 #if !defined(LPTICKER_DELAY_TICKS) || (LPTICKER_DELAY_TICKS < 3)
 #warning "lpticker_delay_ticks value should be set to 3"
 #endif
+
+#define LP_TIMER_WRAP(val) (val & 0xFFFF)
+/* Safe guard is the number of ticks between the current tick and the next
+ * tick we want to program an interrupt for. Programing an interrupt in
+ * between is unreliable */
+#define LP_TIMER_SAFE_GUARD 5
+
 
 LPTIM_HandleTypeDef LptimHandle;
 
@@ -58,9 +68,13 @@ const ticker_info_t *lp_ticker_get_info()
 }
 
 volatile uint8_t  lp_Fired = 0;
+/*  Flag and stored counter to handle delayed programing at low level */
+volatile bool lp_delayed_prog = false;
+volatile bool lp_cmpok = false;
+volatile timestamp_t lp_delayed_counter = 0;
+volatile bool sleep_manager_locked = false;
 
 static int LPTICKER_inited = 0;
-
 static void LPTIM1_IRQHandler(void);
 static void (*irq_handler)(void);
 
@@ -168,6 +182,7 @@ void lp_ticker_init(void)
 #endif
 
     __HAL_LPTIM_ENABLE_IT(&LptimHandle, LPTIM_IT_CMPM);
+    __HAL_LPTIM_ENABLE_IT(&LptimHandle, LPTIM_IT_CMPOK);
     HAL_LPTIM_Counter_Start(&LptimHandle, 0xFFFF);
 
     /* Need to write a compare value in order to get LPTIM_FLAG_CMPOK in set_interrupt */
@@ -175,14 +190,24 @@ void lp_ticker_init(void)
     __HAL_LPTIM_COMPARE_SET(&LptimHandle, 0);
     while (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == RESET) {
     }
+    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+
+    /* Init is called with Interrupts disabled, so the CMPOK interrupt
+     * will not be handler. Let's mark it is now safe to write to LP counter */
+    lp_cmpok = true;
 }
 
 static void LPTIM1_IRQHandler(void)
 {
+    core_util_critical_section_enter();
+
     LptimHandle.Instance = LPTIM1;
 
     if (lp_Fired) {
         lp_Fired = 0;
+        /* We're already in handler and interrupt might be pending,
+         * so clear the flag, to avoid calling irq_handler twice */
+        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
         if (irq_handler) {
             irq_handler();
         }
@@ -193,17 +218,33 @@ static void LPTIM1_IRQHandler(void)
         if (__HAL_LPTIM_GET_IT_SOURCE(&LptimHandle, LPTIM_IT_CMPM) != RESET) {
             /* Clear Compare match flag */
             __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
-
             if (irq_handler) {
                 irq_handler();
             }
         }
     }
 
+    if (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) != RESET) {
+        if (__HAL_LPTIM_GET_IT_SOURCE(&LptimHandle, LPTIM_IT_CMPOK) != RESET) {
+            __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+            lp_cmpok = true;
+            if(sleep_manager_locked) {
+                sleep_manager_unlock_deep_sleep();
+                sleep_manager_locked = false;
+            }
+            if(lp_delayed_prog) {
+                lp_ticker_set_interrupt(lp_delayed_counter);
+                lp_delayed_prog = false;
+            }
+        }
+    }
+
+
 #if defined (__HAL_LPTIM_WAKEUPTIMER_EXTI_CLEAR_FLAG)
     /* EXTI lines are not configured by default */
     __HAL_LPTIM_WAKEUPTIMER_EXTI_CLEAR_FLAG();
 #endif
+    core_util_critical_section_exit();
 }
 
 uint32_t lp_ticker_read(void)
@@ -217,49 +258,102 @@ uint32_t lp_ticker_read(void)
     return lp_time;
 }
 
+/*  This function should always be called from critical section */
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
     LptimHandle.Instance = LPTIM1;
     irq_handler = (void (*)(void))lp_ticker_irq_handler;
+    core_util_critical_section_enter();
 
-    /* CMPOK is set by hardware to inform application that the APB bus write operation to the LPTIM_CMP register has been successfully completed */
-    /* Any successive write before the CMPOK flag be set, will lead to unpredictable results */
-    /* LPTICKER_DELAY_TICKS value prevents OS to call this set interrupt function before CMPOK */
-    MBED_ASSERT(__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == SET);
-
-    if(timestamp < lp_ticker_read()) {
-        /*  Workaround, because limitation */
-        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-        __HAL_LPTIM_COMPARE_SET(&LptimHandle, ~0);
-    } else {
-        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-        __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
-    }
-
-    lp_ticker_clear_interrupt();
-
+    /* Always store the last requested timestamp */
+    lp_delayed_counter = timestamp;
     NVIC_EnableIRQ(LPTIM1_IRQn);
+
+    /* CMPOK is set by hardware to inform application that the APB bus write operation to the
+     * LPTIM_CMP register has been successfully completed.
+     * Any successive write before the CMPOK flag be set, will lead to unpredictable results
+     * We need to prevent to set a new comparator value before CMPOK flag is set by HW */
+    if (lp_cmpok == false) {
+        /* if this is not safe to write, then delay the programing to the
+         * time when CMPOK interrupt will trigger */
+        lp_delayed_prog = true;
+    } else {
+        timestamp_t last_read_counter = lp_ticker_read();
+        lp_ticker_clear_interrupt();
+
+        /*  HW is not able to trig a very short term interrupt, that is
+         *  not less than few ticks away (LP_TIMER_SAFE_GUARD). So let's make sure it'
+         *  s at least current tick + LP_TIMER_SAFE_GUARD */
+        for(uint8_t i = 0; i < LP_TIMER_SAFE_GUARD; i++) {
+            if (LP_TIMER_WRAP(last_read_counter  + i) == timestamp) {
+                timestamp = LP_TIMER_WRAP(timestamp + LP_TIMER_SAFE_GUARD);
+            }
+        }
+        /* Then check if this target timestamp is not in the past, or close to wrap-around */
+        if((timestamp < last_read_counter) && (last_read_counter <= (0xFFFF - LP_TIMER_SAFE_GUARD))) {
+            /*  Workaround, because limitation */
+            __HAL_LPTIM_COMPARE_SET(&LptimHandle, ~0);
+        } else {
+            /*  It is safe to write */
+            __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
+        }
+
+        /* We just programed the CMP so we'll need to wait for cmpok before
+         * next programing */
+        lp_cmpok = false;
+        /*  Prevent from sleeping after compare register was set as we need CMPOK
+         *  interrupt to fire (in ~3x30us cycles) before we can safely enter deep sleep mode */
+        if(!sleep_manager_locked) {
+            sleep_manager_lock_deep_sleep();
+            sleep_manager_locked = true;
+        }
+    }
+    core_util_critical_section_exit();
 }
 
 void lp_ticker_fire_interrupt(void)
 {
+    core_util_critical_section_enter();
     lp_Fired = 1;
+    /* In case we fire interrupt now, then cancel pending programing */
+    lp_delayed_prog = false;
     irq_handler = (void (*)(void))lp_ticker_irq_handler;
     NVIC_SetPendingIRQ(LPTIM1_IRQn);
     NVIC_EnableIRQ(LPTIM1_IRQn);
+    core_util_critical_section_exit();
 }
 
 void lp_ticker_disable_interrupt(void)
 {
+    core_util_critical_section_enter();
+
+    if(!lp_cmpok) {
+        while (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == RESET) {
+        }
+        __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+        lp_cmpok = true;
+    }
+    /*  now that CMPOK is set, allow deep sleep again */
+    if(sleep_manager_locked) {
+        sleep_manager_unlock_deep_sleep();
+        sleep_manager_locked = false;
+    }
+    irq_handler = NULL;
+    lp_delayed_prog = false;
     NVIC_DisableIRQ(LPTIM1_IRQn);
+    NVIC_ClearPendingIRQ(LPTIM1_IRQn);
     LptimHandle.Instance = LPTIM1;
+
+    core_util_critical_section_exit();
 }
 
 void lp_ticker_clear_interrupt(void)
 {
+    core_util_critical_section_enter();
     LptimHandle.Instance = LPTIM1;
     __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
     NVIC_ClearPendingIRQ(LPTIM1_IRQn);
+    core_util_critical_section_exit();
 }
 
 void lp_ticker_free(void)

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -203,8 +203,6 @@ static void LPTIM1_IRQHandler(void)
 {
     core_util_critical_section_enter();
 
-    LptimHandle.Instance = LPTIM1;
-
     if (lp_Fired) {
         lp_Fired = 0;
         /* We're already in handler and interrupt might be pending,
@@ -259,7 +257,6 @@ uint32_t lp_ticker_read(void)
 /*  This function should always be called from critical section */
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    LptimHandle.Instance = LPTIM1;
     core_util_critical_section_enter();
 
     /* Always store the last requested timestamp */
@@ -348,7 +345,6 @@ void lp_ticker_disable_interrupt(void)
     lp_Fired = 0;
     NVIC_DisableIRQ(LPTIM1_IRQn);
     NVIC_ClearPendingIRQ(LPTIM1_IRQn);
-    LptimHandle.Instance = LPTIM1;
 
     core_util_critical_section_exit();
 }
@@ -356,7 +352,6 @@ void lp_ticker_disable_interrupt(void)
 void lp_ticker_clear_interrupt(void)
 {
     core_util_critical_section_enter();
-    LptimHandle.Instance = LPTIM1;
     __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
     NVIC_ClearPendingIRQ(LPTIM1_IRQn);
     core_util_critical_section_exit();

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1889,7 +1889,6 @@
         },
         "overrides": {
             "deep-sleep-latency": 3,
-            "tickless-from-us-ticker": true,
             "init-us-ticker-at-boot": true
         },
         "device_has": [
@@ -2545,7 +2544,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 4, "tickless-from-us-ticker": true },
         "detect_code": ["0744"],
         "device_has_add": [
             "ANALOGOUT",
@@ -2716,7 +2715,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 4, "tickless-from-us-ticker": true },
         "detect_code": ["0743"],
         "macros_add": [
             "MBED_TICKLESS",
@@ -2758,7 +2757,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 4, "tickless-from-us-ticker": true},
         "detect_code": ["0743"],
         "macros_add": [
             "MBED_TICKLESS",
@@ -3061,7 +3060,7 @@
         "device_name": "STM32F746ZG",
         "bootloader_supported": true,
         "overrides": {
-            "lpticker_delay_ticks": 4,
+            "lpticker_delay_ticks": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -3112,7 +3111,7 @@
         "release_versions": ["2", "5"],
         "device_name": "STM32F756ZG",
         "overrides": {
-            "lpticker_delay_ticks": 4,
+            "lpticker_delay_ticks": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -3168,7 +3167,7 @@
         "device_name": "STM32F767ZI",
         "bootloader_supported": true,
         "overrides": {
-            "lpticker_delay_ticks": 4,
+            "lpticker_delay_ticks": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -3204,7 +3203,7 @@
             "STM32H743xx",
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0813"],
         "device_has_add": [
@@ -3265,7 +3264,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0780"],
         "device_has_add": [
             "CRC",
@@ -3291,7 +3290,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0790"],
         "device_has_add": [
             "CRC",
@@ -3317,7 +3316,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0715"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3343,13 +3342,13 @@
             },
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
-                "value": 0
+                "value": 1
             }
         },
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0760"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3403,7 +3402,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0770"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3437,7 +3436,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0779"],
         "device_has_add": [
             "ANALOGOUT",
@@ -3496,7 +3495,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0765"],
         "macros_add": [
             "MBED_TICKLESS",
@@ -3558,7 +3557,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0827"],
         "macros_add": [
             "MBED_TICKLESS",
@@ -3967,7 +3966,7 @@
         },
         "overrides": {
             "lse_available": 0,
-            "lpticker_delay_ticks": 4
+            "lpticker_delay_ticks": 0
         },
         "device_has_add": [
             "ANALOGOUT",
@@ -4003,7 +4002,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0833"],
         "device_has_add": [
             "ANALOGOUT",
@@ -4087,7 +4086,7 @@
         "device_name": "STM32F746NG",
         "bootloader_supported": true,
         "overrides": {
-            "lpticker_delay_ticks": 4,
+            "lpticker_delay_ticks": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -4140,7 +4139,7 @@
         "release_versions": ["2", "5"],
         "device_name": "STM32F769NI",
         "overrides": {
-            "lpticker_delay_ticks": 4,
+            "lpticker_delay_ticks": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },
@@ -4160,7 +4159,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
         "macros_add": [
@@ -4228,7 +4227,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0820"],
         "macros_add": [
             "MBED_TICKLESS",
@@ -4265,7 +4264,7 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["1500"],
         "macros_add": [
             "MBED_TICKLESS",
@@ -7732,7 +7731,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0822"],
         "device_has_add": [
             "ANALOGOUT",
@@ -7768,7 +7767,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0823"],
         "device_has_add": [
             "ANALOGOUT",
@@ -7807,7 +7806,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0776"],
         "device_has_add": [
             "ANALOGOUT",
@@ -7846,7 +7845,7 @@
         "macros_add": [
             "MBED_TICKLESS"
         ],
-        "overrides": { "lpticker_delay_ticks": 4 },
+        "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0839"],
         "device_has_add": [
 			"CRC",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3041,6 +3041,7 @@
         },
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER"
         ],
         "supported_form_factors": ["ARDUINO"],
@@ -3092,6 +3093,7 @@
         },
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER",
             "MBEDTLS_CONFIG_HW_SUPPORT"
         ],
@@ -3149,6 +3151,7 @@
         "supported_form_factors": ["ARDUINO"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER"
         ],
         "detect_code": ["0818"],
@@ -3201,6 +3204,7 @@
         },
         "macros_add": [
             "STM32H743xx",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "MBED_TICKLESS"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
@@ -3265,6 +3269,9 @@
             }
         },
         "overrides": { "lpticker_delay_ticks": 0 },
+        "macros_add": [
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
         "detect_code": ["0780"],
         "device_has_add": [
             "CRC",
@@ -3290,6 +3297,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0790"],
         "device_has_add": [
@@ -3316,6 +3326,9 @@
                 "value": 1
             }
         },
+        "macros_add": [
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0715"],
         "device_has_add": [
@@ -3346,7 +3359,8 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0760"],
@@ -3400,7 +3414,7 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS", "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0770"],
@@ -3434,7 +3448,7 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS", "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0779"],
@@ -3499,6 +3513,7 @@
         "detect_code": ["0765"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER",
             "MBED_SPLIT_HEAP"
         ],
@@ -3561,6 +3576,7 @@
         "detect_code": ["0827"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER",
             "MBEDTLS_CONFIG_HW_SUPPORT",
             "MBED_SPLIT_HEAP"
@@ -3964,7 +3980,11 @@
                 "value": 1
             }
         },
-        "overrides": {
+        "macros_add": [
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
+        ],
+            "overrides": {
             "lse_available": 0,
             "lpticker_delay_ticks": 0
         },
@@ -4000,7 +4020,8 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0833"],
@@ -4067,6 +4088,7 @@
         "detect_code": ["0815"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USB_STM_HAL",
             "USBHOST_OTHER"
         ],
@@ -4120,6 +4142,7 @@
         "detect_code": ["0817"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USB_STM_HAL",
             "USBHOST_OTHER"
         ],
@@ -4164,6 +4187,7 @@
         "detect_code": ["0764"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER",
             "MBED_SPLIT_HEAP"
         ],
@@ -4231,6 +4255,7 @@
         "detect_code": ["0820"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER",
             "MBED_SPLIT_HEAP"
         ],
@@ -4268,6 +4293,7 @@
         "detect_code": ["1500"],
         "macros_add": [
             "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED",
             "USBHOST_OTHER",
             "MBED_SPLIT_HEAP"
         ],
@@ -7729,7 +7755,8 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0822"],
@@ -7765,7 +7792,8 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0823"],
@@ -7804,7 +7832,8 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0776"],
@@ -7843,7 +7872,8 @@
             }
         },
         "macros_add": [
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "EXTRA_IDLE_STACK_REQUIRED"
         ],
         "overrides": { "lpticker_delay_ticks": 0 },
         "detect_code": ["0839"],


### PR DESCRIPTION
### Description
This series of commits aims at removing the latency limitation of the LP ticker wrapper. 

Current situation is that workaround from #9785 makes TICKLESS actually work without real deep sleep usage. #9785  was introduced because of latency issue with the C++ wrapper layer. 

With this Pull request the C+ wrapper layer is removed and replaced by a low level wrapper in lp ticker driver of STM targets. This direction was suggested by @c1728p9 and supported by @mprse 

Implementation of this low level wrapper require many specific implementation detailed in separate commits because of the way the LP TIMER HW is designed. 

In particular, the LP TIMER ticker cannot be programmed for a timestamp in the past, so we need to program a wake-up interrupt at the wrap-around (0xFFFF), then the next interrupt will be programmed again. Also the LP TIMER cannot cope with programming an interrupt within the next few low power clock 32KHz cycles, corresponding to the time it takes for CMPOK flag to be set, which means new comparator value is taken into account. Those design constraints are taken into account in this new implementation. 

The changes in this pull request have dependencies to a few test cases updates: 
#10536 #10698  #10700

Also changes to IDLE stack size are needed:
#10702  #10781 

Also this PR supersedes #10537 that will be closed. The commit from #10537 is actually included in this new PR. 

This PR should also solve #9962 and it reverts #10572 by enabling back LPTIM on NUCLEO_L073RZ.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@c1728p9 @mprse @jeromecoutant 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

The test results are good and show significant improvements on latencies. 
@mprse has verified that interrupt latencie is now lower than it was, allowing reliable serial communication @115200kbps on NUCLEO_L476RG target and 57600kbps on NUCLEO_L073RZ. 

Complete test suites have been run on 
TOOL_CHAIN=ARMC6,GCC_ARM,IAR
Executed targets : ['NUCLEO_WB55RG']
Executed targets : ['NUCLEO_L476RG']
Executed targets : ['NUCLEO_L073RZ'] 
And there is still a pending issue to be understood that might come from common ticker layer and was not seen before. @mprse is looking at it. 