### PR TITLE
usb_device-msd test: fix powershell unmount script issue

### DIFF
--- a/TESTS/host_tests/pyusb_msd.py
+++ b/TESTS/host_tests/pyusb_msd.py
@@ -127,7 +127,17 @@ class PyusbMSDTest(BaseHostTest):
         else:
             self.report_error("unmount")
 
+    def _callback_os_type(self, key, value, timestamp):
+        system_name = platform.system()
+        if system_name == "Windows":
+            self.send_kv("os_type", 1)
+        elif system_name == "Linux":
+            self.send_kv("os_type", 2)
+        elif system_name == "Darwin":
+            self.send_kv("os_type", 3)
+
     def setup(self):
+        self.register_callback("get_os_type", self._callback_os_type)
         self.register_callback("get_serial_number", self._callback_device_ready)
         self.register_callback('check_if_mounted', self._callback_check_if_mounted)
         self.register_callback('check_if_not_mounted', self._callback_check_if_not_mounted)

--- a/TESTS/host_tests/pyusb_msd.py
+++ b/TESTS/host_tests/pyusb_msd.py
@@ -204,25 +204,16 @@ class MSDUtils(object):
     @staticmethod
     def _unmount_windows(serial):
         disk_path = MSDUtils._disk_path_windows(serial)
-        tmp_file = tempfile.NamedTemporaryFile(suffix='.ps1', delete=False)
-        try:
-            # create unmount script
-            tmp_file.write('$disk_leter=$args[0]\n')
-            tmp_file.write('$driveEject = New-Object -comObject Shell.Application\n')
-            tmp_file.write('$driveEject.Namespace(17).ParseName($disk_leter).InvokeVerb("Eject")\n')
-            # close to allow open by other process
-            tmp_file.close()
+        cmd_string = r'(New-Object -comObject Shell.Application).Namespace(17).ParseName("{}").InvokeVerb("Eject")'.format(disk_path)
 
-            try_count = 10
-            while try_count:
-                p = subprocess.Popen(["powershell.exe", tmp_file.name + " " + disk_path], stdout=sys.stdout)
-                p.communicate()
-                try_count -= 1
-                if MSDUtils._disk_path_windows(serial) is None:
-                    return True
-                time.sleep(1)
-        finally:
-            os.remove(tmp_file.name)
+        try_count = 10
+        while try_count:
+            p = subprocess.Popen(["powershell.exe", cmd_string], stdout=sys.stdout)
+            p.communicate()
+            try_count -= 1
+            if MSDUtils._disk_path_windows(serial) is None:
+                return True
+            time.sleep(1)
 
         return False
 

--- a/TESTS/usb_device/README.md
+++ b/TESTS/usb_device/README.md
@@ -136,6 +136,14 @@ The FAT32 filesystem cannot be mounted on a device smaller than 64 kB.
 
 The test can be easily extended to use any block device available in Mbed.
 
+### Windows 8/10: Mass storage tests are failing on test file read
+By default Windows 8 and 10 access and write to removable drives shortly after they are connected. It's caused by drive indexing mechanisms. Because disk used in test has only 64kB its content can be easily corrupted by writing large files, what actually was encountered during test runs.
+
+To prevent Windows from writing to removable drives on connect drive indexing can be turned off with the following procedure:
+- Start the program "gpedit.msc"
+- Navigate to "Computer Configuration \ Administrative Templates \ Windows Components \ Search"
+- Enable the policy "Do not allow locations on removable drives to be added to  libraries."
+
 ### Isochronous endpoints are skipped in loopback tests
 #### Unresolved
 

--- a/TESTS/usb_device/msd/main.cpp
+++ b/TESTS/usb_device/msd/main.cpp
@@ -250,13 +250,10 @@ void msd_process(USBMSD *msd)
  */
 void storage_init()
 {
-    if (mbed_heap_size >= MIN_HEAP_SIZE) {
-        FATFileSystem::format(get_heap_block_device());
-        bool result = prepare_storage(get_heap_block_device(), &heap_fs);
-        TEST_ASSERT_MESSAGE(result, "heap storage initialisation failed");
-    } else {
-        utest_printf("Not enough heap memory for HeapBlockDevice creation. Heap block device init skipped!!!\n");
-    }
+    TEST_ASSERT_MESSAGE(mbed_heap_size >= MIN_HEAP_SIZE, "Not enough heap memory for HeapBlockDevice creation");
+    FATFileSystem::format(get_heap_block_device());
+    bool result = prepare_storage(get_heap_block_device(), &heap_fs);
+    TEST_ASSERT_MESSAGE(result, "heap storage initialisation failed");
 }
 
 /** Test mass storage device mount and unmount
@@ -428,19 +425,13 @@ void mount_unmount_and_data_test(BlockDevice *bd, FileSystem *fs)
 
 void heap_block_device_mount_unmount_test()
 {
-    if (mbed_heap_size < MIN_HEAP_SIZE) {
-        TEST_SKIP_MESSAGE("Not enough heap memory for HeapBlockDevice creation");
-        return;
-    }
+    TEST_ASSERT_MESSAGE(mbed_heap_size >= MIN_HEAP_SIZE, "Not enough heap memory for HeapBlockDevice creation");
     mount_unmount_test<3>(get_heap_block_device(), &heap_fs);
 }
 
 void heap_block_device_mount_unmount_and_data_test()
 {
-    if (mbed_heap_size < MIN_HEAP_SIZE) {
-        TEST_SKIP_MESSAGE("Not enough heap memory for HeapBlockDevice creation");
-        return;
-    }
+    TEST_ASSERT_MESSAGE(mbed_heap_size >= MIN_HEAP_SIZE, "Not enough heap memory for HeapBlockDevice creation");
     mount_unmount_and_data_test(get_heap_block_device(), &heap_fs);
 }
 

--- a/TESTS/usb_device/msd/main.cpp
+++ b/TESTS/usb_device/msd/main.cpp
@@ -345,8 +345,8 @@ void mount_unmount_test(BlockDevice *bd, FileSystem *fs)
             usb.disconnect();
         }
 #else
-        // unmount
-        usb.disconnect();
+            // unmount
+            usb.disconnect();
 #endif
         // check if device is detached on host side
         greentea_send_kv("check_if_not_mounted", 0);

--- a/TESTS/usb_device/msd/main.cpp
+++ b/TESTS/usb_device/msd/main.cpp
@@ -327,7 +327,7 @@ void mount_unmount_test(BlockDevice *bd, FileSystem *fs)
 #ifdef DISABLE_HOST_SIDE_UMOUNT
         greentea_send_kv("get_os_type", 0);
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-        int32_t os_type = atoi(_key);
+        int32_t os_type = atoi(_value);
         if (os_type != OS_WINDOWS) {
 #endif
             // unmount msd device on host side
@@ -340,13 +340,14 @@ void mount_unmount_test(BlockDevice *bd, FileSystem *fs)
             if (!usb.media_removed()) {
                 TEST_ASSERT_EQUAL_LOOP(true, usb.media_removed(), i);
             }
-#ifdef DISABLE_HOST_SIDE_UMOUNT
+
             // unmount since media_removed doesn't disconnects device side
             usb.disconnect();
-        }
-#else
+#ifdef DISABLE_HOST_SIDE_UMOUNT
+        } else {
             // unmount
             usb.disconnect();
+        }
 #endif
         // check if device is detached on host side
         greentea_send_kv("check_if_not_mounted", 0);


### PR DESCRIPTION
### Description

- Fix for the mass storage unmount procedure on Windows machines for usb_device-msd test.
Running PowerShell script on some windows machines is blocked. To avoid this problem unmount script was replace by the code run directly in PowerShell console.
- Improve error handling.
- Encountering further problems with disk unmount on windows machines, drove the decision to disable host side unmount on windows machines to make the test more stable.
- Update test documentation



### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@fkjagodzinski

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
