### PR TITLE
I2c ref impl k64f fixes

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
@@ -424,8 +424,8 @@ static int i2c_master_block_read(i2c_t *obj, uint16_t address, void *data, uint3
 
   if (timeout == 0) {
     if ((obj_s->event == 0)) {
-      // async transfer angoing
-      I2C_MasterTransferAbort(base, &i2cHandle[obj_s->instance]); // issues stop signal
+      // async transfer ongoing, abort it
+      i2c_abort_async(obj);
     }
     return I2C_ERROR_TIMEOUT;
   } else if (obj_s->event == I2C_EVENT_TRANSFER_COMPLETE) {
@@ -494,8 +494,8 @@ int i2c_master_block_write(i2c_t *obj, uint16_t address, const void *data, uint3
 
   if (timeout == 0) {
     if ((obj_s->event == 0)) {
-      // async transfer angoing
-      I2C_MasterTransferAbort(base, &i2cHandle[obj_s->instance]); // issues stop signal
+      // async transfer ongoing, abort it
+      i2c_abort_async(obj);
     }
     return I2C_ERROR_TIMEOUT;
   } else if (obj_s->event == I2C_EVENT_TRANSFER_COMPLETE) {
@@ -642,6 +642,11 @@ void i2c_abort_async(i2c_t *obj)
   I2C_Type *base = i2c_addrs[obj_s->instance];
 
   I2C_MasterTransferAbort(base, &i2cHandle[obj_s->instance]);
+  /* Wait until data transfer complete. */
+  uint16_t _timeout = UINT16_MAX;
+  while ((base->S & kI2C_BusBusyFlag) && (--_timeout))
+  {
+  }
 }
 #endif
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
@@ -596,6 +596,7 @@ bool i2c_transfer_async(i2c_t *obj, const uint8_t *tx, uint32_t tx_length, uint8
 
   if (tx_length && rx_length) {
     obj_s->stop = stop;
+    master_xfer.flags |= kI2C_TransferNoStopFlag;
   } else {
     if (!stop) {
       master_xfer.flags |= kI2C_TransferNoStopFlag;


### PR DESCRIPTION
Provide fixes for new I2C API reference implementation for k64f target:

- fix abort_async implementation
- fix stop generation in transfer_async
- improve error handling in blocking transfer 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond @ARMmbed/mbed-os-hal 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
