### PR TITLE
Nuvoton: Fix channel release in analogout_free()

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/analogout_api.c
@@ -124,7 +124,7 @@ void analogout_free(dac_t *obj)
     /* Channel-level windup from here */
 
     /* Mark channel free */
-    dac_modinit_mask[modidx] &= ~(1 << modidx);
+    dac_modinit_mask[modidx] &= ~(1 << chn);
     
     /* Close channel */
     DAC_Close(dac_base, chn);

--- a/targets/TARGET_NUVOTON/TARGET_M451/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/analogout_api.c
@@ -106,7 +106,7 @@ void analogout_free(dac_t *obj)
     /* Channel-level windup from here */
 
     /* Mark channel free */
-    dac_modinit_mask[modidx] &= ~(1 << modidx);
+    dac_modinit_mask[modidx] &= ~(1 << chn);
     
     /* Close channel */
     DAC_Close(dac_base, chn);

--- a/targets/TARGET_NUVOTON/TARGET_M480/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/analogout_api.c
@@ -115,7 +115,7 @@ void analogout_free(dac_t *obj)
     /* Channel-level windup from here */
 
     /* Mark channel free */
-    dac_modinit_mask[modidx] &= ~(1 << modidx);
+    dac_modinit_mask[modidx] &= ~(1 << chn);
     
     /* Close channel */
     DAC_Close(dac_base, chn);

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/analogout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/analogout_api.c
@@ -110,7 +110,7 @@ void analogout_free(dac_t *obj)
     /* Channel-level windup from here */
 
     /* Mark channel free */
-    dac_modinit_mask[modidx] &= ~(1 << modidx);
+    dac_modinit_mask[modidx] &= ~(1 << chn);
     
     /* Close channel */
     DAC_Close(dac_base, chn);


### PR DESCRIPTION
### Description

This PR fixes DAC channel release bug in `analogout_free()` on Nuvoton targets.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
