### PR TITLE
Doubled ATHandler's BUFF_SIZE

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -570,15 +570,15 @@ TEST_F(TestATHandler, test_ATHandler_read_bytes)
     mbed_poll_stub::int_value = 1;;
 
     // Read 5 bytes
-    EXPECT_TRUE(5 == at.read_bytes(buf, 5));
+    EXPECT_EQ(5, at.read_bytes(buf, 5));
     EXPECT_TRUE(!memcmp(buf, table1, 5));
     // get_char triggered above should have filled in the whole reading buffer(fill_buffer())
-    EXPECT_TRUE(filehandle_stub_table_pos == (strlen(table1) - 1));
+    EXPECT_EQ(filehandle_stub_table_pos, (strlen(table1)));
     // Read another 8 bytes
     EXPECT_TRUE(8 == at.read_bytes(buf, 8) && !memcmp(buf, table1 + 5, 8));
     // Reading more than the 4 bytes left -> ERROR
-    EXPECT_TRUE(-1 == at.read_bytes(buf, 5));
-    EXPECT_TRUE(NSAPI_ERROR_DEVICE_ERROR == at.get_last_error());
+    EXPECT_EQ(-1, at.read_bytes(buf, 5));
+    EXPECT_EQ(NSAPI_ERROR_DEVICE_ERROR, at.get_last_error());
 }
 
 TEST_F(TestATHandler, test_ATHandler_read_string)

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -43,7 +43,7 @@ class FileHandle;
 extern const char *OK;
 extern const char *CRLF;
 
-#define BUFF_SIZE 16
+#define BUFF_SIZE 32
 
 /* AT Error types enumeration */
 enum DeviceErrorType {


### PR DESCRIPTION
### Description
BUFF_SIZE in handle_start method was defined too small for some of our tests. I doubled the value to fix the issue(s). 
This fixes Arm internal ref: IOTCELL-2099 issue

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
