### PR TITLE
ARMC6: Suppress "register deprecated" warning

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -18,7 +18,7 @@
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
-                   "-Wno-reserved-user-defined-literal",
+                   "-Wno-reserved-user-defined-literal", "-Wno-deprecated-register",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DMBED_DEBUG",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -17,7 +17,7 @@
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
-                   "-Wno-reserved-user-defined-literal",
+                   "-Wno-reserved-user-defined-literal", "-Wno-deprecated-register",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DMBED_TRAP_ERRORS_ENABLED=1"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -17,7 +17,7 @@
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
-                   "-Wno-reserved-user-defined-literal",
+                   "-Wno-reserved-user-defined-literal", "-Wno-deprecated-register",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
                    "-fshort-enums", "-fshort-wchar", "-DNDEBUG"],


### PR DESCRIPTION
### Description

Lots of target code, STM in particular, uses the `register` keyword, so
it'll take a little while to clean up. In the interim, some builds are
producing a lot of warnings. Suppress the warning for now, as `register`
remains legal C++14 and C11, despite C++14 deprecating it.

C++17 removes `register`, so code will need to be cleaned before any
further C++ version update.

Fixes #10717

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

