### PR TITLE
Nordic NRF52832 cache ON 

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/system_nrf52.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/system_nrf52.c
@@ -216,7 +216,7 @@ void SystemInit(void)
     while (NRF_CLOCK->EVENTS_LFCLKSTARTED == 0) {
         // Do nothing.
     }
-
+    NRF_NVMC->ICACHECNF=0x01;
     /**
      * Mbed HAL specific code section.
      *


### PR DESCRIPTION
 ### Description

Nordic NRF52832 chip onboard instruction cache is turned ON  to decrease execution time and improve performance. 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

 @kjbracey-arm 
 @pan- 

### Release Notes
 