### PR TITLE
TARGET_STM: SPI: add pulse on master transmissions

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -182,8 +182,14 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
         handle->Init.NSS = SPI_NSS_HARD_OUTPUT;
+#if defined(SPI_NSS_PULSE_ENABLE)
+        handle->Init.NSSPMode = SPI_NSS_PULSE_ENABLE;
+#endif
     } else {
         handle->Init.NSS = SPI_NSS_SOFT;
+#if defined(SPI_NSS_PULSE_DISABLE)
+        handle->Init.NSSPMode = SPI_NSS_PULSE_DISABLE;
+#endif
     }
 
     /* Fill default value */
@@ -206,7 +212,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     handle->Init.TIMode            = SPI_TIMODE_DISABLE;
 
 #if TARGET_STM32H7
-    handle->Init.NSSPMode          = SPI_NSS_PULSE_DISABLE;
     handle->Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_ENABLE;
     handle->Init.FifoThreshold     = SPI_FIFO_THRESHOLD_01DATA;
 #endif


### PR DESCRIPTION
### Description

Add a pulse when using hardware chip select for SPI transmissions.
CS is at low level when a transmission is on-going.

Be careful, this is not compatible with all modes. It will work only
if PHA is 0, ie spi mode is 0 or 2. See stm32xx reference manual,
chapter "NSS pulse mode" for more details.

Fix #10671

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change


