### PR TITLE
Adding stmod_cellular component

### DIFF
--- a/components/cellular/COMPONENT_STMOD_CELLULAR/README.md
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/README.md
@@ -1,0 +1,13 @@
+# STMOD CELLULAR library
+
+This library allows enabling the cellular module that is connected to the STMOD+ connector of the board.
+
+## Supported modems.
+
+Currently supported cellular modules are Quectel UG96 and BG96 expansion boards that are included in [p-l496g-cell01] (https://www.st.com/en/evaluation-tools/p-l496g-cell01.html) and [p-l496g-cell02.] (https://www.st.com/en/evaluation-tools/p-l496g-cell02.html) packs.
+
+## Specifications
+
+The STMOD+ Connector specification can be found [here] (https://www.st.com/content/ccc/resource/technical/document/technical_note/group0/04/7f/90/c1/ad/54/46/1f/DM00323609/files/DM00323609.pdf/jcr:content/translations/en.DM00323609.pdf).
+
+

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
@@ -52,7 +52,8 @@ STModCellular::~STModCellular()
 {
 }
 
-nsapi_error_t STModCellular::soft_power_on() {
+nsapi_error_t STModCellular::soft_power_on()
+{
     tr_debug("STMOD cellular modem power ON\r\n");
 
 #if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_UG96)
@@ -106,7 +107,7 @@ nsapi_error_t STModCellular::soft_power_on() {
     _at->restore_at_timeout();
     _at->unlock();
 
-    tr_debug("Modem %sready to receive AT commands", rdy?"":"NOT ");
+    tr_debug("Modem %sready to receive AT commands", rdy ? "" : "NOT ");
 
 #if DEVICE_SERIAL_FC
     if ((MBED_CONF_STMOD_CELLULAR_CTS != NC) && (MBED_CONF_STMOD_CELLULAR_RTS != NC)) {
@@ -145,7 +146,8 @@ nsapi_error_t STModCellular::soft_power_on() {
     return err;
 }
 
-nsapi_error_t STModCellular::soft_power_off() {
+nsapi_error_t STModCellular::soft_power_off()
+{
     _at->cmd_start("AT+QPOWD");
     _at->cmd_stop();
     wait_ms(1000);

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "STModCellular.h"
+#include "mbed_wait_api.h"
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "CELL"
+
+using namespace mbed;
+
+STModCellular::STModCellular(FileHandle *fh) : STMOD_CELLULAR_MODEM(fh),
+    m_powerkey(MBED_CONF_STMOD_CELLULAR_POWER),
+    m_reset(MBED_CONF_STMOD_CELLULAR_RESET),
+    m_simsel0(MBED_CONF_STMOD_CELLULAR_SIMSEL0),
+    m_simsel1(MBED_CONF_STMOD_CELLULAR_SIMSEL1),
+    m_mdmdtr(MBED_CONF_STMOD_CELLULAR_MDMDTR),
+    m_sim_reset(MBED_CONF_STMOD_CELLULAR_SIM_RESET),
+    m_sim_clk(MBED_CONF_STMOD_CELLULAR_SIM_CLK),
+    m_sim_data(MBED_CONF_STMOD_CELLULAR_SIM_DATA)
+{
+    tr_debug("STModCellular creation\r\n");
+
+    // start with modem disabled
+    m_powerkey.write(0);
+    m_reset.write(1);
+    wait_ms(200);
+    m_reset.write(0);
+    wait_ms(150);
+
+    wait_ms(50);
+    m_simsel0.write(MBED_CONF_STMOD_CELLULAR_SIM_SELECTION & 0x01);
+    m_simsel1.write(MBED_CONF_STMOD_CELLULAR_SIM_SELECTION & 0x02);
+    wait_ms(50);
+}
+
+STModCellular::~STModCellular()
+{
+}
+
+nsapi_error_t STModCellular::soft_power_on() {
+    tr_debug("STMOD cellular modem power ON\r\n");
+
+#if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_UG96)
+    tr_debug("Booting UG96\r\n");
+    m_reset.write(1);
+    wait_ms(200);
+    m_reset.write(0);
+    wait_ms(150);
+    m_powerkey.write(1);
+    wait_ms(150);
+    m_powerkey.write(0);
+    /* Because modem status is not available on STMOD+ connector,
+     * let's wait for Modem complete boot */
+    wait_ms(2300);
+#endif
+#if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_BG96)
+    tr_debug("Booting BG96\r\n");
+    m_powerkey.write(1);
+    m_reset.write(1);
+    wait_ms(150);
+    m_powerkey.write(0);
+    m_reset.write(0);
+    wait_ms(100);
+    m_powerkey.write(1);
+    wait_ms(200);
+    m_powerkey.write(0);
+    wait_ms(5000);
+#endif
+
+    nsapi_error_t err = STMOD_CELLULAR_MODEM::soft_power_on();
+    if (err != 0) {
+        return err;
+    }
+
+    // wait for RDY
+    _at->lock();
+    _at->set_at_timeout(5000);
+    _at->set_stop_tag("RDY");
+    bool rdy = _at->consume_to_stop_tag();
+    (void)rdy;
+
+    /*  Modem may send more bytes are RDY flag */
+    _at->flush();
+
+    /* Turn OFF ECHO before anything else */
+    _at->set_stop_tag(mbed::OK);
+    _at->cmd_start("ATE0");
+    _at->cmd_stop();
+    _at->consume_to_stop_tag();
+
+    _at->restore_at_timeout();
+    _at->unlock();
+
+    tr_debug("Modem %sready to receive AT commands", rdy?"":"NOT ");
+
+#if DEVICE_SERIAL_FC
+    if ((MBED_CONF_STMOD_CELLULAR_CTS != NC) && (MBED_CONF_STMOD_CELLULAR_RTS != NC)) {
+        tr_debug("Enable flow control\r\n");
+
+        _at->lock();
+        // enable CTS/RTS flowcontrol
+        _at->set_stop_tag(mbed::OK);
+        _at->set_at_timeout(400);
+        _at->cmd_start("AT+IFC=");
+        _at->write_int(2);
+        _at->write_int(2);
+        _at->cmd_stop_read_resp();
+        err = _at->get_last_error();
+        _at->restore_at_timeout();
+        _at->unlock();
+
+        if (err == NSAPI_ERROR_OK) {
+            tr_debug("Flow control turned ON");
+        } else {
+            tr_error("Failed to enable hw flow control");
+        }
+    }
+#endif
+
+    wait_ms(500);
+
+#if MBED_CONF_CELLULAR_DEBUG_AT
+    _at->lock();
+    /*  Verify Flow Control settings */
+    _at->cmd_start("AT+IFC?");
+    _at->cmd_stop_read_resp();
+    _at->unlock();
+#endif // MBED_CONF_CELLULAR_DEBUG_AT
+
+    return err;
+}
+
+nsapi_error_t STModCellular::soft_power_off() {
+    _at->cmd_start("AT+QPOWD");
+    _at->cmd_stop();
+    wait_ms(1000);
+    // should wait for POWERED DOWN with a time out up to 65 second according to the manual.
+    // we cannot afford such a long wait though.
+    return STMOD_CELLULAR_MODEM::soft_power_off();
+}
+
+#if MBED_CONF_STMOD_CELLULAR_PROVIDE_DEFAULT
+#include "UARTSerial.h"
+CellularDevice *CellularDevice::get_default_instance()
+{
+    tr_debug("MODEM default instance\r\n");
+
+    static UARTSerial serial(MBED_CONF_STMOD_CELLULAR_TX, MBED_CONF_STMOD_CELLULAR_RX, MBED_CONF_STMOD_CELLULAR_BAUDRATE);
+#if defined (MBED_CONF_STMOD_CELLULAR_RTS) && defined(MBED_CONF_STMOD_CELLULAR_CTS)
+    tr_debug("STMOD_CELLULAR flow control: RTS %d CTS %d", MBED_CONF_STMOD_CELLULAR_RTS, MBED_CONF_STMOD_CELLULAR_CTS);
+    serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_STMOD_CELLULAR_RTS, MBED_CONF_STMOD_CELLULAR_CTS);
+#endif
+    static STModCellular device(&serial);
+    return &device;
+}
+#endif
+

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.h
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STMOD_CELLULAR_H_
+#define STMOD_CELLULAR_H_
+
+#include "QUECTEL_UG96.h"
+#include "QUECTEL_BG96.h"
+#include "DigitalOut.h"
+#include "DigitalIn.h"
+
+/* List of supported STMOD+ cellular expansion boards */
+#define STMOD_BG96 0
+#define STMOD_UG96 1
+
+
+#if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_BG96)
+#define STMOD_CELLULAR_MODEM QUECTEL_BG96
+#endif
+
+#if (MBED_CONF_STMOD_CELLULAR_TYPE == STMOD_UG96)
+#define STMOD_CELLULAR_MODEM QUECTEL_UG96
+#endif
+
+namespace mbed {
+
+class STModCellular : public STMOD_CELLULAR_MODEM {
+private:
+    DigitalOut m_powerkey;
+    DigitalOut m_reset;
+    DigitalOut m_simsel0;
+    DigitalOut m_simsel1;
+    DigitalOut m_mdmdtr;
+    DigitalIn m_sim_reset;
+    DigitalIn m_sim_clk;
+    DigitalIn m_sim_data;
+public:
+    STModCellular(FileHandle *fh);
+    virtual nsapi_error_t soft_power_on();
+    virtual nsapi_error_t soft_power_off();
+    virtual ~STModCellular();
+};
+
+} // namespace mbed
+#endif // STMOD_CELLULAR_H_

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/mbed_lib.json
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/mbed_lib.json
@@ -1,0 +1,69 @@
+{
+    "name": "stmod_cellular",
+    "config": {
+        "type": {
+            "help": "STMOD+ connected modem can be either STMOD_UG96 or STMOD_BG96",
+            "value": "STMOD_BG96"
+        },
+        "sim_selection": {
+            "help": "Module sim selection. 0 for plastic sim, 1 for esim.",
+            "value": 0
+        },
+        "mdmdtr": {
+            "help": "Modem's Data Terminal Ready. Usually not connected to STMOD+ connector. It needs to be set/overwritten otherwise",
+            "value": "NC"
+        },
+        "simsel0": {
+            "help": "Module sim select pin 0. By default connected to STMOD+ pin 18. It needs to be set/overwritten otherwise",
+            "value": "STMOD_18"
+        },
+        "simsel1": {
+            "help": "Module sim select pin 1. By default connected to STMOD+ pin 8. It needs to be set/overwritten otherwise",
+            "value": "STMOD_8"
+        },
+        "sim_reset": {
+            "help": "Module sim reset pin. Used for sim selection sequence. By default connected to STMOD+ pin 17. It needs to be set/overwritten otherwise",
+            "value": "STMOD_17"
+        },
+        "sim_clk": {
+            "help": "Module sim clock pin. Used for sim selection sequence. By default connected to STMOD+ pin 13. It needs to be set/overwritten otherwise",
+            "value": "STMOD_13"
+        },
+        "sim_data": {
+            "help": "Module sim data pin. Used for sim selection sequence. By default connected to STMOD+ pin 19. It needs to be set/overwritten otherwise",
+            "value": "STMOD_19"
+         },
+         "power": {
+            "help": "Modem's power key. By default connected to STMOD+ pin 9. It needs to be set/overwritten otherwise",
+            "value": "STMOD_9"
+        },
+        "reset": {
+            "help": "Modem's reset. By default connected to STMOD+ pin 12. It needs to be set/overwritten otherwise",
+            "value": "STMOD_12"
+        },
+        "tx": {
+            "help": "TX pin for serial connection. STMOD pin 2 is the default STMOD+ UART TX. It needs to be set/overwritten otherwise",
+            "value": "STMOD_2"
+        },
+        "rx": {
+            "help": "RX pin for serial connection. STMOD pin 3 is the default STMOD+ UART TX. It needs to be set/overwritten otherwise.",
+            "value": "STMOD_3"
+        },
+        "rts": {
+            "help": "RTS pin for serial connection. STMOD pin 4 is the default STMOD+ UART RTS. It needs to be set/overwritten otherwise.",
+            "value": "STMOD_4"
+        },
+        "cts": {
+            "help": "CTS pin for serial connection. STMOD pin 1 is the default STMOD+ UART RTS. It needs to be set/overwritten otherwise.",
+            "value": "STMOD_1"
+        },
+        "baudrate" : {
+            "help": "Serial connection baud rate",
+            "value": 115200
+        },
+        "provide-default": {
+            "help": "Provide as default CellularDevice [true/false]",
+            "value": false
+        }
+    }
+}


### PR DESCRIPTION
### Description

stmod_cellular component library adds up support for cellular modem that
are connected to the STMOD+ connector.

Currently supported modems are BG96 and UG96.

Support is fully derived from BG96 and UG96 support from cellular framework, mainly soft power on and off sequences are adapted here.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@MarceloSalazar @AnttiKauppila 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

This library allows enabling the cellular module that is connected to the STMOD+ connector of the board.

Currently supported cellular modules are Quectel UG96 and BG96 expansion boards that are included in [p-l496g-cell01] (https://www.st.com/en/evaluation-tools/p-l496g-cell01.html) and [p-l496g-cell02.] (https://www.st.com/en/evaluation-tools/p-l496g-cell02.html) packs.

The STMOD+ Connector specification can be found [here] (https://www.st.com/content/ccc/resource/technical/document/technical_note/group0/04/7f/90/c1/ad/54/46/1f/DM00323609/files/DM00323609.pdf/jcr:content/translations/en.DM00323609.pdf).
