### PR TITLE
PSA storage: Conform to "PSA 1.0.0" spec release

### DIFF
--- a/components/TARGET_PSA/inc/psa/protected_storage.h
+++ b/components/TARGET_PSA/inc/psa/protected_storage.h
@@ -54,7 +54,7 @@ extern "C" {
  * \retval      PSA_ERROR_GENERIC_ERROR         The operation failed because of an unspecified internal failure
  */
 psa_status_t psa_ps_set(psa_storage_uid_t uid,
-                        uint32_t data_length,
+                        size_t data_length,
                         const void *p_data,
                         psa_storage_create_flags_t create_flags);
 
@@ -65,22 +65,24 @@ psa_status_t psa_ps_set(psa_storage_uid_t uid,
  * \param[in] data_offset       The offset within the data associated with the `uid` to start retrieving data
  * \param[in] data_length       The amount of data to read (and the minimum allocated size of the `p_data` buffer)
  * \param[out] p_data           The buffer where the data will be placed upon successful completion
+ * \param[out] p_data_length    The actual amount of data returned
  *
  * \return      A status indicating the success/failure of the operation
  *
  * \retval      PSA_SUCCESS                  The operation completed successfully
  * \retval      PSA_ERROR_INVALID_ARGUMENT   The operation failed because one or more of the given arguments were invalid (null pointer, wrong flags etc.)
  * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided uid value was not found in the storage
- * \retval      PSA_ERROR_BUFFER_TOO_SMALL   The operation failed because the data associated with provided uid is not the same size as `data_size`
+ * \retval      PSA_ERROR_BUFFER_TOO_SMALL   The operation failed because the data associated with provided uid does not fit `data_size`
  * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
  * \retval      PSA_ERROR_GENERIC_ERROR      The operation failed because of an unspecified internal failure
  * \retval      PSA_ERROR_DATA_CORRUPT       The operation failed because of an authentication failure when attempting to get the key
  * \retval      PSA_ERROR_INVALID_SIGNATURE  The operation failed because the data associated with the UID failed authentication
  */
 psa_status_t psa_ps_get(psa_storage_uid_t uid,
-                        uint32_t data_offset,
-                        uint32_t data_length,
-                        void *p_data);
+                        size_t data_offset,
+                        size_t data_length,
+                        void *p_data,
+                        size_t *p_data_length);
 
 /**
  * \brief Retrieve the metadata about the provided uid
@@ -149,7 +151,7 @@ psa_status_t psa_ps_remove(psa_storage_uid_t uid);
  * \retval PSA_ERROR_GENERIC_ERROR          The operation has failed due to an unspecified error
  */
 psa_status_t psa_ps_create(psa_storage_uid_t uid,
-                           uint32_t size,
+                           size_t size,
                            psa_storage_create_flags_t create_flags);
 
 /**
@@ -179,8 +181,8 @@ psa_status_t psa_ps_create(psa_storage_uid_t uid,
  * \retval PSA_ERROR_INVALID_SIGNATURE      The operation failed because the existing data failed authentication (MAC check failed)
  */
 psa_status_t psa_ps_set_extended(psa_storage_uid_t uid,
-                                 uint32_t data_offset,
-                                 uint32_t data_length,
+                                 size_t data_offset,
+                                 size_t data_length,
                                  const void *p_data);
 
 /**

--- a/components/TARGET_PSA/inc/psa/storage_common.h
+++ b/components/TARGET_PSA/inc/psa/storage_common.h
@@ -33,8 +33,10 @@ extern "C" {
  */
 typedef uint32_t psa_storage_create_flags_t;
 
-#define PSA_STORAGE_FLAG_NONE        0         /**< No flags to pass */
-#define PSA_STORAGE_FLAG_WRITE_ONCE (1 << 0) /**< The data associated with the uid will not be able to be modified or deleted. Intended to be used to set bits in `psa_storage_create_flags_t`*/
+#define PSA_STORAGE_FLAG_NONE                 0         /**< No flags to pass */
+#define PSA_STORAGE_FLAG_WRITE_ONCE           (1 << 0)  /**< The data associated with the uid will not be able to be modified or deleted. Intended to be used to set bits in `psa_storage_create_flags_t`*/
+#define PSA_STORAGE_FLAG_NO_CONFIDENTIALITY   (1 << 1)  /**< The data associated with the uid is public and therefore does not require confidentiality. It therefore only needs to be integrity protected */
+#define PSA_STORAGE_FLAG_NO_REPLAY_PROTECTION (1 << 2)  /**< The data associated with the uid does not require replay protection. This may permit faster storage - but it permits an attecker with physical access to revert to an earlier version of the data.   */
 
 /** \brief A type for UIDs used for identifying data
  */
@@ -44,7 +46,8 @@ typedef uint64_t psa_storage_uid_t;
  * \brief A container for metadata associated with a specific uid
  */
 struct psa_storage_info_t {
-    uint32_t size;                  /**< The size of the data associated with a uid **/
+    size_t capacity;              /**< The allocated capacity of the storage associated with a UID **/
+    size_t size;                  /**< The size of the data associated with a uid **/
     psa_storage_create_flags_t flags;    /**< The flags set when the uid was created **/
 };
 

--- a/components/TARGET_PSA/services/storage/common/psa_storage_common_impl.h
+++ b/components/TARGET_PSA/services/storage/common/psa_storage_common_impl.h
@@ -36,9 +36,9 @@ typedef psa_status_t (*migrate_func_t)(mbed::KVStore *kvstore, const psa_storage
 
 void psa_storage_handle_version(mbed::KVStore *kvstore, const char *version_key, const psa_storage_version_t *version,
                                 migrate_func_t migrate_func);
-psa_status_t psa_storage_set_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, uint32_t data_length, const void *p_data, uint32_t kv_create_flags);
-psa_status_t psa_storage_get_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, uint32_t data_offset, uint32_t data_length, void *p_data);
-psa_status_t psa_storage_get_info_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, struct psa_storage_info_t *p_info);
+psa_status_t psa_storage_set_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, size_t data_length, const void *p_data, uint32_t kv_create_flags);
+psa_status_t psa_storage_get_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, size_t data_offset, size_t data_length, void *p_data, size_t *p_data_length);
+psa_status_t psa_storage_get_info_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid, struct psa_storage_info_t *p_info, uint32_t *kv_get_flags);
 psa_status_t psa_storage_remove_impl(mbed::KVStore *kvstore, int32_t pid, psa_storage_uid_t uid);
 psa_status_t psa_storage_reset_impl(mbed::KVStore *kvstore);
 

--- a/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_EMUL/psa_prot_internal_storage.cpp
+++ b/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_EMUL/psa_prot_internal_storage.cpp
@@ -28,7 +28,7 @@
 // So here we set a global pid value to be used for when calling IMPL functions
 #define PSA_ITS_EMUL_PID        1
 
-psa_status_t psa_its_set(psa_storage_uid_t uid, uint32_t data_length, const void *p_data, psa_storage_create_flags_t create_flags)
+psa_status_t psa_its_set(psa_storage_uid_t uid, size_t data_length, const void *p_data, psa_storage_create_flags_t create_flags)
 {
     if (!p_data && data_length) {
         return PSA_ERROR_INVALID_ARGUMENT;
@@ -47,9 +47,9 @@ psa_status_t psa_its_set(psa_storage_uid_t uid, uint32_t data_length, const void
     return res;
 }
 
-psa_status_t psa_its_get(psa_storage_uid_t uid, uint32_t data_offset, uint32_t data_length, void *p_data)
+psa_status_t psa_its_get(psa_storage_uid_t uid, size_t data_offset, size_t data_length, void *p_data, size_t *p_data_length)
 {
-    if (!p_data && data_length) {
+    if ((!p_data && data_length) || !p_data_length) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
@@ -61,7 +61,7 @@ psa_status_t psa_its_get(psa_storage_uid_t uid, uint32_t data_offset, uint32_t d
         return PSA_ERROR_STORAGE_FAILURE;
     }
 
-    return psa_its_get_impl(PSA_ITS_EMUL_PID, uid, data_offset, data_length, p_data);
+    return psa_its_get_impl(PSA_ITS_EMUL_PID, uid, data_offset, data_length, p_data, p_data_length);
 }
 
 psa_status_t psa_its_get_info(psa_storage_uid_t uid, struct psa_storage_info_t *p_info)

--- a/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_IMPL/pits_impl.cpp
+++ b/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_IMPL/pits_impl.cpp
@@ -43,7 +43,7 @@ extern "C"
 #define ITS_VERSION_KEY "PSA_ITS_VERSION"  // ITS version entry identifier in TDBStore
 
 static KVStore *kvstore = NULL;
-
+static bool initialized = false;
 
 
 MBED_WEAK psa_status_t its_version_migrate(KVStore *kvstore,
@@ -72,18 +72,20 @@ static void its_init(void)
     }
 
     psa_storage_handle_version(kvstore, ITS_VERSION_KEY, &version, its_version_migrate);
+    initialized = true;
 }
 
 // used from test only
 void its_deinit(void)
 {
     kvstore = NULL;
+    initialized = false;
 }
 
 
-psa_status_t psa_its_set_impl(int32_t pid, psa_storage_uid_t uid, uint32_t data_length, const void *p_data, psa_storage_create_flags_t create_flags)
+psa_status_t psa_its_set_impl(int32_t pid, psa_storage_uid_t uid, size_t data_length, const void *p_data, psa_storage_create_flags_t create_flags)
 {
-    if (!kvstore) {
+    if (!initialized) {
         its_init();
     }
 
@@ -94,27 +96,28 @@ psa_status_t psa_its_set_impl(int32_t pid, psa_storage_uid_t uid, uint32_t data_
     return psa_storage_set_impl(kvstore, pid, uid, data_length, p_data, create_flags);
 }
 
-psa_status_t psa_its_get_impl(int32_t pid, psa_storage_uid_t uid, uint32_t data_offset, uint32_t data_length, void *p_data)
+psa_status_t psa_its_get_impl(int32_t pid, psa_storage_uid_t uid, size_t data_offset, size_t data_length, void *p_data, size_t *p_data_length)
 {
-    if (!kvstore) {
+    if (!initialized) {
         its_init();
     }
 
-    return psa_storage_get_impl(kvstore, pid, uid, data_offset, data_length, p_data);
+    return psa_storage_get_impl(kvstore, pid, uid, data_offset, data_length, p_data, p_data_length);
 }
 
 psa_status_t psa_its_get_info_impl(int32_t pid, psa_storage_uid_t uid, struct psa_storage_info_t *p_info)
 {
-    if (!kvstore) {
+    uint32_t kv_get_flags;
+    if (!initialized) {
         its_init();
     }
 
-    return psa_storage_get_info_impl(kvstore, pid, uid, p_info);
+    return psa_storage_get_info_impl(kvstore, pid, uid, p_info, &kv_get_flags);
 }
 
 psa_status_t psa_its_remove_impl(int32_t pid, psa_storage_uid_t uid)
 {
-    if (!kvstore) {
+    if (!initialized) {
         its_init();
     }
 

--- a/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_IMPL/pits_impl.h
+++ b/components/TARGET_PSA/services/storage/its/COMPONENT_PSA_SRV_IMPL/pits_impl.h
@@ -26,8 +26,8 @@ extern "C"
 {
 #endif
 
-psa_status_t psa_its_set_impl(int32_t pid, psa_storage_uid_t uid, uint32_t data_length, const void *p_data, psa_storage_create_flags_t create_flags);
-psa_status_t psa_its_get_impl(int32_t pid, psa_storage_uid_t uid, uint32_t data_offset, uint32_t data_length, void *p_data);
+psa_status_t psa_its_set_impl(int32_t pid, psa_storage_uid_t uid, size_t data_length, const void *p_data, psa_storage_create_flags_t create_flags);
+psa_status_t psa_its_get_impl(int32_t pid, psa_storage_uid_t uid, size_t data_offset, size_t data_length, void *p_data, size_t *p_data_length);
 psa_status_t psa_its_get_info_impl(int32_t pid, psa_storage_uid_t uid, struct psa_storage_info_t *p_info);
 psa_status_t psa_its_remove_impl(int32_t pid, psa_storage_uid_t uid);
 psa_status_t psa_its_reset_impl();

--- a/components/TARGET_PSA/services/storage/its/psa_prot_internal_storage.h
+++ b/components/TARGET_PSA/services/storage/its/psa_prot_internal_storage.h
@@ -97,7 +97,7 @@ MBED_DEPRECATED("PS specific types should not be used")
  *                                               is invalid, for example is `NULL` or references memory the caller cannot access
  */
 psa_status_t psa_its_set(psa_storage_uid_t uid,
-                         uint32_t data_length,
+                         size_t data_length,
                          const void *p_data,
                          psa_storage_create_flags_t create_flags);
 
@@ -108,6 +108,7 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
  * \param[in] data_offset       The starting offset of the data requested
  * \param[in] data_length       the amount of data requested (and the minimum allocated size of the `p_data` buffer)
  * \param[out] p_data           The buffer where the data will be placed upon successful completion
+ * \param[out] p_data_length    The actual amount of data returned
 
  *
  * \return      A status indicating the success/failure of the operation
@@ -120,9 +121,10 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
  *                                           is invalid. For example is `NULL` or references memory the caller cannot access
  */
 psa_status_t psa_its_get(psa_storage_uid_t uid,
-                         uint32_t data_offset,
-                         uint32_t data_length,
-                         void *p_data);
+                         size_t data_offset,
+                         size_t data_length,
+                         void *p_data,
+                         size_t *p_data_length);
 
 /**
  * \brief Retrieve the metadata about the provided uid

--- a/features/frameworks/TARGET_PSA/pal/pal_internal_trusted_storage_intf.c
+++ b/features/frameworks/TARGET_PSA/pal/pal_internal_trusted_storage_intf.c
@@ -34,6 +34,11 @@ uint32_t pal_its_function(int type, va_list valist)
     //psa_ps_create_flags_t   ps_create_flags;
     struct psa_its_info_t          *its_p_info;
     //struct psa_eps_info_t          *ps_p_info;
+    /* TODO: Actual size argument is currently not supported by the testing framework.
+     * Changes need to be implemented in the actual tests.
+     * Should be fixed by the next import of the tests.
+     */
+    size_t actual_size;
 
     switch (type)
     {
@@ -48,7 +53,11 @@ uint32_t pal_its_function(int type, va_list valist)
         offset = va_arg(valist, uint32_t);
         data_length = va_arg(valist, uint32_t);
         p_read_data = va_arg(valist, void*);
-        return psa_its_get(uid, offset, data_length, p_read_data);
+        /* TODO: Actual size argument is currently not supported by the testing framework.
+         * Changes need to be implemented in the actual tests.
+         * Should be fixed by the next import of the tests.
+         */
+        return psa_its_get(uid, offset, data_length, p_read_data, &actual_size);
     case PAL_ITS_GET_INFO:
         uid = va_arg(valist, psa_storage_uid_t);
         its_p_info = va_arg(valist, struct psa_its_info_t*);

--- a/features/frameworks/TARGET_PSA/pal/pal_protected_storage_intf.c
+++ b/features/frameworks/TARGET_PSA/pal/pal_protected_storage_intf.c
@@ -28,6 +28,7 @@ uint32_t pal_ps_function(int type, va_list valist)
 {
 #if PSA_PROTECTED_STORAGE_IMPLEMENTED
     uint32_t                    uid, data_length, offset;
+    size_t                      actual_length;
     const void                  *p_write_data;
     void                        *p_read_data;
     psa_storage_create_flags_t  ps_create_flags;
@@ -46,7 +47,7 @@ uint32_t pal_ps_function(int type, va_list valist)
         offset = va_arg(valist, uint32_t);
         data_length = va_arg(valist, uint32_t);
         p_read_data = va_arg(valist, void*);
-        return psa_ps_get(uid, offset, data_length, p_read_data);
+        return psa_ps_get(uid, offset, data_length, p_read_data, &actual_length);
     case PAL_PS_GET_INFO:
         uid = va_arg(valist, psa_storage_uid_t);
         ps_p_info = va_arg(valist, struct psa_ps_info_t*);

--- a/features/mbedtls/mbed-crypto/platform/COMPONENT_PSA_SRV_IMPL/psa_crypto_its.h
+++ b/features/mbedtls/mbed-crypto/platform/COMPONENT_PSA_SRV_IMPL/psa_crypto_its.h
@@ -106,7 +106,8 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
 psa_status_t psa_its_get(psa_storage_uid_t uid,
                          uint32_t data_offset,
                          uint32_t data_length,
-                         void *p_data);
+                         void *p_data,
+                         size_t *p_data_length);
 
 /**
  * \brief Retrieve the metadata about the provided uid

--- a/features/mbedtls/mbed-crypto/platform/COMPONENT_PSA_SRV_IMPL/psa_crypto_storage.c
+++ b/features/mbedtls/mbed-crypto/platform/COMPONENT_PSA_SRV_IMPL/psa_crypto_storage.c
@@ -95,13 +95,15 @@ static psa_status_t psa_crypto_storage_load( const psa_key_file_id_t key,
 {
     psa_status_t status;
     psa_storage_uid_t data_identifier = psa_its_identifier_of_slot( key );
+    size_t actual_size;
+
     struct psa_storage_info_t data_identifier_info;
 
     status = psa_its_get_info( data_identifier, &data_identifier_info );
     if( status  != PSA_SUCCESS )
         return( status );
 
-    status = psa_its_get( data_identifier, 0, (uint32_t) data_size, data );
+    status = psa_its_get( data_identifier, 0, (uint32_t) data_size, data, &actual_size );
 
     return( status );
 }

--- a/features/mbedtls/mbed-crypto/platform/COMPONENT_PSA_SRV_IMPL/psa_its_file.c
+++ b/features/mbedtls/mbed-crypto/platform/COMPONENT_PSA_SRV_IMPL/psa_its_file.c
@@ -137,7 +137,8 @@ psa_status_t psa_its_get_info( psa_storage_uid_t uid,
 psa_status_t psa_its_get( psa_storage_uid_t uid,
                           uint32_t data_offset,
                           uint32_t data_length,
-                          void *p_data )
+                          void *p_data,
+                          size_t *p_data_length )
 {
     psa_status_t status;
     FILE *stream = NULL;

--- a/features/mbedtls/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/src/default_random_seed.cpp
+++ b/features/mbedtls/platform/TARGET_PSA/COMPONENT_PSA_SRV_IMPL/src/default_random_seed.cpp
@@ -5,7 +5,8 @@
 
 int mbed_default_seed_read(unsigned char *buf, size_t buf_len)
 {
-    psa_status_t rc = psa_its_get(PSA_CRYPTO_ITS_RANDOM_SEED_UID, 0, buf_len, buf);
+    size_t actual_size;
+    psa_status_t rc = psa_its_get(PSA_CRYPTO_ITS_RANDOM_SEED_UID, 0, buf_len, buf, &actual_size);
     return ( rc );
 }
 

--- a/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
+++ b/features/storage/kvstore/filesystemstore/FileSystemStore.cpp
@@ -34,7 +34,9 @@
 
 #define FSST_DEFAULT_FOLDER_PATH "kvstore" //default FileSystemStore folder path on fs
 
-static const uint32_t supported_flags = mbed::KVStore::WRITE_ONCE_FLAG;
+// Only write once flag is supported, other two are kept in storage but ignored
+static const uint32_t supported_flags = mbed::KVStore::WRITE_ONCE_FLAG | mbed::KVStore::REQUIRE_CONFIDENTIALITY_FLAG |
+                                        mbed::KVStore::REQUIRE_REPLAY_PROTECTION_FLAG;
 
 using namespace mbed;
 

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -35,7 +35,8 @@ using namespace mbed;
 
 static const uint32_t delete_flag = (1UL << 31);
 static const uint32_t internal_flags = delete_flag;
-static const uint32_t supported_flags = KVStore::WRITE_ONCE_FLAG;
+// Only write once flag is supported, other two are kept in storage but ignored
+static const uint32_t supported_flags = KVStore::WRITE_ONCE_FLAG | KVStore::REQUIRE_CONFIDENTIALITY_FLAG | KVStore::REQUIRE_REPLAY_PROTECTION_FLAG;
 
 namespace {
 


### PR DESCRIPTION
### Description
 PSA storage: Conform to "PSA 1.0.0" spec release
- Add the no confidentiality & no replay protection flags
- Add actual size parameter in PS/ITS get APIs
- Change a few size parameters from uint32_t to size_t

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@jenia81  @shelib01 

### Release Notes
PSA Storage: Add the integrity only and no replay protection flags.