### PR TITLE
Default to Cordio BLE stack for NRF52* targets

### DIFF
--- a/TESTS/mbed_hal/critical_section/main.cpp
+++ b/TESTS/mbed_hal/critical_section/main.cpp
@@ -28,12 +28,9 @@ using utest::v1::Case;
 
 bool test_are_interrupts_enabled(void)
 {
-    // NRF5x targets don't disable interrupts when in critical section, instead they mask application interrupts this is due to BLE stack
-    // (BLE to be operational requires some interrupts to be always enabled)
-#if defined(TARGET_NRF52)
-    // check if APP interrupts are masked for NRF52 boards
-    return (((NVIC->ISER[0] & __NRF_NVIC_APP_IRQS_0) != 0) || ((NVIC->ISER[1] & __NRF_NVIC_APP_IRQS_1) != 0));
-#elif defined(TARGET_NRF51)
+    // NRF51 targets don't disable interrupts when in critical section, instead they mask application interrupts.
+    // This is due to SoftDevice BLE stack (BLE to be operational requires some interrupts to be always enabled)
+#if defined(TARGET_NRF51)
     // check if APP interrupts are masked for other NRF51 boards
     return ((NVIC->ISER[0] & __NRF_NVIC_APP_IRQS_0) != 0);
 #else

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/transport/main.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/transport/main.cpp
@@ -33,6 +33,10 @@ using ble::vendor::cordio::CordioHCITransportDriver;
 
 extern ble::vendor::cordio::CordioHCIDriver& ble_cordio_get_hci_driver();
 
+#if CORDIO_ZERO_COPY_HCI
+#error [NOT_SUPPORTED] Test not relevant for zero copy hci.
+#endif
+
 namespace ble {
 namespace vendor {
 namespace cordio {

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/stack/sources/pal_crypto.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/stack/sources/pal_crypto.c
@@ -23,7 +23,7 @@
 
 #include "pal_types.h"
 #include "pal_bb_ble.h"
-#if defined(NRF52840_XXAA) && MBED_CONF_CORDIO_LL_NRF52840_CRYPTOCELL310_ACCELERATION
+#if defined(NRF52840_XXAA) && defined(FEATURE_CRYPTOCELL310) && MBED_CONF_CORDIO_LL_NRF52840_CRYPTOCELL310_ACCELERATION
 #include "crys_rsa_kg.h"
 #include "crys_dh.h"
 #include "ssi_pal_types.h"
@@ -34,7 +34,7 @@
 /* Nordic specific definitions. */
 #include "nrf_ecb.h"
 #include "nrf.h"
-#if defined(NRF52840_XXAA) && MBED_CONF_CORDIO_LL_NRF52840_CRYPTOCELL310_ACCELERATION
+#if defined(NRF52840_XXAA) && defined(FEATURE_CRYPTOCELL310) && MBED_CONF_CORDIO_LL_NRF52840_CRYPTOCELL310_ACCELERATION
 #include "nrf52840.h"
 #endif
 #include <string.h>
@@ -690,7 +690,7 @@ bool_t PalCryptoAesCcmDecrypt(PalCryptoEnc_t *pEnc, uint8_t *pBuf)
   return TRUE;
 }
 
-#if defined(NRF52840_XXAA) && MBED_CONF_CORDIO_LL_NRF52840_CRYPTOCELL310_ACCELERATION
+#if defined(NRF52840_XXAA) && defined(FEATURE_CRYPTOCELL310) && MBED_CONF_CORDIO_LL_NRF52840_CRYPTOCELL310_ACCELERATION
 /*************************************************************************************************/
 /*!
  *  \brief  Execute the CCM-Mode encryption algorithm.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7088,6 +7088,7 @@
             "MBED_TICKLESS",
             "MBED_MPU_CUSTOM"
         ],
+        "features": ["BLE"],
         "device_has": [
             "ANALOGIN",
             "FLASH",
@@ -7115,9 +7116,10 @@
             "NRF5x",
             "NRF52",
             "SDK_15_0",
-            "NORDIC_SOFTDEVICE",
-            "SOFTDEVICE_COMMON",
-            "SOFTDEVICE_S132_FULL"
+            "CORDIO",
+            "CORDIO_LL",
+            "SOFTDEVICE_NONE",
+            "NORDIC_CORDIO"
         ],
         "config": {
             "lf_clock_src": {
@@ -7213,7 +7215,7 @@
             "WSF_MAX_HANDLERS=10",
             "MBED_MPU_CUSTOM"
         ],
-        "features": ["CRYPTOCELL310"],
+        "features": ["CRYPTOCELL310", "BLE"],
         "device_has": [
             "ANALOGIN",
             "FLASH",
@@ -7242,9 +7244,10 @@
             "NRF5x",
             "NRF52",
             "SDK_15_0",
-            "NORDIC_SOFTDEVICE",
-            "SOFTDEVICE_COMMON",
-            "SOFTDEVICE_S140_FULL"
+            "CORDIO",
+            "CORDIO_LL",
+            "SOFTDEVICE_NONE",
+            "NORDIC_CORDIO"
         ],
         "config": {
             "lf_clock_src": {


### PR DESCRIPTION
### Description

The BLE stack from SoftDevice is not actively maintained and
has issues (e.g. BLE fails to initialise) when used with Nordic SDK v15.

Note: To verify this PR properly, remove/do not set target-specific labels in mbed_app.json.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@donatieng @pan- @paul-szczepanek-arm 

### Release Notes

Starting with mbed-os 5.13 and the introduction of Nordic SDK V15, Nordic SoftDevice Bluetooth stack is not supported.
Bluetooth remains supported with the help of ARM’s Cordio stack.