### PR TITLE
Add newline after mbed error so greentea shows it

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -125,6 +125,8 @@ WEAK MBED_NORETURN void error(const char *format, ...)
         va_start(arg, format);
         mbed_error_vprintf(format, arg);
         va_end(arg);
+        // Add a newline to prevent any line buffering
+        mbed_error_puts("\n");
 #endif
     }
 


### PR DESCRIPTION
### Description

When the function `error` is called without ending in a newline greentea will not display the error. This is because greentea is performing line buffering.

This patch ensures that all calls to `error` end with a newline. This is done by adding an additional newline to end end of the string.

Example code exhibiting this problem:
```
error("This function is not supported.");
```

Greentea output before this change:
```
++ MbedOS Error Info ++​
Error Status: 0x80FF0100 Code: 256 Module: 255​
Error Message: Fatal Run-time error​
Location: 0x1001766D​
Error Value: 0x0​
Current Thread: main  Id: 0x8003FD8 Entry: 0x1000E64F StackSize: 0x1000 StackMem: 0x8004AE8 SP: 0x8005898​
For more info, visit: https://mbed.com/s/error?error=0x80FF0100&tgt=target​
-- MbedOS Error Info --​
test suite run finished after 240.50 sec...
```

Greentea output after this change:
```
++ MbedOS Error Info ++​
Error Status: 0x80FF0100 Code: 256 Module: 255​
Error Message: Fatal Run-time error​
Location: 0x1001766D​
Error Value: 0x0​
Current Thread: main  Id: 0x8003FD8 Entry: 0x1000E64F StackSize: 0x1000 StackMem: 0x8004AE8 SP: 0x8005898​
For more info, visit: https://mbed.com/s/error?error=0x80FF0100&tgt=target​
-- MbedOS Error Info --​
This function is not supported.
test suite run finished after 240.50 sec...
```

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
