### PR TITLE
M487: Fix wait_ns test failed

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/device/system_M480.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/system_M480.c
@@ -84,13 +84,5 @@ void SystemInit (void)
     SPIM_DISABLE_CACHE();
     SPIM_ENABLE_CCM();
     while (! SPIM_IS_CCM_EN());
-    
-#ifndef MBED_CONF_TARGET_CTRL01_ENABLE
-#define MBED_CONF_TARGET_CTRL01_ENABLE 1
-#endif
-
-#if (! MBED_CONF_TARGET_CTRL01_ENABLE)
-    M32(0x4000c018) |= 0x00000080;
-#endif
 }
 /*** (C) COPYRIGHT 2016 Nuvoton Technology Corp. ***/

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7879,10 +7879,6 @@
             "usb-device-hsusbd": {
                 "help": "Select high-speed USB device or not",
                 "value": 1
-            },
-            "ctrl01-enable": {
-                "help": "Enable control_01",
-                "value": 0
             }
         },
         "inherits": ["Target"],


### PR DESCRIPTION
### Description

This PR is to address #10726, `mbed-os-tests-mbed_platform-wait_ns` test failed. Original control (not to disclose) is for pre-release chip and is not suitable for release chip. It is removed here.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

cc @cyliangtw 