### PR TITLE
BLE: fix flex word

### DIFF
--- a/features/FEATURE_BLE/ble/GattCharacteristic.h
+++ b/features/FEATURE_BLE/ble/GattCharacteristic.h
@@ -701,12 +701,12 @@ public:
         /**
          * Magnetic flux, weber.
          */
-        BLE_GATT_UNIT_MAGNETIC_FLEX_WEBER = 0x272C,
+        BLE_GATT_UNIT_MAGNETIC_FLUX_WEBER = 0x272C,
 
         /**
          * Magnetic flux density, tesla.
          */
-        BLE_GATT_UNIT_MAGNETIC_FLEX_DENSITY_TESLA = 0x272D,
+        BLE_GATT_UNIT_MAGNETIC_FLUX_DENSITY_TESLA = 0x272D,
 
         /**
          * Inductance, henry.


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fixed typo causing magnetic flux to be magnetic flex.

💪💪💪

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
