### PR TITLE
TLSSocket: print certificate info only when tracing is enabled

### DIFF
--- a/features/netsocket/TLSSocketWrapper.cpp
+++ b/features/netsocket/TLSSocketWrapper.cpp
@@ -264,7 +264,7 @@ nsapi_error_t TLSSocketWrapper::continue_handshake()
     tr_info("TLS connection established");
 #endif
 
-#ifdef MBEDTLS_X509_CRT_PARSE_C
+#if defined(MBEDTLS_X509_CRT_PARSE_C) && defined(FEA_TRACE_SUPPORT)
     /* Prints the server certificate and verify it. */
     const size_t buf_size = 1024;
     char *buf = new char[buf_size];


### PR DESCRIPTION
### Description

Print certificate information only when tracing is enabled otherwise it will bring more than 3K of extra flash.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@yogpan01 

