### PR TITLE
Add adjust-check-config script to mbedtls importer

### DIFF
--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -132,6 +132,9 @@ deploy: rsync
 	# Adjusting the default mbed TLS config file to mbed purposes
 	./adjust-config.sh $(MBED_TLS_DIR)/scripts/config.pl $(TARGET_INC)/mbedtls/config.h
 	#
+	# Adjusting the default mbed TLS check-config file to mbed purposes
+	./adjust-check-config.sh $(TARGET_INC)/mbedtls/check_config.h
+	#
 	# Copy and adjust the trimmed config that does not require entropy source
 	cp $(MBED_TLS_DIR)/configs/config-no-entropy.h $(TARGET_INC)/mbedtls/.
 	./adjust-no-entropy-config.sh $(MBED_TLS_DIR)/scripts/config.pl $(TARGET_INC)/mbedtls/config-no-entropy.h

--- a/features/mbedtls/importer/adjust-check-config.sh
+++ b/features/mbedtls/importer/adjust-check-config.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# This file is part of mbed TLS (https://tls.mbed.org)
+#
+# Copyright (c) 2019, Arm Limited, All Rights Reserved
+#
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# * http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Purpose
+#
+# Removes checks from check_config.h that aren't needed for Mbed OS
+#
+# Usage: adjust-check-config.sh [path to check_config file]
+#
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 path/to/check_config.h" >&2
+    exit 1
+fi
+
+FILE=$1
+
+conf() {
+    $SCRIPT -f $FILE --force $@
+}
+
+remove_code() {
+    MATCH_PATTERN=$(IFS=""; printf "%s" "$*")
+
+    perl -0pi -e "s/$MATCH_PATTERN//g" "$FILE"
+}
+
+# When using Mbed Crypto's PSA Entropy Injection feature on Mbed OS, it is
+# not required to opt out of having entropy sources added to your entropy
+# contexts by default (via MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES).
+# As integrated in Mbed OS, MBEDTLS_PSA_INJECT_ENTROPY is compatible with
+# actual entropy sources. PSA entropy injection is implemented using the
+# standard Mbed TLS NV Seed feature, and is as compatible with other
+# entropy sources as the standard Mbed TLS NV Seed feature which does
+# support entropy mixing.
+remove_code                                                                                 \
+    "#if defined\(MBEDTLS_PSA_INJECT_ENTROPY\) &&              \\\\\n"                      \
+    "    !defined\(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES\)\n"                                  \
+    "#error \"MBEDTLS_PSA_INJECT_ENTROPY is not compatible with actual entropy sources\"\n" \
+    "#endif\n"                                                                              \
+    "\n"


### PR DESCRIPTION
### Description

In Mbed OS, there are configuration options with Mbed TLS that we are more comfortable allowing than we do with Mbed TLS on its own. Add a check-config adjusting script to enable removing or changing options in check_config.h

Fixes the entropy sources check that was removed in #10802 from being re-added when the importer script is run.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
