### PR TITLE
LWIP DNS servers setting/getting fixed.

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -94,11 +94,6 @@ static int get_ip_addr_type(const ip_addr_t *ip_addr)
 
 void LWIP::add_dns_addr(struct netif *lwip_netif, const char *interface_name)
 {
-
-    if (!netif_check_default(lwip_netif)) {
-        interface_name = NULL;
-    }
-
     // Check for existing dns address
     for (char numdns = 0; numdns < DNS_MAX_SERVERS; numdns++) {
         const ip_addr_t *dns_ip_addr = dns_getserver(numdns, interface_name);

--- a/features/lwipstack/lwip/src/core/lwip_dns.c
+++ b/features/lwipstack/lwip/src/core/lwip_dns.c
@@ -367,7 +367,7 @@ void
 dns_setserver(u8_t numdns, const ip_addr_t *dnsserver, struct netif *netif)
 {
 
-  if (netif == NULL || netif_check_default(netif)) {
+  if (netif == NULL ) {
     if (numdns < DNS_MAX_SERVERS) {
       if (dnsserver != NULL) {
         dns_servers[numdns] = (*dnsserver);
@@ -390,17 +390,18 @@ dns_setserver(u8_t numdns, const ip_addr_t *dnsserver, struct netif *netif)
  * @return IP address of the indexed DNS server or "ip_addr_any" if the DNS
  *         server has not been configured.
  */
-const ip_addr_t*
+const ip_addr_t *
 dns_getserver(u8_t numdns, const char *interface_name)
 {
-  if (interface_name == NULL) {
-    if (numdns < DNS_MAX_SERVERS) {
-      return &dns_servers[numdns];
+  if (numdns < DNS_MAX_SERVERS) {
+    const ip_addr_t *dns_addr = dns_get_interface_server(numdns, interface_name);
+    if (dns_addr != IP_ADDR_ANY) {
+      return dns_addr;
     } else {
-      return IP_ADDR_ANY;
+      return &dns_servers[numdns];
     }
   } else {
-    return dns_get_interface_server(numdns, interface_name);
+    return IP_ADDR_ANY;
   }
 }
 

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -52,7 +52,7 @@
         },
         "dns-retries": {
             "help": "Number of DNS query retries that the DNS translator makes per server, before moving on to the next server. Total retries/attempts is always limited by dns-total-attempts.",
-            "value": 0
+            "value": 2
         },
         "dns-cache-size": {
             "help": "Number of cached host name resolutions",

--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -105,10 +105,10 @@ static void nsapi_dns_query_async_initiate_next(void);
 // *INDENT-OFF*
 static nsapi_addr_t dns_servers[DNS_SERVERS_SIZE] = {
     {NSAPI_IPv4, {8, 8, 8, 8}},                             // Google
-    {NSAPI_IPv4, {209, 244, 0, 3}},                         // Level 3
-    {NSAPI_IPv4, {84, 200, 69, 80}},                        // DNS.WATCH
     {NSAPI_IPv6, {0x20,0x01, 0x48,0x60, 0x48,0x60, 0,0,     // Google
                   0,0, 0,0, 0,0, 0x88,0x88}},
+    {NSAPI_IPv4, {209, 244, 0, 3}},                         // Level 3
+    {NSAPI_IPv4, {84, 200, 69, 80}},                        // DNS.WATCH
     {NSAPI_IPv6, {0x20,0x01, 0x16,0x08, 0,0x10, 0,0x25,     // DNS.WATCH
                   0,0, 0,0, 0x1c,0x04, 0xb1,0x2f}},
 };


### PR DESCRIPTION
### Description
LWIP DNS server storing and reading  fixed due to IP6 DNS servers getting problem.
Modified default  DNS servers priority.
 
### Pull request type

 
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@mikaleppanen 
@kivaisan 
 

### Release Notes

 
