### PR TITLE
ns_list: avoid UINT_FAST8_MAX (fix ARM C 5 builds)

### DIFF
--- a/features/frameworks/nanostack-libservice/mbed-client-libservice/ns_list.h
+++ b/features/frameworks/nanostack-libservice/mbed-client-libservice/ns_list.h
@@ -148,7 +148,7 @@ union \
 { \
     ns_list_t slist; \
     NS_FUNNY_COMPARE_OK \
-    NS_STATIC_ASSERT(link_offset <= UINT_FAST8_MAX, "link offset too large") \
+    NS_STATIC_ASSERT(link_offset <= (ns_list_offset_t) -1, "link offset too large") \
     NS_FUNNY_COMPARE_RESTORE \
     char (*offset)[link_offset + 1]; \
     entry_type *type; \


### PR DESCRIPTION
### Description

Prevent compilation issues when someone has included <stdint.h> before a header file that needs to include <ns_list.h>.

Some toolchains like ARM C 5 will not provide `UINT_FAST8_MAX` in C++ unless `__STDC_LIMIT_MACROS` is defined, and if this was not defined the first time <stdint.h> was included, it's too late.

We can get the maximum value for our unsigned list offset by casting -1 to it, thanks to modulo arithmetic.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@artokin, @TeroJaasko 
