### PR TITLE
Deinitialize the pin definition

### DIFF
--- a/drivers/AnalogOut.h
+++ b/drivers/AnalogOut.h
@@ -138,8 +138,9 @@ public:
 
     virtual ~AnalogOut()
     {
-        /* Deinitialize the pin configuration totally. 
-        This should allow changing the definition of the pin */
+        /** Deinitialize the pin configuration totally. 
+         *\ This should allow changing the definition of the pin
+         */
           analogout_free(&this->_dac);
     }
 

--- a/drivers/AnalogOut.h
+++ b/drivers/AnalogOut.h
@@ -138,10 +138,9 @@ public:
 
     virtual ~AnalogOut()
     {
-        /** Deinitialize the pin configuration totally. 
-         *\ This should allow changing the definition of the pin
+        /** Deinitialize pin configuration.
          */
-        analogout_free(&this->_dac);
+        analogout_free(&_dac);
     }
 
 protected:

--- a/drivers/AnalogOut.h
+++ b/drivers/AnalogOut.h
@@ -138,7 +138,8 @@ public:
 
     virtual ~AnalogOut()
     {
-        // Do nothing
+        // deinitialize the pin configuration totally. This should allow chaining the definition of the pin
+          analogout_free(&this->_dac);
     }
 
 protected:

--- a/drivers/AnalogOut.h
+++ b/drivers/AnalogOut.h
@@ -138,7 +138,8 @@ public:
 
     virtual ~AnalogOut()
     {
-        // deinitialize the pin configuration totally. This should allow chaining the definition of the pin
+        /* Deinitialize the pin configuration totally. 
+        This should allow changing the definition of the pin */
           analogout_free(&this->_dac);
     }
 

--- a/drivers/AnalogOut.h
+++ b/drivers/AnalogOut.h
@@ -141,7 +141,7 @@ public:
         /** Deinitialize the pin configuration totally. 
          *\ This should allow changing the definition of the pin
          */
-          analogout_free(&this->_dac);
+        analogout_free(&this->_dac);
     }
 
 protected:

--- a/hal/analogout_api.h
+++ b/hal/analogout_api.h
@@ -48,7 +48,6 @@ void analogout_init(dac_t *obj, PinName pin);
 
 /** Release the analogout object
  *
- * Note: This is not currently used in the mbed-drivers
  * @param obj The analogout object
  */
 void analogout_free(dac_t *obj);


### PR DESCRIPTION
Without freeing the DAC, the pin will continue to be configured as DAC. Which make it impossible to change it from AnalogOut to anything else. 
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
