### PR TITLE
Add DEVICE_SERIAL_FC guards to serial HAL API

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -118,11 +118,13 @@ static void uart_test_common(int baudrate, int data_bits, SerialParity parity, i
     serial_init(&serial, tx, rx);
     serial_baud(&serial, baudrate);
     serial_format(&serial, data_bits, parity, stop_bits);
+#if DEVICE_SERIAL_FC
     if (use_flow_control) {
         serial_set_flow_control(&serial, FlowControlRTSCTS, rts, cts);
     } else {
         serial_set_flow_control(&serial, FlowControlNone, NC, NC);
     }
+#endif
 
     // Reset tester stats and select UART
     tester.peripherals_reset();
@@ -277,9 +279,11 @@ void test_init_free(PinName tx, PinName rx, PinName cts = NC, PinName rts = NC)
     serial_init(&serial, tx, rx);
     serial_baud(&serial, 9600);
     serial_format(&serial, 8, ParityNone, 1);
+#if DEVICE_SERIAL_FC
     if (use_flow_control) {
         serial_set_flow_control(&serial, FlowControlRTSCTS, rts, cts);
     }
+#endif
     serial_free(&serial);
 }
 
@@ -302,28 +306,38 @@ void test_common_no_fc(PinName tx, PinName rx)
 
 Case cases[] = {
     // Every set of pins from every peripheral.
-    Case("init/free, FC on", all_ports<UARTPort, DefaultFormFactor, test_init_free>),
     Case("init/free, FC off", all_ports<UARTNoFCPort, DefaultFormFactor, test_init_free_no_fc>),
 
     // One set of pins from every peripheral.
-    Case("basic, 9600, 8N1, FC on", all_peripherals<UARTPort, DefaultFormFactor, test_common<9600, 8, ParityNone, 1> >),
     Case("basic, 9600, 8N1, FC off", all_peripherals<UARTNoFCPort, DefaultFormFactor, test_common_no_fc<9600, 8, ParityNone, 1> >),
 
     // One set of pins from one peripheral.
     // baudrate
-    Case("19200, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<19200, 8, ParityNone, 1> >),
     Case("19200, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, test_common_no_fc<19200, 8, ParityNone, 1> >),
-    Case("38400, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<38400, 8, ParityNone, 1> >),
     Case("38400, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, test_common_no_fc<38400, 8, ParityNone, 1> >),
-    Case("115200, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<115200, 8, ParityNone, 1> >),
     Case("115200, 8N1, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, test_common_no_fc<115200, 8, ParityNone, 1> >),
+    // stop bits
+    Case("9600, 8N2, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, test_common_no_fc<9600, 8, ParityNone, 2> >),
+
+#if DEVICE_SERIAL_FC
+    // Every set of pins from every peripheral.
+    Case("init/free, FC on", all_ports<UARTPort, DefaultFormFactor, test_init_free>),
+
+    // One set of pins from every peripheral.
+    Case("basic, 9600, 8N1, FC on", all_peripherals<UARTPort, DefaultFormFactor, test_common<9600, 8, ParityNone, 1> >),
+
+    // One set of pins from one peripheral.
+    // baudrate
+    Case("19200, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<19200, 8, ParityNone, 1> >),
+    Case("38400, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<38400, 8, ParityNone, 1> >),
+    Case("115200, 8N1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<115200, 8, ParityNone, 1> >),
     // data bits: not tested (some platforms support 8 bits only)
     // parity
     Case("9600, 8O1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<9600, 8, ParityOdd, 1> >),
     Case("9600, 8E1, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<9600, 8, ParityEven, 1> >),
     // stop bits
     Case("9600, 8N2, FC on", one_peripheral<UARTPort, DefaultFormFactor, test_common<9600, 8, ParityNone, 2> >),
-    Case("9600, 8N2, FC off", one_peripheral<UARTNoFCPort, DefaultFormFactor, test_common_no_fc<9600, 8, ParityNone, 2> >),
+#endif
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -511,6 +511,7 @@ typedef Port<1, AnalogoutMaps, DefaultFormFactor, TF1> AnalogoutPort;
 #endif
 
 #if DEVICE_SERIAL
+#if DEVICE_SERIAL_FC
 struct UARTMaps {
     static const PinMap *maps[];
     static const char *const pin_type_names[];
@@ -520,6 +521,7 @@ const PinMap *UARTMaps::maps[] = { serial_tx_pinmap(), serial_rx_pinmap(), seria
 const char *const UARTMaps::pin_type_names[] = { "TX", "RX", "CLS", "RTS" };
 const char *const UARTMaps::name = "UART";
 typedef Port<4, UARTMaps, DefaultFormFactor, TF4> UARTPort;
+#endif
 
 struct UARTNoFCMaps {
     static const PinMap *maps[];

--- a/hal/serial_api.h
+++ b/hal/serial_api.h
@@ -211,6 +211,7 @@ void serial_break_clear(serial_t *obj);
  */
 void serial_pinout_tx(PinName tx);
 
+#if DEVICE_SERIAL_FC
 /** Configure the serial for the flow control. It sets flow control in the hardware
  *  if a serial peripheral supports it, otherwise software emulation is used.
  *
@@ -220,6 +221,7 @@ void serial_pinout_tx(PinName tx);
  * @param txflow The RX pin name
  */
 void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, PinName txflow);
+#endif
 
 /** Get the pins that support Serial TX
  *
@@ -239,6 +241,7 @@ const PinMap *serial_tx_pinmap(void);
  */
 const PinMap *serial_rx_pinmap(void);
 
+#if DEVICE_SERIAL_FC
 /** Get the pins that support Serial CTS
  *
  * Return a PinMap array of pins that support Serial CTS. The
@@ -256,6 +259,7 @@ const PinMap *serial_cts_pinmap(void);
  * @return PinMap array
  */
 const PinMap *serial_rts_pinmap(void);
+#endif
 
 #if DEVICE_SERIAL_ASYNCH
 

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/serial_api.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/serial_api.c
@@ -153,7 +153,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     }
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
-    serial_set_flow_control(obj, FlowControlNone, NC, NC);
 
     is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
 

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/serial_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/serial_api.c
@@ -157,7 +157,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     }
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
-    serial_set_flow_control(obj, FlowControlNone, NC, NC);
     
     is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
     

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8622,6 +8622,7 @@
             "INTERRUPTIN",
             "EMAC",
             "SERIAL",
+            "SERIAL_FC",
             "STDIO_MESSAGES",
             "PWMOUT",
             "SPI",


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Functions related to serial flow control should not be exposed if `DEVICE_SERIAL_FC` is not defined
* `serial_set_flow_control`,
* `serial_cts_pinmap`,
* `serial_rts_pinmap`.

The `tests-mbed_hal_fpga_ci_test_shield-uart` is also updated here.
This patch should fix build errors found here: https://github.com/ARMmbed/mbed-os/pull/10965#issuecomment-509369593.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@0xc0170 @mprse 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
