### PR TITLE
Enable FPGA-based SPI testing on Silicon Labs targets

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -274,6 +274,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName clk, PinName cs)
     spi_enable(obj, true);
 }
 
+void spi_free(spi_t *obj)
+{
+    spi_enable(obj, false);
+    USART_Reset(obj->spi.spi);
+}
+
 void spi_enable_event(spi_t *obj, uint32_t event, uint8_t enable)
 {
     if(enable) obj->spi.event |= event;
@@ -1434,7 +1440,9 @@ const PinMap *spi_master_miso_pinmap()
 
 const PinMap *spi_master_clk_pinmap()
 {
-    return PinMap_SPI_CLK;
+    // We don't currently support hardware CS in master mode.
+    static const PinMap PinMap_SPI_CLK_mod[] = {NC ,  NC   , NC};
+    return PinMap_SPI_CLK_mod;
 }
 
 const PinMap *spi_master_cs_pinmap()


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
This PR enables the SPI tests based on the new FPGA testing shield to pass on Silicon Labs targets by:
- Implementing `spi_free(...)` (which somehow got added to the HAL API and never implemented on our targets)
- Returning no hardware CS pins for an SPI master. Hardware CS is not supported in our HAL in the case of an SPI master, and this is due to legacy, since the official way of handling CS is with a DigitalOut in the application. Adding in support for hardware CS on SPI master now might break legacy applications.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
