### PR TITLE
CThunk: Fix assertion when CThunk object is destroyed

### DIFF
--- a/platform/CThunk.h
+++ b/platform/CThunk.h
@@ -64,8 +64,10 @@ public:
 
     ~CThunk()
     {
-        cthunk_free(_entry);
-        _entry = NULL;
+        if (_entry != NULL) {
+            cthunk_free(_entry);
+            _entry = NULL;
+        }
     }
 
     inline CThunk(T *instance, CCallbackSimple callback)


### PR DESCRIPTION
In case the CThunk object is deleted without having called the
entry() function (and thus _entry is NULL), cthunk_free_real()
will fail with an assertion.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Tested manually with a SPI object (containing a CThunk) that was created and deleted dynamically, using MBED OS 5.12.4. Before the change, deletion of the object caused an assert, after the change it works fine.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
