### PR TITLE
STM32L0: Add DEVICE_SPI_COUNT to DISCO_L072CZ_LRWAN1 + MTB_MURATA_ABZ

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/TARGET_MTB_MURATA_ABZ/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/TARGET_MTB_MURATA_ABZ/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE


### PR DESCRIPTION
Enables simultaneous use of both SPIs without interference.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
STM32L0x2 has two SPIs available, on Murata LoRaWAN SoC the other one is used for the LoRaWAN radio and the other can be used by the application. I noticed that when LoRaWAN is active, the other SPI did not work reliably (apparently as they are both using the GlobalSPI instance). Setting DEVICE_SPI_COUNT helped. After this change the application SPI works together with LoRaWAN.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
