### PR TITLE
Make ARMC5 and IAR develop profile also size optimized

### DIFF
--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -27,7 +27,7 @@
         "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
     },
     "ARM": {
-        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O3", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
@@ -36,7 +36,7 @@
         "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "uARM": {
-        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O3", "-D__MICROLIB",
                    "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -49,7 +49,7 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Oh", "--enable_restrict",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "--enable_restrict",
              "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--vla", "--diag_suppress=Pe546"],


### PR DESCRIPTION
### Description

Due to some historical reasons ARMC 5 compiler behaves very
differently compared to others (GCC, IAR, ARM C 6) as it optimizes
performance rather than size. The compilers should behave the same
way with the same profile, thus ARM C 5 should also drive towards
size.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm @bulislaw  @0xc0170 

### Release Notes

