### PR TITLE
Skip form factor pins marked as NC

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/gpio/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/gpio/main.cpp
@@ -66,6 +66,9 @@ void gpio_inout_test()
 {
     for (int i = 0; i < form_factor->count; i++) {
         const PinName test_pin = form_factor->pins[i];
+        if (test_pin == NC) {
+            continue;
+        }
         if (pinmap_list_has_pin(restricted, test_pin)) {
             printf("Skipping gpio pin %s (%i)\r\n", pinmap_ff_default_pin_to_string(test_pin), test_pin);
             continue;

--- a/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/gpio_irq/main.cpp
@@ -248,6 +248,9 @@ void gpio_irq_test()
 {
     for (uint32_t i = 0; i < form_factor->count; i++) {
         const PinName test_pin = form_factor->pins[i];
+        if (test_pin == NC) {
+            continue;
+        }
         if (pinmap_list_has_pin(restricted, test_pin)) {
             printf("Skipping gpio pin %s (%i)\r\n", pinmap_ff_default_pin_to_string(test_pin), test_pin);
             continue;


### PR DESCRIPTION
### Description

The gpio and gpio_irq FPGA tests run on form factor pins that are marked as NC. This patch changes that behavior so they skip NC pins.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@maciejbocianski @mprse @fkjagodzinski @0xc0170 

