### PR TITLE
Removing I2C and SPI pin names in SDP-K1 PinNames.h file.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_SDP_K1/PinNames.h
@@ -318,13 +318,6 @@ typedef enum {
     USBTX       = STDIO_UART_TX,
     USBRX       = STDIO_UART_RX,
     
-    // SPI and I2C pins on Arduino connector
-    SPI_CS      = D10,
-    SPI_MOSI    = D11,
-    SPI_MISO    = D12,
-    SPI_SCK     = D13,
-    I2C_SDA     = D14,
-    I2C_SCL     = D15,
 
     // Adding these signals for the SDP connector
     SDP_SPI_MOSI = PF_9,		// SDP Connector for SPI lines


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Removing I2C and SPI pin names in SDP-K1 PinNames.h file. This is to ensure the use of Arduino pin names Dxx for I2C and SPI pins in programs written for SDP-K1 board.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
