### PR TITLE
Check Cellular Properties have been set

### DIFF
--- a/features/cellular/framework/AT/AT_CellularBase.cpp
+++ b/features/cellular/framework/AT/AT_CellularBase.cpp
@@ -34,7 +34,7 @@ device_err_t AT_CellularBase::get_device_error() const
     return _at.get_last_device_error();
 }
 
-const intptr_t *AT_CellularBase::_property_array;
+const intptr_t *AT_CellularBase::_property_array = NULL;
 
 void AT_CellularBase::set_cellular_properties(const intptr_t *property_array)
 {
@@ -48,5 +48,9 @@ void AT_CellularBase::set_cellular_properties(const intptr_t *property_array)
 
 intptr_t AT_CellularBase::get_property(CellularProperty key)
 {
-    return _property_array[key];
+    if (_property_array) {
+        return _property_array[key];
+    } else {
+        return NULL;
+    }
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
When returning a pointer to a position in the array, it's better to check that the ARRAY is valid and has been set before.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
