### PR TITLE
Fix Nordic/Mbed Critical Section API Inconsistency (In Builds w/o Softdevice)

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/README.md
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/README.md
@@ -4,6 +4,8 @@ components/libraries
 
 # Modifications
 
+ * Modified util/app_util_platform.c to retarget critical section enter/exit calls to Mbed's HAL API so they both share the same nested critical regions counter. This only applies in builds without `SOFTDEVICE_PRESENT` defined.
+
 Only essential folders have been copied over.
 
 Removed:

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/util/app_util_platform.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/util/app_util_platform.c
@@ -39,6 +39,8 @@
  */
 #include "app_util_platform.h"
 
+#include "mbed_critical.h"
+
 #ifdef SOFTDEVICE_PRESENT
 /* Global nvic state instance, required by nrf_nvic.h */
 nrf_nvic_state_t nrf_nvic_state;
@@ -71,8 +73,13 @@ void app_util_critical_region_enter(uint8_t *p_nested)
     /* return value can be safely ignored */
     (void) sd_nvic_critical_region_enter(p_nested);
 #else
-    app_util_disable_irq();
+    /** Mbed modification
+     *  Retarget nRF SDK to use Mbed critical section API
+     */
+    //app_util_disable_irq();
+	core_util_critical_section_enter();
 #endif
+
 }
 
 void app_util_critical_region_exit(uint8_t nested)
@@ -85,7 +92,11 @@ void app_util_critical_region_exit(uint8_t nested)
     /* return value can be safely ignored */
     (void) sd_nvic_critical_region_exit(nested);
 #else
-    app_util_enable_irq();
+    /** Mbed modification
+	 *  Retarget nRF SDK to use Mbed critical section API
+	 */
+	//app_util_enable_irq();
+	core_util_critical_section_exit();
 #endif
 }
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/util/app_util_platform.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/util/app_util_platform.c
@@ -77,7 +77,7 @@ void app_util_critical_region_enter(uint8_t *p_nested)
      *  Retarget nRF SDK to use Mbed critical section API
      */
     //app_util_disable_irq();
-	core_util_critical_section_enter();
+    core_util_critical_section_enter();
 #endif
 
 }
@@ -93,10 +93,10 @@ void app_util_critical_region_exit(uint8_t nested)
     (void) sd_nvic_critical_region_exit(nested);
 #else
     /** Mbed modification
-	 *  Retarget nRF SDK to use Mbed critical section API
-	 */
-	//app_util_enable_irq();
-	core_util_critical_section_exit();
+     *  Retarget nRF SDK to use Mbed critical section API
+     */
+    //app_util_enable_irq();
+    core_util_critical_section_exit();
 #endif
 }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixed bug causing Nordic drivers to use a different critical section API from Mbed. This caused conflicts when Nordic's critical section API would globally reenable interrupts while Mbed still expected to be in a critical section.

See the issue that exposed this bug here: #10862

Please comment if you think there is a "prettier" way of applying this fix. This was my first solution but I'm not a huge fan of modifying the Nordic SDK if there's a better way to retarget the critical section API calls. Nordic's SDK doesn't seem to provide a nice mechanism for doing this.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
