### PR TITLE
Fix PWM output on Silicon Labs targets for large pulsewidths

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
@@ -342,13 +342,13 @@ void pwmout_pulsewidth(pwmout_t *obj, float seconds)
 
 void pwmout_pulsewidth_ms(pwmout_t *obj, int ms)
 {
-    uint16_t width_cycles = (uint16_t) ((REFERENCE_FREQUENCY >> pwm_prescaler_div) * ms) / 1000;
+    uint16_t width_cycles = (uint16_t) (((REFERENCE_FREQUENCY >> pwm_prescaler_div) * ms) / 1000);
     TIMER_CompareBufSet(PWM_TIMER, obj->channel, width_cycles);
 }
 
 void pwmout_pulsewidth_us(pwmout_t *obj, int us)
 {
-    uint16_t width_cycles = (uint16_t) ((REFERENCE_FREQUENCY >> pwm_prescaler_div) * us) / 1000000;
+    uint16_t width_cycles = (uint16_t) (((uint64_t)(REFERENCE_FREQUENCY >> pwm_prescaler_div) * (uint64_t)us) / 1000000UL);
     TIMER_CompareBufSet(PWM_TIMER, obj->channel, width_cycles);
 }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Two issues were found by the new FPGA-based tests:
* Downcasting too early
* Potential for a uint32_t overflow in an intermediate calculation

Passing test requires #11005  to be merged.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
