### PR TITLE
LoRaPHY: Pass frequency set in rx_config() to caller

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -355,6 +355,8 @@ bool LoRaPHYAU915::rx_config(rx_config_params_t *params)
         // Apply window 1 frequency
         frequency = AU915_FIRST_RX1_CHANNEL
                     + (params->channel % 8) * AU915_STEPWIDTH_RX1_CHANNEL;
+        // Caller may print the frequency to log so update it to match actual frequency
+        params->frequency = frequency;
     }
 
     // Read the physical datarate from the datarates table

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -377,6 +377,8 @@ bool LoRaPHYCN470::rx_config(rx_config_params_t *config)
     if (config->rx_slot == RX_SLOT_WIN_1) {
         // Apply window 1 frequency
         frequency = CN470_FIRST_RX1_CHANNEL + (config->channel % 48) * CN470_STEPWIDTH_RX1_CHANNEL;
+        // Caller may print the frequency to log so update it to match actual frequency
+        config->frequency = frequency;
     }
 
     // Read the physical datarate from the datarates table

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -374,6 +374,8 @@ bool LoRaPHYUS915::rx_config(rx_config_params_t *config)
     if (config->rx_slot == RX_SLOT_WIN_1) {
         // Apply window 1 frequency
         frequency = US915_FIRST_RX1_CHANNEL + (config->channel % 8) * US915_STEPWIDTH_RX1_CHANNEL;
+        // Caller may print the frequency to log so update it to match actual frequency
+        config->frequency = frequency;
     }
 
     // Read the physical datarate from the datarates table


### PR DESCRIPTION
In AU/CN/US PHY, RX1 slot frequency is calculated in rx_config().
Since the caller is printing it to log, modify the frequency in
parameter structure so that the correct value will be printed.

### Description

Target board: DISCO_L072CZ_LRWAN1
MBED version: 5.12.4
Toolchain: GCC ARM (gcc version 7.3.1);

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This is a cosmetic change that practically only affects debug log prints. Tested on target board with US band in use.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
