### PR TITLE
Extend the GPIO HAL API tests

### DIFF
--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -425,6 +425,16 @@ public:
  * pin set to use for testing.
  */
 
+struct GPIOMaps {
+    static const PinMap *maps[];
+    static const char *const pin_type_names[];
+    static const char *const name;
+};
+const PinMap *GPIOMaps::maps[] = { gpio_pinmap() };
+const char *const GPIOMaps::pin_type_names[] = { "IO" };
+const char *const GPIOMaps::name = "GPIO";
+typedef Port<1, GPIOMaps, DefaultFormFactor, TF1> GPIOPort;
+
 #if DEVICE_SPI
 #include "spi_api.h"
 struct SPIMaps {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Use the `MbedTester` to verify the functions from https://github.com/ARMmbed/mbed-os/blob/master/hal/gpio_api.h.

Updated tests:
* `tests-mbed_hal_fpga_ci_test_shield-gpio`.

~**NOTE** This patch won't work without a `gpio_pinmap()` function added in #10644.~

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @mprse @maciejbocianski 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
