### PR TITLE
Include TICKLESS stack size increase even without LPTICKER_DELAY_TICKS

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -40,7 +40,7 @@
 #endif
 
 // Increase the idle thread stack size when tickless is enabled
-#if defined(MBED_TICKLESS) && defined(LPTICKER_DELAY_TICKS) && (LPTICKER_DELAY_TICKS > 0)
+#if defined(EXTRA_IDLE_STACK_REQUIRED) || (defined(MBED_TICKLESS) && defined(LPTICKER_DELAY_TICKS) && (LPTICKER_DELAY_TICKS > 0))
 #define EXTRA_IDLE_STACK MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE_TICKLESS_EXTRA
 #else
 #define EXTRA_IDLE_STACK 0

--- a/rtos/mbed_lib.json
+++ b/rtos/mbed_lib.json
@@ -19,7 +19,7 @@
             "value": 4096
          },
          "idle-thread-stack-size-tickless-extra": {
-            "help": "Additional size to add to the idle thread when tickless is enabled and LPTICKER_DELAY_TICKS is used",
+            "help": "Additional size to add to the idle thread when a specific target or application implementation requires it or in case tickless is enabled and LPTICKER_DELAY_TICKS is used",
             "value": 256
          },
          "idle-thread-stack-size-debug-extra": {


### PR DESCRIPTION
### Description

LPTICKER_DELAY_TICKS extra stack size has been introduced with the LP
ticker C++ wrapper. Now we've removed the wrapper and LPTICKER_DELAY_TICKS
definition, but we still need extra stack size for the low level wrapper.

This change is needed for #10701 

As such the change would impact many targets, more than expected, so maybe there is a better way to create the condition - feedback welcome

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mprse 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
