### PR TITLE
Increase ADC tolerance to 5% in FPGA-based tests

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/analogin/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/analogin/main.cpp
@@ -36,8 +36,8 @@ using namespace utest::v1;
 
 #define analogin_debug_printf(...)
 
-#define DELTA_FLOAT                     0.03f    // 3%
-#define DELTA_U16                       1965     // 3%
+#define DELTA_FLOAT                     0.05f    // 5%
+#define DELTA_U16                       3277     // 5%
 
 const PinList *form_factor = pinmap_ff_default_pins();
 const PinList *restricted = pinmap_restricted_pins();


### PR DESCRIPTION
### Description

During the SiP workshop, we discovered that 3% is too narrow due to a combination of:
- Voltage rail differences between target and FPGA
- Extension of lesser-resolution ADC's to 16-bit results

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers
@c1728p9 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
