### PR TITLE
Update watchdog timing requirements

### DIFF
--- a/TESTS/mbed_hal/reset_reason/main.cpp
+++ b/TESTS/mbed_hal/reset_reason/main.cpp
@@ -29,7 +29,6 @@
 
 #define MSG_VALUE_WATCHDOG_STATUS "wdg_present"
 #define WDG_TIMEOUT_MS 50UL
-#define WDG_TIMEOUT_DELTA_MS 50UL
 
 #else
 #define MSG_VALUE_WATCHDOG_STATUS "no_wdg"
@@ -115,7 +114,7 @@ static cmd_status_t handle_command(const char *key, const char *value)
             TEST_ASSERT_MESSAGE(0, "hal_watchdog_init() error.");
             return CMD_STATUS_ERROR;
         }
-        wait_ms(WDG_TIMEOUT_MS + WDG_TIMEOUT_DELTA_MS);
+        wait_ms(2 * WDG_TIMEOUT_MS); // Watchdog should fire before twice the timeout value.
         TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
         return CMD_STATUS_ERROR;
     }

--- a/TESTS/mbed_hal/watchdog/watchdog_api_tests.h
+++ b/TESTS/mbed_hal/watchdog/watchdog_api_tests.h
@@ -65,32 +65,22 @@ void test_stop();
 
 /** Test Watchdog init multiple times
  *
- * Given @a max_timeout value returned by @a hal_watchdog_get_platform_features():
- *
- * Given @a config.timeout_ms is set to WDG_TIMEOUT_MS,
- * when @a hal_watchdog_init() is called,
- * then @a WATCHDOG_STATUS_OK is returned
- *     and @a hal_watchdog_get_reload_value() returns WDG_TIMEOUT_MS.
- *
- * Given @a config.timeout_ms is set to max_timeout-delta,
- * when @a hal_watchdog_init() is called,
- * then @a WATCHDOG_STATUS_OK is returned
- *     and @a hal_watchdog_get_reload_value() returns max_timeout-delta.
- *
- * Given @a config.timeout_ms is set to max_timeout,
- * when @a hal_watchdog_init() is called,
- * then @a WATCHDOG_STATUS_OK is returned
- *     and @a hal_watchdog_get_reload_value() returns max_timeout.
+ * Given a set of unique timeout values,
+ * when @a config.timeout_ms is set to each of these values (T),
+ * then, for every value T, @a hal_watchdog_init() returns @a WATCHDOG_STATUS_OK
+ *     and @a hal_watchdog_get_reload_value() returns a reload value R
+ *     and T <= R < 2 * T.
  */
 void test_update_config();
 
 /** Test Watchdog init with a valid config
  *
- * Given @a config.timeout_ms is set to X ms,
+ * Given @a config.timeout_ms is set to T ms,
  *     which is within supported Watchdog timeout range,
  * when @a hal_watchdog_init() is called,
  * then @a WATCHDOG_STATUS_OK is returned
- *     and @a hal_watchdog_get_reload_value() returns X.
+ *     and @a hal_watchdog_get_reload_value() returns a reload value R
+ *     and T <= R < 2 * T.
  */
 template<uint32_t timeout_ms>
 void test_init();

--- a/TESTS/mbed_hal/watchdog_timing/watchdog_timing_tests.h
+++ b/TESTS/mbed_hal/watchdog_timing/watchdog_timing_tests.h
@@ -34,8 +34,8 @@
  *
  * Phase 2.
  * Given a device restarted by the watchdog timer,
- * when the device receives time measurement from the host,
- * then time measured by host equals X ms.
+ * when the device receives time measurement T from the host,
+ * then X <= T < 2 * X.
  */
 template<uint32_t timeout_ms, uint32_t delta_ms>
 void test_timing();

--- a/TESTS/mbed_platform/watchdog_mgr_reset/main.cpp
+++ b/TESTS/mbed_platform/watchdog_mgr_reset/main.cpp
@@ -26,8 +26,6 @@
 #include "watchdog_mgr_reset_tests.h"
 #include "mbed.h"
 
-#define TIMEOUT_DELTA_MS 50UL
-
 #define MSG_VALUE_DUMMY "0"
 #define CASE_DATA_INVALID 0xffffffffUL
 #define CASE_DATA_PHASE2_OK 0xfffffffeUL
@@ -48,11 +46,6 @@ struct testcase_data {
     int start_index;
     uint32_t received_data;
 };
-
-void release_sem(Semaphore *sem)
-{
-    sem->release();
-}
 
 testcase_data current_case;
 

--- a/hal/watchdog_api.h
+++ b/hal/watchdog_api.h
@@ -2,6 +2,7 @@
 /** @{*/
 /* mbed Microcontroller Library
  * Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +27,7 @@
 
 /**
  * \defgroup hal_watchdog Watchdog HAL API
- * @{
- */
-
-/** \file watchdog_api.h
+ * Low-level interface to the Independent Watchdog Timer of a target.
  *
  * This module provides platform independent access to the system watchdog timer
  * which is an embedded peripheral that will reset the system in the case of
@@ -38,12 +36,29 @@
  * The watchdog timer initialises a system timer with a time period specified in
  * the configuration. This timer counts down and triggers a system reset when it
  * wraps. To prevent the system reset the timer must be continually
- * kicked/refreshed by calling hal_watchdog_kick which will reset the countdown
+ * kicked/refreshed by calling ::hal_watchdog_kick which will reset the countdown
  * to the user specified reset value.
  *
- * The Watchdog timer must continue to operate in low power modes. It
- * must count down and trigger a reset from within both sleep and deep sleep
- * modes unless the chip is woken to refresh the timer.
+ * # Defined behavior
+ * * Sleep and debug modes don't stop the watchdog timer from counting down.
+ * * The function ::hal_watchdog_init is safe to call repeatedly. The
+ * function's implementation must not do anything if ::hal_watchdog_init has
+ * already initialized the hardware watchdog timer.
+ * * Maximum supported timeout is `UINT32_MAX` milliseconds; minimum timeout
+ * is 1 millisecond.
+ * * The watchdog should trigger at or after the timeout value.
+ * * The watchdog should trigger before twice the timeout value.
+ *
+ * # Undefined behavior
+ * * Calling any function other than ::hal_watchdog_init or
+ * ::hal_watchdog_get_platform_features before you have initialized the watchdog.
+ *
+ * # Notes
+ * * A software reset may not stop the watchdog timer; the behavior is platform specific.
+ *
+ * @see hal_watchdog_tests
+ *
+ * @{
  */
 
 typedef struct {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Relax the timing requirements for watchdog according to https://github.com/ARMmbed/mbed-os/issues/8857#issuecomment-467838213:
* The watchdog should trigger at or after the timeout value.
* The watchdog should trigger before twice the timeout value.

Fixes #8857 

Docs update in https://github.com/ARMmbed/mbed-os-5-docs/pull/1088

~**NOTE:** Marking this as a draft -- we should wait until #10777 is merged.~

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@c1728p9 @rajkan01 @jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
