### PR TITLE
Cellular: Fix PLMN debug trace for IAR

### DIFF
--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -167,7 +167,7 @@ bool CellularStateMachine::open_sim()
 
     if (sim_ready) {
         _cb_data.error = _network.set_registration(_plmn);
-        tr_debug("STM: set_registration: %d, plmn: %s", _cb_data.error, _plmn);
+        tr_debug("STM: set_registration: %d, plmn: %s", _cb_data.error, _plmn ? _plmn : "NULL");
         if (_cb_data.error) {
             return false;
         }


### PR DESCRIPTION

### Description

IAR does not allow printing from null pointer as parameter for %s. PLMN string
can be null depending on user configuration.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarvte @AnttiKauppila 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
