### PR TITLE
Changed EventQueue::cancel to return boolean value

### DIFF
--- a/UNITTESTS/stubs/EventQueue_stub.cpp
+++ b/UNITTESTS/stubs/EventQueue_stub.cpp
@@ -47,8 +47,9 @@ unsigned EventQueue::tick()
     return EventQueue_stub::unsigned_value;
 }
 
-void EventQueue::cancel(int id)
+bool EventQueue::cancel(int id)
 {
+    return true;
 }
 
 int EventQueue::time_left(int id)
@@ -62,6 +63,7 @@ void EventQueue::background(Callback<void(int)> update)
 
 int EventQueue::chain(EventQueue *target)
 {
+    return 0;
 }
 
 } // namespace events

--- a/UNITTESTS/stubs/equeue_stub.c
+++ b/UNITTESTS/stubs/equeue_stub.c
@@ -92,9 +92,9 @@ int equeue_post(equeue_t *queue, void (*cb)(void *), void *event)
     return 0;
 }
 
-void equeue_cancel(equeue_t *queue, int id)
+bool equeue_cancel(equeue_t *queue, int id)
 {
-
+    return true;
 }
 
 void equeue_background(equeue_t *queue,

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -128,13 +128,16 @@ public:
      *
      *  The cancel function is IRQ safe.
      *
-     *  If called while the event queue's dispatch loop is active, the cancel
-     *  function does not guarantee that the event will not execute after it
-     *  returns, as the event may have already begun executing.
+     *  If called while the event queue's dispatch loop is active in another thread,
+     *  the cancel function does not guarantee that the event will not execute after it
+     *  returns, as the event may have already begun executing. A call made from
+     *  the same thread as the dispatch loop will always succeed with a valid id.
      *
      *  @param id       Unique id of the event
+     *  @return         true  if event was successfully cancelled
+     *                  false if event was not cancelled (invalid id or executing already begun)
      */
-    void cancel(int id);
+    bool cancel(int id);
 
     /** Query how much time is left for delayed event
      *

--- a/events/equeue.h
+++ b/events/equeue.h
@@ -184,10 +184,12 @@ int equeue_post(equeue_t *queue, void (*cb)(void *), void *event);
 //
 // The equeue_cancel function is irq safe.
 //
-// If called while the event queue's dispatch loop is active, equeue_cancel
-// does not guarantee that the event will not not execute after it returns as
+// If called while the event queue's dispatch loop is active in another thread,
+// equeue_cancel does not guarantee that the event will not execute after it returns as
 // the event may have already begun executing.
-void equeue_cancel(equeue_t *queue, int id);
+// Returning true guarantees that cancel succeeded and event will not execute.
+// Returning false if invalid id or already started executing.
+bool equeue_cancel(equeue_t *queue, int id);
 
 // Query how much time is left for delayed event
 //

--- a/events/source/EventQueue.cpp
+++ b/events/source/EventQueue.cpp
@@ -50,7 +50,7 @@ unsigned EventQueue::tick()
     return equeue_tick();
 }
 
-void EventQueue::cancel(int id)
+bool EventQueue::cancel(int id)
 {
     return equeue_cancel(&_equeue, id);
 }

--- a/events/source/equeue.c
+++ b/events/source/equeue.c
@@ -374,15 +374,18 @@ int equeue_post(equeue_t *q, void (*cb)(void *), void *p)
     return id;
 }
 
-void equeue_cancel(equeue_t *q, int id)
+bool equeue_cancel(equeue_t *q, int id)
 {
     if (!id) {
-        return;
+        return false;
     }
 
     struct equeue_event *e = equeue_unqueue(q, id);
     if (e) {
         equeue_dealloc(q, e + 1);
+        return true;
+    } else {
+        return false;
     }
 }
 
@@ -603,7 +606,7 @@ static void equeue_chain_dispatch(void *p)
 static void equeue_chain_update(void *p, int ms)
 {
     struct equeue_chain_context *c = (struct equeue_chain_context *)p;
-    equeue_cancel(c->target, c->id);
+    (void)equeue_cancel(c->target, c->id);
 
     if (ms >= 0) {
         c->id = equeue_call_in(c->target, ms, equeue_chain_dispatch, c->q);


### PR DESCRIPTION
### Description

It's important in some cases to know whether the EventQueue::cancel succeeded. Now cancel method returns the boolean value to indicate did the cancel succeed.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
@kivaisan 
### Release Notes

EventQueue::cancel now returns the boolean value to indicate whether the cancel was successful or not.