### PR TITLE
Solve bug: Low frequency clock will now selected by given "lf_clock_src" setting.

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -40,6 +40,7 @@
 
 // Nordic Includes
 #include "nrf.h"
+#include "nrf5x_lf_clk_helper.h"
 
 #include "NRFCordioHCIDriver.h"
 #include "NRFCordioHCITransportDriver.h"
@@ -60,6 +61,14 @@ using namespace ble::vendor::cordio;
 #define CORDIO_LL_MEMORY_FOOTPRINT  41906UL
 #else
 #define CORDIO_LL_MEMORY_FOOTPRINT  12768UL
+#endif
+
+#if MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC == NRF_LF_SRC_SYNTH
+#define NRF_LF_CLK_SRC CLOCK_LFCLKSRC_SRC_Synth
+#elif MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC == NRF_LF_SRC_XTAL
+#define NRF_LF_CLK_SRC CLOCK_LFCLKSRC_SRC_Xtal
+#elif MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC == NRF_LF_SRC_RC
+#define NRF_LF_CLK_SRC CLOCK_LFCLKSRC_SRC_RC
 #endif
 
 /*! \brief      Typical implementation revision number (LlRtCfg_t::implRev). */
@@ -246,7 +255,7 @@ void NRFCordioHCIDriver::do_initialize()
     }
 
     /* configure low-frequency clock */
-    NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos);
+    NRF_CLOCK->LFCLKSRC             = (NRF_LF_CLK_SRC << CLOCK_LFCLKSRC_SRC_Pos);
     NRF_CLOCK->EVENTS_LFCLKSTARTED  = 0;
     NRF_CLOCK->TASKS_LFCLKSTART     = 1;
     while (NRF_CLOCK->EVENTS_LFCLKSTARTED == 0)


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

See issue #10929 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
