### PR TITLE
Re-enable complilation for wifi and nanostack examples

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -117,8 +117,8 @@
       "targets" : [],
       "toolchains" : [],
       "exporters": [],
-      "compile" : false,
-      "export": false,
+      "compile" : true,
+      "export": true,
       "auto-update" : true
     },
     {
@@ -130,9 +130,9 @@
       "targets" : ["K66F", "NUCLEO_F429ZI"],
       "toolchains" : [],
       "exporters": [],
-      "compile" : false,
-      "export": false,
-      "auto-update" : false
+      "compile" : true,
+      "export": true,
+      "auto-update" : true
     },
     {
       "name": "mbed-os-example-cellular",


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Wifi and Nanostack examples had previously been disabled from compiling pending code fixes. This PR re-enables them.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
