### PR TITLE
M23: Fix compile error with mbed fault handler

### DIFF
--- a/platform/TARGET_CORTEX_M/mbed_fault_handler.c
+++ b/platform/TARGET_CORTEX_M/mbed_fault_handler.c
@@ -98,7 +98,7 @@ MBED_NOINLINE void print_context_info(void)
     //Capture CPUID to get core/cpu info
     mbed_error_printf("\nCPUID: %08" PRIX32, SCB->CPUID);
 
-#if !defined(TARGET_M0) && !defined(TARGET_M0P)
+#if !defined(TARGET_M0) && !defined(TARGET_M0P) && !defined(TARGET_M23)
     //Capture fault information registers to infer the cause of exception
     mbed_error_printf("\nHFSR : %08" PRIX32
                       "\nMMFSR: %08" PRIX32


### PR DESCRIPTION
### Description

M23 doesn't implement ARMv8-M Main Extension. So like M0/M0+, these registers `HFSR`/`MMFSR`/`BFSR`/`UFSR`/`DFSR` are not present on M23. Remove access to them in mbed fault handler for M23 targets.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
