### PR TITLE
Cellular: fix athandler to use correct timeout in case of multiple urc's

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -320,8 +320,8 @@ void ATHandler::process_oob()
                     reset_buffer(); // consume anything that could not be handled
                     break;
                 }
-                _start_time = rtos::Kernel::get_ms_count();
             }
+            _start_time = rtos::Kernel::get_ms_count();
         }
         _at_timeout = timeout;
         tr_debug("AT OoB done");


### PR DESCRIPTION
### Description

Start time was not updated when multiple urc's were found and so timeout was set to zero. Now that start time is updated, timeout is correct.
Fixes issue https://github.com/ARMmbed/mbed-os/issues/10549

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica 

### Release Notes
