### PR TITLE
BG96 ipv6 support and socket id fix for BG96 and M26 

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -43,8 +43,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // AT_CMGF
     1,  // AT_CSDH
     1,  // PROPERTY_IPV4_STACK
-    0,  // PROPERTY_IPV6_STACK
-    0,  // PROPERTY_IPV4V6_STACK
+    1,  // PROPERTY_IPV6_STACK
+    1,  // PROPERTY_IPV4V6_STACK
     1,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
 };

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -50,8 +50,12 @@ nsapi_error_t QUECTEL_BG96_CellularStack::socket_connect(nsapi_socket_t handle, 
     CellularSocket *socket = (CellularSocket *)handle;
 
     int modem_connect_id = -1;
-    int request_connect_id = socket->id;
     int err = -1;
+
+    int request_connect_id = find_socket_index(socket);
+    // assert here as its a programming error if the socket container doesn't contain
+    // specified handle
+    MBED_ASSERT(request_connect_id != -1);
 
     _at.lock();
     if (socket->proto == NSAPI_TCP) {

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -302,11 +302,13 @@ nsapi_error_t QUECTEL_M26_CellularStack::socket_connect(nsapi_socket_t handle, c
 {
     CellularSocket *socket = (CellularSocket *)handle;
 
-    MBED_ASSERT(socket->id != -1);
-
     int modem_connect_id = -1;
-    int request_connect_id = socket->id;
     int err = -1;
+
+    int request_connect_id = find_socket_index(socket);
+    // assert here as its a programming error if the socket container doesn't contain
+    // specified handle
+    MBED_ASSERT(request_connect_id != -1);
 
     _at.lock();
     if (socket->proto == NSAPI_TCP) {


### PR DESCRIPTION
### Description
This PR fixes two issues:
- socket id allocation in socket_connect
- IPV6 and IPV4V6 as supported properties for issue https://github.com/ARMmbed/mbed-os-example-cellular/issues/137

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change