### PR TITLE
Add extra idle debug stack size in case all STATS are enabled

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -47,7 +47,7 @@
 #endif
 
 // Increase the idle thread stack size when debug is enabled
-#if defined(MBED_DEBUG)
+#if defined(MBED_DEBUG) || defined(MBED_ALL_STATS_ENABLED)
 #define EXTRA_IDLE_STACK_DEBUG MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE_DEBUG_EXTRA
 #else
 #define EXTRA_IDLE_STACK_DEBUG 0


### PR DESCRIPTION
### Description

Idea is to add the extra DEBUG idle stack size also when ALL STATS configuration is enabled.
This is avoid stack overflows when activating this configuration.

Possibly related PR: #10079


<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
