### PR TITLE
STM32: enable CRC for all L0/L4/F7

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3236,7 +3236,7 @@
         },
         "components_add": ["SPIF"],
         "detect_code": ["9020"],
-        "device_has_add": ["ANALOGOUT", "CAN", "TRNG", "FLASH", "MPU"],
+        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "TRNG", "FLASH", "MPU"],
         "device_has_remove": ["SERIAL_FC"],
         "features": ["LWIP"],
         "release_versions": ["5"],
@@ -4003,6 +4003,7 @@
         "detect_code": ["0833"],
         "device_has_add": [
             "ANALOGOUT",
+            "CRC",
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
@@ -4023,6 +4024,7 @@
         "detect_code": ["0456"],
         "device_has_add": [
             "ANALOGOUT",
+            "CRC",
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
@@ -4068,6 +4070,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "EMAC",
             "SERIAL_ASYNCH",
             "TRNG",
@@ -4120,6 +4123,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "EMAC",
             "SERIAL_ASYNCH",
             "TRNG",
@@ -4163,6 +4167,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "TRNG",
             "FLASH",
             "QSPI",
@@ -4193,6 +4198,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "SERIAL_FC",
             "TRNG",
             "FLASH",
@@ -4228,6 +4234,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "TRNG",
             "FLASH",
             "QSPI",
@@ -4264,6 +4271,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "SERIAL_FC",
             "TRNG",
             "FLASH",
@@ -4366,6 +4374,7 @@
         "device_has_add": [
             "ANALOGOUT",
             "CAN",
+            "CRC",
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",


### PR DESCRIPTION
### Description

All STM32L0, L4 and F7 support CRC feature.

Some targets were missing in the targets.json file

@LMESTM @MarceloSalazar @bulislaw 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
