### PR TITLE
Revert "K64F, STM32F429: IAR linker scripts dynamic  heap fix"

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf
@@ -117,7 +117,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with expanding size, alignment = 8, minimum size = __size_heap__     { };
+define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
@@ -36,7 +36,7 @@ define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start_
 define exported symbol __CRASH_DATA_RAM_END__ = __region_CRASH_DATA_RAM_end__;
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__     { };
+define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };


### PR DESCRIPTION
Reverts ARMmbed/mbed-os#10938 due to K64F bootloader reset  side effect 
If heap dynamic allocation is enabled for IAR, bootloader fails  to verify application after 3 consecutive HW resets.
Further root cause investigation is needed for this issue however to avoid  blocking  of 5.13.1 release  this PR is reverted.

@0xc0170 