### PR TITLE
Fix spif 64 bit erase mask

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -540,8 +540,9 @@ spif_bd_error SPIFBlockDevice::_spi_send_program_command(int prog_inst, const vo
 
 spif_bd_error SPIFBlockDevice::_spi_send_erase_command(int erase_inst, bd_addr_t addr, bd_size_t size)
 {
-    addr = (((int)addr) & 0x00FFF000);
-    _spi_send_general_command(erase_inst, addr, NULL, 0, NULL, 0);
+    bd_addr_t BLOCK_MASK = 0x00FFF000;
+    bd_addr_t erase_addr = (addr & BLOCK_MASK);
+    _spi_send_general_command(erase_inst, erase_addr, NULL, 0, NULL, 0);
     return SPIF_BD_ERROR_OK;
 }
 

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -290,7 +290,7 @@ int SPIFBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
 
         //Send WREN
         if (_set_write_enable() != 0) {
-            tr_error("ERROR: Write Enabe failed\n");
+            tr_error("ERROR: Write Enable failed\n");
             program_failed = true;
             status = SPIF_BD_ERROR_WREN_FAILED;
             goto exit_point;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -540,7 +540,7 @@ spif_bd_error SPIFBlockDevice::_spi_send_program_command(int prog_inst, const vo
 
 spif_bd_error SPIFBlockDevice::_spi_send_erase_command(int erase_inst, bd_addr_t addr, bd_size_t size)
 {
-    bd_addr_t BLOCK_MASK = 0x00FFF000;
+    bd_addr_t BLOCK_MASK = 0xFFFFFFFFFFFFF000;
     bd_addr_t erase_addr = (addr & BLOCK_MASK);
     _spi_send_general_command(erase_inst, erase_addr, NULL, 0, NULL, 0);
     return SPIF_BD_ERROR_OK;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
When sending an erase command over SPI, the SPIF driver first masks the argument address to ensure the address given is indeed a block address. The mask literal `0x00FFF000` and the typecast `(int)addr` are both being interpreted as 16 bit integers by my processor and thus the resulting masked address is always 0. This fix explicitly defines the mask as the same object type as the argument address to ensure regardless of the processor the mask works as intended. 

More info and original issue here -> https://github.com/ARMmbed/mbed-os/issues/10783

Also fixed a typo.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@adbridge 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
