### PR TITLE
mem pool size: Fix calculation of memory pool size for portability

### DIFF
--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -183,8 +183,7 @@ public:
 
 private:
     osMemoryPoolId_t             _id;
-    /* osMemoryPoolNew requires that pool block size is a multiple of 4 bytes. */
-    char                         _pool_mem[((sizeof(T) + 3) & ~3) * pool_sz];
+    char                         _pool_mem[MBED_RTOS_STORAGE_MEM_POOL_MEM_SIZE(pool_sz, sizeof(T))];
     mbed_rtos_storage_mem_pool_t _obj_mem;
 };
 /** @}*/
@@ -192,5 +191,3 @@ private:
 
 }
 #endif
-
-

--- a/rtos/TARGET_CORTEX/mbed_rtos_storage.h
+++ b/rtos/TARGET_CORTEX/mbed_rtos_storage.h
@@ -52,6 +52,9 @@ typedef osRtxEventFlags_t mbed_rtos_storage_event_flags_t;
 typedef osRtxMessage_t mbed_rtos_storage_message_t;
 typedef osRtxTimer_t mbed_rtos_storage_timer_t;
 
+#define MBED_RTOS_STORAGE_MEM_POOL_MEM_SIZE(block_count, block_size) \
+  osRtxMemoryPoolMemSize(block_count, block_size)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Description

Replace the hardcoded value calculation of the memory pool block size
with the RTX preprocessor macro (via a shim layer).
This is in preparation for the replacement of the direct access of RTX
functionalities in Mbed OS with an access via CMSIS.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@0xc0170 

fixes: #9119 
