### PR TITLE
UARTSerial: Free resources

### DIFF
--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -32,7 +32,7 @@ SerialBase::SerialBase(PinName tx, PinName rx, int baud) :
 #endif
     _serial(), _baud(baud), _tx(tx), _rx(rx)
 {
-    init();
+    _init();
 }
 
 void SerialBase::baud(int baudrate)
@@ -153,7 +153,7 @@ void SerialBase:: unlock()
     // Stub
 }
 
-void SerialBase::init(void)
+void SerialBase::_init(void)
 {
     lock();
     for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
@@ -166,7 +166,7 @@ void SerialBase::init(void)
     unlock();
 }
 
-void SerialBase::deinit(void)
+void SerialBase::_deinit(void)
 {
     lock();
     serial_free(&_serial);
@@ -182,7 +182,7 @@ SerialBase::~SerialBase()
         attach(NULL, (IrqType)irq);
     }
 
-    deinit();
+    _deinit();
 }
 
 #if DEVICE_SERIAL_FC

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -155,7 +155,6 @@ void SerialBase:: unlock()
 
 void SerialBase::_init(void)
 {
-    lock();
     for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
         _irq[i] = NULL;
     }
@@ -163,14 +162,11 @@ void SerialBase::_init(void)
     serial_init(&_serial, _tx, _rx);
     serial_baud(&_serial, _baud);
     serial_irq_handler(&_serial, SerialBase::_irq_handler, (uint32_t)this);
-    unlock();
 }
 
 void SerialBase::_deinit(void)
 {
-    lock();
     serial_free(&_serial);
-    unlock();
 }
 
 SerialBase::~SerialBase()

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -165,11 +165,11 @@ protected:
 
     /** Initialize serial port
      */
-    void init(void);
+    void _init(void);
 
     /** Deinitialize serial port
      */
-    void deinit(void);
+    void _deinit(void);
 #endif
 public:
 

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -162,6 +162,14 @@ protected:
     /** Release exclusive access to this serial port
      */
     virtual void unlock(void);
+
+    /** Initialize serial port
+     */
+    void init(void);
+
+    /** Deinitialize serial port
+     */
+    void deinit(void);
 #endif
 public:
 
@@ -304,6 +312,8 @@ protected:
     serial_t         _serial;
     Callback<void()> _irq[IrqCnt];
     int              _baud;
+    PinName          _rx;
+    PinName          _tx;
 #endif
 };
 

--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -374,7 +374,7 @@ int UARTSerial::enable_input(bool enabled)
     api_lock();
     if (_rx_enabled != enabled) {
         if (enabled && !_tx_enabled) {
-            init();
+            _init();
         }
 
         core_util_critical_section_enter();
@@ -391,7 +391,7 @@ int UARTSerial::enable_input(bool enabled)
         _rx_enabled = enabled;
 
         if (!enabled && !_tx_enabled) {
-            deinit();
+            _deinit();
         }
     }
     api_unlock();
@@ -403,7 +403,7 @@ int UARTSerial::enable_output(bool enabled)
     api_lock();
     if (_tx_enabled != enabled) {
         if (enabled && !_rx_enabled) {
-            init();
+            _init();
         }
 
         core_util_critical_section_enter();
@@ -420,7 +420,7 @@ int UARTSerial::enable_output(bool enabled)
         _tx_enabled = enabled;
 
         if (!enabled && !_rx_enabled) {
-            deinit();
+            _deinit();
         }
     }
     api_unlock();

--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -374,12 +374,18 @@ int UARTSerial::enable_input(bool enabled)
     core_util_critical_section_enter();
     if (_rx_enabled != enabled) {
         if (enabled) {
+            if (!_tx_enabled) {
+                init();
+            }
             UARTSerial::rx_irq();
             if (!_rxbuf.full()) {
                 enable_rx_irq();
             }
         } else {
             disable_rx_irq();
+            if (!_tx_enabled) {
+                serial_free(&_serial);
+            }
         }
         _rx_enabled = enabled;
     }
@@ -393,18 +399,35 @@ int UARTSerial::enable_output(bool enabled)
     core_util_critical_section_enter();
     if (_tx_enabled != enabled) {
         if (enabled) {
+            if (!_rx_enabled) {
+                init();
+            }
             UARTSerial::tx_irq();
             if (!_txbuf.empty()) {
                 enable_tx_irq();
             }
         } else {
             disable_tx_irq();
+            if (!_rx_enabled) {
+                serial_free(&_serial);
+            }
         }
         _tx_enabled = enabled;
     }
     core_util_critical_section_exit();
 
     return 0;
+}
+
+void UARTSerial::init() {
+    for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
+        _irq[i] = NULL;
+    }
+
+    serial_init(&_serial, _serial.pin_tx, _serial.pin_rx);
+    serial_baud(&_serial, _baud);
+    serial_irq_handler(&_serial, SerialBase::_irq_handler, (uint32_t)this);
+    enable_rx_irq();
 }
 
 void UARTSerial::wait_ms(uint32_t millisec)

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -254,8 +254,6 @@ public:
 #endif
 
 private:
-    /** Initialize serial */
-    void init();
 
     void wait_ms(uint32_t millisec);
 

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -254,6 +254,8 @@ public:
 #endif
 
 private:
+    /** Initialize serial */
+    void init();
 
     void wait_ms(uint32_t millisec);
 


### PR DESCRIPTION
### Description
If output and input is disabled for `UARTSerial` the pins should be reconfigured to archive lowest power consumption (e.g. to avoid current drain through TX pin). 

With this change the UART interface is switched off if both input and output is disabled. If input or output is enabled again the UART pins are reinitialized.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
