### PR TITLE
STM: Correct macro test in us_ticker_defines.h

### DIFF
--- a/targets/TARGET_STM/us_ticker_defines.h
+++ b/targets/TARGET_STM/us_ticker_defines.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_US_TICKER_DEFINES_H
+#ifndef MBED_US_TICKER_DEFINES_H_
 #define MBED_US_TICKER_DEFINES_H_
 
 #include "us_ticker_data.h"


### PR DESCRIPTION

### Description

Avoids build warning caused by #10609


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant 
