### PR TITLE
Update PROPERTY_IPV6_STACK for target BG96

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -57,7 +57,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // AT_CMGF
     1,  // AT_CSDH
     1,  // PROPERTY_IPV4_STACK
-    0,  // PROPERTY_IPV6_STACK
+    1,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     1,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP


### PR DESCRIPTION
### Description

Hi
We are trying to test a cellular module, BG96 of QUECTEL.
And I referenced the below sample code.
https://os.mbed.com/users/Daniel_Lee/code/mbed-os-example-cellular-BG96/
In my test result, This Property(**PROPERTY_IPV6_STACK**) in QUECTEL_BG96.cpp must be 1 to get successful results.
Please refer to attached files.
[Log1.txt](https://github.com/ARMmbed/mbed-os/files/3338751/Log1.txt): when PROPERTY_IPV6_STACK is 0
[Log2.txt](https://github.com/ARMmbed/mbed-os/files/3338752/Log2.txt): when PROPERTY_IPV6_STACK is 1



<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
