### PR TITLE
Internal delay loop code alignment to 16

### DIFF
--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -132,7 +132,7 @@ void wait_us(int us)
  * the hassle of handling multiple toolchains with different assembler
  * syntax.
  */
-MBED_ALIGN(8)
+MBED_ALIGN(16)
 static const uint16_t delay_loop_code[] = {
     0x1E40, // SUBS R0,R0,#1
     0xBF00, // NOP


### PR DESCRIPTION
 ### Description

Delay loop code alignment to 16 for  decreasing execution time.
Its used by Wait_ns (...)

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

 @kjbracey-arm 
 @pan- 

### Release Notes
 