### PR TITLE
AT Cellular Network: mutex lock issue

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -293,6 +293,7 @@ nsapi_error_t AT_CellularNetwork::get_attach(AttachStatus &status)
 
 nsapi_error_t AT_CellularNetwork::detach()
 {
+    _at.lock();
     tr_debug("Network detach");
     _at.at_cmd_discard("+CGATT", "=0");
 


### PR DESCRIPTION
### Description

A lock was missing in the AT_CellularNetwork::detach function.

Detected with the features-cellular-tests-api-cellular_network test

````
[1561726551.24][CONN][RXD] >>> Running case #5: 'CellularNetwork test detach'...
[1561726557.35][CONN][RXD] [DEBUG]AT+CGATT=0
[1561726557.79][CONN][RXD] [DEBUG]AT+COPS=2
[1561726557.80][CONN][RXD]
[1561726557.80][CONN][RXD]
[1561726557.83][CONN][RXD] ++ MbedOS Error Info ++
[1561726557.87][CONN][RXD] Error Status: 0x80010133 Code: 307 Module: 1
[1561726557.92][CONN][RXD] Error Message: Mutex: 0x20003EBC, Unknown
[1561726557.94][CONN][RXD] Location: 0x801A0AF
[1561726557.96][CONN][RXD] Error Value: 0x20003EBC
[1561726558.07][CONN][RXD] Current Thread: main  Id: 0x200031E4 Entry: 0x801683D StackSize: 0x1000 StackMem: 0x200019D8 SP: 0x2004FF24
[1561726558.16][CONN][RXD] For more info, visit: https://mbed.com/s/error?error=0x80010133&tgt=DISCO_L496AG
[1561726558.19][CONN][RXD] -- MbedOS Error Info --
````


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
