### PR TITLE
Cellular: Stack type fixes

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -385,9 +385,8 @@ bool AT_CellularContext::get_context()
                 // APN matched -> Check PDP type
                 pdp_type_t pdp_type = string_to_pdp_type(pdp_type_from_context);
 
-                // Accept exact matching PDP context type or dual PDP context for IPv4/IPv6 only modems
-                if (get_property(pdp_type_t_to_cellular_property(pdp_type)) ||
-                        ((pdp_type == IPV4V6_PDP_TYPE && (modem_supports_ipv4 || modem_supports_ipv6)) && !_nonip_req)) {
+                // Accept exact matching PDP context type
+                if (get_property(pdp_type_t_to_cellular_property(pdp_type))) {
                     _pdp_type = pdp_type;
                     _cid = cid;
                 }

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -290,8 +290,9 @@ nsapi_size_or_error_t GEMALTO_CINTERION_CellularStack::socket_sendto_impl(Cellul
 {
     if (socket->proto == NSAPI_UDP) {
         const int ip_version = address.get_ip_version();
-        if ((ip_version == NSAPI_IPv4 && _stack_type != IPV4_STACK) ||
-                (ip_version == NSAPI_IPv6 && _stack_type != IPV6_STACK)) {
+        if (_stack_type != IPV4V6_STACK &&
+                ((ip_version == NSAPI_IPv4 && _stack_type != IPV4_STACK) ||
+                (ip_version == NSAPI_IPv6 && _stack_type != IPV6_STACK))) {
             tr_warn("No IP route for %s", address.get_ip_address());
             return NSAPI_ERROR_NO_SOCKET;
         }

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -292,7 +292,7 @@ nsapi_size_or_error_t GEMALTO_CINTERION_CellularStack::socket_sendto_impl(Cellul
         const int ip_version = address.get_ip_version();
         if (_stack_type != IPV4V6_STACK &&
                 ((ip_version == NSAPI_IPv4 && _stack_type != IPV4_STACK) ||
-                (ip_version == NSAPI_IPv6 && _stack_type != IPV6_STACK))) {
+                 (ip_version == NSAPI_IPv6 && _stack_type != IPV6_STACK))) {
             tr_warn("No IP route for %s", address.get_ip_address());
             return NSAPI_ERROR_NO_SOCKET;
         }


### PR DESCRIPTION
### Description
Currently `IPV4V6` stack type is not handled properly for Gemalto Cinterion modules.

First, `PROPERTY_IPV4V6_STACK` is a configurable property and therefore a IPV4V6 PDP type should be accepted only if `PROPERTY_IPV4V6_STACK` is set. No specific treatment is required here i think.

Additionally `GEMALTO_CINTERION_CellularStack::socket_sendto_impl` in general should not return an error when `_stack_type` is `IPV4V6_STACK`.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
