### PR TITLE
Fix nrf52 memory pools

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -24,12 +24,12 @@
         },
         "max-l2cap-channels": {
             "help": "Maximum number of connection oriented channels",
-            "value": 8,
+            "value": 0,
             "macro_name": "L2C_COC_CHAN_MAX"
         },
         "max-l2cap-clients": {
             "help": "Maximum number of connection oriented channel registered clients",
-            "value": 4,
+            "value": 0,
             "macro_name": "L2C_COC_REG_MAX"
         },
         "max-att-writes": {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -53,7 +53,7 @@
         },
         "rx-acl-buffer-size": {
             "help": "Size of the buffer holding the reassembled complete ACL packet. This will limit the effective ATT_MTU (to its value minus 4 bytes for the header). The size of the buffer must be small enough to be allocated from the existing cordio pool. If this value is increased you may need to adjust the memory pool.",
-            "value": 100
+            "value": 70
         },
         "max-prepared-writes": {
             "help": "Number of queued prepare writes supported by server.",

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/mbed_lib.json
@@ -24,12 +24,12 @@
         },
         "max-l2cap-channels": {
             "help": "Maximum number of connection oriented channels",
-            "value": 0,
+            "value": 1,
             "macro_name": "L2C_COC_CHAN_MAX"
         },
         "max-l2cap-clients": {
             "help": "Maximum number of connection oriented channel registered clients",
-            "value": 0,
+            "value": 1,
             "macro_name": "L2C_COC_REG_MAX"
         },
         "max-att-writes": {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO_LL/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO_LL/mbed_lib.json
@@ -3,11 +3,11 @@
     "config": {
         "max-advertising-sets": {
             "help": "Maximum number of advertising sets.",
-            "value": 4
+            "value": 3
         },
         "max-advertising-reports": {
             "help": "Maximum number of pending legacy or extended advertising reports.",
-            "value": 8
+            "value": 4
         },
         "default-extended-advertising-fragmentation-size": {
             "help": "Default extended advertising data fragmentation size.",
@@ -23,7 +23,7 @@
         },
         "rx-buffers": {
             "help": "Default number of receive buffers.",
-            "value": 8
+            "value": 4
         },
         "phy-coded-support": {
             "help": "Coded PHY supported.",
@@ -39,7 +39,7 @@
         },
         "tx-buffers": {
             "help": "Default number of send buffers",
-            "value": 8
+            "value": 4
         },
         "handle-vendor-specific-hci-commands": {
             "help": "Handle VS HCI commands. Valid values are 0 (ignore) and 1 (handle).",

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO_LL/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO_LL/mbed_lib.json
@@ -30,8 +30,8 @@
             "value": 0
         },
         "extended-advertising-size": {
-            "help": "Maximum extended advertising data (and scan data response) size",
-            "value": 128
+            "help": "Maximum extended advertising data (and scan data response) size, Minimum value is 251",
+            "value": 251
         },
         "max-acl-size": {
             "help": "Maximum ACL buffer size",

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_MCU_NRF52840/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_MCU_NRF52840/mbed_lib.json
@@ -7,15 +7,15 @@
         },
         "extended-advertising-size": {
             "help": "Maximum extended advertising data (and scan data response) size",
-            "value": 1650
+            "value": 512
         },
         "max-acl-size": {
             "help": "Maximum ACL buffer size",
-            "value": 512
+            "value": 256
         },
         "tx-buffers": {
             "help": "Default number of send buffers",
-            "value": 16
+            "value": 4
         },
         "cryptocell310-acceleration": {
             "help": "Should the link layer use the Crypto Cell 310 to offload encryption.",

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -67,11 +67,11 @@ using namespace ble::vendor::cordio;
 #define MBED_CONF_CORDIO_LL_TX_BUFFERS                MBED_CONF_CORDIO_LL_NRF52840_TX_BUFFERS
 #define MBED_CONF_CORDIO_LL_PHY_CODED_SUPPORT         MBED_CONF_CORDIO_LL_NRF52840_PHY_CODED_SUPPORT
 
-#define CORDIO_LL_MEMORY_FOOTPRINT  41906UL
+#define CORDIO_LL_MEMORY_FOOTPRINT  15400UL
 
 #else
 
-#define CORDIO_LL_MEMORY_FOOTPRINT  12768UL
+#define CORDIO_LL_MEMORY_FOOTPRINT  12500UL
 
 #endif
 
@@ -235,9 +235,9 @@ ble::vendor::cordio::buf_pool_desc_t NRFCordioHCIDriver::get_buffer_pool_descrip
 {
     static union {
         #if defined(NRF52840_XXAA)
-        uint8_t buffer[ 17304 ];
+        uint8_t buffer[ 4900 ];
         #else
-        uint8_t buffer[ 8920 ];
+        uint8_t buffer[ 4900 ];
         #endif
         uint64_t align;
     };
@@ -246,8 +246,7 @@ ble::vendor::cordio::buf_pool_desc_t NRFCordioHCIDriver::get_buffer_pool_descrip
             {  32, 16 + 4 },
             {  64, 8 },
             { 128, 4 + MBED_CONF_CORDIO_LL_MAX_ADVERTISING_REPORTS },
-		    { aclBufSize, MBED_CONF_CORDIO_LL_TX_BUFFERS + MBED_CONF_CORDIO_LL_RX_BUFFERS },
-            { 272, 1 }
+		    { aclBufSize, MBED_CONF_CORDIO_LL_TX_BUFFERS + MBED_CONF_CORDIO_LL_RX_BUFFERS }
     };
 
     return buf_pool_desc_t(buffer, pool_desc);

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/mbed_lib.json
@@ -14,6 +14,7 @@
         "INIT_PERIPHERAL",
         "INIT_ENCRYPTED",
         "LHCI_ENABLE_VS=0",
-        "BB_CLK_RATE_HZ=1000000"
+        "BB_CLK_RATE_HZ=1000000",
+        "LL_MAX_PER_SCAN=3"
     ]
 }


### PR DESCRIPTION
### Description

Inclusion of https://github.com/ARMmbed/mbed-os/pull/10666 has broken BLE on NRF52_DK. This patch also reduce the RAM necessary to run BLE on NRF52XXX targets. 

* NRF52_DK: 3.3K of RAM saved
* NRF52840_DK: ~39K of RAM saved. 


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@LDong-Arm @paul-szczepanek-arm @donatieng 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->