### PR TITLE
Enable stack dump

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -556,6 +556,44 @@ static void print_error_report(const mbed_error_ctx *ctx, const char *error_msg,
     mbed_stats_sys_get(&sys_stats);
     mbed_error_printf("\nFor more info, visit: https://mbed.com/s/error?error=0x%08X&osver=%" PRId32 "&core=0x%08" PRIX32 "&comp=%d&ver=%" PRIu32 "&tgt=" GET_TARGET_NAME(TARGET_NAME), ctx->error_status, sys_stats.os_version, sys_stats.cpu_id, sys_stats.compiler_id, sys_stats.compiler_version);
 #endif
+
+#if MBED_STACK_DUMP_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
+    /** The internal threshold to detect the end of the stack.
+     * The stack is filled with osRtxStackFillPattern at the end.
+     * However, it is possible that the call stack parameters can theoretically have consecutive osRtxStackFillPattern instances.
+     * For the best effort stack end detection, we will consider STACK_END_MARK_CNT consecutive osRtxStackFillPattern instances as the stack end. */
+#define STACK_END_MARK_CNT  3
+#define STACK_DUMP_WIDTH    8
+    mbed_error_printf("\n\nStack Dump:");
+    // Find the stack end.
+    int stack_end_cnt = 0;
+    uint32_t st_end = ctx->thread_current_sp;
+    for (; st_end >= ctx->thread_stack_mem; st_end -= sizeof(int)) {
+        uint32_t st_val = *((uint32_t *)st_end);
+        if (st_val == osRtxStackFillPattern) {
+            stack_end_cnt++;
+        } else {
+            stack_end_cnt = 0;
+        }
+        if (stack_end_cnt >= STACK_END_MARK_CNT) {
+            st_end += (STACK_END_MARK_CNT - 1) * sizeof(int);
+            break;
+        }
+    }
+    for (uint32_t st = st_end; st <= ctx->thread_current_sp; st += sizeof(int) * STACK_DUMP_WIDTH) {
+        mbed_error_printf("\n0x%08" PRIX32 ":", st);
+        for (int i = 0; i < STACK_DUMP_WIDTH; i++) {
+            uint32_t st_cur = st + i * sizeof(int);
+            if (st_cur > ctx->thread_current_sp) {
+                break;
+            }
+            uint32_t st_val = *((uint32_t *)st_cur);
+            mbed_error_printf("0x%08" PRIX32 " ", st_val);
+        }
+    }
+    mbed_error_printf("\n");
+#endif  // MBED_STACK_DUMP_ENABLED
+
     mbed_error_printf("\n-- MbedOS Error Info --\n");
 }
 #endif //ifndef NDEBUG

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -90,6 +90,12 @@
             "value": null
         },
 
+        "stack-dump-enabled": {
+            "macro_name": "MBED_STACK_DUMP_ENABLED",
+            "help": "Set to 1 or true to enable stack dump.",
+            "value": null
+        },
+
         "cpu-stats-enabled": {
             "macro_name": "MBED_CPU_STATS_ENABLED",
             "help": "Set to 1 to enable cpu stats. When enabled the function mbed_stats_cpu_get returns non-zero data. See mbed_stats.h for more information",


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

In the current mbed-os, there is no stack dump feature as far as I know.
With this code change, now we can have a stack dump as shown in the `Release Notes`.

In the near future we will come up on how to parse the stack and reconstruct the back-trace and call arguments. But even without the parser, the assembly readers can manually decode the stack dump to find the failure.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

For better post-crash debugging with Mbed-OS, you can enable stack dump.
In order to use, the application should add `mbed_app.json` this line.
```
            "platform.stack-dump-enabled": true
```
It is **strongly recommended** that you should save the *.elf file along with your *.bin file. In the future Mbed-OS debugging tutorial, we are planning to introduce how to debug with Mbed-OS stack dump and *.elf file. Without *.elf file, you will need to disassemble the code and manually decode the meaning of the stack.

This is the example of the stack dump from `MBED_ASSERT(false);`.
```
++ MbedOS Error Info ++
Error Status: 0x80FF0144 Code: 324 Module: 255
Error Message: Assertion failed: false
Location: 0x3037
File: ./main.cpp+35
Error Value: 0x0
Current Thread: main  Id: 0x20000E1C Entry: 0x4A5F StackSize: 0x1000 StackMem: 0x20001E08 SP: 0x20002CA4 
For more info, visit: https://mbed.com/s/error?error=0x80FF0144&osver=999999&core=0x410FC241&comp=2&ver=70300&tgt=K64F

Stack Dump:
0x20002998:0xCCCCCCCC 0x200001C8 0x00000008 0x0000000B 0x20002B10 0x00000008 0x00000001 0x20002C48 
0x200029B8:0x00000000 0x00000000 0x00000000 0x00009F53 0x00000080 0x00000000 0x00000000 0x00000000 
0x200029D8:0x00000000 0x00000000 0x00000000 0x0001486C 0x00000001 0x00014840 0x00000000 0x00000000 
0x200029F8:0x00000000 0x00000000 0xFFFFFFFF 0x00009F53 0x00009AB8 0x41010000 0xFFFFFFFF 0x00009ECD 
0x20002A18:0x00000000 0x00000074 0x00000000 0x00000000 0xFFFFFFFF 0x00009F53 0x00009ECC 0x61010000 
0x20002A38:0x20002A44 0x00000000 0x00000000 0x00012A5B 0x00000001 0x0001489C 0x00000003 0x20002AE7 
0x20002A58:0x00000001 0x4006A000 0x0000000A 0xC0000080 0x0000000A 0x20002E68 0x20003030 0xC0000080 
0x20002A78:0x0A003030 0x4006A000 0x0000000A 0x20002E68 0x20003030 0x00003927 0x20003030 0x0000000B 
0x20002A98:0x20003030 0x20000D94 0x20003030 0x0000000B 0x00000016 0x00003D41 0x00000000 0x0000000B 
0x20002AB8:0x20003030 0x00000001 0x0000000B 0x20000D94 0x00000013 0x00003CB1 0x00000015 0x00000013 
0x20002AD8:0x00000000 0x0000000B 0x30303032 0x32333033 0x0000000B 0x00000083 0x200001C8 0x0000FFFF 
0x20002AF8:0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x0001021D 0x00000000 0x00000020 
0x20002B18:0x00000000 0x00000001 0xFFFFFFFF 0x00001F67 0x00001F88 0x210C0000 0x20000000 0x4006A000 
0x20002B38:0x0000003A 0x20002E68 0x20002C3C 0x00003927 0x00000003 0x0000000B 0x20002BA0 0x20000D94 
0x20002B58:0x20002BA0 0x0000000B 0x2000051C 0x00003D41 0x20002C64 0x0000000B 0x20002BA0 0x00000001 
0x20002B78:0x00000000 0x000031E5 0x0000000B 0x0000314F 0x20002C44 0x20002BA0 0x00000002 0x00003119 
0x20002B98:0x20002C44 0x00012A54 0x30307830 0x38373033 0x00203333 0x202C0000 0x69736976 0x68203A74 
0x20002BB8:0x73707474 0x6D2F2F3A 0x2E646562 0x2F6D6F63 0x72652F73 0x3F726F72 0x6F727265 0x78303D72 
0x20002BD8:0x46463038 0x34343130 0x76736F26 0x393D7265 0x39393939 0x6F632639 0x303D6572 0x30313478 
0x20002BF8:0x34324346 0x6F632631 0x323D706D 0x72657626 0x3330373D 0x74263030 0x4B3D7467 0x00463436 
0x20002C18:0x0000000A 0x00003D41 0x0000646D 0x0000000B 0x00011FD0 0x000030D3 0x00004A5F 0x20002C44 
0x20002C38:0x00000000 0x00003797 0x00012A54 0x00012A54 0x20002C44 0x20002C44 0x00000002 0x0001129C 
0x20002C58:0x20002CA4 0x00011FCA 0x00000023 0x00011FD0 0x00011FDC 0x20000CC4 0x00000000 0x000F423F 
0x20002C78:0x410FC241 0x00000002 0x0001129C 0x20000000 0x1FFF0000 0x00000000 0x00000000 0x00030000 
0x20002C98:0x00010000 0x00000000 0x00000000 0x00000000 

-- MbedOS Error Info --
```

This dump routine is smart and only dumps the critical area containing following information.
* backtrace of callers
* call arguments of callers

NOTE: Otherwise, if we dump too much, it will choke up the crash log. 

Also, note that this does not require the application to build with `-funwind-tables` option or have GCC dependency.


### Reference
* Arm internal: https://jira.arm.com/browse/IOTCORE-1217

(CC: @ohadhawk, @JanneKiiskila , @kjbracey-arm , @TeroJaasko , @bulislaw , @kivaisan  )