### PR TITLE
Fix: Allow target size restriction for LPC55S69

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2058,7 +2058,8 @@
         "detect_code": ["0236"],
         "device_name": "LPC55S69JBD100",
         "release_versions": ["5"],
-        "program_cycle_s": 10
+        "program_cycle_s": 10,
+        "sectors": [[0,512]]
     },
     "LPC55S69_NS": {
         "inherits": ["NSPE_Target", "LPC55S69"],


### PR DESCRIPTION
### Description

The build tool uses the sector size found in the CMSIS Pack to determine if
the size that can be specified by `target.restrict_size` is enough to fit
all the parts of a given binary. See `target.restrict_size` documentation
in the Mbed OS manual for more information.

The sector size found in the CMSIS Pack is overriden to allow the build
tool to accurately make the decision.

The target's sectors in the CMSIS Pack are defined in 32KB pages.
However, you can erase pages at the 512 byte level.

This commit changes defined sector erase size to 512 bytes instead of
32 kilobytes.



<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@bridadan @theotherjimmy 

Fixes internal issue IOTCORE-1149
