### PR TITLE
mbedtls: Update to Mbed TLS 2.18.1

### DIFF
--- a/features/mbedtls/VERSION.txt
+++ b/features/mbedtls/VERSION.txt
@@ -1,1 +1,1 @@
-mbedtls-2.18.0-rc3
+mbedtls-2.18.1

--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -27,7 +27,7 @@
 #
 
 # Set the mbed TLS release to import (this can/should be edited before import)
-MBED_TLS_RELEASE ?= mbedtls-2.18.0-rc3
+MBED_TLS_RELEASE ?= mbedtls-2.18.1
 MBED_TLS_REPO_URL ?= git@github.com:ARMmbed/mbedtls-restricted.git
 
 # Translate between mbed TLS namespace and mbed namespace

--- a/features/mbedtls/inc/mbedtls/platform.h
+++ b/features/mbedtls/inc/mbedtls/platform.h
@@ -256,6 +256,7 @@ int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
  *   the destination buffer is too short.
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
+#include <stdarg.h>
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
 int mbedtls_platform_win32_vsnprintf( char *s, size_t n, const char *fmt, va_list arg );
 #endif

--- a/features/mbedtls/inc/mbedtls/version.h
+++ b/features/mbedtls/inc/mbedtls/version.h
@@ -39,7 +39,7 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  17
+#define MBEDTLS_VERSION_MINOR  18
 #define MBEDTLS_VERSION_PATCH  0
 
 /**
@@ -47,9 +47,9 @@
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02110000
-#define MBEDTLS_VERSION_STRING         "2.17.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.17.0"
+#define MBEDTLS_VERSION_NUMBER         0x02120000
+#define MBEDTLS_VERSION_STRING         "2.18.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.18.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/features/mbedtls/mbed-crypto/VERSION.txt
+++ b/features/mbedtls/mbed-crypto/VERSION.txt
@@ -1,1 +1,1 @@
-mbedcrypto-1.1.0d2
+mbedcrypto-1.1.1

--- a/features/mbedtls/mbed-crypto/importer/Makefile
+++ b/features/mbedtls/mbed-crypto/importer/Makefile
@@ -29,7 +29,7 @@
 
 # Set the Mbed Crypto release to import (this can/should be edited before
 # import)
-CRYPTO_RELEASE ?= mbedcrypto-1.1.0d2
+CRYPTO_RELEASE ?= mbedcrypto-1.1.1
 CRYPTO_REPO_URL ?= git@github.com:ARMmbed/mbed-crypto.git
 
 # Translate between Mbed Crypto namespace and Mbed OS namespace

--- a/features/mbedtls/mbed-crypto/src/ecp.c
+++ b/features/mbedtls/mbed-crypto/src/ecp.c
@@ -2004,8 +2004,10 @@ static unsigned char ecp_pick_window_size( const mbedtls_ecp_group *grp,
      * Make sure w is within bounds.
      * (The last test is useful only for very small curves in the test suite.)
      */
+#if( MBEDTLS_ECP_WINDOW_SIZE < 6 )
     if( w > MBEDTLS_ECP_WINDOW_SIZE )
         w = MBEDTLS_ECP_WINDOW_SIZE;
+#endif
     if( w >= grp->nbits )
         w = 2;
 

--- a/features/mbedtls/src/Makefile
+++ b/features/mbedtls/src/Makefile
@@ -35,8 +35,8 @@ LOCAL_CFLAGS += -fPIC -fpic
 endif
 endif
 
-SOEXT_TLS=so.12
-SOEXT_X509=so.0
+SOEXT_TLS=so.13
+SOEXT_X509=so.1
 SOEXT_CRYPTO=so.3
 
 # Set AR_DASH= (empty string) to use an ar implementation that does not accept


### PR DESCRIPTION
### Description

Update to Mbed TLS 2.18.1 and Mbed Crypto 1.1.1.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

