### PR TITLE
SPI FPGA test extension + SPI driver fix (K64F)

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
@@ -69,7 +69,7 @@ void spi_test_init_free(PinName mosi, PinName miso, PinName sclk, PinName ssel)
     spi_free(&spi);
 }
 
-void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t freqency)
+void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t frequency)
 {
     uint32_t sym_mask = ((1 << sym_size) - 1);
 
@@ -84,7 +84,7 @@ void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPI
 
     spi_init(&spi, mosi, miso, sclk, ssel);
     spi_format(&spi, sym_size, spi_mode, 0);
-    spi_frequency(&spi, freqency);
+    spi_frequency(&spi, frequency);
 
     // Configure spi_slave module
     tester.set_mode(spi_mode);
@@ -160,10 +160,10 @@ void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPI
     tester.reset();
 }
 
-template<SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t freqency>
+template<SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t frequency>
 void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
-    spi_test_common(mosi, miso, sclk, ssel, spi_mode, sym_size, transfer_type, freqency);
+    spi_test_common(mosi, miso, sclk, ssel, spi_mode, sym_size, transfer_type, frequency);
 }
 
 Case cases[] = {

--- a/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
@@ -147,7 +147,7 @@ void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPI
 #endif
 
         default:
-            TEST_ASSERT_TRUE(false);
+            TEST_ASSERT_MESSAGE(0, "Unsupported transfer type.");
             break;
 
     }

--- a/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/spi/main.cpp
@@ -34,23 +34,45 @@ using namespace utest::v1;
 #include "pinmap.h"
 #include "test_utils.h"
 
+typedef enum {
+    TRANSFER_SPI_MASTER_WRITE_SYNC,
+    TRANSFER_SPI_MASTER_BLOCK_WRITE_SYNC,
+    TRANSFER_SPI_MASTER_TRANSFER_ASYNC
+} transfer_type_t;
+
+#define FREQ_500_KHZ 500000
+#define FREQ_1_MHZ 1000000
+#define FREQ_2_MHZ 2000000
 
 const int TRANSFER_COUNT = 300;
 SPIMasterTester tester(DefaultFormFactor::pins(), DefaultFormFactor::restricted_pins());
 
+spi_t spi;
+static volatile bool async_trasfer_done;
+
+#if DEVICE_SPI_ASYNCH
+void spi_async_handler()
+{
+    int event = spi_irq_handler_asynch(&spi);
+
+    if (event == SPI_EVENT_COMPLETE) {
+        async_trasfer_done = true;
+    }
+}
+#endif
 
 void spi_test_init_free(PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
-    spi_t spi;
     spi_init(&spi, mosi, miso, sclk, ssel);
     spi_format(&spi, 8, SPITester::Mode0, 0);
     spi_frequency(&spi, 1000000);
     spi_free(&spi);
 }
 
-void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPITester::SpiMode spi_mode, uint32_t sym_size)
+void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t freqency)
 {
     uint32_t sym_mask = ((1 << sym_size) - 1);
+
     // Remap pins for test
     tester.reset();
     tester.pin_map_set(mosi, MbedTester::LogicalPinSPIMosi);
@@ -59,10 +81,10 @@ void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPI
     tester.pin_map_set(ssel, MbedTester::LogicalPinSPISsel);
 
     // Initialize mbed SPI pins
-    spi_t spi;
+
     spi_init(&spi, mosi, miso, sclk, ssel);
     spi_format(&spi, sym_size, spi_mode, 0);
-    spi_frequency(&spi, 1000000);
+    spi_frequency(&spi, freqency);
 
     // Configure spi_slave module
     tester.set_mode(spi_mode);
@@ -73,13 +95,61 @@ void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPI
     tester.peripherals_reset();
     tester.select_peripheral(SPITester::PeripheralSPI);
 
-    // Send and receive test data
     uint32_t checksum = 0;
-    for (int i = 0; i < TRANSFER_COUNT; i++) {
-        uint32_t data = spi_master_write(&spi, (0 - i) & sym_mask);
-        TEST_ASSERT_EQUAL(i & sym_mask, data);
+    int result = 0;
+    uint8_t tx_buf[TRANSFER_COUNT] = {0};
+    uint8_t rx_buf[TRANSFER_COUNT] = {0};
 
-        checksum += (0 - i) & sym_mask;
+    // Send and receive test data
+    switch (transfer_type) {
+        case TRANSFER_SPI_MASTER_WRITE_SYNC:
+            for (int i = 0; i < TRANSFER_COUNT; i++) {
+                uint32_t data = spi_master_write(&spi, (0 - i) & sym_mask);
+                TEST_ASSERT_EQUAL(i & sym_mask, data);
+
+                checksum += (0 - i) & sym_mask;
+            }
+            break;
+
+        case TRANSFER_SPI_MASTER_BLOCK_WRITE_SYNC:
+            for (int i = 0; i < TRANSFER_COUNT; i++) {
+                tx_buf[i] = (0 - i) & sym_mask;
+                checksum += (0 - i) & sym_mask;
+                rx_buf[i] = 0xAA;
+            }
+
+            result = spi_master_block_write(&spi, (const char *)tx_buf, TRANSFER_COUNT, (char *)rx_buf, TRANSFER_COUNT, 0xF5);
+
+            for (int i = 0; i < TRANSFER_COUNT; i++) {
+                TEST_ASSERT_EQUAL(i & sym_mask, rx_buf[i]);
+            }
+            TEST_ASSERT_EQUAL(TRANSFER_COUNT, result);
+            break;
+
+#if DEVICE_SPI_ASYNCH
+        case TRANSFER_SPI_MASTER_TRANSFER_ASYNC:
+            for (int i = 0; i < TRANSFER_COUNT; i++) {
+                tx_buf[i] = (0 - i) & sym_mask;
+                checksum += (0 - i) & sym_mask;
+                rx_buf[i] = 0xAA;
+            }
+
+            async_trasfer_done = false;
+
+            spi_master_transfer(&spi, tx_buf, TRANSFER_COUNT, rx_buf, TRANSFER_COUNT, 8, (uint32_t)spi_async_handler, 0, DMA_USAGE_NEVER);
+            while (!async_trasfer_done);
+
+            for (int i = 0; i < TRANSFER_COUNT; i++) {
+                TEST_ASSERT_EQUAL(i & sym_mask, rx_buf[i]);
+            }
+
+            break;
+#endif
+
+        default:
+            TEST_ASSERT_TRUE(false);
+            break;
+
     }
 
     // Verify that the transfer was successful
@@ -90,10 +160,10 @@ void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel, SPI
     tester.reset();
 }
 
-template<SPITester::SpiMode spi_mode, uint32_t sym_size>
+template<SPITester::SpiMode spi_mode, uint32_t sym_size, transfer_type_t transfer_type, uint32_t freqency>
 void spi_test_common(PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
-    spi_test_common(mosi, miso, sclk, ssel, spi_mode, sym_size);
+    spi_test_common(mosi, miso, sclk, ssel, spi_mode, sym_size, transfer_type, freqency);
 }
 
 Case cases[] = {
@@ -101,16 +171,25 @@ Case cases[] = {
     Case("SPI - init/free test all pins", all_ports<SPIPort, DefaultFormFactor, spi_test_init_free>),
 
     // This will be run for all peripherals
-    Case("SPI - basic test", all_peripherals<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 8> >),
+    Case("SPI - basic test", all_peripherals<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
 
     // This will be run for single pin configuration
-    Case("SPI - mode testing (MODE_1)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode1, 8> >),
-    Case("SPI - mode testing (MODE_2)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode2, 8> >),
-    Case("SPI - mode testing (MODE_3)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode3, 8> >),
+    Case("SPI - mode testing (MODE_1)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode1, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
+    Case("SPI - mode testing (MODE_2)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode2, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
+    Case("SPI - mode testing (MODE_3)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode3, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
 
-    Case("SPI - symbol size testing (4)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 4> >),
-    Case("SPI - symbol size testing (12)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 12> >),
-    Case("SPI - symbol size testing (16)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 16> >)
+    Case("SPI - symbol size testing (4)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 4, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
+    Case("SPI - symbol size testing (12)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 12, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
+    Case("SPI - symbol size testing (16)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 16, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_1_MHZ> >),
+
+    Case("SPI - frequency testing (500 kHz)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_500_KHZ> >),
+    Case("SPI - frequency testing (2 MHz)", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 8, TRANSFER_SPI_MASTER_WRITE_SYNC, FREQ_2_MHZ> >),
+
+    Case("SPI - block write", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 8, TRANSFER_SPI_MASTER_BLOCK_WRITE_SYNC, FREQ_1_MHZ> >),
+
+#if DEVICE_SPI_ASYNCH
+    Case("SPI - async mode", one_peripheral<SPIPort, DefaultFormFactor, spi_test_common<SPITester::Mode0, 8, TRANSFER_SPI_MASTER_TRANSFER_ASYNC, FREQ_1_MHZ> >)
+#endif
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -109,7 +109,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
         master_config.ctarConfig.cpol = (mode & 0x2) ? kDSPI_ClockPolarityActiveLow : kDSPI_ClockPolarityActiveHigh;
         master_config.ctarConfig.cpha = (mode & 0x1) ? kDSPI_ClockPhaseSecondEdge : kDSPI_ClockPhaseFirstEdge;
         master_config.ctarConfig.direction = kDSPI_MsbFirst;
-        master_config.ctarConfig.pcsToSckDelayInNanoSec = 0;
+        master_config.ctarConfig.pcsToSckDelayInNanoSec = 100;
 
         DSPI_MasterInit(spi_address[obj->spi.instance], &master_config, CLOCK_GetFreq(spi_clocks[obj->spi.instance]));
     }


### PR DESCRIPTION
### Description

This PR:
- Extend FPGA SPI test (test: async mode, different frequencies, block write)
- Add the delay between CS assertion and first sclk edge and first sclk edge (K64F).

This PR requires first: PR https://github.com/ARMmbed/mbed-os/pull/10975


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond @0xc0170 @fkjagodzinski @maciejbocianski 


![image](https://user-images.githubusercontent.com/30721012/60805915-d8b36780-a181-11e9-893f-ab36026299cd.png)
