### PR TITLE
Fix Watchdog Doxygen documentation

### DIFF
--- a/drivers/Watchdog.h
+++ b/drivers/Watchdog.h
@@ -31,6 +31,11 @@ namespace mbed {
 /** \ingroup drivers */
 /** \addtogroup drivers-public-api */
 /** @{*/
+/**
+ * \defgroup drivers_Watchdog Watchdog class
+ * @{
+ */
+
 /** A hardware watchdog timer that resets the system in the case of system
  * failures or malfunctions. If you fail to refresh the Watchdog timer periodically,
  * it resets the system after a set period of time.
@@ -57,11 +62,6 @@ namespace mbed {
  * @endcode
  *
  * @note Synchronization level: Interrupt safe
- * @ingroup drivers
- */
-/**
- * \defgroup drivers_Watchdog Watchdog class
- * @{
  */
 class Watchdog : private NonCopyable<Watchdog>  {
 public:


### PR DESCRIPTION
### Description
Ensure the documentation for watchdog falls under `Drivers/Public API/` instead of `Drivers/`
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @gpsimenos 