### PR TITLE
Fix cpu stats use when ticker suspended

### DIFF
--- a/platform/mbed_sleep_manager.c
+++ b/platform/mbed_sleep_manager.c
@@ -45,7 +45,11 @@ static inline us_timestamp_t read_us(void)
     if (NULL == sleep_ticker) {
         sleep_ticker = (ticker_data_t *)get_lp_ticker_data();
     }
-    return ticker_read_us(sleep_ticker);
+    if (sleep_ticker->queue->suspended || !sleep_ticker->queue->initialized) {
+        return sleep_ticker->queue->present_time;
+    } else {
+        return ticker_read_us(sleep_ticker);
+    }
 #else
     return 0;
 #endif


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Small fixes of issues encountered during tests. 
In case CPU STATS option is enabled during tests like hal_manager tests, we can fall into issues that are solved with this patch .


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mprse  @kjbracey-arm 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
