### PR TITLE
HAL I2C: adds missing DEVICE_I2C guards

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/i2c_api.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
@@ -607,3 +610,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "mbed_error.h"
 #include "mbed_wait_api.h"
@@ -291,3 +294,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
@@ -541,3 +544,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/i2c_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
@@ -551,3 +554,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/i2c_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/i2c_api.c
@@ -16,6 +16,8 @@
 #include "mbed_assert.h"
 #include "i2c_api.h"
 
+#if DEVICE_I2C
+
 #include <math.h>
 
 #include "cmsis.h"
@@ -1013,3 +1015,5 @@ void i2c_abort_asynch(i2c_t *obj)
 }
 
 #endif
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/i2c_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/i2c_api.c
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "i2c_api.h"
+
+#if DEVICE_I2C
 
 #include "device.h"
 #include "buffer.h"
 #include "dma_api.h"
-#include "i2c_api.h"
 #include "PeripheralPins.h"
 #include "twi.h"
 #include "pdc.h"
@@ -733,3 +735,5 @@ void i2c_abort_asynch(i2c_t *obj)
 }
 
 #endif
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Cypress/TARGET_PSOC6/i2c_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/i2c_api.c
@@ -16,13 +16,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "mbed_assert.h"
+#include "i2c_api.h"
+
+#if DEVICE_I2C
 
 #include "cmsis.h"
-#include "mbed_assert.h"
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 #include "pinmap.h"
-#include "i2c_api.h"
+
 #include "psoc6_utils.h"
 
 #include "cy_sysclk.h"
@@ -652,3 +655,5 @@ void i2c_abort_asynch(i2c_t *obj_in)
 }
 
 #endif // DEVICE_ASYNCH
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/i2c_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/i2c_api.c
@@ -14,13 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "mbed_assert.h"
+#include "i2c_api.h"
+
+#if DEVICE_I2C
 
 #include "cmsis.h"
-#include "mbed_assert.h"
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 #include "pinmap.h"
-#include "i2c_api.h"
 #include "psoc6_utils.h"
 
 #include "cy_sysclk.h"
@@ -566,3 +568,5 @@ void i2c_abort_asynch(i2c_t *obj_in)
 }
 
 #endif // DEVICE_ASYNCH
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Freescale/TARGET_K20XX/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/i2c_api.c
@@ -16,6 +16,8 @@
 #include "mbed_assert.h"
 #include "i2c_api.h"
 
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "clk_freqs.h"
@@ -390,3 +392,5 @@ void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
     obj->i2c->A1 = address & 0xfe;
 }
 #endif
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Freescale/TARGET_KLXX/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/i2c_api.c
@@ -16,6 +16,8 @@
 #include "mbed_assert.h"
 #include "i2c_api.h"
 
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "clk_freqs.h"
@@ -401,3 +403,4 @@ void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
 }
 #endif
 
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32600/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/i2c_api.c
@@ -33,6 +33,9 @@
 
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "i2cm_regs.h"
 #include "clkman_regs.h"
@@ -446,3 +449,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32610/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/i2c_api.c
@@ -33,6 +33,9 @@
 
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "i2cm_regs.h"
 #include "clkman_regs.h"
@@ -446,3 +449,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32620/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/i2c_api.c
@@ -33,6 +33,9 @@
 
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "i2cm_regs.h"
 #include "clkman_regs.h"
@@ -450,3 +453,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
@@ -33,6 +33,9 @@
 
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "i2cm_regs.h"
 #include "i2cm.h"
 #include "pinmap.h"
@@ -225,3 +228,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
@@ -33,6 +33,9 @@
 
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "i2cm_regs.h"
 #include "i2cm.h"
 #include "pinmap.h"
@@ -226,3 +229,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
@@ -33,6 +33,9 @@
 
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "i2cm_regs.h"
 #include "i2cm.h"
 #include "pinmap.h"
@@ -225,3 +228,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "twi_master.h"
@@ -361,3 +364,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_testing;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h" // For the Peripheral to Pin Definitions found in the individual Target's Platform
@@ -399,3 +402,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
@@ -411,3 +414,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC13XX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
@@ -410,3 +413,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC15XX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 
@@ -247,3 +250,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 
@@ -425,3 +428,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 
@@ -440,3 +443,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/i2c_api.c
@@ -15,6 +15,9 @@
  */
 #include "mbed_assert.h"
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 
@@ -426,3 +429,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_NXP/TARGET_LPC43XX/i2c_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/i2c_api.c
@@ -16,6 +16,9 @@
  * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
@@ -419,3 +422,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/i2c_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/i2c_api.c
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "mbed_assert.h"
 #include "dma_api.h"
-#include "i2c_api.h"
 #include "cmsis.h"
 #include "PeripheralPins.h"
 #include "r_typedefs.h"
@@ -1155,3 +1158,4 @@ void i2c_abort_asynch(i2c_t *obj)
 }
 
 #endif
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/i2c_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/i2c_api.c
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "i2c_api.h"
+
+#if DEVICE_I2C
 
 #include <string.h>
 #include "objects.h"
 #include "PinNames.h"
 #include "hal_i2c.h"
-#include "i2c_api.h"
 
 #if CONFIG_I2C_EN
 
@@ -603,3 +605,4 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length)
 
 #endif // CONFIG_I2C_EN
 
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM066/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM066/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "mbed_error.h"
 #include "PeripheralNames.h"
 #include "pinmap.h"
@@ -361,3 +364,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "mbed_error.h"
 #include "pinmap.h"
 #include "gpio_include.h"
@@ -395,3 +398,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3HQ/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3HQ/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "mbed_error.h"
 #include "pinmap.h"
 #include "gpio_include.h"
@@ -402,3 +405,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "mbed_error.h"
 #include "PeripheralNames.h"
 #include "pinmap.h"
@@ -374,3 +377,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/i2c_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/i2c_api.c
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include <stdlib.h>
 #include <string.h>
-#include "i2c_api.h"
 #include "mbed_error.h"
 #include "PeripheralNames.h"
 #include "pinmap.h"
@@ -221,3 +224,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TT/TARGET_TT_M3HQ/i2c_api.c
+++ b/targets/TARGET_TT/TARGET_TT_M3HQ/i2c_api.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include "mbed_error.h"
 #include "pinmap.h"
 #include "gpio_include.h"
@@ -374,3 +377,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C

--- a/targets/TARGET_TT/TARGET_TT_M4G9/i2c_api.c
+++ b/targets/TARGET_TT/TARGET_TT_M4G9/i2c_api.c
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "i2c_api.h"
+
+#if DEVICE_I2C
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
 #include "mbed_error.h"
-#include "i2c_api.h"
 #include "txz_i2c_api.h"
 #include "PeripheralNames.h"
 #include "pinmap.h"
@@ -209,3 +212,5 @@ const PinMap *i2c_slave_scl_pinmap()
 {
     return PinMap_I2C_SCL;
 }
+
+#endif  // #if DEVICE_I2C


### PR DESCRIPTION
This PR adds missing DEVICE_I2C guards to I2C hal implementations
These guards are essential when one wants to disable i2c hal implementation for specific targets

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 
@ARMmbed/mbed-os-hal 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
