### PR TITLE
Fix <-Wtype-limits> warning in attestation_core - DO NOT MERGE

### DIFF
--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/tfm_impl/attestation_core.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/tfm_impl/attestation_core.c
@@ -707,18 +707,36 @@ attest_add_security_lifecycle_claim(struct attest_token_ctx *token_ctx)
         if (res) {
             return PSA_ATTEST_ERR_GENERAL;
         }
-        security_lifecycle = (enum tfm_security_lifecycle_t)slc_value;
+        switch (slc_value) {
+            case TFM_SLC_UNKNOWN:
+                security_lifecycle = TFM_SLC_UNKNOWN;
+                break;
+            case TFM_SLC_ASSEMBLY_AND_TEST:
+                security_lifecycle = TFM_SLC_ASSEMBLY_AND_TEST;
+                break;
+            case TFM_SLC_PSA_ROT_PROVISIONING:
+                security_lifecycle = TFM_SLC_PSA_ROT_PROVISIONING;
+                break;
+            case TFM_SLC_SECURED:
+                security_lifecycle = TFM_SLC_SECURED;
+                break;
+            case TFM_SLC_NON_PSA_ROT_DEBUG:
+                security_lifecycle = TFM_SLC_NON_PSA_ROT_DEBUG;
+                break;
+            case TFM_SLC_RECOVERABLE_PSA_ROT_DEBUG:
+                security_lifecycle = TFM_SLC_RECOVERABLE_PSA_ROT_DEBUG;
+                break;
+            case TFM_SLC_DECOMMISSIONED:
+                security_lifecycle = TFM_SLC_DECOMMISSIONED;
+                break;
+            default:
+                security_lifecycle = TFM_SLC_UNKNOWN;
+        }
     } else {
         /* If not found in boot status then use callback function to get it
          * from runtime SW
          */
         security_lifecycle = tfm_attest_hal_get_security_lifecycle();
-    }
-
-    /* Sanity check */
-    if (security_lifecycle < TFM_SLC_UNKNOWN ||
-        security_lifecycle > TFM_SLC_DECOMMISSIONED) {
-        return PSA_ATTEST_ERR_GENERAL;
     }
 
     attest_token_add_integer(token_ctx,


### PR DESCRIPTION
Have deterministic value in security_lifecycle to avoid bound checking which is causing compiler warning <-Wtype-limits>

Fixes https://github.com/ARMmbed/mbed-os/issues/10721

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
