### PR TITLE
Add support I2C 3 for target EFM32G11

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
@@ -64,6 +64,11 @@ static uint8_t i2c_get_index(i2c_t *obj)
             index = 1;
             break;
 #endif
+#ifdef I2C2
+        case I2C_2:
+            index = 2;
+            break;
+#endif
         default:
             printf("I2C module not available.. Out of bound access.");
             break;
@@ -83,6 +88,11 @@ static CMU_Clock_TypeDef i2c_get_clock(i2c_t *obj)
 #ifdef I2C1
         case I2C_1:
             clock = cmuClock_I2C1;
+            break;
+#endif
+#ifdef I2C2
+        case I2C_2:
+            clock = cmuClock_I2C2;
             break;
 #endif
         default:
@@ -174,6 +184,11 @@ void i2c_enable_interrupt(i2c_t *obj, uint32_t address, uint8_t enable)
 #ifdef I2C1
         case 1:
             irq_number = I2C1_IRQn;
+            break;
+#endif
+#ifdef I2C2
+        case 2:
+            irq_number = I2C2_IRQn;
             break;
 #endif
     }


### PR DESCRIPTION
### Description

Add support 3rd I2C for target EFM32G11 (When define I2C2).

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Release Notes

Tested on the EFM32GG11_STK3701.
