### PR TITLE
Fix error in tests-mbed_drivers-ticker when LED2 is not connected

### DIFF
--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -71,7 +71,9 @@ void ticker_callback_1(void)
 void ticker_callback_2(void)
 {
     ++callback_trigger_count;
-    switch_led2_state();
+    if (LED2 != NC) {
+        switch_led2_state();
+    }
 }
 
 
@@ -110,7 +112,9 @@ void test_case_1x_ticker()
     Ticker ticker;
 
     led1 = 1;
-    led2 = 1;
+    if (LED2 != NC) {
+        led2 = 1;
+    }
     callback_trigger_count = 0;
 
     greentea_send_kv("timing_drift_check_start", 0);
@@ -151,7 +155,9 @@ void test_case_2x_ticker()
     Ticker ticker1, ticker2;
 
     led1 = 0;
-    led2 = 1;
+    if (LED2 != NC) {
+        led2 = 1;
+    }
     callback_trigger_count = 0;
 
     ticker1.attach_us(ticker_callback_1, 2 * ONE_MILLI_SEC);


### PR DESCRIPTION
### Description

Greentea test tests-mbed_drivers-ticker fails for targets with single LED (with LED2 defined as NC in PinNames.h, like CY8CPROTO_062_4343W).  Update the test logic to not touch LED2 is such case.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
