### PR TITLE
Fix unittest build with MinGW

### DIFF
--- a/features/mbedtls/inc/mbedtls/platform.h
+++ b/features/mbedtls/inc/mbedtls/platform.h
@@ -257,6 +257,7 @@ int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
+#include <stdarg.h>
 int mbedtls_platform_win32_vsnprintf( char *s, size_t n, const char *fmt, va_list arg );
 #endif
 


### PR DESCRIPTION
Unit test build crashes if MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF is defined. Add #include <stdarg.h> to fix this issue.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Building unit tests on Windows 7 with MinGW/MSYS fails at 9% completion because 'va_list' is not declared. Inserting the mentioned #include (like that in the following #if section a few lines later) will fix the issue.

### Details

Command issued:

``mbed test --unittest --generator "MinGW Makefiles" --make-program mingw32-make``

Unfixed build fails with:

``In file included from P:\mbed-os\features\lorawan\lorastack\mac\LoRaMacCrypto.cpp:31:0:``

``p:\mbed-os\features\mbedtls\inc\mbedtls\platform.h:260:75: error: 'va_list' has not been declared``
`` int mbedtls_platform_win32_vsnprintf( char *s, size_t n, const char *fmt, va_list arg );``

Compiler version: g++ (MinGW.org GCC-6.3.0-1) 6.3.0

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
