### PR TITLE
Fix networkinterface non-blocking status test

### DIFF
--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -131,6 +131,10 @@ void NETWORKINTERFACE_STATUS_NONBLOCK()
 
         status = wait_status_callback();
         TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
+
+        wait(1);    // In cellular there might still come disconnected messages from the network which are sent to callback.
+        // This would cause this test to fail as next connect is already ongoing. So wait here a while until (hopefully)
+        // all messages also from the network have arrived.
     }
 
     net->attach(NULL);


### PR DESCRIPTION
### Description

Fix was to add some time between iterations connect-disconnect. In cellular disconnect, cellular network may send disconnect events and if those events come when connect is already ongoing test will fail.
So wait a bit after disconnect so that disconnect events should be over.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@AriParkkila 

### Release Notes
