### PR TITLE
Fix out-of-bounds array access in tests-mbedmicro-rtos-mbed-malloc

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
@@ -122,7 +122,7 @@ void test_alloc_and_free(void)
     int size = SIZE_INCREMENTS;
     int loop = ALLOC_LOOP;
     while (loop) {
-        data = malloc(size);
+        data = count < ALLOC_ARRAY_SIZE ? malloc(size) : NULL;
         if (NULL != data) {
             array[count++] = data;
             memset((void *)data, 0xdeadbeef, size);


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Never allocate more than ALLOC_ARRAY_SIZE bytes in test_alloc_and_free test.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
