### PR TITLE
LwIP: make TCPIP_THREAD_PRIO configurable

### DIFF
--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -111,7 +111,8 @@
 #define TCPIP_THREAD_STACKSIZE      LWIP_ALIGN_UP(MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE, 8)
 #endif
 
-#define TCPIP_THREAD_PRIO           (osPriorityNormal)
+// Thread priority (osPriorityNormal by default)
+#define TCPIP_THREAD_PRIO           (MBED_CONF_LWIP_TCPIP_THREAD_PRIORITY)
 
 // Thread stack size for lwip system threads
 #ifndef MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -104,6 +104,10 @@
             "help": "Maximum timeout (ms) for TCP close handshaking timeout",
             "value": 1000
         },
+        "tcpip-thread-priority": {
+            "help": "Priority of lwip TCPIP thread",
+            "value": "osPriorityNormal"
+        },
         "pbuf-pool-size": {
             "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.",
             "value": null


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Allow targets override TCPIP_THREAD_PRIO from features/lwipstack/mbed_lib.json.
Some PSoC 6 applications require TCPIP_THREAD_PRIO=osPriorityHigh to operate correctly.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
