### PR TITLE
Cellular: Added handling for BG96 network PDP context deactivation

### DIFF
--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -143,11 +143,11 @@ public:
 
 protected:
     virtual void cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx = NULL);
+    void send_disconnect_to_context(int cid);
 
 private:
     void urc_nw_deact();
     void urc_pdn_deact();
-    void send_disconnect_to_context(int cid);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -69,6 +69,8 @@ QUECTEL_BG96::QUECTEL_BG96(FileHandle *fh, PinName pwr, bool active_high, PinNam
       _pwr(pwr, !_active_high),
       _rst(rst, !_active_high)
 {
+    _at->set_urc_handler("+QIURC: \"pdpde",  mbed::Callback<void()>(this, &QUECTEL_BG96::urc_pdpdeact));
+
     AT_CellularBase::set_cellular_properties(cellular_properties);
 }
 
@@ -199,3 +201,16 @@ CellularDevice *CellularDevice::get_default_instance()
     return &device;
 }
 #endif
+
+void QUECTEL_BG96::urc_pdpdeact()
+{
+    _at->lock();
+    _at->skip_param();
+    int cid = _at->read_int();
+    const nsapi_error_t err = _at->unlock_return_error();
+
+    if (err != NSAPI_ERROR_OK) {
+        return;
+    }
+    send_disconnect_to_context(cid);
+}

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
@@ -54,6 +54,7 @@ private:
     bool _active_high;
     DigitalOut _pwr;
     DigitalOut _rst;
+    void urc_pdpdeact();
 };
 } // namespace mbed
 #endif // QUECTEL_BG96_H_

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -20,15 +20,10 @@
 
 using namespace mbed;
 
-const char *QIURC_RECV = "recv";
-const uint8_t QIURC_RECV_LENGTH = 4;
-const char *QIURC_CLOSED = "closed";
-const uint8_t QIURC_CLOSED_LENGTH = 6;
-const uint8_t MAX_QIURC_LENGTH = QIURC_CLOSED_LENGTH;
-
 QUECTEL_BG96_CellularStack::QUECTEL_BG96_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type) : AT_CellularStack(atHandler, cid, stack_type)
 {
-    _at.set_urc_handler("+QIURC:", mbed::Callback<void()>(this, &QUECTEL_BG96_CellularStack::urc_qiurc));
+    _at.set_urc_handler("+QIURC: \"recv", mbed::Callback<void()>(this, &QUECTEL_BG96_CellularStack::urc_qiurc_recv));
+    _at.set_urc_handler("+QIURC: \"close", mbed::Callback<void()>(this, &QUECTEL_BG96_CellularStack::urc_qiurc_closed));
 }
 
 QUECTEL_BG96_CellularStack::~QUECTEL_BG96_CellularStack()
@@ -115,11 +110,20 @@ nsapi_error_t QUECTEL_BG96_CellularStack::socket_connect(nsapi_socket_t handle, 
     return NSAPI_ERROR_NO_CONNECTION;
 }
 
-void QUECTEL_BG96_CellularStack::urc_qiurc()
+void QUECTEL_BG96_CellularStack::urc_qiurc_recv()
 {
-    char urc_string[MAX_QIURC_LENGTH + 1];
+    urc_qiurc(URC_RECV);
+}
+
+void QUECTEL_BG96_CellularStack::urc_qiurc_closed()
+{
+    urc_qiurc(URC_CLOSED);
+}
+
+void QUECTEL_BG96_CellularStack::urc_qiurc(urc_type_t urc_type)
+{
     _at.lock();
-    (void)_at.read_string(urc_string, sizeof(urc_string));
+    _at.skip_param();
     const int sock_id = _at.read_int();
     const nsapi_error_t err = _at.unlock_return_error();
 
@@ -127,20 +131,14 @@ void QUECTEL_BG96_CellularStack::urc_qiurc()
         return;
     }
 
-    bool recv = strcmp(urc_string, "recv") == 0;
-    bool closed = strcmp(urc_string, "closed") == 0;
-
     CellularSocket *sock = find_socket(sock_id);
     if (sock) {
-        if (closed) {
-            tr_error("Socket closed %d", sock_id);
+        if (urc_type == URC_CLOSED) {
+            tr_info("Socket closed %d", sock_id);
             sock->closed = true;
         }
-
-        if (recv || closed) {
-            if (sock->_cb) {
-                sock->_cb(sock->_data);
-            }
+        if (sock->_cb) {
+            sock->_cb(sock->_data);
         }
     }
 }

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
@@ -29,6 +29,11 @@ namespace mbed {
 #define BG96_MAX_SEND_SIZE 1460
 #define BG96_SOCKET_BIND_FAIL 556
 
+typedef enum {
+    URC_RECV,
+    URC_CLOSED,
+} urc_type_t;
+
 class QUECTEL_BG96_CellularStack : public AT_CellularStack {
 public:
     QUECTEL_BG96_CellularStack(ATHandler &atHandler, int cid, nsapi_ip_stack_t stack_type);
@@ -60,8 +65,12 @@ protected: // AT_CellularStack
                                                        void *buffer, nsapi_size_t size);
 
 private:
-    // URC handlers
-    void urc_qiurc();
+    // URC handler
+    void urc_qiurc(urc_type_t urc_type);
+    // URC handler for socket data being received
+    void urc_qiurc_recv();
+    // URC handler for socket being closed
+    void urc_qiurc_closed();
 
     void handle_open_socket_response(int &modem_connect_id, int &err);
 };


### PR DESCRIPTION
### Description

Added support for handling network initiated PDP context deactivation URC "+QIURC: pdpdeact".

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change