### PR TITLE
GR_LYCHEE,RZ_A1H,VK_RZ_A1H: Fix greentea test failure with ARMC6

### DIFF
--- a/TESTS/mbed_drivers/crc/main.cpp
+++ b/TESTS/mbed_drivers/crc/main.cpp
@@ -144,7 +144,7 @@ void test_thread_safety()
     TEST_ASSERT_EQUAL(0, ct.compute_partial_start(&crc));
     TEST_ASSERT_EQUAL(0, ct.compute_partial((void *)&test, 4, &crc));
 
-    Thread t1(osPriorityNormal1, 320);
+    Thread t1(osPriorityNormal1, 380);
     t1.start(callback(test_thread));
     TEST_ASSERT_EQUAL(0, ct.compute_partial((void *)&test[4], 5, &crc));
     TEST_ASSERT_EQUAL(0, ct.compute_partial_stop(&crc));

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/flash_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/flash_api.c
@@ -121,7 +121,7 @@ static RAM_CODE_SEC int32_t read_register(uint8_t cmd, uint8_t * status);
 static RAM_CODE_SEC int32_t data_send(uint32_t bit_width, uint32_t spbssl_level, const uint8_t * buf, int32_t size);
 static RAM_CODE_SEC void spi_mode(void);
 static RAM_CODE_SEC void ex_mode(void);
-static RAM_CODE_SEC void clear_spimd_reg(st_spibsc_spimd_reg_t * regset);
+static RAM_CODE_SEC void clear_spimd_reg(volatile st_spibsc_spimd_reg_t * regset);
 static RAM_CODE_SEC int32_t spibsc_transfer(st_spibsc_spimd_reg_t * regset);
 static RAM_CODE_SEC uint32_t RegRead_32(volatile uint32_t * ioreg, uint32_t shift, uint32_t mask);
 static RAM_CODE_SEC void RegWwrite_32(volatile uint32_t * ioreg, uint32_t write_value, uint32_t shift, uint32_t mask);
@@ -474,7 +474,7 @@ static void ex_mode(void)
     (void)dummy_read_32;
 }
 
-static void clear_spimd_reg(st_spibsc_spimd_reg_t * regset)
+static void clear_spimd_reg(volatile st_spibsc_spimd_reg_t * regset)
 {
     /* ---- command ---- */
     regset->cde    = SPIBSC_OUTPUT_DISABLE;


### PR DESCRIPTION
### Description
Fix for issue #10729

Fix the following test failures.  
- **tests-mbed_drivers-crc**
The task stack is insufficient. It succeeded when it increased from 320 bytes to 380 bytes.  
**Change file** : mbed-os\TESTS\mbed_drivers\crc\main.c

- **tests-mbed_drivers-flashiap** and **tests-mbed_hal-flash**
The flash driver process needs to be located in RAM, but the function "clear_spimd_reg()" has been replaced with "memset()" located in ROM due to the effect of optimization.  
The function "clear_spimd_reg()" has been changed to not be affected by optimization.  
**Change file** : mbed-os\targets\TARGET_RENESAS\TARGET_RZ_A1XX\flash.c  

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
