### PR TITLE
Fix ARMC5 compilation

### DIFF
--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+#include "ns_list.h"
 #include "netsocket/NetworkInterface.h"
 #include "netsocket/NetworkStack.h"
 #include "platform/Callback.h"
 #include "platform/mbed_error.h"
 #include <string.h>
-#include "ns_list.h"
 
 // Default network-interface state
 void NetworkInterface::set_as_default()

--- a/platform/SingletonPtr.h
+++ b/platform/SingletonPtr.h
@@ -131,8 +131,8 @@ struct SingletonPtr {
 
     // This is zero initialized when in global scope
     mutable void *_ptr;
-#if __cplusplus >= 201103L
-    // Align data appropriately
+#if __cplusplus >= 201103L && !defined __CC_ARM
+    // Align data appropriately (ARM Compiler 5 does not support alignas in C++11 mode)
     alignas(T) mutable char _data[sizeof(T)];
 #else
     // Force data to be 8 byte aligned


### PR DESCRIPTION
### Description

Minor tweaks to fix ARM C 5 compatibility.

Pushing "ns_list.h" include to first makes sure "ns_types.h" is included
first, meaning it gets to define `__STDC_LIMIT_MACROS` before the first
include of <stdint.h>, which ensures that UINT8_MAX etc are defined.

Fixes #10789 

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@TeroJaasko 
