### PR TITLE
STM32: pwmout_write: configure channel only when not already enabled

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32f0xx_ll_usart.h"
+#include "stm32f0xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32f1xx_ll_usart.h"
+#include "stm32f1xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32f2xx_ll_usart.h"
+#include "stm32f2xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32f3xx_ll_usart.h"
+#include "stm32f3xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32f4xx_ll_usart.h"
+#include "stm32f4xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32f7xx_ll_usart.h"
+#include "stm32f7xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32H7/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/objects.h
@@ -36,6 +36,7 @@
 #include "PinNames.h"
 #include "stm32h7xx_ll_usart.h"
 #include "stm32h7xx_ll_rtc.h"
+#include "stm32h7xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32L0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32l0xx_ll_usart.h"
+#include "stm32l0xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32l1xx_ll_usart.h"
+#include "stm32l1xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -35,6 +35,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32l4xx_ll_usart.h"
+#include "stm32l4xx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32WB/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/common_objects.h
@@ -37,6 +37,7 @@
 #include "PeripheralNames.h"
 #include "PinNames.h"
 #include "stm32wbxx_ll_usart.h"
+#include "stm32wbxx_ll_tim.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Description
STM32: pwmout_write: configure channel only when not already enabled
to fix PWM glitch on write(), TARGET_STM/pwmout_api.c.

Fixes #10734
### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes


