### PR TITLE
Restrict FPGA tests to Arduino form factor

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/analogin/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/analogin/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] Analog in not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/analogin/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/analogin/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] Analog in not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/analogout/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/analogout/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] Analog out not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/analogout/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/analogout/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] Analog out not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/gpio/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/gpio/main.cpp
@@ -17,6 +17,8 @@
 
 #if !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/gpio/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/gpio/main.cpp
@@ -17,7 +17,7 @@
 
 #if !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] test not supported
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] test not supported
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/i2c/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/i2c/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] I2C not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/i2c/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/i2c/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] I2C not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/pwm/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/pwm/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] PWM not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/pwm/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/pwm/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] PWM not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] SPI not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"

--- a/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] SPI not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -19,7 +19,7 @@
 #error [NOT_SUPPORTED] SERIAL not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
-#elif !TARGET_FF_ARDUINO
+#elif !defined(TARGET_FF_ARDUINO) && !defined(MBED_CONF_TARGET_DEFAULT_FORM_FACTOR)
 #error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 

--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -19,6 +19,8 @@
 #error [NOT_SUPPORTED] SERIAL not supported for this target
 #elif !COMPONENT_FPGA_CI_TEST_SHIELD
 #error [NOT_SUPPORTED] FPGA CI Test Shield is needed to run this test
+#elif !TARGET_FF_ARDUINO
+#error [NOT_SUPPORTED] Test not supported for this form factor
 #else
 
 #include "utest/utest.h"


### PR DESCRIPTION
Currently only the Arduino form factor is supported (support for other form factors will be added in the future).

This patch will prevent the compilation of greentea tests for targets with non-arduino form factors (or no form factos at all). In consequence, this patch will fix compilation errors for `EFM32GG11_STK3701` and `TB_SENSE_12` when `FPGA_CI_TEST_SHIELD` component is added for all targets (https://github.com/ARMmbed/mbed-os/pull/10965#issuecomment-508734380).

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@c1728p9 @mprse @maciejbocianski @jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
