### PR TITLE
Fix netconn_recv_tcp_pbuf ARMC6 linker error

### DIFF
--- a/features/lwipstack/LWIPStack.cpp
+++ b/features/lwipstack/LWIPStack.cpp
@@ -463,6 +463,7 @@ nsapi_size_or_error_t LWIP::socket_send(nsapi_socket_t handle, const void *data,
 
 nsapi_size_or_error_t LWIP::socket_recv(nsapi_socket_t handle, void *data, nsapi_size_t size)
 {
+#if LWIP_TCP
     struct mbed_lwip_socket *s = (struct mbed_lwip_socket *)handle;
 
     if (!s->buf) {
@@ -483,6 +484,9 @@ nsapi_size_or_error_t LWIP::socket_recv(nsapi_socket_t handle, void *data, nsapi
     }
 
     return recv;
+#else
+    return NSAPI_ERROR_UNSUPPORTED;
+#endif
 }
 
 nsapi_size_or_error_t LWIP::socket_sendto(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size)


### PR DESCRIPTION
### Description

If "lwip.tcp-enabled" is set to false, ARMC6 compilation fails to linker error
Error: L6218E: Undefined symbol netconn_recv_tcp_pbuf

LWIP::socket_recv() is TCP socket specific method so implementation can be
enabled only when LWIP_TCP flag is set.

Fixes the compilation bug introduced in PR #10807.
### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
