### PR TITLE
Enable split heap in K64F/K66F devices

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -114,12 +114,12 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; lo
   RW_m_crash_data m_crash_report_ram_start EMPTY m_crash_report_ram_size { ; RW data
   }
   RW_m_data m_data_start m_data_size { ; RW data
-    .ANY (+RW +ZI)
+    .ANY2 (+RW +ZI)
   }
   RW_m_data_2 m_data_2_start m_data_2_size { ; RW data
-    .ANY (+RW +ZI)
+    .ANY1 (+RW +ZI)
   }
-  RW_IRAM1 ImageLimit(RW_m_data_2) {
+  RW_IRAM1 ImageLimit(RW_m_data_2) EMPTY 0 {
   }
   ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (m_data_2_start + m_data_2_size - Stack_Size - AlignExpr(ImageLimit(RW_IRAM1), 16)) { ; Heap region growing up
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -210,6 +210,14 @@ SECTIONS
     __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
   } > m_data
 
+  .heap_0 :
+  {
+    . = ALIGN(8);
+    __mbed_sbrk_start_0 = .;
+    . += (ORIGIN(m_data) + LENGTH(m_data) - .);
+    __mbed_krbs_start_0 = .;
+  } > m_data
+
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
 
@@ -249,8 +257,10 @@ SECTIONS
     . = ALIGN(8);
     __end__ = .;
     PROVIDE(end = .);
+    __mbed_sbrk_start = .;
     __HeapBase = .;
     . = ORIGIN(m_data_2) + LENGTH(m_data_2) - STACK_SIZE;
+    __mbed_krbs_start = .;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
   } > m_data_2

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -210,14 +210,6 @@ SECTIONS
     __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
   } > m_data
 
-  .heap_0 :
-  {
-    . = ALIGN(8);
-    __mbed_sbrk_start_0 = .;
-    . += (ORIGIN(m_data) + LENGTH(m_data) - .);
-    __mbed_krbs_start_0 = .;
-  } > m_data
-
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
 
@@ -231,6 +223,14 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(8);
     __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  .heap_0 :
+  {
+    . = ALIGN(8);
+    __mbed_sbrk_start_0 = .;
+    . += (ORIGIN(m_data) + LENGTH(m_data) - .);
+    __mbed_krbs_start_0 = .;
   } > m_data
 
   __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -118,12 +118,12 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load
   RW_m_crash_data m_crash_report_ram_start EMPTY m_crash_report_ram_size { ; RW data
   } 
   RW_m_data m_data_start m_data_size { ; RW data
-    .ANY (+RW +ZI)
+    .ANY2 (+RW +ZI)
   }
   RW_m_data_2 m_data_2_start m_data_2_size { ; RW data
-    .ANY (+RW +ZI)
+    .ANY1 (+RW +ZI)
   }
-  RW_IRAM1 ImageLimit(RW_m_data_2) {
+  RW_IRAM1 ImageLimit(RW_m_data_2) EMPTY 0 {
   }
   ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (m_data_2_start + m_data_2_size - Stack_Size - AlignExpr(ImageLimit(RW_IRAM1), 16)) { ; Heap region growing up
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -196,7 +196,7 @@ SECTIONS
     . = ALIGN(8);
     __interrupts_ram_end__ = .; /* Define a global symbol at data end */
   } > m_data
-  
+
   .crash_data_ram :
   {
     . = ALIGN(8);
@@ -209,6 +209,13 @@ SECTIONS
     __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
   } > m_data
 
+  .heap_0 :
+  {
+    . = ALIGN(8);
+    __mbed_sbrk_start_0 = .;
+    . += (ORIGIN(m_data) + LENGTH(m_data) - .);
+    __mbed_krbs_start_0 = .;
+  } > m_data
 
   __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
   __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
@@ -270,8 +277,10 @@ SECTIONS
     . = ALIGN(8);
     __end__ = .;
     PROVIDE(end = .);
+    __mbed_sbrk_start = .;
     __HeapBase = .;
     . = ORIGIN(m_data_2) + LENGTH(m_data_2) - STACK_SIZE;
+    __mbed_krbs_start = .;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
   } > m_data_2

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1489,7 +1489,7 @@
             "PSA"
         ],
         "is_disk_virtual": true,
-        "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"],
+        "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "MBED_SPLIT_HEAP"],
         "inherits": ["Target"],
         "detect_code": ["0240"],
         "device_has": [
@@ -1777,7 +1777,7 @@
             "PSA"
         ],
         "is_disk_virtual": true,
-        "macros": ["CPU_MK66FN2M0VMD18", "FSL_RTOS_MBED"],
+        "macros": ["CPU_MK66FN2M0VMD18", "FSL_RTOS_MBED", "MBED_SPLIT_HEAP"],
         "inherits": ["Target"],
         "detect_code": ["0311"],
         "device_has": [

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -26,7 +26,8 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
         "cxx": ["-fno-rtti", "-std=gnu++14"],
-        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign",
+               "--any_contingency", "--keep=os_cb_sections"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
@@ -36,7 +37,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
-        "ld": ["--show_full_path", "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--any_contingency", "--keep=os_cb_sections"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -24,7 +24,8 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
         "cxx": ["-fno-rtti", "-std=gnu++14"],
-        "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--legacyalign", "--any_contingency",
+               "--keep=os_cb_sections"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
@@ -33,7 +34,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
-        "ld": ["--show_full_path", "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--any_contingency", "--keep=os_cb_sections"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -24,7 +24,8 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
         "cxx": ["-fno-rtti", "-std=gnu++14"],
-        "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--legacyalign", "--any_contingency",
+               "--keep=os_cb_sections"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",
@@ -33,7 +34,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
-        "ld": ["--show_full_path",  "--keep=os_cb_sections"]
+        "ld": ["--show_full_path", "--any_contingency", "--keep=os_cb_sections"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
### Description

-Enable MBED_SPLIT_HEAP for K64F and K66F
-Allow GCC_ARM toolchain to utilize remaining 64K memory area
-Make ARM toolchain to start memory filling from 64K region to leave
more space to bigger 192K region

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
