### PR TITLE
PSA TESTS: Include mbedtls/config.h before evaluating MBEDTLS_PSA_CRYPTO_C

### DIFF
--- a/TESTS/mbed-crypto/sanity/main.cpp
+++ b/TESTS/mbed-crypto/sanity/main.cpp
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "psa/crypto.h"
 
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
 #error [NOT_SUPPORTED] Mbed Crypto is OFF - skipping.
@@ -30,7 +26,6 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
-#include "psa/crypto.h"
 #include "entropy.h"
 #include "entropy_poll.h"
 

--- a/TESTS/mbed-crypto/sanity/main.cpp
+++ b/TESTS/mbed-crypto/sanity/main.cpp
@@ -15,6 +15,12 @@
  * limitations under the License.
  */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
 #error [NOT_SUPPORTED] Mbed Crypto is OFF - skipping.
 #endif

--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -16,11 +16,7 @@
 * limitations under the License.
 */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "psa/crypto.h"
 
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
 #error [NOT_SUPPORTED] Mbed Crypto is OFF - skipping.

--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -16,6 +16,12 @@
 * limitations under the License.
 */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
 #error [NOT_SUPPORTED] Mbed Crypto is OFF - skipping.
 #endif // TARGET_PSA

--- a/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "psa/crypto.h"
 
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)) || (!defined(COMPONENT_PSA_SRV_IPC)))
 #error [NOT_SUPPORTED] These tests can run only on SPM-enabled targets and where Mbed Crypto is ON - skipping.
@@ -30,7 +26,6 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
-#include "psa/crypto.h"
 #include "entropy.h"
 #include "entropy_poll.h"
 #include "test_partition_proxy.h"

--- a/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
+++ b/TESTS/psa/crypto_access_control/COMPONENT_NSPE/main.cpp
@@ -15,6 +15,12 @@
  * limitations under the License.
  */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)) || (!defined(COMPONENT_PSA_SRV_IPC)))
 #error [NOT_SUPPORTED] These tests can run only on SPM-enabled targets and where Mbed Crypto is ON - skipping.
 #endif

--- a/TESTS/psa/crypto_init/main.cpp
+++ b/TESTS/psa/crypto_init/main.cpp
@@ -16,6 +16,12 @@
 * limitations under the License.
 */
 
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
 #error [NOT_SUPPORTED] Mbed Crypto is OFF - skipping.
 #endif // TARGET_PSA

--- a/TESTS/psa/crypto_init/main.cpp
+++ b/TESTS/psa/crypto_init/main.cpp
@@ -16,11 +16,7 @@
 * limitations under the License.
 */
 
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "psa/crypto.h"
 
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
 #error [NOT_SUPPORTED] Mbed Crypto is OFF - skipping.
@@ -29,7 +25,6 @@
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
 #include "utest/utest.h"
-#include "crypto.h"
 #include "entropy.h"
 #include "entropy_poll.h"
 


### PR DESCRIPTION
### Description
Include mbedtls/config.h before evaluating MBEDTLS_PSA_CRYPTO_C
Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>

Fixes https://github.com/ARMmbed/mbed-os/pull/10888#issuecomment-508373260

### Pull request type


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@Patater @jeromecoutant 
### Release Notes
