### PR TITLE
PSOC6: add SOFTFP to standard component list

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8262,6 +8262,7 @@
         ],
         "release_versions": ["5"],
         "extra_labels": ["Cypress", "PSOC6"],
+        "components_add": ["SOFTFP"],
         "public": false
     },
     "MCU_PSOC6_M0": {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
This allows Cypress to deliver middleware libraries with
precompiled libraries for SoftFP ahd HardFP, separated by
component-specific sub-directories:

COMPONENT_SOFTFP/TOOLCHAIN_GCC_ARM/libcy_capsense.a
COMPONENT_HARDFP/TOOLCHAIN_GCC_ARM/libcy_capsense.a

Existing solution with hardfp/lib/.mbedignore is not compatible with ModusToolbox projects that have no knowledge of .mbedignore:
https://github.com/cypresssemiconductorco/middleware-capsense/tree/1.20/hardfp/lib

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@anjrcy

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
