### PR TITLE
Reduce Callback.h using C++11

### DIFF
--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -74,13 +74,13 @@ struct is_type {
  *
  * @note Synchronization level: Not protected
  */
-template <typename R>
-class Callback<R()> {
+template <typename R, typename... ArgTs>
+class Callback<R(ArgTs...)> {
 public:
     /** Create a Callback with a static function
      *  @param func     Static function to attach
      */
-    Callback(R(*func)() = 0)
+    Callback(R(*func)(ArgTs...) = 0)
     {
         if (!func) {
             memset(this, 0, sizeof(Callback));
@@ -92,7 +92,7 @@ public:
     /** Attach a Callback
      *  @param func     The Callback to attach
      */
-    Callback(const Callback<R()> &func)
+    Callback(const Callback<R(ArgTs...)> &func)
     {
         memset(this, 0, sizeof(Callback));
         if (func._ops) {
@@ -106,9 +106,9 @@ public:
      *  @param method   Member function to attach
      */
     template<typename T, typename U>
-    Callback(U *obj, R(T::*method)())
+    Callback(U *obj, R(T::*method)(ArgTs...))
     {
-        generate(method_context<T, R(T::*)()>(obj, method));
+        generate(method_context<T, R(T::*)(ArgTs...)>(obj, method));
     }
 
     /** Create a Callback with a member function
@@ -116,9 +116,9 @@ public:
      *  @param method   Member function to attach
      */
     template<typename T, typename U>
-    Callback(const U *obj, R(T::*method)() const)
+    Callback(const U *obj, R(T::*method)(ArgTs...) const)
     {
-        generate(method_context<const T, R(T::*)() const>(obj, method));
+        generate(method_context<const T, R(T::*)(ArgTs...) const>(obj, method));
     }
 
     /** Create a Callback with a member function
@@ -126,9 +126,9 @@ public:
      *  @param method   Member function to attach
      */
     template<typename T, typename U>
-    Callback(volatile U *obj, R(T::*method)() volatile)
+    Callback(volatile U *obj, R(T::*method)(ArgTs...) volatile)
     {
-        generate(method_context<volatile T, R(T::*)() volatile>(obj, method));
+        generate(method_context<volatile T, R(T::*)(ArgTs...) volatile>(obj, method));
     }
 
     /** Create a Callback with a member function
@@ -136,9 +136,9 @@ public:
      *  @param method   Member function to attach
      */
     template<typename T, typename U>
-    Callback(const volatile U *obj, R(T::*method)() const volatile)
+    Callback(const volatile U *obj, R(T::*method)(ArgTs...) const volatile)
     {
-        generate(method_context<const volatile T, R(T::*)() const volatile>(obj, method));
+        generate(method_context<const volatile T, R(T::*)(ArgTs...) const volatile>(obj, method));
     }
 
     /** Create a Callback with a static function and bound pointer
@@ -146,9 +146,9 @@ public:
      *  @param arg      Pointer argument to function
      */
     template<typename T, typename U>
-    Callback(R(*func)(T *), U *arg)
+    Callback(R(*func)(T *, ArgTs...), U *arg)
     {
-        generate(function_context<R(*)(T *), T>(func, arg));
+        generate(function_context<R(*)(T *, ArgTs...), T>(func, arg));
     }
 
     /** Create a Callback with a static function and bound pointer
@@ -156,9 +156,9 @@ public:
      *  @param arg      Pointer argument to function
      */
     template<typename T, typename U>
-    Callback(R(*func)(const T *), const U *arg)
+    Callback(R(*func)(const T *, ArgTs...), const U *arg)
     {
-        generate(function_context<R(*)(const T *), const T>(func, arg));
+        generate(function_context<R(*)(const T *, ArgTs...), const T>(func, arg));
     }
 
     /** Create a Callback with a static function and bound pointer
@@ -166,9 +166,9 @@ public:
      *  @param arg      Pointer argument to function
      */
     template<typename T, typename U>
-    Callback(R(*func)(volatile T *), volatile U *arg)
+    Callback(R(*func)(volatile T *, ArgTs...), volatile U *arg)
     {
-        generate(function_context<R(*)(volatile T *), volatile T>(func, arg));
+        generate(function_context<R(*)(volatile T *, ArgTs...), volatile T>(func, arg));
     }
 
     /** Create a Callback with a static function and bound pointer
@@ -176,9 +176,9 @@ public:
      *  @param arg      Pointer argument to function
      */
     template<typename T, typename U>
-    Callback(R(*func)(const volatile T *), const volatile U *arg)
+    Callback(R(*func)(const volatile T *, ArgTs...), const volatile U *arg)
     {
-        generate(function_context<R(*)(const volatile T *), const volatile T>(func, arg));
+        generate(function_context<R(*)(const volatile T *, ArgTs...), const volatile T>(func, arg));
     }
 
     /** Create a Callback with a function object
@@ -186,7 +186,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)()))
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...)))
     {
         generate(f);
     }
@@ -196,7 +196,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)() const))
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...) const))
     {
         generate(f);
     }
@@ -206,7 +206,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)() volatile))
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...) volatile))
     {
         generate(f);
     }
@@ -216,7 +216,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)() const volatile))
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...) const volatile))
     {
         generate(f);
     }
@@ -230,7 +230,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(U *obj, R(*func)(T *))
+    Callback(U *obj, R(*func)(T *, ArgTs...))
     {
         new (this) Callback(func, obj);
     }
@@ -244,7 +244,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const U *obj, R(*func)(const T *))
+    Callback(const U *obj, R(*func)(const T *, ArgTs...))
     {
         new (this) Callback(func, obj);
     }
@@ -258,7 +258,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile U *obj, R(*func)(volatile T *))
+    Callback(volatile U *obj, R(*func)(volatile T *, ArgTs...))
     {
         new (this) Callback(func, obj);
     }
@@ -272,7 +272,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile U *obj, R(*func)(const volatile T *))
+    Callback(const volatile U *obj, R(*func)(const volatile T *, ArgTs...))
     {
         new (this) Callback(func, obj);
     }
@@ -293,7 +293,7 @@ public:
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)())
+    void attach(R(*func)(ArgTs...))
     {
         this->~Callback();
         new (this) Callback(func);
@@ -306,7 +306,7 @@ public:
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(const Callback<R()> &func)
+    void attach(const Callback<R(ArgTs...)> &func)
     {
         this->~Callback();
         new (this) Callback(func);
@@ -321,7 +321,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(U *obj, R(T::*method)())
+    void attach(U *obj, R(T::*method)(ArgTs...))
     {
         this->~Callback();
         new (this) Callback(obj, method);
@@ -336,7 +336,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(const U *obj, R(T::*method)() const)
+    void attach(const U *obj, R(T::*method)(ArgTs...) const)
     {
         this->~Callback();
         new (this) Callback(obj, method);
@@ -351,7 +351,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile U *obj, R(T::*method)() volatile)
+    void attach(volatile U *obj, R(T::*method)(ArgTs...) volatile)
     {
         this->~Callback();
         new (this) Callback(obj, method);
@@ -366,7 +366,7 @@ public:
     template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile U *obj, R(T::*method)() const volatile)
+    void attach(const volatile U *obj, R(T::*method)(ArgTs...) const volatile)
     {
         this->~Callback();
         new (this) Callback(obj, method);
@@ -381,7 +381,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(T *), U *arg)
+    void attach(R(*func)(T *, ArgTs...), U *arg)
     {
         this->~Callback();
         new (this) Callback(func, arg);
@@ -396,7 +396,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const T *), const U *arg)
+    void attach(R(*func)(const T *, ArgTs...), const U *arg)
     {
         this->~Callback();
         new (this) Callback(func, arg);
@@ -411,7 +411,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(volatile T *), volatile U *arg)
+    void attach(R(*func)(volatile T *, ArgTs...), volatile U *arg)
     {
         this->~Callback();
         new (this) Callback(func, arg);
@@ -426,14 +426,14 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const volatile T *), const volatile U *arg)
+    void attach(R(*func)(const volatile T *, ArgTs...), const volatile U *arg)
     {
         this->~Callback();
         new (this) Callback(func, arg);
     }
 
     /** Attach a function object
-     *  @param f     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -441,22 +441,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)()))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f     Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)() const))
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...)))
     {
         this->~Callback();
         new (this) Callback(f);
@@ -471,7 +456,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)() volatile))
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...) const))
     {
         this->~Callback();
         new (this) Callback(f);
@@ -486,7 +471,22 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
                           "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)() const volatile))
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...) volatile))
+    {
+        this->~Callback();
+        new (this) Callback(f);
+    }
+
+    /** Attach a function object
+     *  @param f Function object to attach
+     *  @note The function object is limited to a single word of storage
+     *  @deprecated
+     *      Replaced by simple assignment 'Callback cb = func'
+     */
+    template <typename F>
+    MBED_DEPRECATED_SINCE("mbed-os-5.4",
+                          "Replaced by simple assignment 'Callback cb = func")
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(ArgTs...) const volatile))
     {
         this->~Callback();
         new (this) Callback(f);
@@ -501,7 +501,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(U *obj, R(*func)(T *))
+    void attach(U *obj, R(*func)(T *, ArgTs...))
     {
         this->~Callback();
         new (this) Callback(func, obj);
@@ -516,7 +516,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const U *obj, R(*func)(const T *))
+    void attach(const U *obj, R(*func)(const T *, ArgTs...))
     {
         this->~Callback();
         new (this) Callback(func, obj);
@@ -531,7 +531,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile U *obj, R(*func)(volatile T *))
+    void attach(volatile U *obj, R(*func)(volatile T *, ArgTs...))
     {
         this->~Callback();
         new (this) Callback(func, obj);
@@ -546,7 +546,7 @@ public:
     template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile U *obj, R(*func)(const volatile T *))
+    void attach(const volatile U *obj, R(*func)(const volatile T *, ArgTs...))
     {
         this->~Callback();
         new (this) Callback(func, obj);
@@ -566,17 +566,17 @@ public:
 
     /** Call the attached function
      */
-    R call() const
+    R call(ArgTs... args) const
     {
         MBED_ASSERT(_ops);
-        return _ops->call(this);
+        return _ops->call(this, args...);
     }
 
     /** Call the attached function
      */
-    R operator()() const
+    R operator()(ArgTs... args) const
     {
-        return call();
+        return call(args...);
     }
 
     /** Test if function has been attached
@@ -602,12 +602,13 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @param args Arguments to be called with function func
      *  @return the value as determined by func which is of
      *      type and determined by the signature of func
      */
-    static R thunk(void *func)
+    static R thunk(void *func, ArgTs... args)
     {
-        return static_cast<Callback *>(func)->call();
+        return static_cast<Callback *>(func)->call(args...);
     }
 
 private:
@@ -616,15 +617,15 @@ private:
     // to guarantee proper size and alignment
     struct _class;
     union {
-        void (*_staticfunc)();
-        void (*_boundfunc)(_class *);
-        void (_class::*_methodfunc)();
+        void (*_staticfunc)(ArgTs...);
+        void (*_boundfunc)(_class *, ArgTs...);
+        void (_class::*_methodfunc)(ArgTs...);
     } _func;
     void *_obj;
 
     // Dynamically dispatched operations
     const struct ops {
-        R(*call)(const void *);
+        R(*call)(const void *, ArgTs...);
         void (*move)(void *, const void *);
         void (*dtor)(void *);
     } *_ops;
@@ -648,9 +649,9 @@ private:
 
     // Function attributes
     template <typename F>
-    static R function_call(const void *p)
+    static R function_call(const void *p, ArgTs... args)
     {
-        return (*(F *)p)();
+        return (*(F *)p)(args...);
     }
 
     template <typename F>
@@ -674,9 +675,9 @@ private:
         method_context(O *obj, M method)
             : method(method), obj(obj) {}
 
-        R operator()() const
+        R operator()(ArgTs... args) const
         {
-            return (obj->*method)();
+            return (obj->*method)(args...);
         }
     };
 
@@ -688,3149 +689,9 @@ private:
         function_context(F func, A *arg)
             : func(func), arg(arg) {}
 
-        R operator()() const
+        R operator()(ArgTs... args) const
         {
-            return func(arg);
-        }
-    };
-};
-
-/** Callback class based on template specialization
- *
- * @note Synchronization level: Not protected
- */
-template <typename R, typename A0>
-class Callback<R(A0)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func     Static function to attach
-     */
-    Callback(R(*func)(A0) = 0)
-    {
-        if (!func) {
-            memset(this, 0, sizeof(Callback));
-        } else {
-            generate(func);
-        }
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     */
-    Callback(const Callback<R(A0)> &func)
-    {
-        memset(this, 0, sizeof(Callback));
-        if (func._ops) {
-            func._ops->move(this, &func);
-        }
-        _ops = func._ops;
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(U *obj, R(T::*method)(A0))
-    {
-        generate(method_context<T, R(T::*)(A0)>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const U *obj, R(T::*method)(A0) const)
-    {
-        generate(method_context<const T, R(T::*)(A0) const>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(volatile U *obj, R(T::*method)(A0) volatile)
-    {
-        generate(method_context<volatile T, R(T::*)(A0) volatile>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const volatile U *obj, R(T::*method)(A0) const volatile)
-    {
-        generate(method_context<const volatile T, R(T::*)(A0) const volatile>(obj, method));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(T *, A0), U *arg)
-    {
-        generate(function_context<R(*)(T *, A0), T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const T *, A0), const U *arg)
-    {
-        generate(function_context<R(*)(const T *, A0), const T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(volatile T *, A0), volatile U *arg)
-    {
-        generate(function_context<R(*)(volatile T *, A0), volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const volatile T *, A0), const volatile U *arg)
-    {
-        generate(function_context<R(*)(const volatile T *, A0), const volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0)))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0) const))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0) volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0) const volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(U *obj, R(*func)(T *, A0))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const U *obj, R(*func)(const T *, A0))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile U *obj, R(*func)(volatile T *, A0))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile U *obj, R(*func)(const volatile T *, A0))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Destroy a callback
-     */
-    ~Callback()
-    {
-        if (_ops) {
-            _ops->dtor(this);
-        }
-    }
-
-    /** Attach a static function
-     *  @param func     Static function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(A0))
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const Callback<R(A0)> &func)
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(U *obj, R(T::*method)(A0))
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const U *obj, R(T::*method)(A0) const)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile U *obj, R(T::*method)(A0) volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile U *obj, R(T::*method)(A0) const volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(T *, A0), U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const T *, A0), const U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(volatile T *, A0), volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const volatile T *, A0), const volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0)))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0) const))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0) volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0) const volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(U *obj, R(*func)(T *, A0))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const U *obj, R(*func)(const T *, A0))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile U *obj, R(*func)(volatile T *, A0))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile U *obj, R(*func)(const volatile T *, A0))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Assign a callback
-     */
-    Callback &operator=(const Callback &that)
-    {
-        if (this != &that) {
-            this->~Callback();
-            new (this) Callback(that);
-        }
-
-        return *this;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0) const
-    {
-        MBED_ASSERT(_ops);
-        return _ops->call(this, a0);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0) const
-    {
-        return call(a0);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const
-    {
-        return _ops;
-    }
-
-    /** Test for equality
-     */
-    friend bool operator==(const Callback &l, const Callback &r)
-    {
-        return memcmp(&l, &r, sizeof(Callback)) == 0;
-    }
-
-    /** Test for inequality
-     */
-    friend bool operator!=(const Callback &l, const Callback &r)
-    {
-        return !(l == r);
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     *  @param a0 An argument to be called with function func
-     *  @return the value as determined by func which is of
-     *      type and determined by the signature of func
-     */
-    static R thunk(void *func, A0 a0)
-    {
-        return static_cast<Callback *>(func)->call(a0);
-    }
-
-private:
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to guarantee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)(A0);
-        void (*_boundfunc)(_class *, A0);
-        void (_class::*_methodfunc)(A0);
-    } _func;
-    void *_obj;
-
-    // Dynamically dispatched operations
-    const struct ops {
-        R(*call)(const void *, A0);
-        void (*move)(void *, const void *);
-        void (*dtor)(void *);
-    } *_ops;
-
-    // Generate operations for function object
-    template <typename F>
-    void generate(const F &f)
-    {
-        static const ops ops = {
-            &Callback::function_call<F>,
-            &Callback::function_move<F>,
-            &Callback::function_dtor<F>,
-        };
-
-        MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
-                           "Type F must not exceed the size of the Callback class");
-        memset(this, 0, sizeof(Callback));
-        new (this) F(f);
-        _ops = &ops;
-    }
-
-    // Function attributes
-    template <typename F>
-    static R function_call(const void *p, A0 a0)
-    {
-        return (*(F *)p)(a0);
-    }
-
-    template <typename F>
-    static void function_move(void *d, const void *p)
-    {
-        new (d) F(*(F *)p);
-    }
-
-    template <typename F>
-    static void function_dtor(void *p)
-    {
-        ((F *)p)->~F();
-    }
-
-    // Wrappers for functions with context
-    template <typename O, typename M>
-    struct method_context {
-        M method;
-        O *obj;
-
-        method_context(O *obj, M method)
-            : method(method), obj(obj) {}
-
-        R operator()(A0 a0) const
-        {
-            return (obj->*method)(a0);
-        }
-    };
-
-    template <typename F, typename A>
-    struct function_context {
-        F func;
-        A *arg;
-
-        function_context(F func, A *arg)
-            : func(func), arg(arg) {}
-
-        R operator()(A0 a0) const
-        {
-            return func(arg, a0);
-        }
-    };
-};
-
-/** Callback class based on template specialization
- *
- * @note Synchronization level: Not protected
- */
-template <typename R, typename A0, typename A1>
-class Callback<R(A0, A1)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func     Static function to attach
-     */
-    Callback(R(*func)(A0, A1) = 0)
-    {
-        if (!func) {
-            memset(this, 0, sizeof(Callback));
-        } else {
-            generate(func);
-        }
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     */
-    Callback(const Callback<R(A0, A1)> &func)
-    {
-        memset(this, 0, sizeof(Callback));
-        if (func._ops) {
-            func._ops->move(this, &func);
-        }
-        _ops = func._ops;
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(U *obj, R(T::*method)(A0, A1))
-    {
-        generate(method_context<T, R(T::*)(A0, A1)>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const U *obj, R(T::*method)(A0, A1) const)
-    {
-        generate(method_context<const T, R(T::*)(A0, A1) const>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(volatile U *obj, R(T::*method)(A0, A1) volatile)
-    {
-        generate(method_context<volatile T, R(T::*)(A0, A1) volatile>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const volatile U *obj, R(T::*method)(A0, A1) const volatile)
-    {
-        generate(method_context<const volatile T, R(T::*)(A0, A1) const volatile>(obj, method));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(T *, A0, A1), U *arg)
-    {
-        generate(function_context<R(*)(T *, A0, A1), T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const T *, A0, A1), const U *arg)
-    {
-        generate(function_context<R(*)(const T *, A0, A1), const T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(volatile T *, A0, A1), volatile U *arg)
-    {
-        generate(function_context<R(*)(volatile T *, A0, A1), volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const volatile T *, A0, A1), const volatile U *arg)
-    {
-        generate(function_context<R(*)(const volatile T *, A0, A1), const volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1)))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1) const))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1) volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1) const volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(U *obj, R(*func)(T *, A0, A1))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const U *obj, R(*func)(const T *, A0, A1))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile U *obj, R(*func)(volatile T *, A0, A1))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Destroy a callback
-     */
-    ~Callback()
-    {
-        if (_ops) {
-            _ops->dtor(this);
-        }
-    }
-
-    /** Attach a static function
-     *  @param func     Static function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(A0, A1))
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const Callback<R(A0, A1)> &func)
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(U *obj, R(T::*method)(A0, A1))
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const U *obj, R(T::*method)(A0, A1) const)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile U *obj, R(T::*method)(A0, A1) volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile U *obj, R(T::*method)(A0, A1) const volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(T *, A0, A1), U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const T *, A0, A1), const U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(volatile T *, A0, A1), volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const volatile T *, A0, A1), const volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1)))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1) const))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1) volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1) const volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(U *obj, R(*func)(T *, A0, A1))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const U *obj, R(*func)(const T *, A0, A1))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile U *obj, R(*func)(volatile T *, A0, A1))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile U *obj, R(*func)(const volatile T *, A0, A1))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Assign a callback
-     */
-    Callback &operator=(const Callback &that)
-    {
-        if (this != &that) {
-            this->~Callback();
-            new (this) Callback(that);
-        }
-
-        return *this;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1) const
-    {
-        MBED_ASSERT(_ops);
-        return _ops->call(this, a0, a1);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1) const
-    {
-        return call(a0, a1);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const
-    {
-        return _ops;
-    }
-
-    /** Test for equality
-     */
-    friend bool operator==(const Callback &l, const Callback &r)
-    {
-        return memcmp(&l, &r, sizeof(Callback)) == 0;
-    }
-
-    /** Test for inequality
-     */
-    friend bool operator!=(const Callback &l, const Callback &r)
-    {
-        return !(l == r);
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     *  @param a0 An argument to be called with function func
-     *  @param a1 An argument to be called with function func
-     *  @return the value as determined by func which is of
-     *      type and determined by the signature of func
-     */
-    static R thunk(void *func, A0 a0, A1 a1)
-    {
-        return static_cast<Callback *>(func)->call(a0, a1);
-    }
-
-private:
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to guarantee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)(A0, A1);
-        void (*_boundfunc)(_class *, A0, A1);
-        void (_class::*_methodfunc)(A0, A1);
-    } _func;
-    void *_obj;
-
-    // Dynamically dispatched operations
-    const struct ops {
-        R(*call)(const void *, A0, A1);
-        void (*move)(void *, const void *);
-        void (*dtor)(void *);
-    } *_ops;
-
-    // Generate operations for function object
-    template <typename F>
-    void generate(const F &f)
-    {
-        static const ops ops = {
-            &Callback::function_call<F>,
-            &Callback::function_move<F>,
-            &Callback::function_dtor<F>,
-        };
-
-        MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
-                           "Type F must not exceed the size of the Callback class");
-        memset(this, 0, sizeof(Callback));
-        new (this) F(f);
-        _ops = &ops;
-    }
-
-    // Function attributes
-    template <typename F>
-    static R function_call(const void *p, A0 a0, A1 a1)
-    {
-        return (*(F *)p)(a0, a1);
-    }
-
-    template <typename F>
-    static void function_move(void *d, const void *p)
-    {
-        new (d) F(*(F *)p);
-    }
-
-    template <typename F>
-    static void function_dtor(void *p)
-    {
-        ((F *)p)->~F();
-    }
-
-    // Wrappers for functions with context
-    template <typename O, typename M>
-    struct method_context {
-        M method;
-        O *obj;
-
-        method_context(O *obj, M method)
-            : method(method), obj(obj) {}
-
-        R operator()(A0 a0, A1 a1) const
-        {
-            return (obj->*method)(a0, a1);
-        }
-    };
-
-    template <typename F, typename A>
-    struct function_context {
-        F func;
-        A *arg;
-
-        function_context(F func, A *arg)
-            : func(func), arg(arg) {}
-
-        R operator()(A0 a0, A1 a1) const
-        {
-            return func(arg, a0, a1);
-        }
-    };
-};
-
-/** Callback class based on template specialization
- *
- * @note Synchronization level: Not protected
- */
-template <typename R, typename A0, typename A1, typename A2>
-class Callback<R(A0, A1, A2)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func     Static function to attach
-     */
-    Callback(R(*func)(A0, A1, A2) = 0)
-    {
-        if (!func) {
-            memset(this, 0, sizeof(Callback));
-        } else {
-            generate(func);
-        }
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     */
-    Callback(const Callback<R(A0, A1, A2)> &func)
-    {
-        memset(this, 0, sizeof(Callback));
-        if (func._ops) {
-            func._ops->move(this, &func);
-        }
-        _ops = func._ops;
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(U *obj, R(T::*method)(A0, A1, A2))
-    {
-        generate(method_context<T, R(T::*)(A0, A1, A2)>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const U *obj, R(T::*method)(A0, A1, A2) const)
-    {
-        generate(method_context<const T, R(T::*)(A0, A1, A2) const>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(volatile U *obj, R(T::*method)(A0, A1, A2) volatile)
-    {
-        generate(method_context<volatile T, R(T::*)(A0, A1, A2) volatile>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const volatile U *obj, R(T::*method)(A0, A1, A2) const volatile)
-    {
-        generate(method_context<const volatile T, R(T::*)(A0, A1, A2) const volatile>(obj, method));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(T *, A0, A1, A2), U *arg)
-    {
-        generate(function_context<R(*)(T *, A0, A1, A2), T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const T *, A0, A1, A2), const U *arg)
-    {
-        generate(function_context<R(*)(const T *, A0, A1, A2), const T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(volatile T *, A0, A1, A2), volatile U *arg)
-    {
-        generate(function_context<R(*)(volatile T *, A0, A1, A2), volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const volatile T *, A0, A1, A2), const volatile U *arg)
-    {
-        generate(function_context<R(*)(const volatile T *, A0, A1, A2), const volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2)))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2) const))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2) volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2) const volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(U *obj, R(*func)(T *, A0, A1, A2))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const U *obj, R(*func)(const T *, A0, A1, A2))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile U *obj, R(*func)(volatile T *, A0, A1, A2))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Destroy a callback
-     */
-    ~Callback()
-    {
-        if (_ops) {
-            _ops->dtor(this);
-        }
-    }
-
-    /** Attach a static function
-     *  @param func     Static function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(A0, A1, A2))
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const Callback<R(A0, A1, A2)> &func)
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(U *obj, R(T::*method)(A0, A1, A2))
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const U *obj, R(T::*method)(A0, A1, A2) const)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile U *obj, R(T::*method)(A0, A1, A2) volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile U *obj, R(T::*method)(A0, A1, A2) const volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(T *, A0, A1, A2), U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const T *, A0, A1, A2), const U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(volatile T *, A0, A1, A2), volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const volatile T *, A0, A1, A2), const volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2)))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2) const))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2) volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2) const volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(U *obj, R(*func)(T *, A0, A1, A2))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const U *obj, R(*func)(const T *, A0, A1, A2))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile U *obj, R(*func)(volatile T *, A0, A1, A2))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Assign a callback
-     */
-    Callback &operator=(const Callback &that)
-    {
-        if (this != &that) {
-            this->~Callback();
-            new (this) Callback(that);
-        }
-
-        return *this;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1, A2 a2) const
-    {
-        MBED_ASSERT(_ops);
-        return _ops->call(this, a0, a1, a2);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1, A2 a2) const
-    {
-        return call(a0, a1, a2);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const
-    {
-        return _ops;
-    }
-
-    /** Test for equality
-     */
-    friend bool operator==(const Callback &l, const Callback &r)
-    {
-        return memcmp(&l, &r, sizeof(Callback)) == 0;
-    }
-
-    /** Test for inequality
-     */
-    friend bool operator!=(const Callback &l, const Callback &r)
-    {
-        return !(l == r);
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     *  @param a0 An argument to be called with function func
-     *  @param a1 An argument to be called with function func
-     *  @param a2 An argument to be called with function func
-     *  @return the value as determined by func which is of
-     *      type and determined by the signature of func
-     */
-    static R thunk(void *func, A0 a0, A1 a1, A2 a2)
-    {
-        return static_cast<Callback *>(func)->call(a0, a1, a2);
-    }
-
-private:
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to guarantee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)(A0, A1, A2);
-        void (*_boundfunc)(_class *, A0, A1, A2);
-        void (_class::*_methodfunc)(A0, A1, A2);
-    } _func;
-    void *_obj;
-
-    // Dynamically dispatched operations
-    const struct ops {
-        R(*call)(const void *, A0, A1, A2);
-        void (*move)(void *, const void *);
-        void (*dtor)(void *);
-    } *_ops;
-
-    // Generate operations for function object
-    template <typename F>
-    void generate(const F &f)
-    {
-        static const ops ops = {
-            &Callback::function_call<F>,
-            &Callback::function_move<F>,
-            &Callback::function_dtor<F>,
-        };
-
-        MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
-                           "Type F must not exceed the size of the Callback class");
-        memset(this, 0, sizeof(Callback));
-        new (this) F(f);
-        _ops = &ops;
-    }
-
-    // Function attributes
-    template <typename F>
-    static R function_call(const void *p, A0 a0, A1 a1, A2 a2)
-    {
-        return (*(F *)p)(a0, a1, a2);
-    }
-
-    template <typename F>
-    static void function_move(void *d, const void *p)
-    {
-        new (d) F(*(F *)p);
-    }
-
-    template <typename F>
-    static void function_dtor(void *p)
-    {
-        ((F *)p)->~F();
-    }
-
-    // Wrappers for functions with context
-    template <typename O, typename M>
-    struct method_context {
-        M method;
-        O *obj;
-
-        method_context(O *obj, M method)
-            : method(method), obj(obj) {}
-
-        R operator()(A0 a0, A1 a1, A2 a2) const
-        {
-            return (obj->*method)(a0, a1, a2);
-        }
-    };
-
-    template <typename F, typename A>
-    struct function_context {
-        F func;
-        A *arg;
-
-        function_context(F func, A *arg)
-            : func(func), arg(arg) {}
-
-        R operator()(A0 a0, A1 a1, A2 a2) const
-        {
-            return func(arg, a0, a1, a2);
-        }
-    };
-};
-
-/** Callback class based on template specialization
- *
- * @note Synchronization level: Not protected
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-class Callback<R(A0, A1, A2, A3)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func     Static function to attach
-     */
-    Callback(R(*func)(A0, A1, A2, A3) = 0)
-    {
-        if (!func) {
-            memset(this, 0, sizeof(Callback));
-        } else {
-            generate(func);
-        }
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     */
-    Callback(const Callback<R(A0, A1, A2, A3)> &func)
-    {
-        memset(this, 0, sizeof(Callback));
-        if (func._ops) {
-            func._ops->move(this, &func);
-        }
-        _ops = func._ops;
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(U *obj, R(T::*method)(A0, A1, A2, A3))
-    {
-        generate(method_context<T, R(T::*)(A0, A1, A2, A3)>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const U *obj, R(T::*method)(A0, A1, A2, A3) const)
-    {
-        generate(method_context<const T, R(T::*)(A0, A1, A2, A3) const>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(volatile U *obj, R(T::*method)(A0, A1, A2, A3) volatile)
-    {
-        generate(method_context<volatile T, R(T::*)(A0, A1, A2, A3) volatile>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const volatile U *obj, R(T::*method)(A0, A1, A2, A3) const volatile)
-    {
-        generate(method_context<const volatile T, R(T::*)(A0, A1, A2, A3) const volatile>(obj, method));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(T *, A0, A1, A2, A3), U *arg)
-    {
-        generate(function_context<R(*)(T *, A0, A1, A2, A3), T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const T *, A0, A1, A2, A3), const U *arg)
-    {
-        generate(function_context<R(*)(const T *, A0, A1, A2, A3), const T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(volatile T *, A0, A1, A2, A3), volatile U *arg)
-    {
-        generate(function_context<R(*)(volatile T *, A0, A1, A2, A3), volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const volatile T *, A0, A1, A2, A3), const volatile U *arg)
-    {
-        generate(function_context<R(*)(const volatile T *, A0, A1, A2, A3), const volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3)))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3) const))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3) volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3) const volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(U *obj, R(*func)(T *, A0, A1, A2, A3))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const U *obj, R(*func)(const T *, A0, A1, A2, A3))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile U *obj, R(*func)(volatile T *, A0, A1, A2, A3))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2, A3))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Destroy a callback
-     */
-    ~Callback()
-    {
-        if (_ops) {
-            _ops->dtor(this);
-        }
-    }
-
-    /** Attach a static function
-     *  @param func     Static function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(A0, A1, A2, A3))
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const Callback<R(A0, A1, A2, A3)> &func)
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(U *obj, R(T::*method)(A0, A1, A2, A3))
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const U *obj, R(T::*method)(A0, A1, A2, A3) const)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile U *obj, R(T::*method)(A0, A1, A2, A3) volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile U *obj, R(T::*method)(A0, A1, A2, A3) const volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(T *, A0, A1, A2, A3), U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const T *, A0, A1, A2, A3), const U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(volatile T *, A0, A1, A2, A3), volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const volatile T *, A0, A1, A2, A3), const volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3)))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3) const))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3) volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3) const volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(U *obj, R(*func)(T *, A0, A1, A2, A3))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const U *obj, R(*func)(const T *, A0, A1, A2, A3))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile U *obj, R(*func)(volatile T *, A0, A1, A2, A3))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2, A3))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Assign a callback
-     */
-    Callback &operator=(const Callback &that)
-    {
-        if (this != &that) {
-            this->~Callback();
-            new (this) Callback(that);
-        }
-
-        return *this;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1, A2 a2, A3 a3) const
-    {
-        MBED_ASSERT(_ops);
-        return _ops->call(this, a0, a1, a2, a3);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1, A2 a2, A3 a3) const
-    {
-        return call(a0, a1, a2, a3);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const
-    {
-        return _ops;
-    }
-
-    /** Test for equality
-     */
-    friend bool operator==(const Callback &l, const Callback &r)
-    {
-        return memcmp(&l, &r, sizeof(Callback)) == 0;
-    }
-
-    /** Test for inequality
-     */
-    friend bool operator!=(const Callback &l, const Callback &r)
-    {
-        return !(l == r);
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     *  @param a0 An argument to be called with function func
-     *  @param a1 An argument to be called with function func
-     *  @param a2 An argument to be called with function func
-     *  @param a3 An argument to be called with function func
-     *  @return the value as determined by func which is of
-     *      type and determined by the signature of func
-     */
-    static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3)
-    {
-        return static_cast<Callback *>(func)->call(a0, a1, a2, a3);
-    }
-
-private:
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to guarantee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)(A0, A1, A2, A3);
-        void (*_boundfunc)(_class *, A0, A1, A2, A3);
-        void (_class::*_methodfunc)(A0, A1, A2, A3);
-    } _func;
-    void *_obj;
-
-    // Dynamically dispatched operations
-    const struct ops {
-        R(*call)(const void *, A0, A1, A2, A3);
-        void (*move)(void *, const void *);
-        void (*dtor)(void *);
-    } *_ops;
-
-    // Generate operations for function object
-    template <typename F>
-    void generate(const F &f)
-    {
-        static const ops ops = {
-            &Callback::function_call<F>,
-            &Callback::function_move<F>,
-            &Callback::function_dtor<F>,
-        };
-
-        MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
-                           "Type F must not exceed the size of the Callback class");
-        memset(this, 0, sizeof(Callback));
-        new (this) F(f);
-        _ops = &ops;
-    }
-
-    // Function attributes
-    template <typename F>
-    static R function_call(const void *p, A0 a0, A1 a1, A2 a2, A3 a3)
-    {
-        return (*(F *)p)(a0, a1, a2, a3);
-    }
-
-    template <typename F>
-    static void function_move(void *d, const void *p)
-    {
-        new (d) F(*(F *)p);
-    }
-
-    template <typename F>
-    static void function_dtor(void *p)
-    {
-        ((F *)p)->~F();
-    }
-
-    // Wrappers for functions with context
-    template <typename O, typename M>
-    struct method_context {
-        M method;
-        O *obj;
-
-        method_context(O *obj, M method)
-            : method(method), obj(obj) {}
-
-        R operator()(A0 a0, A1 a1, A2 a2, A3 a3) const
-        {
-            return (obj->*method)(a0, a1, a2, a3);
-        }
-    };
-
-    template <typename F, typename A>
-    struct function_context {
-        F func;
-        A *arg;
-
-        function_context(F func, A *arg)
-            : func(func), arg(arg) {}
-
-        R operator()(A0 a0, A1 a1, A2 a2, A3 a3) const
-        {
-            return func(arg, a0, a1, a2, a3);
-        }
-    };
-};
-
-/** Callback class based on template specialization
- *
- * @note Synchronization level: Not protected
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-class Callback<R(A0, A1, A2, A3, A4)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func     Static function to attach
-     */
-    Callback(R(*func)(A0, A1, A2, A3, A4) = 0)
-    {
-        if (!func) {
-            memset(this, 0, sizeof(Callback));
-        } else {
-            generate(func);
-        }
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     */
-    Callback(const Callback<R(A0, A1, A2, A3, A4)> &func)
-    {
-        memset(this, 0, sizeof(Callback));
-        if (func._ops) {
-            func._ops->move(this, &func);
-        }
-        _ops = func._ops;
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(U *obj, R(T::*method)(A0, A1, A2, A3, A4))
-    {
-        generate(method_context<T, R(T::*)(A0, A1, A2, A3, A4)>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const U *obj, R(T::*method)(A0, A1, A2, A3, A4) const)
-    {
-        generate(method_context<const T, R(T::*)(A0, A1, A2, A3, A4) const>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(volatile U *obj, R(T::*method)(A0, A1, A2, A3, A4) volatile)
-    {
-        generate(method_context<volatile T, R(T::*)(A0, A1, A2, A3, A4) volatile>(obj, method));
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     */
-    template<typename T, typename U>
-    Callback(const volatile U *obj, R(T::*method)(A0, A1, A2, A3, A4) const volatile)
-    {
-        generate(method_context<const volatile T, R(T::*)(A0, A1, A2, A3, A4) const volatile>(obj, method));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(T *, A0, A1, A2, A3, A4), U *arg)
-    {
-        generate(function_context<R(*)(T *, A0, A1, A2, A3, A4), T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const T *, A0, A1, A2, A3, A4), const U *arg)
-    {
-        generate(function_context<R(*)(const T *, A0, A1, A2, A3, A4), const T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(volatile T *, A0, A1, A2, A3, A4), volatile U *arg)
-    {
-        generate(function_context<R(*)(volatile T *, A0, A1, A2, A3, A4), volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T, typename U>
-    Callback(R(*func)(const volatile T *, A0, A1, A2, A3, A4), const volatile U *arg)
-    {
-        generate(function_context<R(*)(const volatile T *, A0, A1, A2, A3, A4), const volatile T>(func, arg));
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4)))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4) const))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4) volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     */
-    template <typename F>
-    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4) const volatile))
-    {
-        generate(f);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(U *obj, R(*func)(T *, A0, A1, A2, A3, A4))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const U *obj, R(*func)(const T *, A0, A1, A2, A3, A4))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile U *obj, R(*func)(volatile T *, A0, A1, A2, A3, A4))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2, A3, A4))
-    {
-        new (this) Callback(func, obj);
-    }
-
-    /** Destroy a callback
-     */
-    ~Callback()
-    {
-        if (_ops) {
-            _ops->dtor(this);
-        }
-    }
-
-    /** Attach a static function
-     *  @param func     Static function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(A0, A1, A2, A3, A4))
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a Callback
-     *  @param func     The Callback to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const Callback<R(A0, A1, A2, A3, A4)> &func)
-    {
-        this->~Callback();
-        new (this) Callback(func);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(U *obj, R(T::*method)(A0, A1, A2, A3, A4))
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const U *obj, R(T::*method)(A0, A1, A2, A3, A4) const)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile U *obj, R(T::*method)(A0, A1, A2, A3, A4) volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a member function
-     *  @param obj      Pointer to object to invoke member function on
-     *  @param method   Member function to attach
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template<typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile U *obj, R(T::*method)(A0, A1, A2, A3, A4) const volatile)
-    {
-        this->~Callback();
-        new (this) Callback(obj, method);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(T *, A0, A1, A2, A3, A4), U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const T *, A0, A1, A2, A3, A4), const U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(volatile T *, A0, A1, A2, A3, A4), volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(R(*func)(const volatile T *, A0, A1, A2, A3, A4), const volatile U *arg)
-    {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4)))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4) const))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4) volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a function object
-     *  @param f Function object to attach
-     *  @note The function object is limited to a single word of storage
-     *  @deprecated
-     *      Replaced by simple assignment 'Callback cb = func'
-     */
-    template <typename F>
-    MBED_DEPRECATED_SINCE("mbed-os-5.4",
-                          "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R(F::*)(A0, A1, A2, A3, A4) const volatile))
-    {
-        this->~Callback();
-        new (this) Callback(f);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(U *obj, R(*func)(T *, A0, A1, A2, A3, A4))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const U *obj, R(*func)(const T *, A0, A1, A2, A3, A4))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile U *obj, R(*func)(volatile T *, A0, A1, A2, A3, A4))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T, typename U>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2, A3, A4))
-    {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Assign a callback
-     */
-    Callback &operator=(const Callback &that)
-    {
-        if (this != &that) {
-            this->~Callback();
-            new (this) Callback(that);
-        }
-
-        return *this;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const
-    {
-        MBED_ASSERT(_ops);
-        return _ops->call(this, a0, a1, a2, a3, a4);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const
-    {
-        return call(a0, a1, a2, a3, a4);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const
-    {
-        return _ops;
-    }
-
-    /** Test for equality
-     */
-    friend bool operator==(const Callback &l, const Callback &r)
-    {
-        return memcmp(&l, &r, sizeof(Callback)) == 0;
-    }
-
-    /** Test for inequality
-     */
-    friend bool operator!=(const Callback &l, const Callback &r)
-    {
-        return !(l == r);
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     *  @param a0 An argument to be called with function func
-     *  @param a1 An argument to be called with function func
-     *  @param a2 An argument to be called with function func
-     *  @param a3 An argument to be called with function func
-     *  @param a4 An argument to be called with function func
-     *  @return the value as determined by func which is of
-     *      type and determined by the signature of func
-     */
-    static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-    {
-        return static_cast<Callback *>(func)->call(a0, a1, a2, a3, a4);
-    }
-
-private:
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to guarantee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)(A0, A1, A2, A3, A4);
-        void (*_boundfunc)(_class *, A0, A1, A2, A3, A4);
-        void (_class::*_methodfunc)(A0, A1, A2, A3, A4);
-    } _func;
-    void *_obj;
-
-    // Dynamically dispatched operations
-    const struct ops {
-        R(*call)(const void *, A0, A1, A2, A3, A4);
-        void (*move)(void *, const void *);
-        void (*dtor)(void *);
-    } *_ops;
-
-    // Generate operations for function object
-    template <typename F>
-    void generate(const F &f)
-    {
-        static const ops ops = {
-            &Callback::function_call<F>,
-            &Callback::function_move<F>,
-            &Callback::function_dtor<F>,
-        };
-
-        MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
-                           "Type F must not exceed the size of the Callback class");
-        memset(this, 0, sizeof(Callback));
-        new (this) F(f);
-        _ops = &ops;
-    }
-
-    // Function attributes
-    template <typename F>
-    static R function_call(const void *p, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-    {
-        return (*(F *)p)(a0, a1, a2, a3, a4);
-    }
-
-    template <typename F>
-    static void function_move(void *d, const void *p)
-    {
-        new (d) F(*(F *)p);
-    }
-
-    template <typename F>
-    static void function_dtor(void *p)
-    {
-        ((F *)p)->~F();
-    }
-
-    // Wrappers for functions with context
-    template <typename O, typename M>
-    struct method_context {
-        M method;
-        O *obj;
-
-        method_context(O *obj, M method)
-            : method(method), obj(obj) {}
-
-        R operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const
-        {
-            return (obj->*method)(a0, a1, a2, a3, a4);
-        }
-    };
-
-    template <typename F, typename A>
-    struct function_context {
-        F func;
-        A *arg;
-
-        function_context(F func, A *arg)
-            : func(func), arg(arg) {}
-
-        R operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const
-        {
-            return func(arg, a0, a1, a2, a3, a4);
+            return func(arg, args...);
         }
     };
 };
@@ -3844,10 +705,10 @@ typedef Callback<void(int)> event_callback_t;
  *  @param func     Static function to attach
  *  @return         Callback with inferred type
  */
-template <typename R>
-Callback<R()> callback(R(*func)() = 0)
+template <typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(R(*func)(ArgTs...) = 0)
 {
-    return Callback<R()>(func);
+    return Callback<R(ArgTs...)>(func);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3855,10 +716,10 @@ Callback<R()> callback(R(*func)() = 0)
  *  @param func     Static function to attach
  *  @return         Callback with inferred type
  */
-template <typename R>
-Callback<R()> callback(const Callback<R()> &func)
+template <typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(const Callback<R(ArgTs...)> &func)
 {
-    return Callback<R()>(func);
+    return Callback<R(ArgTs...)>(func);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3867,10 +728,10 @@ Callback<R()> callback(const Callback<R()> &func)
  *  @param method   Member function to attach
  *  @return         Callback with inferred type
  */
-template<typename T, typename U, typename R>
-Callback<R()> callback(U *obj, R(T::*method)())
+template<typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(U *obj, R(T::*method)(ArgTs...))
 {
-    return Callback<R()>(obj, method);
+    return Callback<R(ArgTs...)>(obj, method);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3879,10 +740,10 @@ Callback<R()> callback(U *obj, R(T::*method)())
  *  @param method   Member function to attach
  *  @return         Callback with inferred type
  */
-template<typename T, typename U, typename R>
-Callback<R()> callback(const U *obj, R(T::*method)() const)
+template<typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(const U *obj, R(T::*method)(ArgTs...) const)
 {
-    return Callback<R()>(obj, method);
+    return Callback<R(ArgTs...)>(obj, method);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3891,10 +752,10 @@ Callback<R()> callback(const U *obj, R(T::*method)() const)
  *  @param method   Member function to attach
  *  @return         Callback with inferred type
  */
-template<typename T, typename U, typename R>
-Callback<R()> callback(volatile U *obj, R(T::*method)() volatile)
+template<typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(volatile U *obj, R(T::*method)(ArgTs...) volatile)
 {
-    return Callback<R()>(obj, method);
+    return Callback<R(ArgTs...)>(obj, method);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3903,10 +764,10 @@ Callback<R()> callback(volatile U *obj, R(T::*method)() volatile)
  *  @param method   Member function to attach
  *  @return         Callback with inferred type
  */
-template<typename T, typename U, typename R>
-Callback<R()> callback(const volatile U *obj, R(T::*method)() const volatile)
+template<typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(const volatile U *obj, R(T::*method)(ArgTs...) const volatile)
 {
-    return Callback<R()>(obj, method);
+    return Callback<R(ArgTs...)>(obj, method);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3915,10 +776,10 @@ Callback<R()> callback(const volatile U *obj, R(T::*method)() const volatile)
  *  @param arg      Pointer argument to function
  *  @return         Callback with inferred type
  */
-template <typename T, typename U, typename R>
-Callback<R()> callback(R(*func)(T *), U *arg)
+template <typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(R(*func)(T *, ArgTs...), U *arg)
 {
-    return Callback<R()>(func, arg);
+    return Callback<R(ArgTs...)>(func, arg);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3927,10 +788,10 @@ Callback<R()> callback(R(*func)(T *), U *arg)
  *  @param arg      Pointer argument to function
  *  @return         Callback with inferred type
  */
-template <typename T, typename U, typename R>
-Callback<R()> callback(R(*func)(const T *), const U *arg)
+template <typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(R(*func)(const T *, ArgTs...), const U *arg)
 {
-    return Callback<R()>(func, arg);
+    return Callback<R(ArgTs...)>(func, arg);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3939,10 +800,10 @@ Callback<R()> callback(R(*func)(const T *), const U *arg)
  *  @param arg      Pointer argument to function
  *  @return         Callback with inferred type
  */
-template <typename T, typename U, typename R>
-Callback<R()> callback(R(*func)(volatile T *), volatile U *arg)
+template <typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(R(*func)(volatile T *, ArgTs...), volatile U *arg)
 {
-    return Callback<R()>(func, arg);
+    return Callback<R(ArgTs...)>(func, arg);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3951,10 +812,10 @@ Callback<R()> callback(R(*func)(volatile T *), volatile U *arg)
  *  @param arg      Pointer argument to function
  *  @return         Callback with inferred type
  */
-template <typename T, typename U, typename R>
-Callback<R()> callback(R(*func)(const volatile T *), const volatile U *arg)
+template <typename T, typename U, typename R, typename... ArgTs>
+Callback<R(ArgTs...)> callback(R(*func)(const volatile T *, ArgTs...), const volatile U *arg)
 {
-    return Callback<R()>(func, arg);
+    return Callback<R(ArgTs...)>(func, arg);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3965,12 +826,12 @@ Callback<R()> callback(R(*func)(const volatile T *), const volatile U *arg)
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename T, typename U, typename R>
+template <typename T, typename U, typename R, typename... ArgTs>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
                       "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(U *obj, R(*func)(T *))
+Callback<R(ArgTs...)> callback(U *obj, R(*func)(T *, ArgTs...))
 {
-    return Callback<R()>(func, obj);
+    return Callback<R(ArgTs...)>(func, obj);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3981,12 +842,12 @@ Callback<R()> callback(U *obj, R(*func)(T *))
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename T, typename U, typename R>
+template <typename T, typename U, typename R, typename... ArgTs>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
                       "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(const U *obj, R(*func)(const T *))
+Callback<R(ArgTs...)> callback(const U *obj, R(*func)(const T *, ArgTs...))
 {
-    return Callback<R()>(func, obj);
+    return Callback<R(ArgTs...)>(func, obj);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -3997,12 +858,12 @@ Callback<R()> callback(const U *obj, R(*func)(const T *))
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename T, typename U, typename R>
+template <typename T, typename U, typename R, typename... ArgTs>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
                       "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(volatile U *obj, R(*func)(volatile T *))
+Callback<R(ArgTs...)> callback(volatile U *obj, R(*func)(volatile T *, ArgTs...))
 {
-    return Callback<R()>(func, obj);
+    return Callback<R(ArgTs...)>(func, obj);
 }
 
 /** Create a callback class with type inferred from the arguments
@@ -4013,927 +874,12 @@ Callback<R()> callback(volatile U *obj, R(*func)(volatile T *))
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename T, typename U, typename R>
+template <typename T, typename U, typename R, typename... ArgTs>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
                       "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(const volatile U *obj, R(*func)(const volatile T *))
+Callback<R(ArgTs...)> callback(const volatile U *obj, R(*func)(const volatile T *, ArgTs...))
 {
-    return Callback<R()>(func, obj);
-}
-
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0>
-Callback<R(A0)> callback(R(*func)(A0) = 0)
-{
-    return Callback<R(A0)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0>
-Callback<R(A0)> callback(const Callback<R(A0)> &func)
-{
-    return Callback<R(A0)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(U *obj, R(T::*method)(A0))
-{
-    return Callback<R(A0)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(const U *obj, R(T::*method)(A0) const)
-{
-    return Callback<R(A0)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(volatile U *obj, R(T::*method)(A0) volatile)
-{
-    return Callback<R(A0)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(const volatile U *obj, R(T::*method)(A0) const volatile)
-{
-    return Callback<R(A0)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(R(*func)(T *, A0), U *arg)
-{
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(R(*func)(const T *, A0), const U *arg)
-{
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(R(*func)(volatile T *, A0), volatile U *arg)
-{
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0>
-Callback<R(A0)> callback(R(*func)(const volatile T *, A0), const volatile U *arg)
-{
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(U *obj, R(*func)(T *, A0))
-{
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(const U *obj, R(*func)(const T *, A0))
-{
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(volatile U *obj, R(*func)(volatile T *, A0))
-{
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(const volatile U *obj, R(*func)(const volatile T *, A0))
-{
-    return Callback<R(A0)>(func, obj);
-}
-
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R(*func)(A0, A1) = 0)
-{
-    return Callback<R(A0, A1)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const Callback<R(A0, A1)> &func)
-{
-    return Callback<R(A0, A1)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(U *obj, R(T::*method)(A0, A1))
-{
-    return Callback<R(A0, A1)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const U *obj, R(T::*method)(A0, A1) const)
-{
-    return Callback<R(A0, A1)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(volatile U *obj, R(T::*method)(A0, A1) volatile)
-{
-    return Callback<R(A0, A1)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const volatile U *obj, R(T::*method)(A0, A1) const volatile)
-{
-    return Callback<R(A0, A1)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R(*func)(T *, A0, A1), U *arg)
-{
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R(*func)(const T *, A0, A1), const U *arg)
-{
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R(*func)(volatile T *, A0, A1), volatile U *arg)
-{
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R(*func)(const volatile T *, A0, A1), const volatile U *arg)
-{
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(U *obj, R(*func)(T *, A0, A1))
-{
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(const U *obj, R(*func)(const T *, A0, A1))
-{
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(volatile U *obj, R(*func)(volatile T *, A0, A1))
-{
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1))
-{
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R(*func)(A0, A1, A2) = 0)
-{
-    return Callback<R(A0, A1, A2)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const Callback<R(A0, A1, A2)> &func)
-{
-    return Callback<R(A0, A1, A2)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(U *obj, R(T::*method)(A0, A1, A2))
-{
-    return Callback<R(A0, A1, A2)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const U *obj, R(T::*method)(A0, A1, A2) const)
-{
-    return Callback<R(A0, A1, A2)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(volatile U *obj, R(T::*method)(A0, A1, A2) volatile)
-{
-    return Callback<R(A0, A1, A2)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const volatile U *obj, R(T::*method)(A0, A1, A2) const volatile)
-{
-    return Callback<R(A0, A1, A2)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R(*func)(T *, A0, A1, A2), U *arg)
-{
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R(*func)(const T *, A0, A1, A2), const U *arg)
-{
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R(*func)(volatile T *, A0, A1, A2), volatile U *arg)
-{
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R(*func)(const volatile T *, A0, A1, A2), const volatile U *arg)
-{
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(U *obj, R(*func)(T *, A0, A1, A2))
-{
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(const U *obj, R(*func)(const T *, A0, A1, A2))
-{
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(volatile U *obj, R(*func)(volatile T *, A0, A1, A2))
-{
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2))
-{
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R(*func)(A0, A1, A2, A3) = 0)
-{
-    return Callback<R(A0, A1, A2, A3)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const Callback<R(A0, A1, A2, A3)> &func)
-{
-    return Callback<R(A0, A1, A2, A3)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(U *obj, R(T::*method)(A0, A1, A2, A3))
-{
-    return Callback<R(A0, A1, A2, A3)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const U *obj, R(T::*method)(A0, A1, A2, A3) const)
-{
-    return Callback<R(A0, A1, A2, A3)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(volatile U *obj, R(T::*method)(A0, A1, A2, A3) volatile)
-{
-    return Callback<R(A0, A1, A2, A3)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const volatile U *obj, R(T::*method)(A0, A1, A2, A3) const volatile)
-{
-    return Callback<R(A0, A1, A2, A3)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R(*func)(T *, A0, A1, A2, A3), U *arg)
-{
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R(*func)(const T *, A0, A1, A2, A3), const U *arg)
-{
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R(*func)(volatile T *, A0, A1, A2, A3), volatile U *arg)
-{
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R(*func)(const volatile T *, A0, A1, A2, A3), const volatile U *arg)
-{
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(U *obj, R(*func)(T *, A0, A1, A2, A3))
-{
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(const U *obj, R(*func)(const T *, A0, A1, A2, A3))
-{
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(volatile U *obj, R(*func)(volatile T *, A0, A1, A2, A3))
-{
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2, A3))
-{
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R(*func)(A0, A1, A2, A3, A4) = 0)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @return         Callback with inferred type
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const Callback<R(A0, A1, A2, A3, A4)> &func)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(U *obj, R(T::*method)(A0, A1, A2, A3, A4))
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const U *obj, R(T::*method)(A0, A1, A2, A3, A4) const)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile U *obj, R(T::*method)(A0, A1, A2, A3, A4) volatile)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj      Optional pointer to object to bind to function
- *  @param method   Member function to attach
- *  @return         Callback with inferred type
- */
-template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile U *obj, R(T::*method)(A0, A1, A2, A3, A4) const volatile)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R(*func)(T *, A0, A1, A2, A3, A4), U *arg)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R(*func)(const T *, A0, A1, A2, A3, A4), const U *arg)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R(*func)(volatile T *, A0, A1, A2, A3, A4), volatile U *arg)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with inferred type
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R(*func)(const volatile T *, A0, A1, A2, A3, A4), const volatile U *arg)
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(U *obj, R(*func)(T *, A0, A1, A2, A3, A4))
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(const U *obj, R(*func)(const T *, A0, A1, A2, A3, A4))
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile U *obj, R(*func)(volatile T *, A0, A1, A2, A3, A4))
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type inferred from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with inferred type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                      "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile U *obj, R(*func)(const volatile T *, A0, A1, A2, A3, A4))
-{
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
+    return Callback<R(ArgTs...)>(func, obj);
 }
 
 /**@}*/


### PR DESCRIPTION

### Description

The bulk of Callback.h was auto-generated as 6 specialisations, handling zero to five arguments.

This can now be handled without specialisation using C++11 variadic templates, reducing the file from 4,900 lines to 900 lines.

This should reduce compilation time, and offset potential increases from use of `<type_traits>` or a local `mbed_cxxsupport.h` equivalent.

Several other improvents to `Callback` are possible and/or desirable with C++11, such as the ability to store lambdas, but this commit is purely the variadic simplification.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan-, @bulislaw, @geky
