### PR TITLE
FastModel: trun off MPU for FVP_MPS2_M0P

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/CMSDK_CM0plus.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/CMSDK_CM0plus.h
@@ -98,7 +98,7 @@ typedef enum IRQn {
 
 /* --------  Configuration of the Cortex-M0+ Processor and Core Peripherals  ------ */
 #define __CM0PLUS_REV             0x0000    /* Core revision r0p0                              */
-#define __MPU_PRESENT             1         /* MPU present or not                              */
+#define __MPU_PRESENT             0         /* MPU present or not                              */
 #define __VTOR_PRESENT            1         /* VTOR present or not                             */
 #define __NVIC_PRIO_BITS          2         /* Number of Bits used for Priority Levels         */
 #define __Vendor_SysTickConfig    0         /* Set to 1 if different SysTick Config is used    */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8071,8 +8071,7 @@
     "FVP_MPS2_M0P": {
         "inherits": ["FVP_MPS2"],
         "core": "Cortex-M0+",
-        "macros_add": ["CMSDK_CM0plus"],
-        "device_has_add": ["MPU"]
+        "macros_add": ["CMSDK_CM0plus"]
     },
     "FVP_MPS2_M3": {
         "inherits": ["FVP_MPS2"],


### PR DESCRIPTION
### Description

MPU is optional on Cortex-M0plus
By default, on FVP_MPS2_M0P target not having the MPU, so the SDK was miss-configured. 
Fixing the issue by turning them off.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

