### PR TITLE
PSA protected storage: Add encrypt & RB protect flags by default to set.

### DIFF
--- a/components/TARGET_PSA/services/storage/common/psa_storage_common_impl.cpp
+++ b/components/TARGET_PSA/services/storage/common/psa_storage_common_impl.cpp
@@ -185,23 +185,14 @@ static void generate_fn(char *tdb_filename, uint32_t tdb_filename_size, psa_stor
 
 psa_status_t psa_storage_set_impl(KVStore *kvstore, int32_t pid, psa_storage_uid_t uid,
                                   uint32_t data_length, const void *p_data,
-                                  psa_storage_create_flags_t create_flags)
+                                  uint32_t kv_create_flags)
 {
-    if ((create_flags & (~FLAGS_MSK)) != 0) {
-        return PSA_ERROR_NOT_SUPPORTED;
-    }
-
     if (uid == 0) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
     // Generate KVStore key
     char kv_key[PSA_STORAGE_FILE_NAME_MAX] = {'\0'};
     generate_fn(kv_key, PSA_STORAGE_FILE_NAME_MAX, uid, pid);
-
-    uint32_t kv_create_flags = 0;
-    if (create_flags & PSA_STORAGE_FLAG_WRITE_ONCE) {
-        kv_create_flags = KVStore::WRITE_ONCE_FLAG;
-    }
 
     int status = kvstore->set(kv_key, p_data, data_length, kv_create_flags);
 

--- a/components/TARGET_PSA/services/storage/common/psa_storage_common_impl.h
+++ b/components/TARGET_PSA/services/storage/common/psa_storage_common_impl.h
@@ -36,7 +36,7 @@ typedef psa_status_t (*migrate_func_t)(mbed::KVStore *kvstore, const psa_storage
 
 void psa_storage_handle_version(mbed::KVStore *kvstore, const char *version_key, const psa_storage_version_t *version,
                                 migrate_func_t migrate_func);
-psa_status_t psa_storage_set_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, uint32_t data_length, const void *p_data, psa_storage_create_flags_t create_flags);
+psa_status_t psa_storage_set_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, uint32_t data_length, const void *p_data, uint32_t kv_create_flags);
 psa_status_t psa_storage_get_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, uint32_t data_offset, uint32_t data_length, void *p_data);
 psa_status_t psa_storage_get_info_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, struct psa_storage_info_t *p_info);
 psa_status_t psa_storage_remove_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid);

--- a/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_IMPL/pits_impl.cpp
+++ b/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_IMPL/pits_impl.cpp
@@ -87,6 +87,10 @@ psa_status_t psa_its_set_impl(int32_t pid, psa_storage_uid_t uid, uint32_t data_
         its_init();
     }
 
+    if (create_flags & ~PSA_STORAGE_FLAG_WRITE_ONCE) {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+
     return psa_storage_set_impl(kvstore, pid, uid, data_length, p_data, create_flags);
 }
 


### PR DESCRIPTION
### Description
This PR fixes a bug in PSA protected storage set API: It adds the encrypt and rollback protect flags to the KVStore flags (if it's not mapped to the internal storage). Otherwise, this doesn't comply to protected storage security definitions.
Tested with tests-psa-its_ps test on K64F (with SD and with only internal storage enabled) and K66F boards.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@shelib01 @jenia81 