### PR TITLE
LPC55S69: fix cosFactor data size in header file

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/drivers/fsl_powerquad_data.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/drivers/fsl_powerquad_data.h
@@ -26,12 +26,12 @@ extern int32_t idct64_twiddle[128];
 extern int32_t idct128_twiddle[256];
 extern int32_t idct256_twiddle[512];
 extern int32_t idct512_twiddle[1024];
-extern int32_t dct16_cosFactor[32];
-extern int32_t dct32_cosFactor[64];
-extern int32_t dct64_cosFactor[128];
-extern int32_t dct128_cosFactor[256];
-extern int32_t dct256_cosFactor[512];
-extern int32_t dct512_cosFactor[1024];
+extern int32_t dct16_cosFactor[16];
+extern int32_t dct32_cosFactor[32];
+extern int32_t dct64_cosFactor[64];
+extern int32_t dct128_cosFactor[128];
+extern int32_t dct256_cosFactor[256];
+extern int32_t dct512_cosFactor[512];
 
 /*******************************************************************************
  * API


### PR DESCRIPTION
### Description

The file `fsl_powerquad_data.h` declares several dctXXX_cosFactor arrays with sizes twice larger compared to the actual definitions in `fsl_powerquad_data.c`.

As an example, in [`fsl_powerquad_data.h:29`](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/drivers/fsl_powerquad_data.h#L29), we find:
```c
extern int32_t dct16_cosFactor[32];
```
Whereas in [`fsl_powerquad_data.c:459`](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/drivers/fsl_powerquad_data.c#L459), we find:
```c
int32_t dct16_cosFactor[16] = ...
```
### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@maclobdell 