### PR TITLE
Increase dns-response-wait-time

### DIFF
--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -44,7 +44,7 @@
         },
         "dns-response-wait-time": {
             "help": "How long the DNS translator waits for a reply from a server in milliseconds",
-            "value": 5000
+            "value": 10000
         },
         "dns-total-attempts": {
             "help": "Number of total DNS query attempts that the DNS translator makes",


### PR DESCRIPTION
###  Description

Increased DNS query timeout value from 5 seconds to 10 seconds because in some cellular networks or with some modems, DNS response can take longer than 5 seconds to arrive.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
