### PR TITLE
bootloader: Fix LPC55S69 bootloader segmentation

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_ARMC6/LPC55S69_cm33_core0_flash.sct
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_ARMC6/LPC55S69_cm33_core0_flash.sct
@@ -77,12 +77,23 @@
   #define MBED_RAM_SIZE       NS_DATA_SIZE
 #endif
 
+#if !defined(NVIC_INTERRUPT_NUM)
+  #define NVIC_INTERRUPT_NUM     60
+#endif
+
+#if !defined(EXCEPTION_VECT_NUM)
+  #define EXCEPTION_VECT_NUM     16
+#endif
+
+#if !defined(MEMORY_ADDR_SIZE_IN_BYTE)
+  #define MEMORY_ADDR_SIZE_IN_BYTE     4
+#endif
 
 #define  m_interrupts_start            MBED_APP_START
-#define  m_interrupts_size             0x140
+#define  m_interrupts_size             ((NVIC_INTERRUPT_NUM + EXCEPTION_VECT_NUM) * MEMORY_ADDR_SIZE_IN_BYTE)
 
-#define  m_text_start                  MBED_APP_START + 0x140
-#define  m_text_size                   MBED_APP_SIZE - 0x140
+#define  m_text_start                  MBED_APP_START + m_interrupts_size
+#define  m_text_size                   MBED_APP_SIZE - m_interrupts_size
 
 #define  m_interrupts_ram_start        MBED_RAM_START
 #define  m_interrupts_ram_size         __ram_vector_table_size__
@@ -93,13 +104,13 @@
 #define  m_usb_sram_start              0x40100000
 #define  m_usb_sram_size               0x00004000
 
-LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
+LR_IROM1 m_interrupts_start (AlignExpr(m_text_start, 8)+m_text_size-m_interrupts_start) {   ; load region size_region
 
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
 
-  ER_IROM1 m_text_start FIXED m_text_size { ; load address = execution address
+  ER_IROM1 AlignExpr(m_text_start, 8) FIXED m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_GCC_ARM/LPC55S69_cm33_core0_flash.ld
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_GCC_ARM/LPC55S69_cm33_core0_flash.ld
@@ -57,6 +57,22 @@ __ram_vector_table__ = 1;
     #define MBED_BOOT_STACK_SIZE 0x400
 #endif
 
+#if !defined(NVIC_INTERRUPT_NUM)
+  #define NVIC_INTERRUPT_NUM     60
+#endif
+
+#if !defined(EXCEPTION_VECT_NUM)
+  #define EXCEPTION_VECT_NUM     16
+#endif
+
+#if !defined(MEMORY_ADDR_SIZE_IN_BYTE)
+  #define MEMORY_ADDR_SIZE_IN_BYTE     4
+#endif
+
+#if !defined(MBED_INTERRUPTS_SIZE)
+  #define MBED_INTERRUPTS_SIZE ((NVIC_INTERRUPT_NUM + EXCEPTION_VECT_NUM) * MEMORY_ADDR_SIZE_IN_BYTE)
+#endif
+
 __stack_size__ = MBED_BOOT_STACK_SIZE;
 
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0800;
@@ -64,8 +80,8 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x200 : 0x0;
 
 MEMORY
 {
-  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x140
-  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x140, LENGTH = MBED_APP_SIZE - 0x140
+  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = MBED_INTERRUPTS_SIZE
+  m_text                (RX)  : ORIGIN = MBED_APP_START + MBED_INTERRUPTS_SIZE, LENGTH = MBED_APP_SIZE - MBED_INTERRUPTS_SIZE
   m_data                (RW)  : ORIGIN = MBED_RAM_START, LENGTH = MBED_RAM_SIZE
   m_usb_sram            (RW)  : ORIGIN = 0x40100000, LENGTH = 0x00004000
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_IAR/LPC55S69_cm33_core0_flash.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_IAR/LPC55S69_cm33_core0_flash.icf
@@ -80,10 +80,26 @@ if (isdefinedsymbol(__heap_size__)) {
   define symbol __size_heap__          = 0x0400;
 }
 
-define symbol m_interrupts_start     = MBED_APP_START;
-define symbol m_interrupts_end       = (MBED_APP_START + 0x13F);
+if (!isdefinedsymbol(NVIC_INTERRUPT_NUM)) {
+  define symbol NVIC_INTERRUPT_NUM   = 60;
+}
 
-define symbol m_text_start           = (MBED_APP_START + 0x140);
+if (!isdefinedsymbol(EXCEPTION_VECT_NUM)) {
+  define symbol EXCEPTION_VECT_NUM   = 16;
+}
+
+if (!isdefinedsymbol(MEMORY_ADDR_SIZE_IN_BYTE)) {
+  define symbol MEMORY_ADDR_SIZE_IN_BYTE   = 4;
+}
+
+if (!isdefinedsymbol(MBED_INTERRUPTS_SIZE)) {
+  define symbol MBED_INTERRUPTS_SIZE   = ((NVIC_INTERRUPT_NUM + EXCEPTION_VECT_NUM) * MEMORY_ADDR_SIZE_IN_BYTE);
+}
+
+define symbol m_interrupts_start     = MBED_APP_START;
+define symbol m_interrupts_end       = (MBED_APP_START + (MBED_INTERRUPTS_SIZE - 1));
+
+define symbol m_text_start           = (MBED_APP_START + MBED_INTERRUPTS_SIZE);
 define symbol m_text_end             = (MBED_APP_START + MBED_APP_SIZE - 1);
 
 define symbol m_interrupts_ram_start = MBED_RAM_START;


### PR DESCRIPTION
### Description

As the build tool in mbed-os 5.13 cannot appropriately deal with a segmented
bootloader when combining it with an application, this commit adjusts the
size reserved for interrupts (via the linker file) to avoid a bootloader
segmentation due to an unpopulated ROM area.

The microcontroller has a total of 60 vector interrupts + 16 exception
handlers. The allocated ROM flash for interrupts should be (60 + 16) x word
size in bytes = 76 x 4 = 304 = 0x130.

This commit changes the interrupt reserved space from 0x140 to 0x130.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@bridadan @theotherjimmy 

Fixes internal issue IOTCORE-1149
