### PR TITLE
Remove macro MBEDTLS_PSA_CRYPTO_C from PSA targets

### DIFF
--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/attest_crypto.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/attest_crypto.c
@@ -8,6 +8,12 @@
  * See BSD-3-Clause license in README.md
  */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #include "t_cose_crypto.h"
 #include "tfm_plat_defs.h"
 #include "psa/crypto.h"

--- a/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_PSA_SRV_IPC/psa_crypto_spm.c
@@ -19,6 +19,12 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #if defined(MBEDTLS_PSA_CRYPTO_C)
 
 #include <stdlib.h>

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2074,7 +2074,6 @@
             "MBED_FAULT_HANDLER_DISABLED",
             "CMSIS_NVIC_VIRTUAL",
             "MBED_MPU_CUSTOM",
-            "MBEDTLS_PSA_CRYPTO_C",
             "NXP_LPADC"
         ],
         "components_add": ["FLASHIAP"],
@@ -5445,8 +5444,7 @@
             "MBED_FAULT_HANDLER_DISABLED",
             "CMSIS_NVIC_VIRTUAL",
             "LPTICKER_DELAY_TICKS=1",
-            "MBED_MPU_CUSTOM",
-            "MBEDTLS_PSA_CRYPTO_C"
+            "MBED_MPU_CUSTOM"
         ],
         "extra_labels_add": ["MUSCA_A1_NS", "PSA", "TFM"],
         "post_binary_hook": {"function": "ArmMuscaA1Code.binary_hook"},
@@ -8331,7 +8329,6 @@
         "extra_labels_add": ["PSA", "MBED_SPM"],
         "components_add": ["SPM_MAILBOX", "FLASHIAP"],
         "device_has_remove": ["CRC"],
-        "macros_add": ["MBEDTLS_PSA_CRYPTO_C"],
         "hex_filename": "psa_release_1.0.hex",
         "overrides": {
             "secure-rom-start": "0x10000000",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2125,8 +2125,7 @@
             "__STARTUP_COPY_MULTIPLE",
             "MBED_MPU_CUSTOM",
             "DAUTH_CHIP_DEFAULT",
-            "MBEDTLS_PSA_CRYPTO_SPM",
-            "MBEDTLS_PSA_CRYPTO_C"
+            "MBEDTLS_PSA_CRYPTO_SPM"
         ],
         "components_add": ["FLASHIAP"],
         "extra_labels_add": [
@@ -5470,7 +5469,6 @@
             "MBED_MPU_CUSTOM",
             "DAUTH_CHIP_DEFAULT",
             "MBEDTLS_PSA_CRYPTO_SPM",
-            "MBEDTLS_PSA_CRYPTO_C",
             "MBEDTLS_ENTROPY_NV_SEED"
         ],
         "components_add": ["FLASHIAP"],
@@ -8309,7 +8307,6 @@
         "macros_add": [
             "MBED_TICKLESS",
             "MBEDTLS_PSA_CRYPTO_SPM",
-            "MBEDTLS_PSA_CRYPTO_C",
             "PU_ENABLE"
         ],
         "deliver_to_target": "CY8CKIT_062_WIFI_BT_PSA",


### PR DESCRIPTION
### Description

1. Include MBEDTLS_CONFIG_FILE before evaluating MBEDTLS_PSA_CRYPTO_C
2. Remove macro MBEDTLS_PSA_CRYPTO_C from PSA targets

Fixes https://github.com/ARMmbed/mbed-os/issues/10883

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>

### Pull request type
    [x ] Fix
    [ ] Refactor
    [x ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@Patater 

### Release Notes

