### PR TITLE
Toolchain attributes - use C++11/C11

### DIFF
--- a/platform/mbed_assert.h
+++ b/platform/mbed_assert.h
@@ -24,6 +24,7 @@
 #ifndef MBED_ASSERT_H
 #define MBED_ASSERT_H
 
+#include <stdbool.h>
 #include "mbed_preprocessor.h"
 #include "mbed_toolchain.h"
 
@@ -124,7 +125,7 @@ do {                                                     \
  *  };
  *  @endcode
  */
-#define MBED_STRUCT_STATIC_ASSERT(expr, msg) int : (expr) ? 0 : -1
+#define MBED_STRUCT_STATIC_ASSERT(expr, msg) bool : (expr) ? 0 : -1
 
 
 #endif

--- a/platform/mbed_assert.h
+++ b/platform/mbed_assert.h
@@ -24,7 +24,6 @@
 #ifndef MBED_ASSERT_H
 #define MBED_ASSERT_H
 
-#include <stdbool.h>
 #include "mbed_preprocessor.h"
 #include "mbed_toolchain.h"
 
@@ -125,8 +124,14 @@ do {                                                     \
  *  };
  *  @endcode
  */
+#if defined(__cplusplus) && (__cplusplus >= 201103L || __cpp_static_assert >= 200410L)
+#define MBED_STRUCT_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
+#elif !defined(__cplusplus) && __STDC_VERSION__ >= 201112L
+#define MBED_STRUCT_STATIC_ASSERT(expr, msg) _Static_assert(expr, msg)
+#else
+#include <stdbool.h>
 #define MBED_STRUCT_STATIC_ASSERT(expr, msg) bool : (expr) ? 0 : -1
-
+#endif
 
 #endif
 

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -72,7 +72,11 @@
  *  @endcode
  */
 #ifndef MBED_ALIGN
-#if defined(__ICCARM__)
+#if __cplusplus >= 201103 && !defined __CC_ARM
+#define MBED_ALIGN(N) alignas(N)
+#elif __STDC_VERSION__ >= 201112 && !defined __CC_ARM
+#define MBED_ALIGN(N) _Alignas(N)
+#elif defined(__ICCARM__)
 #define MBED_ALIGN(N) _Pragma(MBED_STRINGIFY(data_alignment=N))
 #else
 #define MBED_ALIGN(N) __attribute__((aligned(N)))
@@ -298,7 +302,11 @@
  *  @endcode
  */
 #ifndef MBED_NORETURN
-#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
+#if __cplusplus >= 201103
+#define MBED_NORETURN [[noreturn]]
+#elif __STDC_VERSION__ >= 201112
+#define MBED_NORETURN _Noreturn
+#elif defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
 #define MBED_NORETURN __attribute__((noreturn))
 #elif defined(__ICCARM__)
 #define MBED_NORETURN __noreturn


### PR DESCRIPTION
### Description

Use standard C++11/C11 forms for `MBED_STRUCT_STATIC_ASSERT`, `MBED_NORETURN` and `MBED_ALIGN` when available.

Using standard forms increases the chances that code analysis tools such Coverity will recognise them - particularly important for "no return".

Fix excess alignment problem caused by non-C++11 `MBED_STRUCT_STATIC_ASSERT` fallback using `int`.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

