### PR TITLE
Proposal: updating FPU flag for v8-M SoCs.

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -559,12 +559,15 @@ class ARMC6(ARM_STD):
         elif core == "Cortex-M4F":
             self.flags['common'].append("-mfpu=fpv4-sp-d16")
             self.flags['common'].append("-mfloat-abi=hard")
-        elif core == "Cortex-M7F" or core.startswith("Cortex-M33F"):
+        elif core == "Cortex-M7F":
             self.flags['common'].append("-mfpu=fpv5-sp-d16")
             self.flags['common'].append("-mfloat-abi=hard")
         elif core == "Cortex-M7FD":
             self.flags['common'].append("-mfpu=fpv5-d16")
             self.flags['common'].append("-mfloat-abi=hard")
+        elif core.startswith("Cortex-M33F"):
+            self.cpu.append("-mfpu=fp-armv8")
+            self.cpu.append("-mfloat-abi=hard")
 
         asm_ld_cpu = {
             "Cortex-M0+": "Cortex-M0plus",

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -99,11 +99,14 @@ class GCC(mbedToolchain):
         if core == "Cortex-M4F":
             self.cpu.append("-mfpu=fpv4-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
-        elif core == "Cortex-M7F" or core.startswith("Cortex-M33F"):
+        elif core == "Cortex-M7F":
             self.cpu.append("-mfpu=fpv5-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
         elif core == "Cortex-M7FD":
             self.cpu.append("-mfpu=fpv5-d16")
+            self.cpu.append("-mfloat-abi=softfp")
+        elif core.startswith("Cortex-M33F"):
+            self.cpu.append("-mfpu=fp-armv8")
             self.cpu.append("-mfloat-abi=softfp")
 
         if target.core == "Cortex-A9":


### PR DESCRIPTION
### Description
While analysing the issue https://github.com/ARMmbed/mbed-os/issues/10887 reported by @jeromecoutant, I observed that we are using v7-M FPU flags for v8-M as well. 
For both GCC and ARMCC, we are setting `-mfpu=fpv5-sp-d16` in case of v8-M.

My proposal is to set it to `-mfpu=fp-armv8` for v8-M which is supported by both GCC and ARMCC.


Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>



### Pull request type

    [x] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@Patater 

### Release Notes

