### PR TITLE
PSOC6: add LwIP configuration for Cypress boards

### DIFF
--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -175,6 +175,48 @@
             "pbuf-pool-size": 16,
             "mem-size": 51200
         },
+        "CYW943012P6EVB_01": {
+            "tcpip-thread-stacksize": 8192,
+            "default-thread-stacksize": 640,
+            "ppp-thread-stacksize": 896,
+            "memp-num-tcp-seg": 24,
+            "tcp-socket-max": 10,
+            "udp-socket-max":10,
+            "socket-max":18,
+            "tcp-mss": 1540,
+            "tcp-snd-buf": "(6 * TCP_MSS)",
+            "tcp-wnd": "(TCP_MSS * 6)",
+            "pbuf-pool-size": 48,
+            "mem-size": 65536
+        },
+        "CY8CPROTO_062_4343W": {
+            "tcpip-thread-stacksize": 8192,
+            "default-thread-stacksize": 640,
+            "ppp-thread-stacksize": 896,
+            "memp-num-tcp-seg": 24,
+            "tcp-socket-max": 10,
+            "udp-socket-max":10,
+            "socket-max":18,
+            "tcp-mss": 1540,
+            "tcp-snd-buf": "(6 * TCP_MSS)",
+            "tcp-wnd": "(TCP_MSS * 6)",
+            "pbuf-pool-size": 96,
+            "mem-size": 92610
+        },
+        "CY8CKIT_062_WIFI_BT": {
+            "tcpip-thread-stacksize": 8192,
+            "default-thread-stacksize": 640,
+            "ppp-thread-stacksize": 896,
+            "memp-num-tcp-seg": 48,
+            "tcp-socket-max": 10,
+            "udp-socket-max":10,
+            "socket-max":18,
+            "tcp-mss": 1540,
+            "tcp-snd-buf": "(6 * TCP_MSS)",
+            "tcp-wnd": "(TCP_MSS * 6)",
+            "pbuf-pool-size": 48,
+            "mem-size": 65536
+        },
         "MIMXRT1050_EVK": {
             "mem-size": 36560
         },


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Configure Cypress boards to use LwIP stack settings compatible with the requirements of the WHD WiFi driver and Cypress middleware applications.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@balajicyp @kask01 @morser499 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
