### PR TITLE
Allow re-initialising an I2C peripheral on Silicon Labs targets

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
@@ -119,6 +119,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 
     /* Initializing the I2C */
     /* Using default settings */
+    i2c_reset(obj);
     I2C_Init_TypeDef i2cInit = I2C_INIT_DEFAULT;
     I2C_Init(obj->i2c.i2c, &i2cInit);
 
@@ -315,6 +316,8 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
 
 void i2c_reset(i2c_t *obj)
 {
+    i2c_enable_interrupt(obj, 0, false);
+    i2c_enable(obj, false);
     /* EMLib function */
     I2C_Reset(obj->i2c.i2c);
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Allows the FPGA based test to pass, but requires #11004 before it will

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@c1728p9 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
