### PR TITLE
TARGET_STM: Add DEVICE_SPI_COUNT to use SPIs without interference

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     UART_2 = (int)USART2_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_2 = (int)USART2_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/PeripheralNames.h
@@ -44,6 +44,7 @@ typedef enum {
     UART_1 = (int)USART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 1
 typedef enum {
     SPI_1 = (int)SPI1_BASE
 } SPIName;

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_2 = (int)USART2_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE // for compilation

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/PeripheralNames.h
@@ -47,6 +47,7 @@ typedef enum {
     UART_4 = (int)USART4_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/PeripheralNames.h
@@ -51,6 +51,7 @@ typedef enum {
     UART_4 = (int)USART4_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     UART_8 = (int)USART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/TARGET_NUCLEO_F302R8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/TARGET_NUCLEO_F302R8/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_2 = (int)SPI2_BASE,
     SPI_3 = (int)SPI3_BASE

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 1
 typedef enum {
     SPI_1 = (int)SPI1_BASE
 } SPIName;

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/TARGET_DISCO_F303VC/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/TARGET_DISCO_F303VC/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     UART_5 = (int)UART5_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     UART_5 = (int)UART5_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/PeripheralNames.h
@@ -55,12 +55,12 @@ typedef enum {
     UART_5 = (int)UART5_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,
     SPI_3 = (int)SPI3_BASE,
     SPI_4 = (int)SPI4_BASE
-
 } SPIName;
 
 typedef enum {

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_DISCO_F334C8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_DISCO_F334C8/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 1
 typedef enum {
     SPI_1 = (int)SPI1_BASE
 } SPIName;

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_NUCLEO_F334R8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_NUCLEO_F334R8/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 1
 typedef enum {
     SPI_1 = (int)SPI1_BASE
 } SPIName;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
 #define STDIO_UART_RX  PB_7
 #define STDIO_UART     UART_1
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/PeripheralNames.h
@@ -60,6 +60,7 @@ typedef enum {
 #define STDIO_UART_RX  PA_3
 #define STDIO_UART     UART_2
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
 #define STDIO_UART_RX  PA_10
 #define STDIO_UART     UART_1
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/TARGET_DISCO_F401VC/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/TARGET_DISCO_F401VC/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_STEVAL_3DP001V1/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_STEVAL_3DP001V1/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/TARGET_ARCH_MAX/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/TARGET_ARCH_MAX/PeripheralNames.h
@@ -58,6 +58,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE,
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/TARGET_DISCO_F407VG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/TARGET_DISCO_F407VG/PeripheralNames.h
@@ -56,6 +56,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE,
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/TARGET_NUCLEO_F410RB/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/TARGET_NUCLEO_F410RB/PeripheralNames.h
@@ -51,6 +51,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_ELMO_F411RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_ELMO_F411RE/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE, ELMO_RF_SPI2 = SPI_1,
     SPI_2 = (int)SPI2_BASE, ELMO_SPI1 = SPI_2,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/PeripheralNames.h
@@ -46,6 +46,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_SAKURAIO_EVB_01/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_SAKURAIO_EVB_01/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
 #define STDIO_UART_RX  PB_7
 #define STDIO_UART     UART_1
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PeripheralNames.h
@@ -33,6 +33,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/PeripheralNames.h
@@ -33,6 +33,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/PeripheralNames.h
@@ -33,6 +33,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PeripheralNames.h
@@ -43,6 +43,7 @@ typedef enum {
     UART_10 = (int)UART10_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PeripheralNames.h
@@ -43,6 +43,7 @@ typedef enum {
     UART_10 = (int)UART10_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 5
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PeripheralNames.h
@@ -54,6 +54,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MTB_STM32_F439/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MTB_STM32_F439/PeripheralNames.h
@@ -58,6 +58,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_BG96/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_BG96/PeripheralNames.h
@@ -60,6 +60,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_B96B_F446VE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_B96B_F446VE/PeripheralNames.h
@@ -60,6 +60,7 @@ typedef enum {
     DMA_2 = (int)DMA2_BASE
 } DMAName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 4
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PeripheralNames.h
@@ -58,6 +58,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_UHURU_RAVEN/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_UHURU_RAVEN/PeripheralNames.h
@@ -59,6 +59,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/PeripheralNames.h
@@ -58,6 +58,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 6
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PeripheralNames.h
@@ -45,6 +45,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 1
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
 } SPIName;

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PeripheralNames.h
@@ -45,6 +45,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 1
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
 } SPIName;

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_DISCO_L053C8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_DISCO_L053C8/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_NUCLEO_L053R8/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_NUCLEO_L053R8/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/PeripheralNames.h
@@ -54,6 +54,7 @@ typedef enum {
 #define STDIO_UART_RX  PA_3
 #define STDIO_UART     UART_2
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     UART_3 = (int)USART3_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/PeripheralNames.h
@@ -52,6 +52,7 @@ typedef enum {
     UART_5 = (int)UART5_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/PeripheralNames.h
@@ -67,6 +67,7 @@ typedef enum {
 #define STDIO_UART     UART_2
 #endif
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/PeripheralNames.h
@@ -54,6 +54,7 @@ typedef enum {
 #define STDIO_UART_RX  PA_3
 #define STDIO_UART     UART_2
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_MTS_DRAGONFLY_L471QG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_MTS_DRAGONFLY_L471QG/PeripheralNames.h
@@ -59,6 +59,7 @@ typedef enum {
 #define STDIO_UART_RX  PB_7
 #define STDIO_UART     UART_1
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/PeripheralNames.h
@@ -50,6 +50,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_3 = (int)SPI3_BASE

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PeripheralNames.h
@@ -51,6 +51,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_MTB_ADV_WISE_1510/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_MTB_ADV_WISE_1510/PeripheralNames.h
@@ -51,6 +51,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_MTB_STM_L475/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_MTB_STM_L475/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_RHOMBIO_L476DMW1K/PeripheralNames.h
@@ -57,6 +57,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_SILICA_SENSOR_NODE/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_SILICA_SENSOR_NODE/PeripheralNames.h
@@ -59,6 +59,7 @@ typedef enum {
 #define STDIO_UART_RX  PD_2
 #define STDIO_UART     UART_5
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/PeripheralNames.h
@@ -55,6 +55,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/TARGET_NUCLEO_L4R5ZI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/TARGET_NUCLEO_L4R5ZI/PeripheralNames.h
@@ -53,6 +53,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 3
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/TARGET_NUCLEO_WB55RG/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/TARGET_STM32WB55xG/TARGET_NUCLEO_WB55RG/PeripheralNames.h
@@ -32,6 +32,7 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
+#define DEVICE_SPI_COUNT 2
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE


### PR DESCRIPTION
### Description

Extend to all STM targets the work done on #10752 
Half works around #10827


### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@embeddedteam103 
@kjbracey-arm 
@LMESTM 
