### PR TITLE
Workarounds for GAP advertising issues on Cordio

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -457,17 +457,6 @@ GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandler>::
     _random_static_identity_address = _pal_gap.get_random_address();
 
     _pal_gap.set_event_handler(this);
-
-#if BLE_FEATURE_EXTENDED_ADVERTISING
-    if (is_extended_advertising_available()) {
-        setExtendedAdvertisingParameters(
-            LEGACY_ADVERTISING_HANDLE,
-            AdvertisingParameters()
-        );
-    }
-
-    _existing_sets.set(LEGACY_ADVERTISING_HANDLE);
-#endif // BLE_FEATURE_EXTENDED_ADVERTISING
 }
 
 template <template<class> class PalGapImpl, class PalSecurityManager, class ConnectionEventMonitorEventHandler>
@@ -3470,7 +3459,19 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
     if (_deprecated_scan_api_used) {
         MBED_ERROR(mixed_scan_api_error, "Use of up to date scan API with deprecated API");
     }
-    _non_deprecated_scan_api_used = true;
+    if (!_non_deprecated_scan_api_used) {
+        _non_deprecated_scan_api_used = true;
+#if BLE_FEATURE_EXTENDED_ADVERTISING
+        if (const_cast<GenericGap*>(this)->is_extended_advertising_available()) {
+            const_cast<GenericGap*>(this)->setExtendedAdvertisingParameters(
+                LEGACY_ADVERTISING_HANDLE,
+                AdvertisingParameters()
+            );
+        }
+        const_cast<BitArray<MAX_ADVERTISING_SETS>*>(&_existing_sets)->set(LEGACY_ADVERTISING_HANDLE);
+#endif
+    }
+
 }
 
 template <template<class> class PalGapImpl, class PalSecurityManager, class ConnectionEventMonitorEventHandler>

--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -1424,6 +1424,17 @@ ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEve
         return err;
     }
 
+#if defined(TARGET_CORDIO_LL)
+    // TODO: fix advertising set creation in the link layer.
+    // The Cordio link layer implements legacy API on top of extended advertising
+    // and has an issue that no advertising set is created until we set parameters.
+    // As a workaround, set advertising data again to ensure it takes effect.
+    err = setAdvertisingData_(this->_advPayload, this->_scanResponse);
+    if (err) {
+        return err;
+    }
+#endif
+
     err = _pal_gap.advertising_enable(true);
     if (err) {
         return err;


### PR DESCRIPTION
### Description

Due to possible issues in Cordio link layer, GAP payload is _not_ advertised if it is set _before_ adverting parameters is. This impacts both new and legacy APIs.

Workarounds:
API v1: Force setAdvertisingData during startAdvertising, to ensure data gets advertised.
API v2: Delay setExtendedAdvertisingParameters to the first use of API v2. Previously this was done during GenericGap initialisation and always failed because the stack was not ready.

This PR depends on #10709 since nRF52/nRF52840 on Cordio stack is needed in order to reproduce the issue (and test this PR).

(Thanks to @pan- for help with debugging and proposed workarounds.)

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan- @paul-szczepanek-arm 