### PR TITLE
Cellular: Remove IPV6 and IPV4V6 as supported properties for BG96

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -57,8 +57,8 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // AT_CMGF
     1,  // AT_CSDH
     1,  // PROPERTY_IPV4_STACK
-    1,  // PROPERTY_IPV6_STACK
-    1,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_IPV6_STACK
+    0,  // PROPERTY_IPV4V6_STACK
     1,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
 };


### PR DESCRIPTION
### Description
Need to revert part of what was introduced by: https://github.com/ARMmbed/mbed-os/commit/3e6f5eba6c7da02f65220f6e9bc33804445c613b

Reason being:
IPV6 and IPV6V4 support is also network dependent not only modem.

Having these properties enabled for a modem requires a fallback mechanism during PDP context activation, so that if IPV6 context fails to activate it should be tried activating an IPV4 context. This mechanism is missing at the moment and that can result in impossibility to establish successful connection when network only supports IPV4 contexts.


### Pull request type
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change