### PR TITLE
Add <mstd_xxx> C++ headers

### DIFF
--- a/.astyleignore
+++ b/.astyleignore
@@ -20,6 +20,7 @@
 ^features/storage/filesystem/littlefs/littlefs/
 ^features/unsupported/
 ^hal/storage_abstraction
+^platform/cxxsupport
 ^rtos/TARGET_CORTEX/rtx4
 ^rtos/TARGET_CORTEX/rtx5
 ^targets

--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -95,6 +95,7 @@ set(unittest-includes-base
   "${PROJECT_SOURCE_DIR}/target_h/events"
   "${PROJECT_SOURCE_DIR}/target_h/events/equeue"
   "${PROJECT_SOURCE_DIR}/target_h/platform"
+  "${PROJECT_SOURCE_DIR}/target_h/platform/cxxsupport"
   "${PROJECT_SOURCE_DIR}/target_h/drivers"
   "${PROJECT_SOURCE_DIR}/stubs"
   "${PROJECT_SOURCE_DIR}/.."

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_algorithm
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_algorithm
@@ -1,0 +1,110 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_ALGORITHM_
+#define MSTD_ALGORITHM_
+
+/* <mstd_algorithm>
+ *
+ * - provides <algorithm>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - std::min, std::max for std::initializer_list
+ *   - std::all_of, std::any_of, std::none_of
+ *   - std::find_if_not
+ *   - std::equal (2-range forms)
+ *   - std::copy_n, std::move, std::move_backward
+ *   - mstd::min, mstd::max constexpr replacements
+ */
+
+#include <algorithm>
+
+namespace mstd {
+using std::min;
+using std::max;
+using std::minmax;
+using std::initializer_list;
+using std::all_of;
+using std::any_of;
+using std::none_of;
+using std::for_each;
+using std::find;
+using std::find_if;
+using std::find_if_not;
+using std::find_end;
+using std::find_first_of;
+using std::adjacent_find;
+using std::count;
+using std::count_if;
+using std::mismatch;
+using std::equal;
+using std::search;
+using std::search_n;
+using std::copy;
+using std::copy_n;
+using std::copy_if;
+using std::move;
+using std::move_backward;
+using std::swap_ranges;
+using std::iter_swap;
+using std::transform;
+using std::replace;
+using std::replace_if;
+using std::replace_copy;
+using std::replace_copy_if;
+using std::fill;
+using std::fill_n;
+using std::generate;
+using std::generate_n;
+using std::remove;
+using std::remove_if;
+using std::remove_copy;
+using std::remove_copy_if;
+using std::unique;
+using std::unique_copy;
+using std::reverse;
+using std::reverse_copy;
+using std::rotate;
+using std::rotate_copy;
+using std::partition;
+using std::stable_partition;
+using std::sort;
+using std::stable_sort;
+using std::partial_sort;
+using std::partial_sort_copy;
+using std::nth_element;
+using std::lower_bound;
+using std::upper_bound;
+using std::equal_range;
+using std::binary_search;
+using std::merge;
+using std::inplace_merge;
+using std::includes;
+using std::set_union;
+using std::set_intersection;
+using std::set_difference;
+using std::set_symmetric_difference;
+using std::push_heap;
+using std::pop_heap;
+using std::make_heap;
+using std::sort_heap;
+using std::min_element;
+using std::max_element;
+using std::lexicographical_compare;
+using std::next_permutation;
+using std::prev_permutation;
+}
+
+#endif // MSTD_ALGORITHM_

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_atomic
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_atomic
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MSTD_ATOMIC_
+#define MSTD_ATOMIC_
+
+#include <atomic>
+
+namespace mstd {
+using std::atomic;
+using std::atomic_is_lock_free;
+using std::atomic_store;
+using std::atomic_store_explicit;
+using std::atomic_load;
+using std::atomic_load_explicit;
+using std::atomic_exchange;
+using std::atomic_exchange_explicit;
+using std::atomic_compare_exchange_weak;
+using std::atomic_compare_exchange_weak_explicit;
+using std::atomic_compare_exchange_strong;
+using std::atomic_compare_exchange_strong_explicit;
+using std::atomic_fetch_add;
+using std::atomic_fetch_add_explicit;
+using std::atomic_fetch_sub;
+using std::atomic_fetch_sub_explicit;
+using std::atomic_fetch_and;
+using std::atomic_fetch_and_explicit;
+using std::atomic_fetch_or;
+using std::atomic_fetch_or_explicit;
+using std::atomic_fetch_xor;
+using std::atomic_fetch_xor_explicit;
+using std::atomic_flag;
+using std::atomic_flag_test_and_set;
+using std::atomic_flag_test_and_set_explicit;
+using std::atomic_flag_clear;
+using std::atomic_flag_clear_explicit;
+using std::atomic_init;
+using std::memory_order;
+using std::kill_dependency;
+using std::atomic_thread_fence;
+using std::atomic_signal_fence;
+}
+
+#endif

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_cstddef
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_cstddef
@@ -1,0 +1,54 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_CSTDDEF_
+#define MSTD_CSTDDEF_
+
+/* <mstd_cstddef>
+ *
+ * - provides <cstddef>
+ * - For ARM C 5, standard C++11/14 features:
+ * - - adds macro replacements for alignof and alignas keywords
+ * - - adds missing std::nullptr_t
+ * - For all toolchains:
+ * - - MSTD_CONSTEXPR_XX_14 macros that can be used to mark
+ *     things that are valid as constexpr only for C++14 or later,
+ *     permitting constexpr use where ARM C 5 would reject it.
+ */
+
+#include <cstddef>
+
+/* Macros that can be used to mark functions and objects that are
+ * constexpr in C++14 or later, but not in earlier versions.
+ */
+#if __cplusplus >= 201402
+#define MSTD_CONSTEXPR_FN_14 constexpr
+#define MSTD_CONSTEXPR_OBJ_14 constexpr
+#else
+#define MSTD_CONSTEXPR_FN_14 inline
+#define MSTD_CONSTEXPR_OBJ_14 const
+#endif
+
+namespace mstd
+{
+using std::size_t;
+using std::ptrdiff_t;
+using std::nullptr_t;
+using std::max_align_t;
+
+}
+
+#endif // MSTD_CSTDDEF_

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_functional
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_functional
@@ -1,0 +1,141 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under tUNChe License.
+ */
+#ifndef MSTD_FUNCTIONAL_
+#define MSTD_FUNCTIONAL_
+
+/* <mstd_functional>
+ *
+ * - includes toolchain's <functional>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - std::mem_fn,
+ *   - std::reference_wrapper, std::ref, std::cref
+ *   - transparent std::plus<> etc
+ *   - std::bit_and, std::bit_or, std::bit_xor, std::bit_not
+ * - For all toolchains, C++17/20 backports:
+ *   - mbed::not_fn (C++17)
+ *   - mbed::invoke (C++17)
+ *   - mstd::unwrap_reference, mstd::unwrap_ref_decay (C++20)
+ */
+
+#include <functional>
+
+#include <mstd_memory> // addressof
+#include <mstd_utility> // forward
+#include <mstd_type_traits>
+
+namespace mstd {
+
+// [func.invoke]
+#if __cpp_lib_invoke >= 201411
+using std::invoke;
+#else
+template <typename F, typename... Args>
+invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
+{
+    return impl::INVOKE(std::forward<F>(f), std::forward<Args>(args)...);
+}
+#endif // __cpp_lib_invoke
+
+} // namespace mstd
+
+namespace mstd {
+using std::reference_wrapper;
+using std::ref;
+using std::cref;
+using std::plus;
+using std::minus;
+using std::multiplies;
+using std::divides;
+using std::modulus;
+using std::negate;
+using std::equal_to;
+using std::not_equal_to;
+using std::greater;
+using std::less;
+using std::greater_equal;
+using std::less_equal;
+using std::logical_and;
+using std::logical_or;
+using std::logical_not;
+using std::bit_and;
+using std::bit_or;
+using std::bit_xor;
+using std::bit_not;
+
+#if __cpp_lib_not_fn >= 201603
+using std::not_fn;
+#else
+namespace impl {
+// [func.not_fn]
+template <typename F>
+class not_fn_t {
+    std::decay_t<F> fn;
+public:
+    explicit not_fn_t(F&& f) : fn(std::forward<F>(f)) { }
+    not_fn_t(const not_fn_t &other) = default;
+    not_fn_t(not_fn_t &&other) = default;
+
+    template<typename... Args>
+    auto operator()(Args&&... args) & -> decltype(!std::declval<invoke_result_t<std::decay_t<F> &, Args...>>())
+    {
+        return !mstd::invoke(fn, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) const & -> decltype(!std::declval<invoke_result_t<std::decay_t<F> const &, Args...>>())
+    {
+        return !mstd::invoke(fn, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) && -> decltype(!std::declval<invoke_result_t<std::decay_t<F>, Args...>>())
+    {
+        return !mstd::invoke(std::move(fn), std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) const && -> decltype(!std::declval<invoke_result_t<std::decay_t<F> const, Args...>>())
+    {
+        return !mstd::invoke(std::move(fn), std::forward<Args>(args)...);
+    }
+};
+}
+
+template <typename F>
+impl::not_fn_t<F> not_fn_t(F&& f)
+{
+    return impl::not_fn_t<F>(std::forward<F>(f));
+}
+#endif
+
+/* C++20 unwrap_reference */
+template <typename T>
+struct unwrap_reference : type_identity<T> { };
+template <typename T>
+struct unwrap_reference<std::reference_wrapper<T>> : type_identity<T &> { };
+template <typename T>
+using unwrap_reference_t = typename unwrap_reference<T>::type;
+
+/* C++20 unwrap_ref_decay */
+template <typename T>
+struct unwrap_ref_decay : unwrap_reference<std::decay_t<T>> { };
+template <typename T>
+using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+
+}
+
+#endif // MSTD_FUNCTIONAL_

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_iterator
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_iterator
@@ -1,0 +1,149 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_ITERATOR_
+#define MSTD_ITERATOR_
+
+/* <mstd_iterator>
+ *
+ * - includes toolchain's <iterator>
+ * - For ARM C 5, C++11/14 features:
+ *   - std::begin, std::end, etc
+ *   - std::move_iterator, std::make_move_iterator
+ * - For all toolchains, C++17/20 backports:
+ *   - mbed::size
+ *   - mbed::ssize
+ *   - mbed::empty
+ *   - mbed::data
+ */
+
+#include <iterator>
+#include <mstd_type_traits>
+
+namespace mstd {
+using std::initializer_list;
+using std::iterator_traits;
+// omitting deprecated std::iterator
+using std::input_iterator_tag;
+using std::output_iterator_tag;
+using std::forward_iterator_tag;
+using std::bidirectional_iterator_tag;
+using std::random_access_iterator_tag;
+using std::advance;
+using std::distance;
+using std::next;
+using std::prev;
+using std::reverse_iterator;
+using std::make_reverse_iterator;
+using std::back_insert_iterator;
+using std::back_inserter;
+using std::front_insert_iterator;
+using std::front_inserter;
+using std::insert_iterator;
+using std::inserter;
+using std::move_iterator;
+using std::make_move_iterator;
+using std::istream_iterator;
+using std::ostream_iterator;
+using std::istreambuf_iterator;
+using std::ostreambuf_iterator;
+using std::begin;
+using std::end;
+using std::cbegin;
+using std::cend;
+using std::rbegin;
+using std::rend;
+using std::crbegin;
+using std::crend;
+
+#if __cpp_lib_nonmember_container_access >= 201411
+using std::size;
+using std::empty;
+using std::data;
+#else
+// [iterator.container]
+template <class C>
+constexpr auto size(const C &c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, size_t N>
+constexpr size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto empty(const C &c) -> decltype(c.empty())
+{
+    return c.empty();
+}
+
+template <class T, size_t N>
+constexpr bool empty(T (&)[N]) noexcept
+{
+    return false;
+}
+
+template <class E>
+constexpr bool empty(initializer_list<E> il)
+{
+    return il.size() == 0;
+}
+
+template <class C>
+constexpr auto data(C &c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C &c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, size_t N>
+constexpr T *data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E *data(initializer_list<E> il)
+{
+    return il.begin();
+}
+#endif
+
+// C++20
+template <class C>
+constexpr auto ssize(const C &c) -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>
+{
+    return static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size());
+}
+
+template <class T, ptrdiff_t N>
+constexpr ptrdiff_t ssize(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+}
+
+
+#endif // MSTD_ITERATOR_

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_memory
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_memory
@@ -1,0 +1,138 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_MEMORY_
+#define MSTD_MEMORY_
+
+/* <mstd_memory>
+ *
+ * - includes toolchain's <memory>
+ * - For ARM C 5, C++11/14 features:
+ *   - std::align
+ *   - std::addressof
+ *   - std::uninitialized_copy_n
+ *   - std::unique_ptr, std::make_unique, std::default_delete
+ * - For all toolchains, C++17 backports:
+ *   - mstd::uninitialized_default_construct, mstd::uninitialized_value_construct
+ *   - mstd::uninitialized_move, mstd::uninitialized_move_n
+ *   - mstd::destroy_at, mstd::destroy, mstd::destroy_n
+ */
+
+#include <memory>
+
+#include <mstd_type_traits>
+#include <mstd_utility> // std::pair
+#include <mstd_iterator> // std::iterator_traits
+
+namespace mstd {
+    using std::align;
+    using std::allocator;
+    using std::addressof;
+
+    // [uninitialized.construct.default] (C++17)
+    template <class ForwardIterator, class Size>
+    void uninitialized_default_construct(ForwardIterator first, ForwardIterator last) {
+        for (; first != last; ++first) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type;
+        }
+    }
+
+    template <class ForwardIterator, class Size>
+    ForwardIterator uninitialized_default_construct_n(ForwardIterator first, Size n) {
+        for (; n; ++first, --n) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type;
+        }
+
+        return first;
+    }
+
+    // [uninitialized.construct.value] (C++17)
+    template <class ForwardIterator, class Size>
+    void uninitialized_value_construct(ForwardIterator first, ForwardIterator last) {
+        for (; first != last; ++first) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type();
+        }
+    }
+
+    template <class ForwardIterator, class Size>
+    ForwardIterator uninitialized_value_construct_n(ForwardIterator first, Size n) {
+        for (; n; ++first, --n) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type();
+        }
+
+        return first;
+    }
+
+    // [uninitialized.move] (C++17)
+    template <class InputIterator, class ForwardIterator>
+    ForwardIterator uninitialized_move(InputIterator first, InputIterator last, ForwardIterator result) {
+        for (; first != last; ++result, (void) ++first) {
+            ::new (static_cast<void*>(addressof(*result)))
+                  typename std::iterator_traits<ForwardIterator>::value_type(move(*first));
+        }
+
+        return result;
+    }
+
+    template <class InputIterator, class Size, class ForwardIterator>
+    std::pair<InputIterator, ForwardIterator> uninitialized_move_n(InputIterator first, Size n, ForwardIterator result) {
+        for ( ; n > 0; ++result, (void) ++first, --n) {
+            ::new (static_cast<void*>(addressof(*result)))
+                  typename std::iterator_traits<ForwardIterator>::value_type(std::move(*first));
+        }
+
+        return { first, result };
+    }
+
+    using std::uninitialized_copy;
+    using std::uninitialized_copy_n;
+    using std::uninitialized_fill;
+    using std::uninitialized_fill_n;
+
+    // [specialized.destroy] (C++17)
+    template <class T>
+    void destroy_at(T *location)
+    {
+        location->~T();
+    }
+
+    template <class ForwardIterator>
+    void destroy(ForwardIterator first, ForwardIterator last)
+    {
+        for (; first != last; ++first) {
+            destroy_at(addressof(*first));
+        }
+    }
+
+    template <class ForwardIterator, class Size>
+    ForwardIterator destroy_n(ForwardIterator first, Size n)
+    {
+        for (; n > 0; (void)++first, --n) {
+            destroy_at(addressof(*first));
+        }
+        return first;
+    }
+
+    using std::default_delete;
+    using std::unique_ptr;
+    using std::make_unique;
+}
+
+#endif // MSTD_MEMORY_

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_mutex
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_mutex
@@ -1,0 +1,92 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_MUTEX_
+#define MSTD_MUTEX_
+
+#include <mutex>
+
+namespace mstd {
+using std::defer_lock;
+using std::defer_lock_t;
+using std::try_to_lock;
+using std::try_to_lock_t;
+using std::adopt_lock;
+using std::adopt_lock_t;
+
+using std::lock_guard;
+using std::unique_lock;
+
+using std::try_lock;
+using std::lock;
+
+#if __cpp_lib_scoped_lock >= 201703
+using std::scoped_lock;
+#else
+// [thread.lock.scoped]
+// 2+ locks - use std::lock
+template <class... MutexTypes>
+class scoped_lock
+#if 0 // no definition yet - needs tuple
+    tuple<MutexTypes &...> pm;
+    static void ignore(...) { }
+public:
+    explicit scoped_lock(MutexTypes &... m) : pm(tie(m...)) { mstd::lock(m...); }
+    explicit scoped_lock(adopt_lock_t, MutexTypes &... m) noexcept : pm(mstd::tie(m...)) { }
+    ~scoped_lock() { mstd::apply([](MutexTypes &... m) { ignore( (void(m.unlock()),0) ...); }, pm); }
+
+    scoped_lock(const scoped_lock &) = delete;
+    scoped_lock &operator=(const scoped_lock &) = delete;
+}
+#else
+;
+#endif
+
+// 0 locks - no-op
+template <>
+class scoped_lock<> {
+public:
+    explicit scoped_lock() = default;
+    explicit scoped_lock(adopt_lock_t) noexcept { }
+    ~scoped_lock() = default;
+
+    scoped_lock(const scoped_lock &) = delete;
+    scoped_lock &operator=(const scoped_lock &) = delete;
+};
+
+// 1 lock - simple lock, equivalent to lock_guard<Mutex>
+template <class Mutex>
+class scoped_lock<Mutex> {
+    Mutex &pm;
+public:
+    using mutex_type = Mutex;
+    explicit scoped_lock(Mutex &m) : pm(m) { m.lock(); }
+    explicit scoped_lock(adopt_lock_t, Mutex &m) noexcept : pm(m) { }
+    ~scoped_lock() { pm.unlock(); }
+
+    scoped_lock(const scoped_lock &) = delete;
+    scoped_lock &operator=(const scoped_lock &) = delete;
+};
+#endif
+
+using std::once_flag;
+using std::call_once;
+
+using std::mutex;
+using std::recursive_mutex;
+}
+
+#endif // MSTD_MUTEX_

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_type_traits
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_type_traits
@@ -1,0 +1,483 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_TYPE_TRAITS_
+#define MSTD_TYPE_TRAITS_
+
+/* <mstd_type_traits>
+ *
+ * - includes toolchain's <type_traits>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - std::integral_constant, std::true_type, std::false_type
+ *   - primary type categories (std::is_void, std::is_integral etc)
+ *   - composite type categories (std::is_reference etc)
+ *   - type properties (std::is_const, std::is_constructible etc), except std::is_final
+ *   - type property queries (std::alignment_of, std::rank, std::extent)
+ *   - type relations (std::is_same, std::is_base_of, std::is_convertible)
+ *   - const-volatile modifications (std::remove_cv, std::add_const etc)
+ *   - reference modifications (std::remove_reference, std::add_lvalue_reference etc)
+ *   - sign modifications (std::make_signed, std::make_unsigned)
+ *   - array modifications (std::remove_extent, std::remove_all_extents)
+ *   - pointer modifications (std::remove_pointer, std::add_pointer)
+ *   - other modifications:
+ *      - std::aligned_storage
+ *      - std::decay
+ *      - std::enable_if
+ *      - std::conditional
+ *      - std::common_type
+ *      - std::underlying_type
+ *      - std::result_of
+ * - For all toolchains, C++17/20 backports:
+ *   - mstd::type_identity
+ *   - mstd::bool_constant
+ *   - mstd::void_t
+ *   - mstd::is_invocable, mbed::is_invocable_r, etc
+ *   - mstd::invoke_result
+ *   - logical operator traits (mstd::conjunction, mstd::disjunction, mstd::negation)
+ */
+
+#include <mstd_cstddef>
+#include <type_traits>
+
+// The template stuff in here is too confusing for astyle
+// *INDENT-OFF*
+
+
+namespace mstd {
+
+/* C++20 type identity */
+template<typename T>
+struct type_identity {
+    using type = T;
+};
+
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
+
+/* C++17 void_t (foundation for detection idiom) */
+/* void_t<Args...> is void if args are valid, else a substitution failure */
+#if __cpp_lib_void_t >= 201411
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
+/* C++17 bool_constant */
+#if __cpp_lib_bool_constant >= 201505
+using std::bool_constant;
+#else
+template <bool B>
+using bool_constant = std::integral_constant<bool, B>;
+#endif
+
+/* Forward declarations */
+#if __cpp_lib_is_invocable >= 201703
+using std::invoke_result;
+#else
+template <typename F, typename... Args>
+struct invoke_result;
+#endif
+
+using std::is_same;
+using std::conditional;
+using std::conditional_t;
+using std::enable_if;
+using std::enable_if_t;
+using std::is_convertible;
+using std::is_object;
+using std::is_reference;
+
+/* Reinvent or pull in good stuff not in C++14 into namespace mstd */
+/* C++17 logical operations on traits */
+#if __cpp_lib_logical_traits >= 201510
+using std::conjunction;
+using std::disjunction;
+using std::negation;
+#else
+template<class...>
+struct conjunction : std::true_type { };
+template<class B1>
+struct conjunction<B1> : B1 { };
+template<class B1, class... BN>
+struct conjunction<B1, BN...> : std::conditional_t<bool(B1::value), conjunction<BN...>, B1> { };
+
+template<class...>
+struct disjunction : std::false_type { };
+template<class B1>
+struct disjunction<B1> : B1 { };
+template<class B1, class... BN>
+struct disjunction<B1, BN...> : std::conditional_t<bool(B1::value), B1, disjunction<BN...>> { };
+
+template<class B>
+struct negation : bool_constant<!bool(B::value)> { };
+#endif
+
+/* C++ detection idiom from Library fundamentals v2 TS */
+/* Place into mstd::experimental to match their std::experimental */
+namespace experimental {
+
+namespace impl {
+template <class Default, class Void, template<class...> class Op, class... Args>
+struct detector {
+    using value_t = std::false_type;
+    using type = Default;
+};
+
+template <class Default, template<class...> class Op, class... Args>
+struct detector<Default, void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+};
+
+} // namespace impl
+
+struct nonesuch {
+    ~nonesuch() = delete;
+    nonesuch(nonesuch const &) = delete;
+    void operator=(nonesuch const &) = delete;
+};
+
+#if 0
+/* Deactivated because impl::detector appears to not work on ARM C 5; it seems to produce
+ * hard errors in the template template parameter expansion. You can use void_t directly instead.
+ *
+ * Reactivate if working ARM C 5 implementation discovered, or ARM C 5 support
+ * dropped.
+ */
+
+template<template<class...> class Op, class... Args>
+using is_detected = typename impl::detector<nonesuch, void, Op, Args...>::value_t;
+
+template<template<class...> class Op, class... Args>
+using detected_t = typename impl::detector<nonesuch, void, Op, Args...>::type;
+
+template<class Default, template<class...> class Op, class... Args>
+using detected_or = typename impl::detector<Default, void, Op, Args...>;
+
+template<class Default, template<class...> class Op, class... Args>
+using detected_or_t = typename detected_or<Default, Op, Args...>::type;
+
+template<class Expected, template<class...> class Op, class... Args>
+using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
+
+template<class To, template<class...> class Op, class... Args>
+using is_detected_convertible = std::is_convertible<detected_t<Op, Args...>, To>;
+#endif // if 0 - deactivated detector idiom
+} // namespace experimental
+} // namespace mstd
+
+/* More post-C++14 stuff */
+namespace mstd {
+
+using std::remove_const;
+using std::remove_const_t;
+using std::remove_volatile;
+using std::remove_volatile_t;
+using std::remove_cv;
+using std::remove_cv_t;
+using std::add_const;
+using std::add_const_t;
+using std::add_volatile;
+using std::add_volatile_t;
+using std::add_cv;
+using std::add_cv_t;
+using std::remove_reference;
+using std::remove_reference_t;
+using std::add_lvalue_reference;
+using std::add_rvalue_reference;
+using std::is_void;
+using std::is_null_pointer;
+using std::is_integral;
+using std::is_floating_point;
+using std::is_array;
+using std::is_pointer;
+using std::is_lvalue_reference;
+using std::is_rvalue_reference;
+using std::is_enum;
+using std::is_union;
+using std::is_class;
+using std::is_function;
+using std::is_member_function_pointer;
+using std::is_member_object_pointer;
+using std::is_reference;
+using std::is_arithmetic;
+using std::is_fundamental;
+using std::is_compound;
+using std::is_member_pointer;
+using std::is_scalar;
+using std::is_object;
+using std::is_const;
+using std::is_volatile;
+using std::is_trivial;
+using std::is_trivially_copyable;
+using std::is_standard_layout;
+using std::is_pod;
+using std::is_literal_type;
+using std::is_empty;
+using std::is_polymorphic;
+using std::is_abstract;
+using std::is_signed;
+using std::is_unsigned;
+using std::is_constructible;
+using std::is_default_constructible;
+using std::is_copy_constructible;
+using std::is_move_constructible;
+using std::is_assignable;
+using std::is_copy_assignable;
+using std::is_move_assignable;
+using std::is_destructible;
+using std::is_trivially_constructible;
+using std::is_trivially_default_constructible;
+using std::is_trivially_copy_constructible;
+using std::is_trivially_move_constructible;
+using std::is_trivially_assignable;
+using std::is_trivially_copy_assignable;
+using std::is_trivially_move_assignable;
+using std::is_trivially_destructible;
+// Exceptions are disabled in mbed, so short-circuit nothrow tests
+// (Compilers don't make noexcept() return false with exceptions
+// disabled, presumably to preserve binary compatibility, so the
+// std versions of these are unduly pessimistic).
+template <typename T, typename... Args>
+struct is_nothrow_constructible : is_constructible<T, Args...> { };
+template <typename T>
+struct is_nothrow_default_constructible : is_default_constructible<T> { };
+template <typename T>
+struct is_nothrow_copy_constructible : is_copy_constructible<T> { };
+template <typename T>
+struct is_nothrow_move_constructible : is_move_constructible<T> { };
+template <typename To, typename From>
+struct is_nothrow_assignable: is_assignable<To, From> { };
+template <typename T>
+struct is_nothrow_copy_assignable : is_copy_assignable<T> { };
+template <typename T>
+struct is_nothrow_move_assignable : is_move_assignable<T> { };
+using std::has_virtual_destructor;
+using std::alignment_of;
+using std::rank;
+using std::extent;
+using std::is_convertible;
+using std::is_base_of;
+using std::make_signed;
+using std::make_signed_t;
+using std::make_unsigned;
+using std::make_unsigned_t;
+using std::remove_extent;
+using std::remove_extent_t;
+using std::remove_all_extents;
+using std::remove_all_extents_t;
+using std::remove_pointer;
+using std::remove_pointer_t;
+using std::add_pointer;
+using std::add_pointer_t;
+using std::aligned_storage;
+using std::aligned_storage_t;
+using std::decay;
+using std::decay_t;
+using std::common_type;
+using std::common_type_t;
+using std::result_of;
+using std::result_of_t;
+
+/* C++20 remove_cvref */
+template <typename T>
+struct remove_cvref : type_identity<std::remove_cv_t<std::remove_reference_t<T>>> { };
+
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+/* C++20 unwrap_reference */
+template <typename T>
+struct unwrap_reference : type_identity<T> { };
+template <typename T>
+struct unwrap_reference<std::reference_wrapper<T>> : type_identity<T &> { };
+template <typename T>
+using unwrap_reference_t = typename unwrap_reference<T>::type;
+
+/* C++20 unwrap_ref_decay */
+template <typename T>
+struct unwrap_ref_decay : unwrap_reference<std::decay_t<T>> { };
+template <typename T>
+using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+
+}
+
+#if __cpp_lib_invoke < 201411
+#include <utility> // want std::forward
+#include <functional> // want std::reference_wrapper
+#elif __cpp_lib_is_invocable < 201703
+#include <functional> // want std::invoke
+#endif
+
+namespace mstd {
+/* C++17 invoke_result, is_invocable, invoke */
+#if __cpp_lib_is_invocable >= 201703
+/* Library has complete suite - pull it into mstd */
+using std::invoke_result;
+using std::invoke_result_t;
+using std::is_invocable;
+using std::is_nothrow_invocable;
+using std::is_invocable_r;
+using std::is_nothrow_invocable_r;
+#else // __cpp_lib_is_invocable
+namespace impl {
+#if __cpp_lib_invoke >= 201411
+/* Library has just invoke - make it our impl::INVOKE so we can create invoke_result */
+template <typename F, typename... Args>
+using INVOKE = std::invoke<F, Args...>;
+#else // __cpp_lib_invoke
+/* Define our own INVOKE */
+template <typename T>
+struct is_reference_wrapper : std::false_type { };
+
+template <typename T>
+struct is_reference_wrapper<std::reference_wrapper<T>> : std::true_type { };
+
+/* F is pointer to member function, and 1st arg decays to matching class */
+template<typename Base, typename F, typename T1, class... Args>
+auto INVOKE(F Base::* fn, T1 &&target, Args &&...args)
+// Noexcept specifications generate compiler errors unpacking args
+//noexcept(noexcept((std::forward<T1>(target).*fn)(std::forward<Args>(args)...)))
+ -> std::enable_if_t<std::is_function<F>::value &&
+                     std::is_base_of<Base, std::decay_t<T1>>::value,
+                     decltype((std::forward<T1>(target).*fn)(std::forward<Args>(args)...))>
+{
+    return (std::forward<T1>(target).*fn)(std::forward<Args>(args)...);
+}
+/* F is pointer to member function, and 1st arg is a reference wrapper  */
+template<typename Base, typename F, typename T1, class... Args>
+auto INVOKE(F Base::* fn, T1 &&target, Args &&...args)
+//noexcept(noexcept((std::forward<T1>(target).get().*fn)(std::forward<Args>(args)...)))
+ -> std::enable_if_t<std::is_function<F>::value &&
+                     is_reference_wrapper<std::decay_t<T1>>::value,
+                     decltype((std::forward<T1>(target).get().*fn)(std::forward<Args>(args)...))>
+{
+    return (std::forward<T1>(target).get().*fn)(std::forward<Args>(args)...);
+}
+/* F is pointer to member function, and 1st arg doesn't match class and isn't reference wrapper - assume pointer */
+template<typename Base, typename F, typename T1, class... Args>
+auto INVOKE(F Base::* fn, T1 &&target, Args &&...args)
+//noexcept(noexcept(((*std::forward<T1>(target)).*fn)(std::forward<Args>(args)...)))
+ -> std::enable_if_t<std::is_function<F>::value &&
+                     !std::is_base_of<Base, std::decay_t<T1>>::value &&
+                     !is_reference_wrapper<std::decay_t<T1>>::value,
+                     decltype(((*std::forward<T1>(target)).*fn)(std::forward<Args>(args)...))>
+{
+    return ((*std::forward<T1>(target)).*fn)(std::forward<Args>(args)...);
+}
+/* F is pointer to member object, and only arg decays to matching class */
+template<typename Base, typename F, typename T1>
+auto INVOKE(F Base::* obj, T1 &&target)
+//noexcept(noexcept(std::forward<T1>(target).*obj))
+ -> std::enable_if_t<!std::is_function<F>::value &&
+                     std::is_base_of<Base, std::decay_t<T1>>::value,
+                     decltype(std::forward<T1>(target).*obj)>
+{
+    return std::forward<T1>(target).*obj;
+}
+/* F is pointer to member object, and only arg is a reference wrapper */
+template<typename Base, typename F, typename T1>
+auto INVOKE(F Base::* obj, T1 &&target)
+//noexcept(noexcept(std::forward<T1>(target).get().*obj))
+ -> std::enable_if_t<!std::is_function<F>::value &&
+                     is_reference_wrapper<std::decay_t<T1>>::value,
+                     decltype(std::forward<T1>(target).get().*obj)>
+{
+    return std::forward<T1>(target).get().*obj;
+}
+/* F is pointer to member object, and only arg doesn't match class and isn't reference wrapper - assume pointer */
+template<typename Base, typename F, typename T1>
+auto INVOKE(F Base::* obj, T1 &&target)
+//noexcept(noexcept((*std::forward<T1>(target)).*obj))
+ -> std::enable_if_t<!std::is_function<F>::value &&
+                     !std::is_base_of<Base, std::decay_t<T1>>::value &&
+                     !is_reference_wrapper<std::decay_t<T1>>::value,
+                     decltype((*std::forward<T1>(target)).*obj)>
+{
+    return (*std::forward<T1>(target)).*obj;
+}
+/* F is not a pointer to member */
+template<typename F, typename... Args>
+auto INVOKE(F&& f, Args&&... args)
+//noexcept(noexcept(std::forward<F>(f)(std::forward<Args>(args)...)))
+ -> std::enable_if_t<!std::is_member_pointer<std::decay_t<F>>::value ||
+                      (std::is_member_object_pointer<std::decay_t<F>>::value && sizeof...(args) != 1),
+                     decltype(std::forward<F>(f)(std::forward<Args>(args)...))>
+{
+    return std::forward<F>(f)(std::forward<Args>(args)...);
+}
+#endif // __cpp_lib_invoke
+
+template <typename Void, typename F, typename... Args>
+struct invoke_result { };
+template <typename F, typename... Args> // void_t<decltype(INVOKE)> appears not to work here - why?
+struct invoke_result<decltype(void(INVOKE(std::declval<F>(), std::declval<Args>()...))), F, Args...> :
+    type_identity<decltype(INVOKE(std::declval<F>(), std::declval<Args>()...))> { };
+
+// This would be a lot shorter if we could get the detector idiom to work and use it
+template <typename R, typename InvokeResult, typename = void>
+struct is_invocable_r : std::false_type { };
+template <typename R, typename InvokeResult>
+struct is_invocable_r <R, InvokeResult, void_t<typename InvokeResult::type>> :
+    disjunction<std::is_void<R>, std::is_convertible<typename InvokeResult::type, R>> { };
+
+template <typename R, typename InvokeResult, typename = void>
+struct is_nothrow_invocable_r : std::false_type { };
+template <typename R, typename InvokeResult>
+struct is_nothrow_invocable_r<R, InvokeResult, void_t<typename InvokeResult::type>> :
+    disjunction<std::is_void<R>,
+                     conjunction<std::is_convertible<typename InvokeResult::type, R>,
+                                 std::is_nothrow_constructible<R, typename InvokeResult::type>>> { };
+
+} //namespace impl
+
+template <class F, class... Args>
+struct invoke_result : impl::invoke_result<void, F, Args...> { };
+
+template <class F, class... Args>
+using invoke_result_t = typename invoke_result<F, Args...>::type;
+
+template <class F, class... Args>
+struct is_invocable : impl::is_invocable_r<void, invoke_result<F, Args...>> { };
+
+#if 0 // No exceptions in mbed OS
+template <class F, class... Args>
+struct is_nothrow_invocable : impl::is_nothrow_invocable_r<void, invoke_result<F, Args...>> { };
+#else
+template <class F, class... Args>
+struct is_nothrow_invocable : impl::is_invocable_r<void, invoke_result<F, Args...>> { };
+#endif
+
+template <typename R, typename F, typename... Args>
+struct is_invocable_r : impl::is_invocable_r<R, invoke_result<F, Args...>> { };
+
+#if 0 // No exceptions in mbed OS
+template <typename R, typename F, typename... Args>
+struct is_nothrow_invocable_r : conjunction<impl::is_nothrow_invocable_r<R, invoke_result<F>>,
+                                            std::is_convertible<invoke_result_t<F, Args...>, R>> { };
+#else
+template <typename R, typename F, typename... Args>
+struct is_nothrow_invocable_r : impl::is_invocable_r<R, invoke_result<F, Args...>> { };
+#endif
+
+#endif // __cpp_lib_is_invocable
+
+
+} // namespace mstd
+
+
+#endif /* MSTD_TYPE_TRAITS_ */

--- a/UNITTESTS/target_h/platform/cxxsupport/mstd_utility
+++ b/UNITTESTS/target_h/platform/cxxsupport/mstd_utility
@@ -1,0 +1,75 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_UTILITY_
+#define MSTD_UTILITY_
+
+/* <mstd_utility>
+ *
+ * - includes toolchain's <utility>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - include <initializer_list>
+ *   - std::move, std::forward, std::exchange
+ *   - std::declval
+ *   - std::integer_sequence
+ *   - include <algorithm> to get default std::swap
+ *   - mstd::swap - substitute for std::swap that can move
+ *   - std::swap(array)
+ * - Swap assistance, to ensure moves happen on ARM C 5
+ *   - mstd::swap - alias for std::swap, or a local moving implementation for ARM C 5
+ * - For all toolchains, C++17/20 backports:
+ *   - mstd::as_const
+ */
+
+#include <utility>
+
+namespace mstd {
+using std::swap;
+
+namespace rel_ops { using namespace std::rel_ops; }
+using std::initializer_list;
+using std::exchange;
+using std::forward;
+using std::move;
+// No exceptions in mbed OS
+template <typename T>
+T &&move_if_noexcept(T &t) noexcept
+{
+    return mstd::move(t);
+}
+using std::declval;
+using std::make_pair;
+using std::get;
+using std::pair;
+using std::integer_sequence;
+
+// C++17 [utility.as_const] */
+#if __cpp_lib_as_const >= 201510
+using std::as_const;
+#else
+template <typename _TypeT>
+constexpr std::add_const_t<_TypeT> &as_const(_TypeT &__t) noexcept
+{
+    return __t;
+}
+
+template <typename _TypeT>
+void as_const(_TypeT &&) = delete;
+#endif
+
+} // namespace mstd
+
+#endif // MSTD_UTILITY_

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -345,15 +345,21 @@ protected:
     enum SPIName { GlobalSPI };
 #endif
 
+    // All members of spi_peripheral_s must be initialized to make the structure
+    // constant-initialized, and hence able to be omitted by the linker,
+    // as SingletonPtr now relies on C++ constant-initialization. (Previously it
+    // worked through C++ zero-initialization). And all the constants should be zero
+    // to ensure it stays in the actual zero-init part of the image if used, avoiding
+    // an initialized-data cost.
     struct spi_peripheral_s {
         /* Internal SPI name identifying the resources. */
-        SPIName name;
+        SPIName name = SPIName(0);
         /* Internal SPI object handling the resources' state. */
-        spi_t spi;
+        spi_t spi{};
         /* Used by lock and unlock for thread safety */
         SingletonPtr<PlatformMutex> mutex;
         /* Current user of the SPI */
-        SPI *owner;
+        SPI *owner = nullptr;
 #if DEVICE_SPI_ASYNCH && TRANSACTION_QUEUE_SIZE_SPI
         /* Queue of pending transfers */
         SingletonPtr<CircularBuffer<Transaction<SPI>, TRANSACTION_QUEUE_SIZE_SPI> > transaction_buffer;

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -42,11 +42,17 @@ static const fhss_api_t *fhss_active_handle = NULL;
 static EventQueue *equeue;
 #endif
 
+// All members of fhss_timeout_s must be initialized to make the structure
+// constant-initialized, and hence able to be omitted by the linker,
+// as SingletonPtr now relies on C++ constant-initialization. (Previously it
+// worked through C++ zero-initialization). And all the constants should be zero
+// to ensure it stays in the actual zero-init part of the image if used, avoiding
+// an initialized-data cost.
 struct fhss_timeout_s {
-    void (*fhss_timer_callback)(const fhss_api_t *fhss_api, uint16_t);
-    uint32_t start_time;
-    uint32_t stop_time;
-    bool active;
+    void (*fhss_timer_callback)(const fhss_api_t *fhss_api, uint16_t) = nullptr;
+    uint32_t start_time = 0;
+    uint32_t stop_time = 0;
+    bool active = false;
     SingletonPtr<Timeout> timeout;
 };
 

--- a/mbed.h
+++ b/mbed.h
@@ -89,7 +89,7 @@
 #include "platform/mbed_wait_api.h"
 #include "platform/mbed_thread.h"
 #include "hal/sleep_api.h"
-#include "platform/Atomic.h"
+#include "platform/mbed_atomic.h"
 #include "platform/mbed_power_mgmt.h"
 #include "platform/mbed_rtc_time.h"
 #include "platform/mbed_poll.h"

--- a/platform/Atomic.h
+++ b/platform/Atomic.h
@@ -20,11 +20,12 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <memory>
+#include <mstd_memory>
+#include <mstd_type_traits>
+#include <mstd_utility>
 #include "platform/mbed_assert.h"
 #include "platform/mbed_atomic.h"
 #include "platform/mbed_critical.h"
-#include "platform/mbed_cxxsupport.h"
 #include "platform/CriticalSectionLock.h"
 
 /*
@@ -141,16 +142,16 @@ template<typename N>
 struct atomic_container_is_lock_free;
 
 template<>
-struct atomic_container_is_lock_free<uint8_t> : mbed::bool_constant<bool(MBED_ATOMIC_CHAR_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint8_t> : mstd::bool_constant<bool(MBED_ATOMIC_CHAR_LOCK_FREE)> { };
 
 template<>
-struct atomic_container_is_lock_free<uint16_t> : mbed::bool_constant<bool(MBED_ATOMIC_SHORT_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint16_t> : mstd::bool_constant<bool(MBED_ATOMIC_SHORT_LOCK_FREE)> { };
 
 template<>
-struct atomic_container_is_lock_free<uint32_t> : mbed::bool_constant<bool(MBED_ATOMIC_INT_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint32_t> : mstd::bool_constant<bool(MBED_ATOMIC_INT_LOCK_FREE)> { };
 
 template<>
-struct atomic_container_is_lock_free<uint64_t> : mbed::bool_constant<bool(MBED_ATOMIC_LLONG_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint64_t> : mstd::bool_constant<bool(MBED_ATOMIC_LLONG_LOCK_FREE)> { };
 
 template<typename T>
 using atomic_is_lock_free = atomic_container_is_lock_free<atomic_container_t<T>>;
@@ -702,15 +703,15 @@ struct AtomicWithBitwise : public AtomicWithAdd<T, A> {
  */
 // *INDENT-OFF*
 template<typename T, typename = void>
-struct AtomicSelector : mbed::type_identity<AtomicBaseRaw<T>> { };
+struct AtomicSelector : mstd::type_identity<AtomicBaseRaw<T>> { };
 
 template<typename T>
 struct AtomicSelector<T, std::enable_if_t<std::is_same<bool, T>::value>>
-                        : mbed::type_identity<AtomicBaseInt<T>> { };
+                        : mstd::type_identity<AtomicBaseInt<T>> { };
 
 template<typename T>
 struct AtomicSelector<T, std::enable_if_t<std::is_integral<T>::value && !std::is_same<bool, T>::value>>
-                        : mbed::type_identity<AtomicWithBitwise<T>> { };
+                        : mstd::type_identity<AtomicWithBitwise<T>> { };
 // *INDENT-ON*
 
 template<typename T>

--- a/platform/SingletonPtr.h
+++ b/platform/SingletonPtr.h
@@ -71,20 +71,50 @@ inline static void singleton_unlock(void)
 #endif
 }
 
-/** Utility class for creating an using a singleton
+/** Utility class for creating and using a singleton
  *
  * @note Synchronization level: Thread safe
  *
- * @note: This class must only be used in a static context -
- * this class must never be allocated or created on the
- * stack.
- *
  * @note: This class is lazily initialized on first use.
- * This class is a POD type so if it is not used it will
- * be garbage collected.
+ * This class has a constexpr default constructor so if it is
+ * not used as a non-local variable it will be garbage collected.
+ *
+ * @note: This class would normally be used in a static standalone
+ * context. It does not call the destructor of the wrapped object
+ * when it is destroyed, effectively ensuring linker exclusion of the
+ * destructor for static objects. If used in another context, such as
+ * a member of a normal class wanting "initialize on first-use"
+ * semantics on a member, care should be taken to call the destroy
+ * method manually if necessary.
+ *
+ * @note: If used as a sub-object of a class, that class's own
+ * constructor must be constexpr to achieve its exclusion by
+ * the linker when unused. That will require explicit
+ * initialization of its other members.
+ *
+ * @note: More detail on initialization: Formerly, SingletonPtr
+ * had no constructor, so was "zero-initialized" when non-local.
+ * So if enclosed in another class with no constructor, the whole
+ * thing would be zero-initialized, and linker-excludable.
+ * Having no constructor meant SingletonPtr was not constexpr,
+ * which limited applicability in other contexts. With its new
+ * constexpr constructor, it is now "constant-initialized" when
+ * non-local. This achieves the same effect as a standalone
+ * non-local object, but as a sub-object linker exclusion is
+ * now only achieved if the outer object is itself using a
+ * constexpr constructor to get constant-initialization.
+ * Otherwise, the outer object will be neither zero-initialized
+ * nor constant-initialized, so will be "dynamic-initialized",
+ * and likely to be left in by the linker.
  */
 template <class T>
 struct SingletonPtr {
+
+    // Initializers are required to make default constructor constexpr
+    // This adds no overhead as a static object - the compiler and linker can
+    // figure out that we are effectively zero-init, and either place us in
+    // ".bss", or exclude us if unused.
+    constexpr SingletonPtr() noexcept : _ptr(), _data() { }
 
     /** Get a pointer to the underlying singleton
      *
@@ -93,13 +123,13 @@ struct SingletonPtr {
      */
     T *get() const
     {
-        T *p = static_cast<T *>(core_util_atomic_load_ptr(&_ptr));
+        T *p = core_util_atomic_load(&_ptr);
         if (p == NULL) {
             singleton_lock();
-            p = static_cast<T *>(_ptr);
+            p = _ptr;
             if (p == NULL) {
                 p = new (_data) T();
-                core_util_atomic_store_ptr(&_ptr, p);
+                core_util_atomic_store(&_ptr, p);
             }
             singleton_unlock();
         }
@@ -129,8 +159,42 @@ struct SingletonPtr {
         return *get();
     }
 
-    // This is zero initialized when in global scope
-    mutable void *_ptr;
+    /** Get a pointer to the underlying singleton
+     *
+     * Gets a pointer without initialization - can be
+     * used as an optimization when it is known that
+     * initialization must have already occurred.
+     *
+     * @returns
+     *   A pointer to the singleton, or NULL if not
+     *   initialized.
+     */
+    T *get_no_init() const
+    {
+        return _ptr;
+    }
+
+    /** Destroy the underlying singleton
+     *
+     * The underlying singleton is never automatically destroyed;
+     * this is a potential optimization to avoid destructors
+     * being pulled into an embedded image on the exit path,
+     * which should never occur. The destructor can be
+     * manually invoked via this call.
+     *
+     * Unlike construction, this is not thread-safe. After this call,
+     * no further operations on the object are permitted.
+     *
+     * Is a no-op if the object has not been constructed.
+     */
+    void destroy()
+    {
+        if (_ptr) {
+            _ptr->~T();
+        }
+    }
+
+    mutable T *_ptr;
 #if __cplusplus >= 201103L && !defined __CC_ARM
     // Align data appropriately (ARM Compiler 5 does not support alignas in C++11 mode)
     alignas(T) mutable char _data[sizeof(T)];

--- a/platform/cxxsupport/README.md
+++ b/platform/cxxsupport/README.md
@@ -1,0 +1,65 @@
+## C++ support ##
+
+Mbed OS supports a number of toolchains, and the files here provide support
+to smooth over C++ library differences.
+
+The current baseline version is C++14, so we hope for full C++14 library
+support.
+
+Omissions are:
+* areas like chrono and threads, which depend on OS support, where
+  retargeting is not complete.
+* atomics and shared pointers, as atomic implementations for ARMv6-M
+  are not provided by all toolchains, and the ARMv7-M implementations include
+  DMB instructions we do not want/need for non-SMP.
+
+User code should normally be able to include C++14 headers and get
+most expected functionality. (But bear in mind that many C++ library
+features like streams and STL containers are quite heavy and may
+not be appropriate for small embnedded use).
+
+However, ARM C 5 has only C++11 language support (at least a large subset), and
+no C++11/14 library. For the headers that are totally new in C++11,
+they are provided here in TOOLCHAIN_ARMC5 under their standard C++11 name.
+(Eg `<array>`, `<cinttypes>`, `<initializer_list>`, `<type_traits>`).
+But for headers that already exist in C++03, extensions are required.
+
+So, to support ARM C 5, use `#include <mstd_utility>`, rather than
+`#include <utility>` if you need C++11 or later features from that header.
+
+Each `mstd_` file includes the toolchain's corresponding header file,
+which will provide its facilities in `namespace std`. Any missing
+C++11/C++14 facilities for ARM C 5 are also provided in `namespace std`.
+
+Then APIs from `namespace std` are added to `namespace mstd`, with adjustment
+if necessary, and APIs being omitted if not suitable for embedded use.
+For example:
+
+   * `std::size_t` (`<cstddef>`) - toolchain's `std::size_t`
+   * `mstd::size_t` (`<mstd_cstddef>`) - alias for `std::size_t`
+   * `std::swap` (`<utility>`) - toolchain's `std::swap` (not move-capable for ARM C 5)
+   * `mstd::swap` (`<mstd_utility>`) - alias for `std::swap` or move-capable ARM C 5 replacement.
+   * `std::atomic` (`<atomic>`) - toolchain's `std::atomic` (not implemented for IAR ARMv6)
+   * `mstd::atomic` (`<mstd_atomic>`) - custom `mstd::atomic` for all toolchains
+   * `std::void_t` (`<type_traits>`) - toolchain's `std::void_t` if available (it's C++17 so likely not)
+   * `mstd::void_t` (`<mstd_type_traits>`) - alias for `std::void_t` if available, else local implementation
+   * `std::thread` (`<thread>`) - toolchain's `std::thread` - not available or ported
+   * `mstd::thread` - doesn't exist - `mstd` APIs only exist if available on all toolchains
+
+Using `std::xxx` will generally work, but may suffer from toolchain variance. `mstd::xxx` should always be better - it will either be an alias to `std::xxx`, or work better for Mbed OS.
+
+In portable code, when compiling for non-Mbed OS, the directive `namespace mstd == std` can be used
+to cover the difference:
+
+```C++
+// my_code.c
+#if TARGET_LIKE_MBED
+#include <mstd_atomic>
+#else
+#include <atomic>
+namespace mstd = std;
+#endif
+
+mstd::atomic my_atomic;
+```
+

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/_move.h
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/_move.h
@@ -1,0 +1,68 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __move_h
+#define __move_h
+
+namespace std
+{
+template <typename T>
+struct remove_reference { using type = T; };
+
+template <typename T>
+struct remove_reference<T &> { using type = T; };
+
+template <typename T>
+struct remove_reference<T &&> { using type = T; };
+
+template <typename T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+// Note that these implementations do not function as
+// constant expressions in ARM C 5, so are not marked constexpr.
+// This makes them C++11 compliant, but not C++14.
+
+// [forward]
+template <typename _TypeT>
+_TypeT &&forward(remove_reference_t<_TypeT> &__t) noexcept
+{
+    return static_cast<_TypeT &&>(__t);
+}
+
+template <typename _TypeT>
+_TypeT &&forward(remove_reference_t<_TypeT> &&__t) noexcept
+{
+    return static_cast<_TypeT &&>(__t);
+}
+
+template <typename _TypeT>
+remove_reference_t<_TypeT> &&move(_TypeT &&__t) noexcept
+{
+    return static_cast<remove_reference_t<_TypeT> &&>(__t);
+}
+
+// [utility.exchange]
+template <typename _TypeT, typename _TypeU = _TypeT>
+_TypeT exchange(_TypeT &__obj, _TypeU &&__new_val)
+{
+    _TypeT __old_val = std::move(__obj);
+    __obj = std::forward<_TypeU>(__new_val);
+    return __old_val;
+}
+
+} // namespace std
+
+#endif /* __move_h */

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/array
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/array
@@ -1,0 +1,171 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __array
+#define __array
+
+#include <initializer_list> // required by standard
+
+#include <cstddef> // size_t, ptrdiff_t
+#include <algorithm> // fill and swap_ranges
+
+namespace std {
+template <typename>
+struct reverse_iterator;
+
+// [array]
+template <typename _TypeT, size_t _Size>
+struct array {
+    // [array.overview]
+    _TypeT _C_elem[_Size];
+
+    using value_type = _TypeT;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reference = _TypeT &;
+    using const_reference = const _TypeT &;
+    using pointer = _TypeT *;
+    using const_pointer = const _TypeT *;
+    using iterator = _TypeT *;
+    using const_iterator = const _TypeT *;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    // [array.size]
+    constexpr size_type size() const noexcept
+    {
+        return _Size;
+    }
+    // [array.data]
+    _TypeT *data() noexcept
+    {
+        return _C_elem;
+    }
+    const _TypeT *data() const noexcept
+    {
+        return _C_elem;
+    }
+    // [array.fill]
+    void fill(const _TypeT &value)
+    {
+        std::fill(begin(), end(), value);
+    }
+    // [array.swap]
+    void swap(array &__y)
+    {
+        std::swap_ranges(begin(), end(), __y.begin());
+    }
+    _TypeT &at(size_t pos)
+    {
+        MBED_ASSERT(pos < size());
+        return _C_elem[pos];
+    }
+    const _TypeT &at(size_t pos) const
+    {
+        MBED_ASSERT(pos < size());
+        return _C_elem[pos];
+    }
+    _TypeT &operator[](size_t pos)
+    {
+        return _C_elem[pos];
+    }
+    const _TypeT &operator[](size_t pos) const
+    {
+        return _C_elem[pos];
+    }
+    _TypeT &front()
+    {
+        return _C_elem[0];
+    }
+    const _TypeT &front() const
+    {
+        return _C_elem[0];
+    }
+    _TypeT &back()
+    {
+        return _C_elem[_Size - 1];
+    }
+    const _TypeT &back() const
+    {
+        return _C_elem[_Size - 1];
+    }
+    constexpr bool empty() const noexcept
+    {
+        return false;
+    }
+    constexpr size_type max_size() const noexcept
+    {
+        return _Size;
+    }
+    iterator begin() noexcept
+    {
+        return _C_elem;
+    }
+    const_iterator begin() const noexcept
+    {
+        return _C_elem;
+    }
+    const_iterator cbegin() const noexcept
+    {
+        return _C_elem;
+    }
+    iterator end() noexcept
+    {
+        return _C_elem + _Size;
+    }
+    const_iterator end() const noexcept
+    {
+        return _C_elem + _Size;
+    }
+    const_iterator cend() const noexcept
+    {
+        return _C_elem + _Size;
+    }
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+    const_reverse_iterator rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+};
+
+// [array.special]
+template <class _TypeT, size_t _Size>
+void swap(array<_TypeT, _Size> &__x, array<_TypeT, _Size> &__y)
+{
+    __x.swap(__y);
+}
+
+} // namespace std
+
+#endif /* __array */

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/atomic
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/atomic
@@ -1,0 +1,62 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __atomic
+#define __atomic
+
+// Just go straight to the main file
+#include <mstd_atomic>
+
+#define ATOMIC_VAR_INIT(x) { x }
+#define ATOMIC_FLAG_INIT MSTD_ATOMIC_FLAG_INIT
+
+// And then pull it all into our std
+namespace std {
+using mstd::atomic;
+using mstd::atomic_is_lock_free;
+using mstd::atomic_store;
+using mstd::atomic_store_explicit;
+using mstd::atomic_load;
+using mstd::atomic_load_explicit;
+using mstd::atomic_exchange;
+using mstd::atomic_exchange_explicit;
+using mstd::atomic_compare_exchange_weak;
+using mstd::atomic_compare_exchange_weak_explicit;
+using mstd::atomic_compare_exchange_strong;
+using mstd::atomic_compare_exchange_strong_explicit;
+using mstd::atomic_fetch_add;
+using mstd::atomic_fetch_add_explicit;
+using mstd::atomic_fetch_sub;
+using mstd::atomic_fetch_sub_explicit;
+using mstd::atomic_fetch_and;
+using mstd::atomic_fetch_and_explicit;
+using mstd::atomic_fetch_or;
+using mstd::atomic_fetch_or_explicit;
+using mstd::atomic_fetch_xor;
+using mstd::atomic_fetch_xor_explicit;
+using mstd::atomic_flag;
+using mstd::atomic_flag_test_and_set;
+using mstd::atomic_flag_test_and_set_explicit;
+using mstd::atomic_flag_clear;
+using mstd::atomic_flag_clear_explicit;
+using mstd::atomic_init;
+using mstd::memory_order;
+using mstd::kill_dependency;
+using mstd::atomic_thread_fence;
+using mstd::atomic_signal_fence;
+}
+
+#endif /* __atomic */

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/cinttypes
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/cinttypes
@@ -1,0 +1,38 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __cinttypes
+#define __cinttypes
+
+#include <cstdint>
+
+/* Poor but conforming implementation - get everything into global namespace, then add to std */
+#include "stdint.h"
+#include "inttypes.h"
+
+namespace std {
+    using ::imaxdiv_t;
+    using ::abs;
+    using ::div;
+    using ::imaxabs;
+    using ::imaxdiv;
+    using ::strtoimax;
+    using ::strtoumax;
+    using ::wcstoimax;
+    using ::wcstoumax;
+}
+
+#endif /* __cinttypes */

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/initializer_list
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/initializer_list
@@ -1,0 +1,76 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __initializer_list
+#define __initializer_list
+
+#include <cstddef>
+
+namespace std {
+
+// [support.initlist]
+template <class _TypeE>
+struct initializer_list {
+    using value_type = _TypeE;
+    using reference = const _TypeE &;
+    using const_reference = const _TypeE &;
+    using size_type = size_t;
+    using iterator = const _TypeE *;
+    using const_iterator = const _TypeE *;
+
+    // [support.initlist.cons]
+    constexpr initializer_list() noexcept : _C_ptr(nullptr), _C_count(0)
+    {
+    }
+    constexpr initializer_list(const _TypeE *p, size_type n) noexcept : _C_ptr(p), _C_count(n)
+    {
+    }
+    // [support.initlist.access]
+    constexpr const _TypeE *begin() const noexcept
+    {
+        return _C_ptr;
+    }
+    constexpr const _TypeE *end() const noexcept
+    {
+        return _C_ptr + _C_count;
+    }
+    constexpr size_t size() const noexcept
+    {
+        return _C_count;
+    }
+private:
+    const _TypeE *_C_ptr;
+    size_t _C_count;
+};
+
+// [support.initlist.range]
+template <class _TypeE>
+constexpr const _TypeE *begin(initializer_list<_TypeE> il) noexcept
+{
+    return il.begin();
+}
+
+template <class _TypeE>
+constexpr const _TypeE *end(initializer_list<_TypeE> il) noexcept
+{
+    return il.end();
+}
+
+
+} // namespace std
+
+#endif /* __initializer_list */
+

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/mutex
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/mutex
@@ -1,0 +1,45 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __mutex
+#define __mutex
+
+// Just go straight to the main file - we also need IAR implementation, so do it there
+#include <mstd_mutex>
+
+// And then pull it all into our std
+namespace std {
+using mstd::defer_lock;
+using mstd::defer_lock_t;
+using mstd::try_to_lock;
+using mstd::try_to_lock_t;
+using mstd::adopt_lock;
+using mstd::adopt_lock_t;
+
+using mstd::lock_guard;
+using mstd::unique_lock;
+using mstd::scoped_lock;
+using mstd::try_lock;
+using mstd::lock;
+
+using mstd::once_flag;
+using mstd::call_once;
+
+using mstd::mutex;
+using mstd::recursive_mutex;
+}
+
+#endif /* __mutex */

--- a/platform/cxxsupport/TOOLCHAIN_ARMC5/type_traits
+++ b/platform/cxxsupport/TOOLCHAIN_ARMC5/type_traits
@@ -1,0 +1,25 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __type_traits
+#define __type_traits
+
+// Just go straight to the main file - separating out C++11 core is not reasonable
+#include <mstd_type_traits>
+
+// Note that mstd_type_traits defines everything in std for ARM C 5 for us.
+
+#endif /* __type_traits */

--- a/platform/cxxsupport/mstd_algorithm
+++ b/platform/cxxsupport/mstd_algorithm
@@ -1,0 +1,385 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_ALGORITHM_
+#define MSTD_ALGORITHM_
+
+/* <mstd_algorithm>
+ *
+ * - provides <algorithm>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - std::min, std::max for std::initializer_list
+ *   - std::all_of, std::any_of, std::none_of
+ *   - std::find_if_not
+ *   - std::equal (2-range forms)
+ *   - std::copy_n, std::move, std::move_backward
+ *   - mstd::min, mstd::max constexpr replacements
+ */
+
+#include <algorithm>
+
+#ifdef __CC_ARM
+#include <mstd_utility>
+#endif
+
+namespace mstd {
+#ifdef __CC_ARM
+// Really want basic min/max to be constexpr as per C++14
+template <typename T>
+constexpr const T &max(const T &a, const T &b)
+{
+    return a < b ? b : a;
+}
+
+template <typename T, class Compare>
+constexpr const T &max(const T &a, const T &b, Compare comp)
+{
+    return comp(a, b) ? b : a;
+}
+
+template <typename T>
+constexpr const T &min(const T &a, const T &b)
+{
+    return b < a ? b : a;
+}
+
+template <typename T>
+constexpr const T &min(const T &a, const T &b, Compare comp)
+{
+    return comp(b, a) ? b : a;
+}
+
+// Maybe sort out C++14 constexpr for these later - these are C++11 at least
+template <typename T>
+T max(initializer_list<T> il)
+{
+    return *std::max_element(begin(il), end(il));
+}
+
+template <typename T, class Compare>
+T max(initializer_list<T> il, Compare comp)
+{
+    return *std::max_element(begin(il), end(il), comp);
+}
+
+template <typename T>
+T min(initializer_list<T> il)
+{
+    return *std::min_element(begin(il), end(il));
+}
+
+template <typename T, class Compare>
+T min(initializer_list<T> il, Compare comp)
+{
+    return *std::min_element(begin(il), end(il), comp);
+}
+
+template <typename T1, typename T2>
+class pair;
+
+template <typename T>
+constexpr pair<const T &, const T &> minmax(const T &a, const T &b)
+{
+    if (b < a) {
+        return pair<const T &, const T &>(b, a);
+    } else {
+        return pair<const T &, const T &>(a, b);
+    }
+}
+
+template <typename T, class Compare>
+constexpr pair<const T &, const T &> minmax(const T &a, const T &b, Compare comp)
+{
+    if (comp(b, a)) {
+        return pair<const T &, const T &>(b, a);
+    } else {
+        return pair<const T &, const T &>(a, b);
+    }
+}
+#else
+using std::min;
+using std::max;
+using std::minmax;
+#endif
+}
+
+#ifdef __CC_ARM
+
+namespace std {
+// [alg.all_of]
+template <class InputIterator, class Predicate>
+bool all_of(InputIterator first, InputIterator last, Predicate pred)
+{
+    for (; first != last; ++first) {
+        if (!pred(*first)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// [alg.any_of]
+template <class InputIterator, class Predicate>
+bool any_of(InputIterator first, InputIterator last, Predicate pred)
+{
+    for (; first != last; ++first) {
+        if (pred(*first)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// [alg.none_of]
+template <class InputIterator, class Predicate>
+bool none_of(InputIterator first, InputIterator last, Predicate pred)
+{
+    for (; first != last; ++first) {
+        if (pred(*first)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// [alg.find]
+template<class InputIterator, class Predicate>
+InputIterator find_if_not(InputIterator first, InputIterator last, Predicate pred)
+{
+    for (; first != last; ++first) {
+        if (!pred(*first)) {
+            return first;
+        }
+    }
+    return first;
+}
+
+// [alg.equal]
+namespace impl {
+template<class RandomAccessIterator1, class RandomAccessIterator2>
+bool equal(RandomAccessIterator1 first1, RandomAccessIterator1 last1,
+           RandomAccessIterator2 first2, RandomAccessIterator2 last2,
+           random_access_iterator_tag,
+           random_access_iterator_tag)
+{
+    if (last1 - first1 != last2 - first2) {
+        return false;
+    }
+    return equal(first1, last1, first2);
+}
+
+template<class RandomAccessIterator1, class RandomAccessIterator2, class BinaryPredicate>
+bool equal(RandomAccessIterator1 first1, RandomAccessIterator1 last1,
+           RandomAccessIterator2 first2, RandomAccessIterator2 last2,
+           BinaryPredicate pred,
+           random_access_iterator_tag,
+           random_access_iterator_tag)
+{
+    if (last1 - first1 != last2 - first2) {
+        return false;
+    }
+    return equal(first1, last1, first2, pred);
+}
+
+template<class InputIterator1, class InputIterator2>
+bool equal(InputIterator1 first1, InputIterator1 last1,
+           InputIterator2 first2, InputIterator2 last2,
+           input_iterator_tag,
+           input_iterator_tag)
+{
+    for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
+        if (!(*first1 == *first2)) {
+            return false;
+        }
+    }
+    return first1 == last1 && first2 == last2;
+}
+
+template<class InputIterator1, class InputIterator2, class BinaryPredicate>
+bool equal(InputIterator1 first1, InputIterator1 last1,
+           InputIterator2 first2, InputIterator2 last2,
+           BinaryPredicate pred,
+           input_iterator_tag,
+           input_iterator_tag)
+{
+    for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
+        if (!pred(*first1, *first2)) {
+            return false;
+        }
+    }
+    return first1 == last1 && first2 == last2;
+}
+}
+
+template<class InputIterator1, class InputIterator2>
+bool equal(InputIterator1 first1, InputIterator1 last1,
+           InputIterator2 first2, InputIterator2 last2)
+{
+    return impl::equal(first1, last1, first2, last2,
+                       typename iterator_traits<InputIterator1>::iterator_category(),
+                       typename iterator_traits<InputIterator2>::iterator_category());
+}
+
+template<class InputIterator1, class InputIterator2, class BinaryPredicate>
+bool equal(InputIterator1 first1, InputIterator1 last1,
+           InputIterator2 first2, InputIterator2 last2,
+           BinaryPredicate pred)
+{
+    return impl::equal(first1, last1, first2, last2, pred,
+                       typename iterator_traits<InputIterator1>::iterator_category(),
+                       typename iterator_traits<InputIterator2>::iterator_category());
+
+}
+
+// [alg.copy]
+
+namespace impl
+{
+template<class RandomAccessIterator, class Size, class OutputIterator>
+OutputIterator copy_n(RandomAccessIterator first, Size n, OutputIterator result, random_access_iterator_tag)
+{
+    // presumably this should have memcpy etc optimisations
+    return std::copy(first, first + n, result);
+}
+
+template<class InputIterator, class Size, class OutputIterator>
+OutputIterator copy_n(InputIterator first, Size n, OutputIterator result, input_iterator_tag)
+{
+    for (Size i = 0; i < n; ++i) {
+        *result++ = *first++;
+    }
+    return result;
+}
+}
+
+template<class InputIterator, class Size, class OutputIterator>
+OutputIterator copy_n(InputIterator first, Size n, OutputIterator result)
+{
+    return impl::copy_n(first, n, result,
+                        typename iterator_traits<InputIterator>::iterator_category());
+}
+
+template<class InputIterator, class OutputIterator, class Predicate>
+OutputIterator copy_if(InputIterator first, InputIterator last, OutputIterator result, Predicate pred)
+{
+    for (; first != last; ++first) {
+        if (pred(*first)) {
+            *result++ = *first;
+        }
+    }
+    return result;
+}
+
+// [alg.move]
+
+template<class InputIterator, class OutputIterator>
+OutputIterator move(InputIterator first, InputIterator last, OutputIterator result)
+{
+    while (first != last) {
+        *result++ = std::move(*first++);
+    }
+    return result;
+}
+
+template<class BidirectionalIterator1, class BidirectionalIterator2>
+BidirectionalIterator2 move_backward(BidirectionalIterator1 first, BidirectionalIterator1 last, BidirectionalIterator2 result)
+{
+    while (last != first) {
+        *--result = std::move(*--last);
+    }
+    return result;
+}
+
+}
+
+#endif // __CC_ARM
+
+namespace mstd
+{
+using std::initializer_list;
+using std::all_of;
+using std::any_of;
+using std::none_of;
+using std::for_each;
+using std::find;
+using std::find_if;
+using std::find_if_not;
+using std::find_end;
+using std::find_first_of;
+using std::adjacent_find;
+using std::count;
+using std::count_if;
+using std::mismatch;
+using std::equal;
+using std::search;
+using std::search_n;
+using std::copy;
+using std::copy_n;
+using std::copy_if;
+using std::move;
+using std::move_backward;
+using std::swap_ranges;
+using std::iter_swap;
+using std::transform;
+using std::replace;
+using std::replace_if;
+using std::replace_copy;
+using std::replace_copy_if;
+using std::fill;
+using std::fill_n;
+using std::generate;
+using std::generate_n;
+using std::remove;
+using std::remove_if;
+using std::remove_copy;
+using std::remove_copy_if;
+using std::unique;
+using std::unique_copy;
+using std::reverse;
+using std::reverse_copy;
+using std::rotate;
+using std::rotate_copy;
+using std::partition;
+using std::stable_partition;
+using std::sort;
+using std::stable_sort;
+using std::partial_sort;
+using std::partial_sort_copy;
+using std::nth_element;
+using std::lower_bound;
+using std::upper_bound;
+using std::equal_range;
+using std::binary_search;
+using std::merge;
+using std::inplace_merge;
+using std::includes;
+using std::set_union;
+using std::set_intersection;
+using std::set_difference;
+using std::set_symmetric_difference;
+using std::push_heap;
+using std::pop_heap;
+using std::make_heap;
+using std::sort_heap;
+using std::min_element;
+using std::max_element;
+using std::lexicographical_compare;
+using std::next_permutation;
+using std::prev_permutation;
+
+}
+
+#endif // MSTD_ALGORITHM_

--- a/platform/cxxsupport/mstd_atomic
+++ b/platform/cxxsupport/mstd_atomic
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef MBED_ATOMIC_H
-#define MBED_ATOMIC_H
+#ifndef MSTD_ATOMIC_
+#define MSTD_ATOMIC_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -29,7 +29,7 @@
 #include "platform/CriticalSectionLock.h"
 
 /*
- * Atomic template and types are designed to be as close as possible to C++11
+ * mstd::atomic template and types are designed to be as close as possible to C++11
  * std::atomic. Key differences:
  *
  * - Operations are specified as atomic with respect to interrupts as well as
@@ -43,34 +43,34 @@
  */
 
 #ifndef MBED_EXCLUSIVE_ACCESS
-#define MBED_ATOMIC_BOOL_LOCK_FREE      0
-#define MBED_ATOMIC_CHAR_LOCK_FREE      0
-#define MBED_ATOMIC_CHAR16_T_LOCK_FREE  0
-#define MBED_ATOMIC_CHAR32_T_LOCK_FREE  0
-#define MBED_ATOMIC_WCHAR_T_LOCK_FREE   0
-#define MBED_ATOMIC_SHORT_LOCK_FREE     0
-#define MBED_ATOMIC_INT_LOCK_FREE       0
-#define MBED_ATOMIC_LONG_LOCK_FREE      0
-#define MBED_ATOMIC_LLONG_LOCK_FREE     0
-#define MBED_ATOMIC_POINTER_LOCK_FREE   0
+#define MSTD_ATOMIC_BOOL_LOCK_FREE      0
+#define MSTD_ATOMIC_CHAR_LOCK_FREE      0
+#define MSTD_ATOMIC_CHAR16_T_LOCK_FREE  0
+#define MSTD_ATOMIC_CHAR32_T_LOCK_FREE  0
+#define MSTD_ATOMIC_WCHAR_T_LOCK_FREE   0
+#define MSTD_ATOMIC_SHORT_LOCK_FREE     0
+#define MSTD_ATOMIC_INT_LOCK_FREE       0
+#define MSTD_ATOMIC_LONG_LOCK_FREE      0
+#define MSTD_ATOMIC_LLONG_LOCK_FREE     0
+#define MSTD_ATOMIC_POINTER_LOCK_FREE   0
 #else
-#define MBED_ATOMIC_BOOL_LOCK_FREE      2
-#define MBED_ATOMIC_CHAR_LOCK_FREE      2
-#define MBED_ATOMIC_CHAR16_T_LOCK_FREE  2
-#define MBED_ATOMIC_CHAR32_T_LOCK_FREE  2
-#define MBED_ATOMIC_WCHAR_T_LOCK_FREE   2
-#define MBED_ATOMIC_SHORT_LOCK_FREE     2
-#define MBED_ATOMIC_INT_LOCK_FREE       2
-#define MBED_ATOMIC_LONG_LOCK_FREE      2
-#define MBED_ATOMIC_LLONG_LOCK_FREE     0
-#define MBED_ATOMIC_POINTER_LOCK_FREE   2
+#define MSTD_ATOMIC_BOOL_LOCK_FREE      2
+#define MSTD_ATOMIC_CHAR_LOCK_FREE      2
+#define MSTD_ATOMIC_CHAR16_T_LOCK_FREE  2
+#define MSTD_ATOMIC_CHAR32_T_LOCK_FREE  2
+#define MSTD_ATOMIC_WCHAR_T_LOCK_FREE   2
+#define MSTD_ATOMIC_SHORT_LOCK_FREE     2
+#define MSTD_ATOMIC_INT_LOCK_FREE       2
+#define MSTD_ATOMIC_LONG_LOCK_FREE      2
+#define MSTD_ATOMIC_LLONG_LOCK_FREE     0
+#define MSTD_ATOMIC_POINTER_LOCK_FREE   2
 #endif
 
-namespace mbed {
+namespace mstd {
 
 /** Atomic template
  *
- * `mbed::Atomic<T>` is intended to work as per C++14 `std::atomic<T>`. `T` must be a
+ * `mstd::atomic<T>` is intended to work as per C++14 `std::atomic<T>`. `T` must be a
  * _TriviallyCopyable_, _CopyConstructible_ and _CopyAssignable_ type.
  * - All standard methods of `std::atomic` are supplied:
  *   + For any `T`: `load`, `store`, `exchange`, `compare_exchange_weak`,
@@ -85,15 +85,15 @@ namespace mbed {
  *   otherwise critical sections are used.
  * - If used with large objects, interrupt latency may be impacted.
  * - Valid initialisation forms are:
- *   + `Atomic<int> foo;` (zero initialized if static or thread-local, else value indeterminate)
+ *   + `atomic<int> foo;` (zero initialized if static or thread-local, else value indeterminate)
  *   + `atomic_init(&foo, 2);` (initialize a default-initialized variable, once only, not atomic)
- *   + `Atomic<int> foo(2);` (value initialization)
- *   + `Atomic<int> foo = { 2 };` (also legal C11 with _Atomic int)
- *   + `Atomic<int> foo = 2;` (C++17 or later only - also legal C11 with _Atomic int)
+ *   + `atomic<int> foo(2);` (value initialization)
+ *   + `atomic<int> foo = { 2 };` (also legal C11 with _Atomic int)
+ *   + `atomic<int> foo = 2;` (C++17 or later only - also legal C11 with _Atomic int)
  *   Note that the lack of a copy constructor limits the simple-looking assignment initialization
  *   to C++17 or later only.
  * - The value constructor is not available for small custom types.
- * - `MBED_ATOMIC_XXX_LOCK_FREE` replaces `ATOMIC_XXX_LOCK_FREE` - "locking" forms
+ * - `MSTD_ATOMIC_XXX_LOCK_FREE` replaces `ATOMIC_XXX_LOCK_FREE` - "locking" forms
  *   take a critical section, non-locking do not.
  * - For `bool`, integer types and pointers, storage is compatible with the
  *   plain types. If necessary, they can be substituted as plain types for C
@@ -101,7 +101,7 @@ namespace mbed {
  *   @code
  *       struct foo {
  *       #ifdef __cplusplus
- *          mbed::atomic_uint32_t counter; // Use C++ templates from C++ code
+ *          mstd::atomic_uint32_t counter; // Use C++ templates from C++ code
  *       #else
  *          uint32_t counter;  // Could use core_util_atomic_xxx_u32 from C code, or just have this for structure layout.
  *       #endif
@@ -109,9 +109,9 @@ namespace mbed {
  *   @endcode
  */
 template<typename T>
-class Atomic;
+class atomic;
 
-/* Pull C enum from mbed_critical.h into mbed namespace */
+/* Pull C enum from mbed_critical.h into mstd namespace */
 using memory_order = ::mbed_memory_order;
 constexpr memory_order memory_order_relaxed = mbed_memory_order_relaxed;
 constexpr memory_order memory_order_consume = mbed_memory_order_consume;
@@ -127,12 +127,12 @@ namespace impl {
  */
 // *INDENT-OFF*
 template<typename T>
-using atomic_container = std::conditional  <sizeof(T) <= sizeof(uint8_t),  uint8_t,
-                         std::conditional_t<sizeof(T) <= sizeof(uint16_t), uint16_t,
-                         std::conditional_t<sizeof(T) <= sizeof(uint32_t), uint32_t,
-                         std::conditional_t<sizeof(T) <= sizeof(uint64_t), uint64_t,
-                                                                           T
-                                           >>>>;
+using atomic_container = conditional  <sizeof(T) <= sizeof(uint8_t),  uint8_t,
+                         conditional_t<sizeof(T) <= sizeof(uint16_t), uint16_t,
+                         conditional_t<sizeof(T) <= sizeof(uint32_t), uint32_t,
+                         conditional_t<sizeof(T) <= sizeof(uint64_t), uint64_t,
+                                                                      T
+                                      >>>>;
 // *INDENT-ON*
 
 template<typename T>
@@ -142,16 +142,16 @@ template<typename N>
 struct atomic_container_is_lock_free;
 
 template<>
-struct atomic_container_is_lock_free<uint8_t> : mstd::bool_constant<bool(MBED_ATOMIC_CHAR_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint8_t> : bool_constant<bool(MSTD_ATOMIC_CHAR_LOCK_FREE)> { };
 
 template<>
-struct atomic_container_is_lock_free<uint16_t> : mstd::bool_constant<bool(MBED_ATOMIC_SHORT_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint16_t> : bool_constant<bool(MSTD_ATOMIC_SHORT_LOCK_FREE)> { };
 
 template<>
-struct atomic_container_is_lock_free<uint32_t> : mstd::bool_constant<bool(MBED_ATOMIC_INT_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint32_t> : bool_constant<bool(MSTD_ATOMIC_INT_LOCK_FREE)> { };
 
 template<>
-struct atomic_container_is_lock_free<uint64_t> : mstd::bool_constant<bool(MBED_ATOMIC_LLONG_LOCK_FREE)> { };
+struct atomic_container_is_lock_free<uint64_t> : bool_constant<bool(MSTD_ATOMIC_LLONG_LOCK_FREE)> { };
 
 template<typename T>
 using atomic_is_lock_free = atomic_container_is_lock_free<atomic_container_t<T>>;
@@ -571,7 +571,7 @@ protected:
 
 /* Template for an integer or pointer Atomic, including increment and
  * decrement functionality. If StrideT is void, then the increment and
- * decrement operators are ill-formed, as desired for Atomic<void *>.
+ * decrement operators are ill-formed, as desired for atomic<void *>.
  */
 template<typename T, typename DiffT = T, typename StrideT = char, typename A = atomic_container_t<T>>
 struct AtomicWithAdd : public AtomicBaseInt<T, A> {
@@ -703,15 +703,15 @@ struct AtomicWithBitwise : public AtomicWithAdd<T, A> {
  */
 // *INDENT-OFF*
 template<typename T, typename = void>
-struct AtomicSelector : mstd::type_identity<AtomicBaseRaw<T>> { };
+struct AtomicSelector : type_identity<AtomicBaseRaw<T>> { };
 
 template<typename T>
-struct AtomicSelector<T, std::enable_if_t<std::is_same<bool, T>::value>>
-                        : mstd::type_identity<AtomicBaseInt<T>> { };
+struct AtomicSelector<T, enable_if_t<is_same<bool, T>::value>>
+                        : type_identity<AtomicBaseInt<T>> { };
 
 template<typename T>
-struct AtomicSelector<T, std::enable_if_t<std::is_integral<T>::value && !std::is_same<bool, T>::value>>
-                        : mstd::type_identity<AtomicWithBitwise<T>> { };
+struct AtomicSelector<T, enable_if_t<is_integral<T>::value && !is_same<bool, T>::value>>
+                        : type_identity<AtomicWithBitwise<T>> { };
 // *INDENT-ON*
 
 template<typename T>
@@ -720,23 +720,23 @@ using Atomic = typename AtomicSelector<T>::type;
 } // namespace impl
 
 template<typename T>
-void atomic_init(volatile Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept;
+void atomic_init(volatile atomic<T> *obj, typename atomic<T>::value_type desired) noexcept;
 
 template<typename T>
-void atomic_init(Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept;
+void atomic_init(atomic<T> *obj, typename atomic<T>::value_type desired) noexcept;
 
 /* Base template - let impl::Atomic<T> dispatch to raw, base integer or integer-with-bitwise */
 template<typename T>
-struct Atomic : public impl::Atomic<T> {
+struct atomic : public impl::Atomic<T> {
     // Constraints from LWG 3012
-    static_assert(std::is_trivially_copyable<T>::value, "Atomic types must be TriviallyCopyable");
-    static_assert(std::is_copy_constructible<T>::value, "Atomic types must be CopyConstructible");
-    static_assert(std::is_move_constructible<T>::value, "Atomic types must be MoveConstructible");
-    static_assert(std::is_copy_assignable<T>::value, "Atomic types must be CopyAssignable");
-    static_assert(std::is_move_assignable<T>::value, "Atomic types must be MoveAssignable");
-    Atomic() noexcept = default;
-    Atomic(const Atomic &) = delete;
-    constexpr Atomic(T v) noexcept : impl::Atomic<T>(std::move(v))
+    static_assert(is_trivially_copyable<T>::value, "Atomic types must be TriviallyCopyable");
+    static_assert(is_copy_constructible<T>::value, "Atomic types must be CopyConstructible");
+    static_assert(is_move_constructible<T>::value, "Atomic types must be MoveConstructible");
+    static_assert(is_copy_assignable<T>::value, "Atomic types must be CopyAssignable");
+    static_assert(is_move_assignable<T>::value, "Atomic types must be MoveAssignable");
+    atomic() noexcept = default;
+    atomic(const atomic &) = delete;
+    constexpr atomic(T v) noexcept : impl::Atomic<T>(std::move(v))
     {
     }
     operator T() const volatile noexcept
@@ -757,10 +757,10 @@ struct Atomic : public impl::Atomic<T> {
         this->store(desired);
         return desired;
     }
-    Atomic &operator=(const Atomic &) = delete;
+    atomic &operator=(const atomic &) = delete;
 private:
-    friend void atomic_init<>(volatile Atomic *obj, typename Atomic::value_type desired) noexcept;
-    friend void atomic_init<>(Atomic *obj, typename Atomic::value_type desired) noexcept;
+    friend void atomic_init<>(volatile atomic *obj, typename atomic::value_type desired) noexcept;
+    friend void atomic_init<>(atomic *obj, typename atomic::value_type desired) noexcept;
 };
 
 
@@ -770,10 +770,10 @@ private:
  * "aptr.load()->member" to use it to access a structure. *aptr is fine though.
  */
 template<typename T>
-struct Atomic<T *> : public impl::AtomicWithAdd<T *, ptrdiff_t, T> {
-    Atomic() noexcept = default;
-    Atomic(const Atomic &) = delete;
-    constexpr Atomic(T *v) noexcept : impl::AtomicWithAdd<T *, ptrdiff_t, T>(v)
+struct atomic<T *> : public impl::AtomicWithAdd<T *, ptrdiff_t, T> {
+    atomic() noexcept = default;
+    atomic(const atomic &) = delete;
+    constexpr atomic(T *v) noexcept : impl::AtomicWithAdd<T *, ptrdiff_t, T>(v)
     {
     }
     operator T *() const volatile noexcept
@@ -794,190 +794,190 @@ struct Atomic<T *> : public impl::AtomicWithAdd<T *, ptrdiff_t, T> {
         this->store(desired);
         return desired;
     }
-    Atomic &operator=(const Atomic &) = delete;
+    atomic &operator=(const atomic &) = delete;
 private:
-    friend void atomic_init<>(volatile Atomic *obj, typename Atomic::value_type desired) noexcept;
-    friend void atomic_init<>(Atomic *obj, typename Atomic::value_type desired) noexcept;
+    friend void atomic_init<>(volatile atomic *obj, typename atomic::value_type desired) noexcept;
+    friend void atomic_init<>(atomic *obj, typename atomic::value_type desired) noexcept;
 };
 
-using atomic_bool           = Atomic<bool>;
-using atomic_char           = Atomic<char>;
-using atomic_schar          = Atomic<signed char>;
-using atomic_uchar          = Atomic<unsigned char>;
-using atomic_char16_t       = Atomic<char16_t>;
-using atomic_char32_t       = Atomic<char32_t>;
-using atomic_wchar_t        = Atomic<wchar_t>;
-using atomic_short          = Atomic<short>;
-using atomic_ushort         = Atomic<unsigned short>;
-using atomic_int            = Atomic<int>;
-using atomic_uint           = Atomic<unsigned int>;
-using atomic_long           = Atomic<long>;
-using atomic_ulong          = Atomic<unsigned long>;
-using atomic_llong          = Atomic<long long>;
-using atomic_ullong         = Atomic<unsigned long long>;
-using atomic_int8_t         = Atomic<int8_t>;
-using atomic_uint8_t        = Atomic<uint8_t>;
-using atomic_int16_t        = Atomic<int16_t>;
-using atomic_uint16_t       = Atomic<uint16_t>;
-using atomic_int32_t        = Atomic<int32_t>;
-using atomic_uint32_t       = Atomic<uint32_t>;
-using atomic_int64_t        = Atomic<int64_t>;
-using atomic_uint64_t       = Atomic<uint64_t>;
-using atomic_int_least8_t   = Atomic<int_least8_t>;
-using atomic_uint_least8_t  = Atomic<uint_least8_t>;
-using atomic_int_least16_t  = Atomic<int_least16_t>;
-using atomic_uint_least16_t = Atomic<uint_least16_t>;
-using atomic_int_least32_t  = Atomic<int_least32_t>;
-using atomic_uint_least32_t = Atomic<uint_least32_t>;
-using atomic_int_least64_t  = Atomic<int_least64_t>;
-using atomic_uint_least64_t = Atomic<uint_least64_t>;
-using atomic_int_fast8_t    = Atomic<int_fast8_t>;
-using atomic_uint_fast8_t   = Atomic<uint_fast8_t>;
-using atomic_int_fast16_t   = Atomic<int_fast16_t>;
-using atomic_uint_fast16_t  = Atomic<uint_fast16_t>;
-using atomic_int_fast32_t   = Atomic<int_fast32_t>;
-using atomic_uint_fast32_t  = Atomic<uint_fast32_t>;
-using atomic_int_fast64_t   = Atomic<int_fast64_t>;
-using atomic_uint_fast64_t  = Atomic<uint_fast64_t>;
-using atomic_intptr_t       = Atomic<intptr_t>;
-using atomic_uintptr_t      = Atomic<uintptr_t>;
-using atomic_size_t         = Atomic<size_t>;
-using atomic_ptrdiff_t      = Atomic<ptrdiff_t>;
-using atomic_intmax_t       = Atomic<intmax_t>;
-using atomic_uintmax_t      = Atomic<uintmax_t>;
+using atomic_bool           = atomic<bool>;
+using atomic_char           = atomic<char>;
+using atomic_schar          = atomic<signed char>;
+using atomic_uchar          = atomic<unsigned char>;
+using atomic_char16_t       = atomic<char16_t>;
+using atomic_char32_t       = atomic<char32_t>;
+using atomic_wchar_t        = atomic<wchar_t>;
+using atomic_short          = atomic<short>;
+using atomic_ushort         = atomic<unsigned short>;
+using atomic_int            = atomic<int>;
+using atomic_uint           = atomic<unsigned int>;
+using atomic_long           = atomic<long>;
+using atomic_ulong          = atomic<unsigned long>;
+using atomic_llong          = atomic<long long>;
+using atomic_ullong         = atomic<unsigned long long>;
+using atomic_int8_t         = atomic<int8_t>;
+using atomic_uint8_t        = atomic<uint8_t>;
+using atomic_int16_t        = atomic<int16_t>;
+using atomic_uint16_t       = atomic<uint16_t>;
+using atomic_int32_t        = atomic<int32_t>;
+using atomic_uint32_t       = atomic<uint32_t>;
+using atomic_int64_t        = atomic<int64_t>;
+using atomic_uint64_t       = atomic<uint64_t>;
+using atomic_int_least8_t   = atomic<int_least8_t>;
+using atomic_uint_least8_t  = atomic<uint_least8_t>;
+using atomic_int_least16_t  = atomic<int_least16_t>;
+using atomic_uint_least16_t = atomic<uint_least16_t>;
+using atomic_int_least32_t  = atomic<int_least32_t>;
+using atomic_uint_least32_t = atomic<uint_least32_t>;
+using atomic_int_least64_t  = atomic<int_least64_t>;
+using atomic_uint_least64_t = atomic<uint_least64_t>;
+using atomic_int_fast8_t    = atomic<int_fast8_t>;
+using atomic_uint_fast8_t   = atomic<uint_fast8_t>;
+using atomic_int_fast16_t   = atomic<int_fast16_t>;
+using atomic_uint_fast16_t  = atomic<uint_fast16_t>;
+using atomic_int_fast32_t   = atomic<int_fast32_t>;
+using atomic_uint_fast32_t  = atomic<uint_fast32_t>;
+using atomic_int_fast64_t   = atomic<int_fast64_t>;
+using atomic_uint_fast64_t  = atomic<uint_fast64_t>;
+using atomic_intptr_t       = atomic<intptr_t>;
+using atomic_uintptr_t      = atomic<uintptr_t>;
+using atomic_size_t         = atomic<size_t>;
+using atomic_ptrdiff_t      = atomic<ptrdiff_t>;
+using atomic_intmax_t       = atomic<intmax_t>;
+using atomic_uintmax_t      = atomic<uintmax_t>;
 
 template<typename T>
-void atomic_init(Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept
+void atomic_init(atomic<T> *obj, typename atomic<T>::value_type desired) noexcept
 {
     obj->init(desired);
 }
 
 template<typename T>
-void atomic_init(volatile Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept
+void atomic_init(volatile atomic<T> *obj, typename atomic<T>::value_type desired) noexcept
 {
     obj->init(desired);
 }
 
 template<typename T>
-bool atomic_is_lock_free(const Atomic<T> *obj) noexcept
+bool atomic_is_lock_free(const atomic<T> *obj) noexcept
 {
     return obj->is_lock_free();
 }
 
 template<typename T>
-bool atomic_is_lock_free(const volatile Atomic<T> *obj) noexcept
+bool atomic_is_lock_free(const volatile atomic<T> *obj) noexcept
 {
     return obj->is_lock_free();
 }
 
 template<typename T>
-void atomic_store(Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept
+void atomic_store(atomic<T> *obj, typename atomic<T>::value_type desired) noexcept
 {
     obj->store(desired);
 }
 
 template<typename T>
-void atomic_store(volatile Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept
+void atomic_store(volatile atomic<T> *obj, typename atomic<T>::value_type desired) noexcept
 {
     obj->store(desired);
 }
 
 template<typename T>
-void atomic_store_explicit(Atomic<T> *obj, typename Atomic<T>::value_type desired, memory_order order) noexcept
+void atomic_store_explicit(atomic<T> *obj, typename atomic<T>::value_type desired, memory_order order) noexcept
 {
     obj->store(desired, order);
 }
 
 template<typename T>
-void atomic_store_explicit(volatile Atomic<T> *obj, typename Atomic<T>::value_type desired, memory_order order) noexcept
+void atomic_store_explicit(volatile atomic<T> *obj, typename atomic<T>::value_type desired, memory_order order) noexcept
 {
     obj->store(desired, order);
 }
 
 template<typename T>
-T atomic_load(const Atomic<T> *obj) noexcept
+T atomic_load(const atomic<T> *obj) noexcept
 {
     return obj->load();
 }
 
 template<typename T>
-T atomic_load(const volatile Atomic<T> *obj) noexcept
+T atomic_load(const volatile atomic<T> *obj) noexcept
 {
     return obj->load();
 }
 
 template<typename T>
-T atomic_load_explicit(const Atomic<T> *obj, memory_order order) noexcept
+T atomic_load_explicit(const atomic<T> *obj, memory_order order) noexcept
 {
     return obj->load(order);
 }
 
 template<typename T>
-T atomic_load_explicit(const volatile Atomic<T> *obj, memory_order order) noexcept
+T atomic_load_explicit(const volatile atomic<T> *obj, memory_order order) noexcept
 {
     return obj->load(order);
 }
 
 template<typename T>
-T atomic_exchange(Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept
+T atomic_exchange(atomic<T> *obj, typename atomic<T>::value_type desired) noexcept
 {
     return obj->exchange(desired);
 }
 
 template<typename T>
-T atomic_exchange(volatile Atomic<T> *obj, typename Atomic<T>::value_type desired) noexcept
+T atomic_exchange(volatile atomic<T> *obj, typename atomic<T>::value_type desired) noexcept
 {
     return obj->exchange(desired);
 }
 
 template<typename T>
-T atomic_exchange_explicit(Atomic<T> *obj, typename Atomic<T>::value_type desired, memory_order order) noexcept
+T atomic_exchange_explicit(atomic<T> *obj, typename atomic<T>::value_type desired, memory_order order) noexcept
 {
     return obj->exchange(desired, order);
 }
 
 template<typename T>
-T atomic_exchange_explicit(volatile Atomic<T> *obj, typename Atomic<T>::value_type desired, memory_order order) noexcept
+T atomic_exchange_explicit(volatile atomic<T> *obj, typename atomic<T>::value_type desired, memory_order order) noexcept
 {
     return obj->exchange(desired, order);
 }
 
 template<typename T>
-bool atomic_compare_exchange_weak(Atomic<T> *obj,
-                                  typename Atomic<T>::value_type *currentExpected,
-                                  typename Atomic<T>::value_type desired) noexcept
+bool atomic_compare_exchange_weak(atomic<T> *obj,
+                                  typename atomic<T>::value_type *currentExpected,
+                                  typename atomic<T>::value_type desired) noexcept
 {
     return obj->compare_exchange_weak(obj, *currentExpected, desired);
 }
 
 template<typename T>
-bool atomic_compare_exchange_weak(volatile Atomic<T> *obj,
-                                  typename Atomic<T>::value_type *currentExpected,
-                                  typename Atomic<T>::value_type desired) noexcept
+bool atomic_compare_exchange_weak(volatile atomic<T> *obj,
+                                  typename atomic<T>::value_type *currentExpected,
+                                  typename atomic<T>::value_type desired) noexcept
 {
     return obj->compare_exchange_weak(obj, *currentExpected, desired);
 }
 
 template<typename T>
-bool atomic_compare_exchange_strong(Atomic<T> *obj,
-                                    typename Atomic<T>::value_type *currentExpected,
-                                    typename Atomic<T>::value_type desired) noexcept
+bool atomic_compare_exchange_strong(atomic<T> *obj,
+                                    typename atomic<T>::value_type *currentExpected,
+                                    typename atomic<T>::value_type desired) noexcept
 {
     return obj->compare_exchange_strong(obj, *currentExpected, desired);
 }
 
 template<typename T>
-bool atomic_compare_exchange_strong(volatile Atomic<T> *obj,
-                                    typename Atomic<T>::value_type *currentExpected,
-                                    typename Atomic<T>::value_type desired) noexcept
+bool atomic_compare_exchange_strong(volatile atomic<T> *obj,
+                                    typename atomic<T>::value_type *currentExpected,
+                                    typename atomic<T>::value_type desired) noexcept
 {
     return obj->compare_exchange_strong(obj, *currentExpected, desired);
 }
 
 template<typename T>
-bool atomic_compare_exchange_weak_explicit(Atomic<T> *obj,
-                                           typename Atomic<T>::value_type *currentExpected,
-                                           typename Atomic<T>::value_type desired,
+bool atomic_compare_exchange_weak_explicit(atomic<T> *obj,
+                                           typename atomic<T>::value_type *currentExpected,
+                                           typename atomic<T>::value_type desired,
                                            memory_order success,
                                            memory_order failure) noexcept
 {
@@ -985,9 +985,9 @@ bool atomic_compare_exchange_weak_explicit(Atomic<T> *obj,
 }
 
 template<typename T>
-bool atomic_compare_exchange_weak_explicit(volatile Atomic<T> *obj,
-                                           typename Atomic<T>::value_type *currentExpected,
-                                           typename Atomic<T>::value_type desired,
+bool atomic_compare_exchange_weak_explicit(volatile atomic<T> *obj,
+                                           typename atomic<T>::value_type *currentExpected,
+                                           typename atomic<T>::value_type desired,
                                            memory_order success,
                                            memory_order failure) noexcept
 {
@@ -995,9 +995,9 @@ bool atomic_compare_exchange_weak_explicit(volatile Atomic<T> *obj,
 }
 
 template<typename T>
-bool atomic_compare_exchange_strong_explicit(Atomic<T> *obj,
-                                             typename Atomic<T>::value_type *currentExpected,
-                                             typename Atomic<T>::value_type desired,
+bool atomic_compare_exchange_strong_explicit(atomic<T> *obj,
+                                             typename atomic<T>::value_type *currentExpected,
+                                             typename atomic<T>::value_type desired,
                                              memory_order success,
                                              memory_order failure) noexcept
 {
@@ -1005,9 +1005,9 @@ bool atomic_compare_exchange_strong_explicit(Atomic<T> *obj,
 }
 
 template<typename T>
-bool atomic_compare_exchange_strong_explicit(volatile Atomic<T> *obj,
-                                             typename Atomic<T>::value_type *currentExpected,
-                                             typename Atomic<T>::value_type desired,
+bool atomic_compare_exchange_strong_explicit(volatile atomic<T> *obj,
+                                             typename atomic<T>::value_type *currentExpected,
+                                             typename atomic<T>::value_type desired,
                                              memory_order success,
                                              memory_order failure) noexcept
 {
@@ -1015,121 +1015,121 @@ bool atomic_compare_exchange_strong_explicit(volatile Atomic<T> *obj,
 }
 
 template<typename T>
-T atomic_fetch_add(Atomic<T> *obj, typename Atomic<T>::difference_type arg) noexcept
+T atomic_fetch_add(atomic<T> *obj, typename atomic<T>::difference_type arg) noexcept
 {
     return obj->fetch_add(arg);
 }
 
 template<typename T>
-T atomic_fetch_add(volatile Atomic<T> *obj, typename Atomic<T>::difference_type arg) noexcept
+T atomic_fetch_add(volatile atomic<T> *obj, typename atomic<T>::difference_type arg) noexcept
 {
     return obj->fetch_add(arg);
 }
 
 template<typename T>
-T atomic_fetch_add_explicit(Atomic<T> *obj, typename Atomic<T>::difference_type arg, memory_order order) noexcept
+T atomic_fetch_add_explicit(atomic<T> *obj, typename atomic<T>::difference_type arg, memory_order order) noexcept
 {
     return obj->fetch_add(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_add_explicit(volatile Atomic<T> *obj, typename Atomic<T>::difference_type arg, memory_order order) noexcept
+T atomic_fetch_add_explicit(volatile atomic<T> *obj, typename atomic<T>::difference_type arg, memory_order order) noexcept
 {
     return obj->fetch_add(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_sub(Atomic<T> *obj, typename Atomic<T>::difference_type arg) noexcept
+T atomic_fetch_sub(atomic<T> *obj, typename atomic<T>::difference_type arg) noexcept
 {
     return obj->fetch_sub(arg);
 }
 
 template<typename T>
-T atomic_fetch_sub(volatile Atomic<T> *obj, typename Atomic<T>::difference_type arg) noexcept
+T atomic_fetch_sub(volatile atomic<T> *obj, typename atomic<T>::difference_type arg) noexcept
 {
     return obj->fetch_sub(arg);
 }
 
 template<typename T>
-T atomic_fetch_sub_explicit(Atomic<T> *obj, typename Atomic<T>::difference_type arg, memory_order order) noexcept
+T atomic_fetch_sub_explicit(atomic<T> *obj, typename atomic<T>::difference_type arg, memory_order order) noexcept
 {
     return obj->fetch_sub(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_sub_explicit(volatile Atomic<T> *obj, typename Atomic<T>::difference_type arg, memory_order order) noexcept
+T atomic_fetch_sub_explicit(volatile atomic<T> *obj, typename atomic<T>::difference_type arg, memory_order order) noexcept
 {
     return obj->fetch_sub(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_and(Atomic<T> *obj, typename Atomic<T>::value_type arg) noexcept
+T atomic_fetch_and(atomic<T> *obj, typename atomic<T>::value_type arg) noexcept
 {
     return obj->fetch_and(arg);
 }
 
 template<typename T>
-T atomic_fetch_and(volatile Atomic<T> *obj, typename Atomic<T>::value_type arg) noexcept
+T atomic_fetch_and(volatile atomic<T> *obj, typename atomic<T>::value_type arg) noexcept
 {
     return obj->fetch_and(arg);
 }
 
 template<typename T>
-T atomic_fetch_and_explicit(Atomic<T> *obj, typename Atomic<T>::value_type arg, memory_order order) noexcept
+T atomic_fetch_and_explicit(atomic<T> *obj, typename atomic<T>::value_type arg, memory_order order) noexcept
 {
     return obj->fetch_and(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_and_explicit(volatile Atomic<T> *obj, typename Atomic<T>::value_type arg, memory_order order) noexcept
+T atomic_fetch_and_explicit(volatile atomic<T> *obj, typename atomic<T>::value_type arg, memory_order order) noexcept
 {
     return obj->fetch_and(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_or(Atomic<T> *obj, typename Atomic<T>::value_type arg) noexcept
+T atomic_fetch_or(atomic<T> *obj, typename atomic<T>::value_type arg) noexcept
 {
     return obj->fetch_or(arg);
 }
 
 template<typename T>
-T atomic_fetch_or(volatile Atomic<T> *obj, typename Atomic<T>::value_type arg) noexcept
+T atomic_fetch_or(volatile atomic<T> *obj, typename atomic<T>::value_type arg) noexcept
 {
     return obj->fetch_or(arg);
 }
 
 template<typename T>
-T atomic_fetch_or_explicit(Atomic<T> *obj, typename Atomic<T>::value_type arg, memory_order order) noexcept
+T atomic_fetch_or_explicit(atomic<T> *obj, typename atomic<T>::value_type arg, memory_order order) noexcept
 {
     return obj->fetch_or(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_or_explicit(volatile Atomic<T> *obj, typename Atomic<T>::value_type arg, memory_order order) noexcept
+T atomic_fetch_or_explicit(volatile atomic<T> *obj, typename atomic<T>::value_type arg, memory_order order) noexcept
 {
     return obj->fetch_or(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_xor(Atomic<T> *obj, typename Atomic<T>::value_type arg) noexcept
+T atomic_fetch_xor(atomic<T> *obj, typename atomic<T>::value_type arg) noexcept
 {
     return obj->fetch_xor(arg);
 }
 
 template<typename T>
-T atomic_fetch_xor(volatile Atomic<T> *obj, typename Atomic<T>::value_type arg) noexcept
+T atomic_fetch_xor(volatile atomic<T> *obj, typename atomic<T>::value_type arg) noexcept
 {
     return obj->fetch_xor(arg);
 }
 
 template<typename T>
-T atomic_fetch_xor_explicit(Atomic<T> *obj, typename Atomic<T>::value_type arg, memory_order order) noexcept
+T atomic_fetch_xor_explicit(atomic<T> *obj, typename atomic<T>::value_type arg, memory_order order) noexcept
 {
     return obj->fetch_xor(arg, order);
 }
 
 template<typename T>
-T atomic_fetch_xor_explicit(volatile Atomic<T> *obj, typename Atomic<T>::value_type arg, memory_order order) noexcept
+T atomic_fetch_xor_explicit(volatile atomic<T> *obj, typename atomic<T>::value_type arg, memory_order order) noexcept
 {
     return obj->fetch_xor(arg, order);
 }
@@ -1207,7 +1207,7 @@ MBED_FORCEINLINE void atomic_flag_clear_explicit(atomic_flag *flag, memory_order
     flag->clear(order);
 }
 
-#define MBED_ATOMIC_FLAG_INIT { CORE_UTIL_ATOMIC_FLAG_INIT }
+#define MSTD_ATOMIC_FLAG_INIT { CORE_UTIL_ATOMIC_FLAG_INIT }
 
 template<typename T>
 T kill_dependency(T y) noexcept
@@ -1232,6 +1232,6 @@ MBED_FORCEINLINE void atomic_thread_fence(memory_order order) noexcept
 
 /**@}*/
 
-} // namespace mbed
+} // namespace mstd
 
 #endif

--- a/platform/cxxsupport/mstd_cstddef
+++ b/platform/cxxsupport/mstd_cstddef
@@ -1,0 +1,75 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_CSTDDEF_
+#define MSTD_CSTDDEF_
+
+/* <mstd_cstddef>
+ *
+ * - provides <cstddef>
+ * - For ARM C 5, standard C++11/14 features:
+ * - - adds macro replacements for alignof and alignas keywords
+ * - - adds missing std::nullptr_t
+ * - For all toolchains:
+ * - - MSTD_CONSTEXPR_XX_14 macros that can be used to mark
+ *     things that are valid as constexpr only for C++14 or later,
+ *     permitting constexpr use where ARM C 5 would reject it.
+ */
+
+#include <cstddef>
+
+/* Macros that can be used to mark functions and objects that are
+ * constexpr in C++14 or later, but not in earlier versions.
+ */
+#if __cplusplus >= 201402
+#define MSTD_CONSTEXPR_FN_14 constexpr
+#define MSTD_CONSTEXPR_OBJ_14 constexpr
+#else
+#define MSTD_CONSTEXPR_FN_14 inline
+#define MSTD_CONSTEXPR_OBJ_14 const
+#endif
+
+#ifdef __CC_ARM
+
+// [expr.alignof]
+#define alignof(T) __alignof__(T)
+
+// [dcl.align]
+// Types not supported - workaround is to use alignas(alignof(T)), which is legal anyway
+#ifndef __alignas_is_defined
+#define __alignas_is_defined
+#define alignas(N) __attribute__((aligned(N)))
+#endif
+
+namespace std
+{
+// [cstddef.syn]
+using nullptr_t = decltype(nullptr);
+
+} // namespace std
+
+#endif // __CC_ARM
+
+namespace mstd
+{
+using std::size_t;
+using std::ptrdiff_t;
+using std::nullptr_t;
+using std::max_align_t;
+
+}
+
+#endif // MSTD_CSTDDEF_

--- a/platform/cxxsupport/mstd_functional
+++ b/platform/cxxsupport/mstd_functional
@@ -1,0 +1,508 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under tUNChe License.
+ */
+#ifndef MSTD_FUNCTIONAL_
+#define MSTD_FUNCTIONAL_
+
+/* <mstd_functional>
+ *
+ * - includes toolchain's <functional>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - std::mem_fn,
+ *   - std::reference_wrapper, std::ref, std::cref
+ *   - transparent std::plus<> etc
+ *   - std::bit_and, std::bit_or, std::bit_xor, std::bit_not
+ * - For all toolchains, C++17/20 backports:
+ *   - mstd::not_fn (C++17)
+ *   - mstd::invoke (C++17)
+ *   - mstd::unwrap_reference, mstd::unwrap_ref_decay (C++20)
+ */
+
+#include <functional>
+
+#include <mstd_memory> // addressof
+#include <mstd_utility> // forward
+#include <mstd_type_traits>
+
+#ifdef __CC_ARM
+
+namespace std
+{
+// [func.memfn]
+namespace impl {
+template <typename R, typename T>
+class mem_fn_t {
+    R T::* pm;
+public:
+    mem_fn_t(R T::* pm) : pm(pm) { }
+    template <typename... Args>
+    invoke_result_t<R T::*, Args...> operator()(Args&&... args) const
+    {
+        return std::invoke(pm, std::forward<Args>(args)...);
+    }
+};
+}
+
+template <class R, class T>
+impl::mem_fn_t<R, T> mem_fn(R T::* pm)
+{
+    return impl::mem_fn_t<R, T>(pm);
+}
+
+} // namespace std
+
+#endif // __CC_ARM
+
+namespace mstd {
+
+// [func.invoke]
+#if __cpp_lib_invoke >= 201411
+using std::invoke;
+#else
+template <typename F, typename... Args>
+invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
+{
+    return impl::INVOKE(std::forward<F>(f), std::forward<Args>(args)...);
+}
+#endif // __cpp_lib_invoke
+
+} // namespace mstd
+
+#ifdef __CC_ARM
+namespace std {
+
+    using mstd::invoke;
+
+// [refwrap]
+template <typename T>
+class reference_wrapper {
+    T &FUN(T &x) noexcept { return x; }
+    void FUN(T &&x) = delete;
+    T *ptr;
+public:
+    using type = T;
+    // [refwrap.const]
+#if 0
+    // decltype doesn't seem to work well enough for this revised version
+    template <typename U,
+                typename = enable_if_t<!is_same<reference_wrapper, decay_t<U>>::value &&
+                                       !is_void<decltype(FUN(declval<U>()))>::value>>
+    reference_wrapper(U&& x) //noexcept(noexcept(FUN(declval<U>())))
+        : ptr(addressof(FUN(forward<U>(x)))) { }
+#else
+    reference_wrapper(T &x) noexcept : ptr(addressof(x)) { }
+    reference_wrapper(T &&x) = delete;
+#endif
+
+    reference_wrapper(const reference_wrapper &) noexcept = default;
+    // [refwrap.assign]
+    reference_wrapper &operator=(const reference_wrapper &) noexcept = default;
+
+    // [refwrap.access]
+    operator T &() const noexcept { return *ptr; }
+    T &get() const noexcept { return *ptr; }
+
+    // [refwrap.invoke]
+    template <typename... ArgTypes>
+    invoke_result_t<T &, ArgTypes...> operator()(ArgTypes&&... args) const
+    {
+        return std::invoke(get(), forward<ArgTypes>(args)...);
+    }
+};
+
+// [refwrap.helpers]
+template <typename T>
+reference_wrapper<T> ref(T &t) noexcept
+{
+    return reference_wrapper<T>(t);
+}
+
+template <typename T>
+reference_wrapper<T> ref(reference_wrapper<T> &t) noexcept
+{
+    return ref(t.get());
+}
+
+template <typename T>
+void ref(const T &&) = delete;
+
+template <typename T>
+reference_wrapper<const T> cref(const T &t) noexcept
+{
+    return reference_wrapper<const T>(t);
+}
+
+template <typename T>
+reference_wrapper<const T> cref(reference_wrapper<T> &t) noexcept
+{
+    return cref(t.get());
+}
+
+template <typename T>
+void cref(const T &&) = delete;
+
+// ARMC5 has basic plus<T> etc - we can add plus<void> specialisations;
+// and the language rules allow us to add the default void arguments missing
+// from its header.
+
+template <typename T = void> struct plus;
+template <typename T = void> struct minus;
+template <typename T = void> struct multiplies;
+template <typename T = void> struct divides;
+template <typename T = void> struct modulus;
+template <typename T = void> struct negate;
+template <typename T = void> struct equal_to;
+template <typename T = void> struct not_equal_to;
+template <typename T = void> struct greater;
+template <typename T = void> struct less;
+template <typename T = void> struct greater_equal;
+template <typename T = void> struct less_equal;
+template <typename T = void> struct logical_and;
+template <typename T = void> struct logical_or;
+template <typename T = void> struct logical_not;
+
+// [arithmetic.operations.plus]
+template <>
+struct plus<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) + std::forward<U>(u))
+    {
+        return std::forward<T>(t) + std::forward<U>(u);
+    }
+};
+
+// [arithmetic.operations.minus]
+template <>
+struct minus<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) - std::forward<U>(u))
+    {
+        return std::forward<T>(t) - std::forward<U>(u);
+    }
+};
+
+// [arithmetic.operations.multiplies]
+template <>
+struct multiplies<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) * std::forward<U>(u))
+    {
+        return std::forward<T>(t) * std::forward<U>(u);
+    }
+};
+
+// [arithmetic.operations.divides]
+template <>
+struct divides<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) / std::forward<U>(u))
+    {
+        return std::forward<T>(t) / std::forward<U>(u);
+    }
+};
+
+// [arithmetic.operations.modulus]
+template <>
+struct modulus<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) % std::forward<U>(u))
+    {
+        return std::forward<T>(t) % std::forward<U>(u);
+    }
+};
+
+// [arithmetic.operations.negate]
+template <>
+struct negate<void> {
+    using is_transparent = true_type;
+    template <typename T>
+    constexpr auto operator()(T&& t) const -> decltype(-std::forward<T>(t))
+    {
+        return -std::forward<T>(t);
+    }
+};
+
+// [comparisons.equal_to]
+template <>
+struct equal_to<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) == std::forward<U>(u))
+    {
+        return std::forward<T>(t) == std::forward<U>(u);
+    }
+};
+
+// [comparisons.not_equal_to]
+template <>
+struct not_equal_to<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) != std::forward<U>(u))
+    {
+        return std::forward<T>(t) != std::forward<U>(u);
+    }
+};
+
+// [comparisons.greater]
+template <>
+struct greater<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) > std::forward<U>(u))
+    {
+        return std::forward<T>(t) > std::forward<U>(u);
+    }
+};
+
+// [comparisons.less]
+template <>
+struct less<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) < std::forward<U>(u))
+    {
+        return std::forward<T>(t) < std::forward<U>(u);
+    }
+};
+
+// [comparisons.greater_equal]
+template <>
+struct greater_equal<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) >= std::forward<U>(u))
+    {
+        return std::forward<T>(t) >= std::forward<U>(u);
+    }
+};
+
+// [comparisons.less_equal]
+template <>
+struct less_equal<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) <= std::forward<U>(u))
+    {
+        return std::forward<T>(t) <= std::forward<U>(u);
+    }
+};
+
+// [logical.operations.and]
+template <>
+struct logical_and<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) && std::forward<U>(u))
+    {
+        return std::forward<T>(t) && std::forward<U>(u);
+    }
+};
+
+// [logical.operations.or]
+template <>
+struct logical_or<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) || std::forward<U>(u))
+    {
+        return std::forward<T>(t) || std::forward<U>(u);
+    }
+};
+
+// [logical.operations.not]
+template <>
+struct logical_not<void> {
+    using is_transparent = true_type;
+    template <typename T>
+    constexpr auto operator()(T&& t) const -> decltype(!std::forward<T>(t))
+    {
+        return !std::forward<T>(t);
+    }
+};
+
+// [bitwise.operations.and]
+template <typename T = void>
+struct bit_and {
+    constexpr T operator()(const T &x, const T &y) const
+    {
+        return x & y;
+    }
+};
+
+template <>
+struct bit_and<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t,U&& u) const -> decltype(std::forward<T>(t) & std::forward<U>(u))
+    {
+        return std::forward<T>(t) & std::forward<U>(u);
+    }
+};
+
+// [bitwise.operations.or]
+template <typename T = void>
+struct bit_or {
+    constexpr T operator()(const T &x, const T &y) const
+    {
+        return x & y;
+    }
+};
+
+template <>
+struct bit_or<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t,U&& u) const -> decltype(std::forward<T>(t) | std::forward<U>(u))
+    {
+        return std::forward<T>(t) | std::forward<U>(u);
+    }
+};
+
+// [bitwise.operations.xor]
+template <typename T = void>
+struct bit_xor {
+    constexpr T operator()(const T &x, const T &y) const
+    {
+        return x ^ y;
+    }
+};
+
+template <>
+struct bit_xor<void> {
+    using is_transparent = true_type;
+    template <typename T, typename U>
+    constexpr auto operator()(T&& t,U&& u) const -> decltype(std::forward<T>(t) ^ std::forward<U>(u))
+    {
+        return std::forward<T>(t) ^ std::forward<U>(u);
+    }
+};
+
+// [bitwise.operations.not]
+template <typename T = void>
+struct bit_not {
+    constexpr T operator()(const T &arg) const
+    {
+        return ~arg;
+    }
+};
+
+template <>
+struct bit_not<void> {
+    using is_transparent = true_type;
+    template <typename T>
+    constexpr auto operator()(T&& arg) const -> decltype(~std::forward<T>(arg))
+    {
+        return ~std::forward<T>(arg);
+    }
+};
+
+} // namespace std
+
+#endif // __CC_ARM
+
+namespace mstd {
+using std::reference_wrapper;
+using std::ref;
+using std::cref;
+using std::plus;
+using std::minus;
+using std::multiplies;
+using std::divides;
+using std::modulus;
+using std::negate;
+using std::equal_to;
+using std::not_equal_to;
+using std::greater;
+using std::less;
+using std::greater_equal;
+using std::less_equal;
+using std::logical_and;
+using std::logical_or;
+using std::logical_not;
+using std::bit_and;
+using std::bit_or;
+using std::bit_xor;
+using std::bit_not;
+
+#if __cpp_lib_not_fn >= 201603
+using std::not_fn;
+#else
+namespace impl {
+// [func.not_fn]
+template <typename F>
+class not_fn_t {
+    std::decay_t<F> fn;
+public:
+    explicit not_fn_t(F&& f) : fn(std::forward<F>(f)) { }
+    not_fn_t(const not_fn_t &other) = default;
+    not_fn_t(not_fn_t &&other) = default;
+
+    template<typename... Args>
+    auto operator()(Args&&... args) & -> decltype(!std::declval<invoke_result_t<std::decay_t<F> &, Args...>>())
+    {
+        return !mstd::invoke(fn, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) const & -> decltype(!std::declval<invoke_result_t<std::decay_t<F> const &, Args...>>())
+    {
+        return !mstd::invoke(fn, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) && -> decltype(!std::declval<invoke_result_t<std::decay_t<F>, Args...>>())
+    {
+        return !mstd::invoke(std::move(fn), std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    auto operator()(Args&&... args) const && -> decltype(!std::declval<invoke_result_t<std::decay_t<F> const, Args...>>())
+    {
+        return !mstd::invoke(std::move(fn), std::forward<Args>(args)...);
+    }
+};
+}
+
+template <typename F>
+impl::not_fn_t<F> not_fn_t(F&& f)
+{
+    return impl::not_fn_t<F>(std::forward<F>(f));
+}
+#endif
+
+/* C++20 unwrap_reference */
+template <typename T>
+struct unwrap_reference : type_identity<T> { };
+template <typename T>
+struct unwrap_reference<std::reference_wrapper<T>> : type_identity<T &> { };
+template <typename T>
+using unwrap_reference_t = typename unwrap_reference<T>::type;
+
+/* C++20 unwrap_ref_decay */
+template <typename T>
+struct unwrap_ref_decay : unwrap_reference<std::decay_t<T>> { };
+template <typename T>
+using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+
+}
+
+#endif // MSTD_FUNCTIONAL_

--- a/platform/cxxsupport/mstd_iterator
+++ b/platform/cxxsupport/mstd_iterator
@@ -1,0 +1,460 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_ITERATOR_
+#define MSTD_ITERATOR_
+
+/* <mstd_iterator>
+ *
+ * - includes toolchain's <iterator>
+ * - For ARM C 5, C++11/14 features:
+ *   - std::begin, std::end, etc
+ *   - std::make_reverse_iterator
+ *   - std::move_iterator, std::make_move_iterator
+ * - For all toolchains, C++17/20 backports:
+ *   - mbed::size
+ *   - mbed::ssize
+ *   - mbed::empty
+ *   - mbed::data
+ */
+
+#include <iterator>
+#include <mstd_type_traits>
+
+#ifdef __CC_ARM
+
+#include <mstd_cstddef> // size_t
+
+namespace std {
+
+template <typename E>
+struct initializer_list;
+
+// [iterator.operations]
+template <typename ForwardIterator>
+ForwardIterator next(ForwardIterator x, typename iterator_traits<ForwardIterator>::difference_type n = 1)
+{
+    advance(x, n);
+    return x;
+}
+
+template <typename BidirectionalIterator>
+BidirectionalIterator prev(BidirectionalIterator x, typename iterator_traits<BidirectionalIterator>::difference_type n = 1)
+{
+    advance(x, -n);
+    return x;
+}
+
+// [reverse.iter.make]
+template <typename Iterator>
+reverse_iterator<Iterator> make_reverse_iterator(Iterator i)
+{
+    return reverse_iterator<Iterator>(i);
+}
+
+// [move.iterators]
+template <typename Iterator>
+class move_iterator {
+    Iterator current;
+    using R = typename iterator_traits<Iterator>::reference;
+public:
+    using iterator_type = Iterator;
+    using iterator_category = typename iterator_traits<Iterator>::iterator_category;
+    using value_type = typename iterator_traits<Iterator>::value_type;
+    using difference_type = typename iterator_traits<Iterator>::difference_type;
+    using pointer = Iterator;
+    using reference = conditional_t<is_reference<R>::value,
+                                    remove_reference_t<R> &&,
+                                    R>;
+
+    // [move.iter.op.const]
+    constexpr move_iterator() : current() { }
+    constexpr explicit move_iterator(Iterator i) : current(i) { }
+
+    template <typename U>
+    constexpr move_iterator(const move_iterator<U> &u) : current(u.base()) { }
+
+    // [move.iter.op=]
+    template <typename U>
+    move_iterator &operator=(const move_iterator<U> &u)
+    {
+        current = u.base();
+        return *this;
+    }
+
+    // [move.iter.op.conv]
+    constexpr Iterator base() const
+    {
+        return current;
+    }
+
+    // [move.iter.op.star]
+    constexpr reference operator*() const
+    {
+        return static_cast<reference>(*current);
+    }
+
+    // [move.iter.op.ref]
+    constexpr pointer operator->() const
+    {
+        return current;
+    }
+
+    // [move.iter.op.incr]
+    move_iterator &operator++()
+    {
+        ++current;
+        return *this;
+    }
+
+    move_iterator operator++(int)
+    {
+        move_iterator tmp = *this;
+        ++current;
+        return tmp;
+    }
+
+    // [move.iter.op.decr]
+    move_iterator &operator--()
+    {
+        --current;
+        return *this;
+    }
+
+    move_iterator operator--(int)
+    {
+        move_iterator tmp = *this;
+        --current;
+        return tmp;
+    }
+
+    // [move.iter.op.+]
+    constexpr move_iterator operator+(difference_type n) const
+    {
+        return move_iterator(current + n);
+    }
+
+    // [move.iter.op.+=]
+    move_iterator &operator+=(difference_type n)
+    {
+        current += n;
+        return *this;
+    }
+
+    // [move.iter.op.-]
+    constexpr move_iterator operator-(difference_type n) const
+    {
+        return move_iterator(current - n);
+    }
+
+    // [move.iter.op.-=]
+    move_iterator &operator-=(difference_type n)
+    {
+        current -= n;
+        return *this;
+    }
+
+    // [move.iter.op.index]
+    constexpr auto operator[](difference_type n) const -> decltype(std::move(current[n]))
+    {
+        return std::move(current[n]);
+    }
+};
+
+// [move.iter.op.cmp]
+template <typename Iterator1, typename Iterator2>
+bool operator==(const move_iterator<Iterator1> &x, const move_iterator<Iterator2> &y)
+{
+    return x.base() == y.base();
+}
+
+template <typename Iterator1, typename Iterator2>
+bool operator!=(const move_iterator<Iterator1> &x, const move_iterator<Iterator2> &y)
+{
+    return !(x == y);
+}
+
+template <typename Iterator1, typename Iterator2>
+bool operator<(const move_iterator<Iterator1> &x, const move_iterator<Iterator2> &y)
+{
+    return x.base() < y.base();
+}
+
+template <typename Iterator1, typename Iterator2>
+bool operator<=(const move_iterator<Iterator1> &x, const move_iterator<Iterator2> &y)
+{
+    return !(y < x);
+}
+
+template <typename Iterator1, typename Iterator2>
+bool operator>(const move_iterator<Iterator1> &x, const move_iterator<Iterator2> &y)
+{
+    return y < x;
+}
+
+template <typename Iterator1, typename Iterator2>
+bool operator>=(const move_iterator<Iterator1> &x, const move_iterator<Iterator2> &y)
+{
+    return !(x < y);
+}
+
+// [move.iter.nonmember]
+template <typename Iterator1, typename Iterator2>
+auto operator-(const move_iterator<Iterator1> &x,
+               const move_iterator<Iterator2> &y) -> decltype(x.base() - y.base())
+{
+    return x.base() - y.base();
+}
+
+template <typename Iterator>
+move_iterator<Iterator> operator+(typename move_iterator<Iterator>::difference_type n, const move_iterator<Iterator> &x)
+{
+    return x + n;
+}
+
+template <typename Iterator>
+constexpr move_iterator<Iterator> make_move_iterator(Iterator i)
+{
+    return move_iterator<Iterator>(i);
+}
+
+// [iterator.range]
+template <class C>
+constexpr auto begin(C &c) -> decltype(c.begin())
+{
+    return c.begin();
+}
+
+template <class C>
+constexpr auto begin(const C &c) -> decltype(c.begin())
+{
+    return c.begin();
+}
+
+template <class C>
+constexpr auto end(C &c) -> decltype(c.end())
+{
+    return c.end();
+}
+
+template <class C>
+constexpr auto end(const C &c) -> decltype(c.end())
+{
+    return c.end();
+}
+
+template <class T, size_t N>
+constexpr T *begin(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class T, size_t N>
+constexpr T *end(T (&array)[N]) noexcept
+{
+    return array + N;
+}
+
+template <class C>
+constexpr auto cbegin(const C &c) noexcept(noexcept(std::begin(c))) -> decltype(std::begin(c))
+{
+    return std::begin(c);
+}
+
+
+template <class C>
+constexpr auto cend(const C &c) noexcept(noexcept(std::end(c))) -> decltype(std::end(c))
+{
+    return std::end(c);
+}
+
+template <class C>
+constexpr auto rbegin(C &c) -> decltype(c.rbegin())
+{
+    return c.rbegin();
+}
+
+template <class C>
+constexpr auto rbegin(const C &c) -> decltype(c.rbegin())
+{
+    return c.rbegin();
+}
+
+template <class C>
+constexpr auto rend(C &c) -> decltype(c.rend())
+{
+    return c.rend();
+}
+
+template <class C>
+constexpr auto rend(const C &c) -> decltype(c.rend())
+{
+    return c.rend();
+}
+
+template <class T, size_t N>
+reverse_iterator<T *> rbegin(T (&array)[N])
+{
+    return reverse_iterator<T *>(array + N);
+}
+
+template <class T, size_t N>
+reverse_iterator<T *> rend(T (&array)[N])
+{
+    return reverse_iterator<T *>(array);
+}
+
+template <class E>
+reverse_iterator<const E *> rbegin(initializer_list<E> il)
+{
+    return reverse_iterator<const E *>(il.end());
+}
+
+template <class E>
+reverse_iterator<const E *> rend(initializer_list<E> il)
+{
+    return reverse_iterator<const E *>(il.end());
+}
+
+template <class C>
+constexpr auto crbegin(const C &c) -> decltype(std::rbegin(c))
+{
+    return std::rbegin(c);
+}
+
+template <class C>
+constexpr auto crend(const C &c) -> decltype(std::rend(c))
+{
+    return std::rend(c);
+}
+
+} // namespace std
+#endif
+
+namespace mstd {
+using std::initializer_list;
+using std::iterator_traits;
+// omitting deprecated std::iterator
+using std::input_iterator_tag;
+using std::output_iterator_tag;
+using std::forward_iterator_tag;
+using std::bidirectional_iterator_tag;
+using std::random_access_iterator_tag;
+using std::advance;
+using std::distance;
+using std::next;
+using std::prev;
+using std::reverse_iterator;
+using std::make_reverse_iterator;
+using std::back_insert_iterator;
+using std::back_inserter;
+using std::front_insert_iterator;
+using std::front_inserter;
+using std::insert_iterator;
+using std::inserter;
+using std::move_iterator;
+using std::make_move_iterator;
+using std::istream_iterator;
+using std::ostream_iterator;
+using std::istreambuf_iterator;
+using std::ostreambuf_iterator;
+using std::begin;
+using std::end;
+using std::cbegin;
+using std::cend;
+using std::rbegin;
+using std::rend;
+using std::crbegin;
+using std::crend;
+
+#if __cpp_lib_nonmember_container_access >= 201411
+using std::size;
+using std::empty;
+using std::data;
+#else
+// [iterator.container]
+template <class C>
+constexpr auto size(const C &c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, size_t N>
+constexpr size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto empty(const C &c) -> decltype(c.empty())
+{
+    return c.empty();
+}
+
+template <class T, size_t N>
+constexpr bool empty(T (&)[N]) noexcept
+{
+    return false;
+}
+
+template <class E>
+constexpr bool empty(initializer_list<E> il)
+{
+    return il.size() == 0;
+}
+
+template <class C>
+constexpr auto data(C &c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C &c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, size_t N>
+constexpr T *data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E *data(initializer_list<E> il)
+{
+    return il.begin();
+}
+#endif
+
+// C++20
+template <class C>
+constexpr auto ssize(const C &c) -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>
+{
+    return static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size());
+}
+
+template <class T, ptrdiff_t N>
+constexpr ptrdiff_t ssize(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+}
+
+
+#endif // MSTD_ITERATOR_

--- a/platform/cxxsupport/mstd_memory
+++ b/platform/cxxsupport/mstd_memory
@@ -23,12 +23,19 @@
  * - For ARM C 5, C++11/14 features:
  *   - std::align
  *   - std::addressof
+ *   - std::uninitialized_copy_n
  *   - std::unique_ptr, std::make_unique, std::default_delete
+ * - For all toolchains, C++17 backports:
+ *   - mstd::uninitialized_default_construct, mstd::uninitialized_value_construct
+ *   - mstd::uninitialized_move, mstd::uninitialized_move_n
+ *   - mstd::destroy_at, mstd::destroy, mstd::destroy_n
  */
 
 #include <memory>
 
 #include <mstd_type_traits>
+#include <mstd_utility> // std::pair
+#include <mstd_iterator> // std::iterator_traits
 
 #ifdef __CC_ARM
 
@@ -59,6 +66,19 @@ T *addressof(T &arg) noexcept
 {
     return reinterpret_cast<T *>(const_cast<char *>(&reinterpret_cast<const volatile char &>(arg)));
 }
+
+// [uninitialized.copy] - ARMCC has pre-C++11 uninitialized_copy
+template <class InputIterator, class Size, class ForwardIterator>
+ForwardIterator uninitialized_copy_n(InputIterator first, Size n, ForwardIterator result) {
+    for ( ; n > 0; ++result, (void) ++first, --n) {
+        ::new (static_cast<void*>(addressof(*result)))
+              typename std::iterator_traits<ForwardIterator>::value_type(*first);
+    }
+
+    return result;
+}
+
+// [uninitialized.fill] - ARMCC has pre-C++11 uninitialized_fill and uninitialized_fill_n
 
 // [unique.ptr]
 namespace impl
@@ -496,12 +516,97 @@ bool operator>=(nullptr_t, const unique_ptr<T, D> &x) noexcept
 #endif // __CC_ARM
 
 namespace mstd {
+    using std::align;
     using std::allocator;
+    using std::addressof;
+
+    // [uninitialized.construct.default] (C++17)
+    template <class ForwardIterator, class Size>
+    void uninitialized_default_construct(ForwardIterator first, ForwardIterator last) {
+        for (; first != last; ++first) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type;
+        }
+    }
+
+    template <class ForwardIterator, class Size>
+    ForwardIterator uninitialized_default_construct_n(ForwardIterator first, Size n) {
+        for (; n; ++first, --n) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type;
+        }
+
+        return first;
+    }
+
+    // [uninitialized.construct.value] (C++17)
+    template <class ForwardIterator, class Size>
+    void uninitialized_value_construct(ForwardIterator first, ForwardIterator last) {
+        for (; first != last; ++first) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type();
+        }
+    }
+
+    template <class ForwardIterator, class Size>
+    ForwardIterator uninitialized_value_construct_n(ForwardIterator first, Size n) {
+        for (; n; ++first, --n) {
+            ::new (static_cast<void*>(addressof(*first)))
+                    typename std::iterator_traits<ForwardIterator>::value_type();
+        }
+
+        return first;
+    }
+
+    // [uninitialized.move] (C++17)
+    template <class InputIterator, class ForwardIterator>
+    ForwardIterator uninitialized_move(InputIterator first, InputIterator last, ForwardIterator result) {
+        for (; first != last; ++result, (void) ++first) {
+            ::new (static_cast<void*>(addressof(*result)))
+                  typename std::iterator_traits<ForwardIterator>::value_type(move(*first));
+        }
+
+        return result;
+    }
+
+    template <class InputIterator, class Size, class ForwardIterator>
+    std::pair<InputIterator, ForwardIterator> uninitialized_move_n(InputIterator first, Size n, ForwardIterator result) {
+        for ( ; n > 0; ++result, (void) ++first, --n) {
+            ::new (static_cast<void*>(addressof(*result)))
+                  typename std::iterator_traits<ForwardIterator>::value_type(std::move(*first));
+        }
+
+        return { first, result };
+    }
+
     using std::uninitialized_copy;
+    using std::uninitialized_copy_n;
     using std::uninitialized_fill;
     using std::uninitialized_fill_n;
-    using std::addressof;
-    using std::align;
+
+    // [specialized.destroy] (C++17)
+    template <class T>
+    void destroy_at(T *location)
+    {
+        location->~T();
+    }
+
+    template <class ForwardIterator>
+    void destroy(ForwardIterator first, ForwardIterator last)
+    {
+        for (; first != last; ++first) {
+            destroy_at(addressof(*first));
+        }
+    }
+
+    template <class ForwardIterator, class Size>
+    ForwardIterator destroy_n(ForwardIterator first, Size n)
+    {
+        for (; n > 0; (void)++first, --n) {
+            destroy_at(addressof(*first));
+        }
+        return first;
+    }
 
     using std::default_delete;
     using std::unique_ptr;

--- a/platform/cxxsupport/mstd_memory
+++ b/platform/cxxsupport/mstd_memory
@@ -23,13 +23,17 @@
  * - For ARM C 5, C++11/14 features:
  *   - std::align
  *   - std::addressof
+ *   - std::unique_ptr, std::make_unique, std::default_delete
  */
 
 #include <memory>
 
+#include <mstd_type_traits>
+
 #ifdef __CC_ARM
 
 #include <cstddef> // size_t, ptrdiff_t
+#include <_move.h> // exchange
 
 namespace std
 {
@@ -56,6 +60,437 @@ T *addressof(T &arg) noexcept
     return reinterpret_cast<T *>(const_cast<char *>(&reinterpret_cast<const volatile char &>(arg)));
 }
 
+// [unique.ptr]
+namespace impl
+{
+    /* Base version - use T * */
+    template <typename T, typename D, typename = void>
+    struct unique_ptr_type_helper {
+        typedef T *type;
+    };
+
+    /* if "remove_reference_t<D>::pointer" is a type, specialise to use it */
+    template <typename T, typename D>
+    struct unique_ptr_type_helper<T, D, mstd::void_t<typename remove_reference_t<D>::pointer>> {
+        typedef typename remove_reference_t<D>::pointer type;
+    };
+
+    template <class T, class D>
+    using unique_ptr_type_helper_t = typename unique_ptr_type_helper<T, D>::type;
+
+    // Want to eliminate storage for the deleter - could just use it as a base
+    // class, for empty base optimisation, if we knew it was a class. But it could be
+    // a pointer or reference. Here's a version that uses deleter as base,
+    template<class D, typename = void>
+    class deleter_store : private D {
+    public:
+        constexpr deleter_store() noexcept = default;
+        template <typename _D>
+        constexpr deleter_store(_D &&d) noexcept : D(std::forward<_D>(d)) { }
+
+        D &get_deleter() noexcept { return static_cast<D &>(*this); }
+        const D &get_deleter() const noexcept { return static_cast<const D &>(*this); }
+    };
+
+    //Here's a version that stores (for pointer/reference)
+    template<class D>
+    class deleter_store<D, enable_if_t<!is_class<D>::value>> {
+        D d;
+    public:
+        constexpr deleter_store() noexcept : d() { }
+        template <typename _D>
+        constexpr deleter_store(_D &&d) noexcept : d(std::forward<_D>(d)) { }
+
+        D &get_deleter() noexcept { return d; }
+        const D &get_deleter() const noexcept { return d; }
+    };
+}
+
+// [unique.ptr.dltr.dflt]
+template<class T>
+struct default_delete {
+    constexpr default_delete() noexcept = default;
+
+    template <class U, class = enable_if_t<is_convertible<U *, T *>::value>>
+    default_delete(const default_delete<U> &d) noexcept { }
+
+    void operator()(T *ptr) const
+    {
+        // Program is ill-formed if T is incomplete - generate diagnostic by breaking compilation
+        // (Behaviour of raw delete of incomplete class is undefined if complete class is non-trivial, else permitted)
+        static_assert(sizeof(T) == sizeof(T), "Cannot delete incomplete type");
+        delete ptr;
+    }
+};
+
+// [unique.ptr.dltr.dflt1]
+template<class T>
+struct default_delete<T[]> {
+    constexpr default_delete() noexcept = default;
+
+    template <class U, class = enable_if_t<is_convertible<U (*)[], T (*)[]>::value>>
+    default_delete(const default_delete<U> &d) noexcept { }
+
+    template <class U, class = enable_if_t<is_convertible<U (*)[], T (*)[]>::value>>
+    void operator()(U *ptr) const
+    {
+        delete[] ptr;
+    }
+};
+
+// [unique.ptr.single]
+template<
+    class T,
+    class D = default_delete<T>
+> class unique_ptr : public impl::deleter_store<D>
+{
+    template <class U, class E>
+    static constexpr bool is_compatible_unique_ptr()
+    {
+        return is_convertible<typename unique_ptr<U,E>::pointer, pointer>::value &&
+                !is_array<U>::value;
+    }
+public:
+    typedef impl::unique_ptr_type_helper_t<T, D> pointer;
+    typedef T element_type;
+    typedef D deleter_type;
+    // [unique.ptr.single.ctor]
+    template <class _D = D, typename = enable_if_t<!is_pointer<_D>::value && is_default_constructible<_D>::value>>
+    constexpr unique_ptr() noexcept : impl::deleter_store<D>(), ptr_() { }
+    template <class _D = D, typename = enable_if_t<!is_pointer<_D>::value && is_default_constructible<_D>::value>>
+    constexpr unique_ptr(nullptr_t) noexcept : unique_ptr() { }
+    template <class _D = D, typename = enable_if_t<!is_pointer<_D>::value && is_default_constructible<_D>::value>>
+    explicit unique_ptr(pointer ptr) noexcept : impl::deleter_store<D>(), ptr_(ptr) { }
+    template <class _D = D, typename = enable_if_t<is_copy_constructible<_D>::value>>
+    unique_ptr(pointer ptr, const D &d) noexcept : impl::deleter_store<D>(d), ptr_(ptr) { }
+    template <class _D = D, typename = enable_if_t<is_move_constructible<_D>::value>>
+    unique_ptr(pointer ptr, enable_if_t<!is_lvalue_reference<_D>::value, _D &&> d) noexcept : impl::deleter_store<D>(move(d)), ptr_(ptr) { }
+    template <class _D = D, typename _A = remove_reference_t<_D>>
+    unique_ptr(pointer ptr, enable_if_t<is_lvalue_reference<_D>::value, _A &&> d) = delete;
+    unique_ptr(const unique_ptr &) = delete;
+    unique_ptr(unique_ptr &&u) noexcept : impl::deleter_store<D>(forward<D>(u.get_deleter())), ptr_(u.ptr_) { u.ptr_ = nullptr; }
+    template <class U, class E, class = enable_if_t<
+                          is_compatible_unique_ptr<U, E>() &&
+                          (is_reference<D>::value ? is_same<E, D>::value : is_convertible<E,D>::value)>>
+    unique_ptr(unique_ptr<U, E>&& u) noexcept : impl::deleter_store<D>(std::forward<E>(u.get_deleter())), ptr_(u.release()) { }
+
+    // [unique.ptr.single.dtor]
+    ~unique_ptr()
+    {
+        if (ptr_) {
+            this->get_deleter()(ptr_);
+        }
+    }
+
+    // [unique.ptr.single.modifiers]
+    pointer release() noexcept
+    {
+        return std::exchange(ptr_, nullptr);
+    }
+
+    void reset(pointer ptr = pointer()) noexcept
+    {
+        pointer old = std::exchange(ptr_, ptr);
+        if (old) {
+            this->get_deleter()(old);
+        }
+    }
+
+    void swap(unique_ptr &other) noexcept
+    {
+        using std::swap;
+        swap(this->get_deleter(), other.get_deleter());
+        swap(ptr_, other.ptr_);
+    }
+
+    // [unique.ptr.single.asgn]
+    unique_ptr &operator=(const unique_ptr &r) = delete;
+    unique_ptr &operator=(unique_ptr &&r) noexcept
+    {
+        reset(r.release());
+        this->get_deleter() = std::forward<D>(r.get_deleter());
+        return *this;
+    }
+    unique_ptr &operator=(nullptr_t) noexcept
+    {
+        reset();
+        return *this;
+    }
+
+    template <class U, class E>
+    enable_if_t<is_compatible_unique_ptr<U, E>() &&
+        is_assignable<D &, E &&>::value,
+    unique_ptr> &operator=(unique_ptr<U, E> &&u) noexcept
+    {
+        reset(u.release());
+        this->get_deleter() = std::forward<E>(u.get_deleter());
+        return *this;
+    }
+
+    // [unique.ptr.single.observers]
+    pointer get() const noexcept { return ptr_; }
+    pointer operator->() const noexcept { return ptr_; }
+    add_lvalue_reference_t<T> operator*() const noexcept { return *ptr_; }
+    explicit operator bool() const noexcept { return ptr_; }
+private:
+    pointer ptr_;
+};
+
+// [unique.ptr.runtime]
+template<class T, class D>
+class unique_ptr<T[], D> : public impl::deleter_store<D>
+{
+    template <class U>
+    static constexpr bool is_compatible_pointer()
+    {
+        return is_same<U, pointer>::value ||
+               is_same<U, nullptr_t>::value ||
+               (is_same<pointer, element_type *>::value && is_pointer<U>::value &&
+                is_convertible<remove_pointer_t<U> (*)[], element_type (*)[]>::value);
+    }
+
+    template <class U, class E, class UP = unique_ptr<U,E>>
+    static constexpr bool is_compatible_unique_ptr()
+    {
+        return is_array<U>::value &&
+               is_same<pointer, element_type *>::value &&
+               is_same<typename UP::pointer, typename UP::element_type *>::value &&
+               is_convertible<typename UP::element_type(*)[], element_type(*)[]>::value;
+    }
+public:
+    typedef impl::unique_ptr_type_helper_t<T, D> pointer;
+    typedef T element_type;
+    typedef D deleter_type;
+
+    // [unique.ptr.runtime.ctor] / [unique.ptr.single.ctor]
+    template <class _D = D, typename = enable_if_t<!is_pointer<_D>::value && is_default_constructible<_D>::value>>
+    constexpr unique_ptr() noexcept : impl::deleter_store<D>(), ptr_() { }
+
+    template <class _D = D, typename = enable_if_t<!is_pointer<_D>::value && is_default_constructible<_D>::value>>
+    constexpr unique_ptr(nullptr_t) noexcept : unique_ptr() { }
+
+    template <class _D = D, typename = enable_if_t<!is_pointer<_D>::value && is_default_constructible<_D>::value>,
+              class U, typename = enable_if_t<is_compatible_pointer<U>()>>
+    explicit unique_ptr(U ptr) noexcept : impl::deleter_store<D>(), ptr_(ptr) { }
+
+    template <class _D = D, typename = enable_if_t<is_copy_constructible<_D>::value>,
+              class U, typename = enable_if_t<is_compatible_pointer<U>()>>
+    unique_ptr(U ptr, const D &d) noexcept : impl::deleter_store<D>(d), ptr_(ptr) { }
+
+    template <class _D = D, typename = enable_if_t<is_move_constructible<_D>::value>,
+              class U, typename = enable_if_t<is_compatible_pointer<U>()>>
+    unique_ptr(U ptr, enable_if_t<!is_lvalue_reference<_D>::value, _D &&> d) noexcept : impl::deleter_store<D>(std::move(d)), ptr_(ptr) { }
+
+    template <class _D = D, typename _A = remove_reference_t<_D>,
+              class U, typename = enable_if_t<is_compatible_pointer<U>()>>
+    unique_ptr(U ptr, enable_if_t<is_lvalue_reference<_D>::value, _A &&> d) = delete;
+
+    unique_ptr(const unique_ptr &) = delete;
+    unique_ptr(unique_ptr &&u) noexcept : impl::deleter_store<D>(std::forward<D>(u.get_deleter())), ptr_(u.ptr_) { u.ptr_ = nullptr; }
+
+    template <class U, class E,
+    typename = enable_if_t<is_compatible_unique_ptr<U, E>() &&
+                 (is_reference<D>::value ? is_same<E,D>::value : is_convertible<E,D>::value)>>
+    unique_ptr(unique_ptr<U, E>&& u) noexcept : impl::deleter_store<D>(std::forward<E>(u.get_deleter())), ptr_(u.release()) { }
+
+    // [unique.ptr.single.dtor]
+    ~unique_ptr()
+    {
+        if (ptr_) {
+            this->get_deleter()(ptr_);
+        }
+    }
+
+    // [unique.ptr.runtime.modifiers] / [unique.ptr.single.modifiers]
+    pointer release() noexcept
+    {
+        return std::exchange(ptr_, nullptr);
+    }
+
+    void reset(pointer ptr = pointer()) noexcept
+    {
+        pointer old = std::exchange(ptr_, ptr);
+        if (old) {
+            this->get_deleter()(old);
+        }
+    }
+
+    template <class U>
+    void reset(U) = delete;
+
+    void swap(unique_ptr &other) noexcept
+    {
+        using std::swap;
+        swap(this->get_deleter(), other.get_deleter());
+        swap(ptr_, other.ptr_);
+    }
+
+    // [unique.ptr.runtime.asgn] / [unique.ptr.single.asgn]
+    unique_ptr &operator=(const unique_ptr &r) = delete;
+    unique_ptr &operator=(unique_ptr &&r) noexcept
+    {
+        reset(r.release());
+        this->get_deleter() = std::forward<D>(r.get_deleter());
+        return *this;
+    }
+    unique_ptr &operator=(nullptr_t) noexcept
+    {
+        reset();
+        return *this;
+    }
+    template <class U, class E>
+    enable_if_t<is_compatible_unique_ptr<U, E>() &&
+                     is_assignable<D &, E &&>::value,
+    unique_ptr> &operator=(unique_ptr<U, E> &&u) noexcept
+    {
+        reset(u.release());
+        this->get_deleter() = std::forward<E>(u.get_deleter());
+        return *this;
+    }
+
+    // [unique.ptr.runtime.observers] / [unique.ptr.single.observers]
+    pointer get() const noexcept { return ptr_; }
+    T &operator[](size_t index) const { return ptr_[index]; }
+    explicit operator bool() const noexcept { return ptr_; }
+private:
+    pointer ptr_;
+};
+
+// [unique.ptr.create]
+template <typename T, typename... Args>
+enable_if_t<!is_array<T>::value,
+unique_ptr<T>> make_unique(Args &&... args)
+{
+    return unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template <typename T>
+enable_if_t<is_array<T>::value && extent<T>::value == 0,
+unique_ptr<T>> make_unique(size_t size)
+{
+    return unique_ptr<T>(new remove_extent_t<T>[size]());
+}
+
+template <typename T, typename... Args>
+enable_if_t<extent<T>::value != 0,
+void> make_unique(Args &&... args) = delete;
+
+// [unique.ptr.special]
+template< class T, class D>
+void swap(unique_ptr<T,D> &lhs, unique_ptr<T,D> &rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+
+template<class T1, class D1, class T2, class D2>
+bool operator==(const unique_ptr<T1, D1> &x, const unique_ptr<T2, D2> &y)
+{
+    return x.get() == y.get();
+}
+
+template<class T1, class D1, class T2, class D2>
+bool operator!=(const unique_ptr<T1, D1> &x, const unique_ptr<T2, D2> &y)
+{
+    return x.get() != y.get();
+}
+
+template<class T1, class D1, class T2, class D2>
+bool operator<(const unique_ptr<T1, D1> &x, const unique_ptr<T2, D2> &y)
+{
+    using CT = common_type_t<typename unique_ptr<T1, D1>::pointer, typename unique_ptr<T2, D2>::pointer>;
+    return less<CT>()(x.get(), y.get());
+}
+
+template<class T1, class D1, class T2, class D2>
+bool operator<=(const unique_ptr<T1, D1> &x, const unique_ptr<T2, D2> &y)
+{
+    return !(y < x);
+}
+
+template<class T1, class D1, class T2, class D2>
+bool operator>(const unique_ptr<T1, D1> &x, const unique_ptr<T2, D2> &y)
+{
+    return y < x;
+}
+
+template<class T1, class D1, class T2, class D2>
+bool operator>=(const unique_ptr<T1, D1> &x, const unique_ptr<T2, D2> &y)
+{
+    return !(x < y);
+}
+
+template <class T, class D>
+bool operator==(const unique_ptr<T, D> &x, nullptr_t) noexcept
+{
+    return !x;
+}
+
+template <class T, class D>
+bool operator==(nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+    return !x;
+}
+
+template <class T, class D>
+bool operator!=(const unique_ptr<T, D> &x, nullptr_t) noexcept
+{
+    return bool(x);
+}
+
+template <class T, class D>
+bool operator!=(nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+    return bool(x);
+}
+
+template <class T, class D>
+bool operator<(const unique_ptr<T, D> &x, nullptr_t) noexcept
+{
+    return less<typename unique_ptr<T, D>::pointer>()(x.get(), nullptr);
+}
+
+template <class T, class D>
+bool operator<(nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+    return less<typename unique_ptr<T, D>::pointer>()(nullptr, x.get());
+}
+
+template <class T, class D>
+bool operator>(const unique_ptr<T, D> &x, nullptr_t) noexcept
+{
+    return nullptr < x;
+}
+
+template <class T, class D>
+bool operator>(nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+    return x < nullptr;
+}
+
+template <class T, class D>
+bool operator<=(const unique_ptr<T, D> &x, nullptr_t) noexcept
+{
+    return !(nullptr < x);
+}
+
+template <class T, class D>
+bool operator<=(nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+    return !(x < nullptr);
+}
+
+template <class T, class D>
+bool operator>=(const unique_ptr<T, D> &x, nullptr_t) noexcept
+{
+    return !(x < nullptr);
+}
+
+template <class T, class D>
+bool operator>=(nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+    return !(nullptr < x);
+}
+
 } // namespace std
 
 #endif // __CC_ARM
@@ -67,6 +502,10 @@ namespace mstd {
     using std::uninitialized_fill_n;
     using std::addressof;
     using std::align;
+
+    using std::default_delete;
+    using std::unique_ptr;
+    using std::make_unique;
 }
 
 #endif // MSTD_MEMORY_

--- a/platform/cxxsupport/mstd_memory
+++ b/platform/cxxsupport/mstd_memory
@@ -1,0 +1,72 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_MEMORY_
+#define MSTD_MEMORY_
+
+/* <mstd_memory>
+ *
+ * - includes toolchain's <memory>
+ * - For ARM C 5, C++11/14 features:
+ *   - std::align
+ *   - std::addressof
+ */
+
+#include <memory>
+
+#ifdef __CC_ARM
+
+#include <cstddef> // size_t, ptrdiff_t
+
+namespace std
+{
+// [ptr.align]
+inline void *align(size_t alignment, size_t size, void *&ptr, size_t &space) noexcept
+{
+    /* Behavior is undefined if alignment is not a power of 2 */
+    uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
+    uintptr_t new_addr = (addr + (alignment - 1)) & ~(alignment - 1);
+    uintptr_t pad = new_addr - addr;
+    if (pad + size <= space) {
+        space -= pad;
+        ptr = reinterpret_cast<void *>(new_addr);
+        return ptr;
+    } else {
+        return nullptr;
+    }
+}
+
+// [specialized.addressof]
+template <typename T>
+T *addressof(T &arg) noexcept
+{
+    return reinterpret_cast<T *>(const_cast<char *>(&reinterpret_cast<const volatile char &>(arg)));
+}
+
+} // namespace std
+
+#endif // __CC_ARM
+
+namespace mstd {
+    using std::allocator;
+    using std::uninitialized_copy;
+    using std::uninitialized_fill;
+    using std::uninitialized_fill_n;
+    using std::addressof;
+    using std::align;
+}
+
+#endif // MSTD_MEMORY_

--- a/platform/cxxsupport/mstd_mutex
+++ b/platform/cxxsupport/mstd_mutex
@@ -1,0 +1,425 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_MUTEX_
+#define MSTD_MUTEX_
+
+/* <mstd_mutex>
+ *
+ * - includes toolchain's <mutex> (if any)
+ * - For toolchains not providing them, local implementation of C++11/14 equivalent features:
+ *   - mstd::defer_lock etc
+ *   - mstd::lock_guard
+ *   - mstd::unique_lock
+ *   - mstd::lock
+ *   - mstd::try_lock
+ * - If not available, local version of:
+ *   - mstd::scoped_lock (C++17)
+ * - For all toolchains, local implementations:
+ *   - mstd::call_once, mstd::once_flag
+ *   - mstd::mutex, mstd::recursive_mutex
+ *
+ * Toolchains will vary greatly in how much is in namespace std, depending on retargetting.
+ */
+
+#if !defined __CC_ARM && !defined __IAR_SYSTEMS_ICC__
+#include <mutex>
+#endif
+
+#if MBED_CONF_RTOS_PRESENT
+#include "platform/SingletonPtr.h"
+#include "rtos/Mutex.h"
+#endif
+
+#include <mstd_utility>
+#include <mstd_functional>
+
+#include "mbed_atomic.h"
+#include "mbed_assert.h"
+
+extern "C" int __cxa_guard_acquire(int *guard_object_p);
+extern "C" void __cxa_guard_release(int *guard_object_p);
+
+// IAR does not provide <mutex> at all - it errors on inclusion
+// ARMC6 provides it, but it is empty unless _ARM_LIBCPP_EXTERNAL_THREADS is defined
+// GCC has it, and only the actual `mutex` types are conditional on _GLIBCXX_HAS_GTHREADS
+// So pick up std stuff, unless ARMC5, ICC, or ARMC6-without-threads
+namespace mstd {
+#if !defined __CC_ARM && !defined __IAR_SYSTEMS_ICC__ && !defined _LIBCPP_HAS_NO_THREADS
+using std::defer_lock;
+using std::defer_lock_t;
+using std::try_to_lock;
+using std::try_to_lock_t;
+using std::adopt_lock;
+using std::adopt_lock_t;
+
+using std::lock_guard;
+using std::unique_lock;
+using std::try_lock;
+using std::lock;
+#else
+// [thread.lock]
+struct defer_lock_t { };
+struct try_to_lock_t { };
+struct adopt_lock_t { };
+constexpr defer_lock_t defer_lock;
+constexpr try_to_lock_t try_to_lock;
+constexpr adopt_lock_t adopt_lock;
+
+// [thread.lock.guard]
+template <class Mutex>
+class lock_guard {
+    Mutex &pm;
+public:
+    using mutex_type = Mutex;
+    explicit lock_guard(Mutex &m) : pm(m) { m.lock(); }
+    lock_guard(Mutex &m, adopt_lock_t) noexcept : pm(m) { }
+    ~lock_guard() { pm.unlock(); }
+
+    lock_guard(const lock_guard &) = delete;
+    lock_guard &operator=(const lock_guard &) = delete;
+};
+
+
+// [thread.lock.unique]
+template<class Mutex>
+class unique_lock {
+public:
+    using mutex_type = Mutex;
+
+    unique_lock() noexcept : pm(nullptr), owns(false) { }
+    explicit unique_lock(mutex_type &m) : pm(&m), owns(true) { m.lock(); }
+    unique_lock(mutex_type &m, defer_lock_t) noexcept : pm(&m), owns(false) { }
+    unique_lock(mutex_type &m, try_to_lock_t) : pm(&m), owns(m.try_lock()) { }
+    unique_lock(mutex_type &m, adopt_lock_t) : pm(&m), owns(true)  { }
+#if 0 // disabled until we have functional mstd::chrono for all toolchains
+    template <class Clock, class Duration>
+    unique_lock(mutex_type &m, const chrono::time_point<Clock, Duration> &abs_time) : pm(&m), owns(m.try_lock_until(abs_time)) { }
+    template <class Rep, class Period>
+    unique_lock(mutex_type &m, const chrono::duration<Rep, Period> &rel_time) : pm(&m), owns(m.try_lock_for(rel_time)) { }
+#endif
+    ~unique_lock() { if (owns) pm->unlock(); }
+
+    unique_lock(const unique_lock &) = delete;
+    unique_lock &operator=(const unique_lock &) = delete;
+
+    unique_lock(unique_lock &&u) noexcept : pm(u.pm), owns(u.owns) {
+        u.pm = nullptr;
+        u.owns = false;
+    }
+
+    unique_lock &operator=(unique_lock &&u) noexcept {
+        if (owns) {
+            pm->unlock();
+        }
+        pm = mstd::exchange(u.pm, nullptr);
+        owns = mstd::exchange(u.owns, false);
+        return *this;
+    }
+
+    void lock() {
+        MBED_ASSERT(!owns);
+        pm->lock();
+        owns = true;
+    }
+
+    bool try_lock() {
+        MBED_ASSERT(!owns);
+        return owns = pm->try_lock();
+    }
+
+#if 0 // disabled until we have functional mstd::chrono for all toolchains
+    template <class Clock, class Duration>
+    bool try_lock_until(const chrono::time_point<Clock, Duration> &abs_time) {
+        MBED_ASSERT(!owns);
+        return owns = pm->try_lock_until(abs_time);
+    }
+
+    template <class Rep, class Period>
+    bool try_lock_for(const chrono::duration<Rep, Period> &rel_time) {
+        MBED_ASSERT(!owns);
+        return owns = pm->try_lock_for(rel_time);
+    }
+#endif
+
+    void unlock() {
+        MBED_ASSERT(owns);
+        pm->unlock();
+        owns = false;
+    }
+
+    void swap(unique_lock &u) noexcept {
+        mstd::swap(pm, u.pm);
+        mstd::swap(owns, u.owns);
+    }
+
+    mutex_type *release() noexcept {
+        owns = false;
+        return mstd::exchange(pm, nullptr);
+    }
+
+    bool owns_lock() const noexcept {
+        return owns;
+    }
+
+    explicit operator bool() const noexcept {
+        return owns;
+    }
+
+    mutex_type *mutex() const noexcept {
+        return pm;
+    }
+
+private:
+    mutex_type *pm;
+    bool owns;
+};
+
+template<class Mutex>
+void swap(unique_lock<Mutex> &x, unique_lock<Mutex> &y) noexcept
+{
+    x.swap(y);
+}
+
+// [thread.lock.algorithm]
+template <class L1, class L2>
+int try_lock(L1 &l1, L2 &l2)
+{
+    unique_lock<L1> u1(l1, try_to_lock);
+    if (!u1) {
+        return 0;
+    }
+    if (l2.try_lock()) {
+        u1.release();
+        return -1;
+    } else {
+        return 1;
+    }
+}
+
+template <class L1, class L2, class L3, class... LN>
+int try_lock(L1 &l1, L2 &l2, L3 &l3, LN &... ln)
+{
+    unique_lock<L1> u1(l1, try_to_lock);
+    if (!u1) {
+        return 0;
+    }
+    int result = mstd::try_lock(l2, l3, ln...);
+    if (result == -1) {
+        u1.release(); // make u1 release l1 so it remains locked when we return
+        return -1;
+    } else {
+        return result + 1; // u1 unlocks l1 when we return
+    }
+}
+
+// Howard Hinnant's "smart" algorithm from
+// http://howardhinnant.github.io/dining_philosophers.html
+//
+// 1) Lock a mutex
+// 2) Try-lock all the rest
+// 3) If try-lock fails, retry, but starting with the mutex whose try-lock failed
+//    (so we expect to block on that lock)
+//
+// Do not bother with the "polite" yield, as it adds an OS dependency and we
+// want to optimise for space, not speed.
+// Use of unique_lock is necessary to make the code correct in case of exceptions;
+// we don't strictly require this, but stick with the RAII form nevertheless -
+// overhead of unique_lock should be minimal with optimisation enabled.
+template <class L1, class L2>
+void lock(L1 &l1, L2 &l2)
+{
+    for (;;) {
+        {
+            unique_lock<L1> u1(l1);
+            if (l2.try_lock()) {
+                u1.release(); // make u1 release l1 so it remains locked when we return
+                return;
+            }
+        } // u1 unlocks l1 when we leave scope
+        {
+            unique_lock<L2> u2(l2);
+            if (l1.try_lock()) {
+                u2.release();
+                return;
+            }
+        } // u2 unlocks l2 when we leave scope
+    }
+}
+
+namespace impl {
+template <class L1, class L2, class L3, class... LN>
+void lock_from(int first, L1 &l1, L2 &l2, L3 &l3, LN &... ln)
+{
+    for (;;) {
+        switch (first) {
+        case 1:
+            {
+                unique_lock<L1> u1(l1);
+                first = mstd::try_lock(l2, l3, ln...);
+                if (first == -1) {
+                    u1.release();
+                    return;
+                }
+            }
+            first += 2;
+            break;
+        case 2:
+            {
+                unique_lock<L2> u2(l2);
+                first = mstd::try_lock(l3, ln..., l1);
+                if (first == -1) {
+                    u2.release();
+                    return;
+                }
+            }
+            first += 3;
+            if (first > 3 + sizeof...(LN)) {
+                first = 1;
+            }
+            break;
+        default:
+            return impl::lock_from(first - 2, l3, ln..., l1, l2);
+        }
+    }
+}
+}
+
+template <class L1, class L2, class L3, class... LN>
+void lock(L1 &l1, L2 &l2, L3 &l3, LN &... ln)
+{
+    impl::lock_from(1, l1, l2, l3, ln...);
+}
+
+#endif
+
+
+#if __cpp_lib_scoped_lock >= 201703
+using std::scoped_lock;
+#else
+// [thread.lock.scoped]
+// 2+ locks - use std::lock
+template <class... MutexTypes>
+class scoped_lock
+#if 0 // no definition yet - needs tuple
+    tuple<MutexTypes &...> pm;
+    static void ignore(...) { }
+public:
+    explicit scoped_lock(MutexTypes &... m) : pm(tie(m...)) { mstd::lock(m...); }
+    explicit scoped_lock(adopt_lock_t, MutexTypes &... m) noexcept : pm(mstd::tie(m...)) { }
+    ~scoped_lock() { mstd::apply([](MutexTypes &... m) { ignore( (void(m.unlock()),0) ...); }, pm); }
+
+    scoped_lock(const scoped_lock &) = delete;
+    scoped_lock &operator=(const scoped_lock &) = delete;
+}
+#else
+;
+#endif
+
+// 0 locks - no-op
+template <>
+class scoped_lock<> {
+public:
+    explicit scoped_lock() = default;
+    explicit scoped_lock(adopt_lock_t) noexcept { }
+    ~scoped_lock() = default;
+
+    scoped_lock(const scoped_lock &) = delete;
+    scoped_lock &operator=(const scoped_lock &) = delete;
+};
+
+// 1 lock - simple lock, equivalent to lock_guard<Mutex>
+template <class Mutex>
+class scoped_lock<Mutex> {
+    Mutex &pm;
+public:
+    using mutex_type = Mutex;
+    explicit scoped_lock(Mutex &m) : pm(m) { m.lock(); }
+    explicit scoped_lock(adopt_lock_t, Mutex &m) noexcept : pm(m) { }
+    ~scoped_lock() { pm.unlock(); }
+
+    scoped_lock(const scoped_lock &) = delete;
+    scoped_lock &operator=(const scoped_lock &) = delete;
+};
+#endif
+
+// [thread.once.onceflag]
+// Always local implementation - need to investigate GCC + ARMC6 retargetting
+struct once_flag {
+    constexpr once_flag() noexcept : __guard() { }
+    once_flag(const once_flag &) = delete;
+    once_flag &operator=(const once_flag &) = delete;
+    ~once_flag() = default;
+private:
+    template <class Callable, class... Args>
+    friend void call_once(once_flag &flag, Callable&& f, Args&&... args);
+    int __guard;
+};
+
+// [thread.once.callonce]
+template <class Callable, class... Args>
+void call_once(once_flag &flag, Callable&& f, Args&&... args)
+{
+    if (!(core_util_atomic_load_explicit(&flag.__guard, mbed_memory_order_acquire) & 1)) {
+        if (__cxa_guard_acquire(&flag.__guard)) {
+             mstd::invoke(mstd::forward<Callable>(f), mstd::forward<Args>(args)...);
+             __cxa_guard_release(&flag.__guard);
+        }
+    }
+}
+
+// [thread.mutex.class]
+// Always local implementation - need to investigate GCC + ARMC6 retargetting
+#if MBED_CONF_RTOS_PRESENT
+class _Mutex_base {
+    // Constructor must be constexpr - we are required to initialise on first use
+    // not in our constructor. (So that mutex use in static constructors is safe).
+    SingletonPtr<rtos::Mutex> _pm;
+public:
+    constexpr _Mutex_base() noexcept = default;
+    ~_Mutex_base();
+    _Mutex_base(const _Mutex_base &) = delete;
+    _Mutex_base &operator=(const _Mutex_base &) = delete;
+    void lock();
+    bool try_lock();
+    void unlock();
+};
+#else
+class _Mutex_base {
+public:
+    constexpr _Mutex_base() noexcept = default;
+    ~_Mutex_base() = default;
+    _Mutex_base(const _Mutex_base &) = delete;
+    _Mutex_base &operator=(const _Mutex_base &) = delete;
+    void lock() { }
+    bool try_lock() { return true; }
+    void unlock() { }
+};
+#endif
+
+// We don't currently distinguish implementations (and aren't required to -
+// current thread not owning a non-recursive one is a precondition, we don't
+// have to take any special action).
+class mutex : public _Mutex_base {
+};
+
+// [thread.mutex.recursive]
+class recursive_mutex : public _Mutex_base {
+};
+
+} // namespace mstd
+
+#endif // MSTD_MUTEX_

--- a/platform/cxxsupport/mstd_mutex.cpp
+++ b/platform/cxxsupport/mstd_mutex.cpp
@@ -1,0 +1,50 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mstd_mutex>
+
+#if MBED_CONF_RTOS_PRESENT
+
+/* SharedPointer<Mutex> lazy-init kerfuffle will generate code - don't inline it */
+namespace mstd {
+
+// Lock and try lock use SingletonPtr::get() to lazy-init
+void _Mutex_base::lock()
+{
+    _pm.get()->lock();
+}
+
+bool _Mutex_base::try_lock()
+{
+    return _pm.get()->trylock();
+}
+
+// Unlock knows it must have been initted, so optimise with get_no_init()
+void _Mutex_base::unlock()
+{
+    _pm.get_no_init()->unlock();
+}
+
+// And don't forget to destroy - SingletonPtr doesn't do it automatically
+_Mutex_base::~_Mutex_base()
+{
+    _pm.destroy();
+}
+
+} // namespace mstd
+
+#endif

--- a/platform/cxxsupport/mstd_type_traits
+++ b/platform/cxxsupport/mstd_type_traits
@@ -14,28 +14,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_CXXSUPPORT_H
-#define MBED_CXXSUPPORT_H
+#ifndef MSTD_TYPE_TRAITS_
+#define MSTD_TYPE_TRAITS_
 
-#include "mbed_toolchain.h"
-
-/* Mbed OS code is expected to work as C++14 or later, but
- * we currently also want to not totally break ARM Compiler 5, which has a
- * subset of C++11 language and no C++11 library.
+/* <mstd_type_traits>
  *
- * This adaptation file fills out missing namespace std functionality for
- * ARM Compiler 5, and backports some post-C++14 features into namespace mbed.
+ * - includes toolchain's <type_traits>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - std::integral_constant, std::true_type, std::false_type
+ *   - primary type categories (std::is_void, std::is_integral etc)
+ *   - composite type categories (std::is_reference etc)
+ *   - type properties (std::is_const, std::is_constructible etc), except std::is_final
+ *   - type property queries (std::alignment_of, std::rank, std::extent)
+ *   - type relations (std::is_same, std::is_base_of, std::is_convertible)
+ *   - const-volatile modifications (std::remove_cv, std::add_const etc)
+ *   - reference modifications (std::remove_reference, std::add_lvalue_reference etc)
+ *   - sign modifications (std::make_signed, std::make_unsigned)
+ *   - array modifications (std::remove_extent, std::remove_all_extents)
+ *   - pointer modifications (std::remove_pointer, std::add_pointer)
+ *   - other modifications:
+ *      - std::aligned_storage
+ *      - std::decay
+ *      - std::enable_if
+ *      - std::conditional
+ *      - std::common_type
+ *      - std::underlying_type
+ *      - std::result_of
+ * - For all toolchains, C++17/20 backports:
+ *   - mstd::type_identity
+ *   - mstd::bool_constant
+ *   - mstd::void_t
+ *   - mstd::is_invocable, mbed::is_invocable_r, etc
+ *   - mstd::invoke_result
+ *   - logical operator traits (mstd::conjunction, mstd::disjunction, mstd::negation)
  */
 
-/* Macros that can be used to mark functions and objects that are
- * constexpr in C++14 or later, but not in earlier versions.
- */
-#if __cplusplus >= 201402
-#define MBED_CONSTEXPR_FN_14 constexpr
-#define MBED_CONSTEXPR_OBJ_14 constexpr
+#include <mstd_cstddef>
+#ifdef __CC_ARM
+#include <_move.h>
 #else
-#define MBED_CONSTEXPR_FN_14 inline
-#define MBED_CONSTEXPR_OBJ_14 const
+#include <type_traits>
 #endif
 
 // The template stuff in here is too confusing for astyle
@@ -43,18 +61,6 @@
 
 /* Start with some core C++11 type trait building blocks for ARMC5 */
 #ifdef __CC_ARM
-
-/* ARMC5 lacks alignof and alignas keyword - do the best we can */
-
-/* alignof */
-#define alignof(T) __alignof__(T)
-
-/* alignas(N) */
-/* Types not supported - workaround is to use alignas(alignof(T)), which is legal anyway */
-#ifndef __alignas_is_defined
-#define __alignas_is_defined
-#define alignas(N) __attribute__((aligned(N)))
-#endif
 
 namespace std {
 
@@ -82,15 +88,9 @@ using true_type = integral_constant<bool, true>;
 using false_type = integral_constant<bool, false>;
 
 } // namespace std
-#else
-#include <cstddef>
-#include <type_traits>
-#include <utility>
-#include <functional>
 #endif
 
-/* Add some foundational stuff from C++17 or later or TS into namespace mbed */
-namespace mbed {
+namespace mstd {
 
 /* C++20 type identity */
 template<typename T>
@@ -103,7 +103,7 @@ using type_identity_t = typename type_identity<T>::type;
 
 /* C++17 void_t (foundation for detection idiom) */
 /* void_t<Args...> is void if args are valid, else a substitution failure */
-#if __cplusplus >= 201703 || __cpp_lib_void_t >= 201411
+#if __cpp_lib_void_t >= 201411
 using std::void_t;
 #elif defined __CC_ARM
 namespace impl {
@@ -118,7 +118,7 @@ using void_t = void;
 #endif
 
 /* C++17 bool_constant */
-#if __cplusplus >= 201703 || __cpp_lib_bool_constant >= 201505
+#if __cpp_lib_bool_constant >= 201505
 using std::bool_constant;
 #else
 template <bool B>
@@ -126,15 +126,20 @@ using bool_constant = std::integral_constant<bool, B>;
 #endif
 
 /* Forward declarations */
+#if __cpp_lib_is_invocable >= 201703
+using std::invoke_result;
+#else
 template <typename F, typename... Args>
 struct invoke_result;
+#endif
 
-} // namespace mbed
+} // namespace mstd
 
 #ifdef __CC_ARM
+namespace std {
+
 /* Fill in core missing C++11/C++14 functionality for ARM C 5 into namespace std */
 /* First, the things needed to support the detector idiom. */
-namespace std {
 
 /* is_same */
 template <typename, typename>
@@ -145,10 +150,10 @@ struct is_same<T, T> : true_type { };
 
 /* conditional */
 template <bool B, typename T, typename F>
-struct conditional : mbed::type_identity<F> { };
+struct conditional : mstd::type_identity<F> { };
 
 template <typename T, typename F>
-struct conditional<true, T, F> : mbed::type_identity<T> { };
+struct conditional<true, T, F> : mstd::type_identity<T> { };
 
 template <bool B, typename T, typename F>
 using conditional_t = typename conditional<B, T, F>::type;
@@ -158,7 +163,7 @@ template <bool B, typename T = void>
 struct enable_if {  };
 
 template <typename T>
-struct enable_if<true, T> : mbed::type_identity<T> { };
+struct enable_if<true, T> : mstd::type_identity<T> { };
 
 template <bool B, typename T = void>
 using enable_if_t = typename enable_if<B, T>::type;
@@ -179,11 +184,20 @@ class reference_wrapper;
 } // namespace std
 #endif // __CC_ARM
 
-/* Reinvent or pull in good stuff not in C++14 into namespace mbed */
-namespace mbed {
+namespace mstd {
 
+using std::is_same;
+using std::conditional;
+using std::conditional_t;
+using std::enable_if;
+using std::enable_if_t;
+using std::is_convertible;
+using std::is_object;
+using std::is_reference;
+
+/* Reinvent or pull in good stuff not in C++14 into namespace mstd */
 /* C++17 logical operations on traits */
-#if __cplusplus >= 201703 || __cpp_lib_logical_traits >= 201510
+#if __cpp_lib_logical_traits >= 201510
 using std::conjunction;
 using std::disjunction;
 using std::negation;
@@ -207,7 +221,7 @@ struct negation : bool_constant<!bool(B::value)> { };
 #endif
 
 /* C++ detection idiom from Library fundamentals v2 TS */
-/* Place into mbed::experimental to match their std::experimental */
+/* Place into mstd::experimental to match their std::experimental */
 namespace experimental {
 
 namespace impl {
@@ -258,34 +272,27 @@ template<class To, template<class...> class Op, class... Args>
 using is_detected_convertible = std::is_convertible<detected_t<Op, Args...>, To>;
 #endif // if 0 - deactivated detector idiom
 } // namespace experimental
-} // namespace mbed
+} // namespace mstd
 
 #ifdef __CC_ARM
 /* More missing C++11/C++14 functionality for ARM C 5 */
-#include <iterator>
 namespace std {
-
-/* nullptr_t */
-using nullptr_t = decltype(nullptr);
-
-/* maxalign_t */
-union maxalign_t { long double ld; long long ll; };
 
 /* remove_const/volatile/cv */
 template <typename T>
-struct remove_const : mbed::type_identity<T> { };
+struct remove_const : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_const<const T> : mbed::type_identity<T> { };
+struct remove_const<const T> : mstd::type_identity<T> { };
 
 template <typename T>
 using remove_const_t = typename remove_const<T>::type;
 
 template <typename T>
-struct remove_volatile : mbed::type_identity<T> { };
+struct remove_volatile : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_volatile<volatile T> : mbed::type_identity<T> { };
+struct remove_volatile<volatile T> : mstd::type_identity<T> { };
 
 template <typename T>
 using remove_volatile_t = typename remove_volatile<T>::type;
@@ -298,54 +305,41 @@ using remove_cv_t = typename remove_cv<T>::type;
 
 /* add_const/volatile/cv */
 template <typename T>
-struct add_const : mbed::type_identity<const T> { };
+struct add_const : mstd::type_identity<const T> { };
 
 template <typename T>
 using add_const_t = typename add_const<T>::type;
 
 template <typename T>
-struct add_volatile : mbed::type_identity<volatile T> { };
+struct add_volatile : mstd::type_identity<volatile T> { };
 
 template <typename T>
 using add_volatile_t = typename add_volatile<T>::type;
 
 template <typename T>
-struct add_cv : mbed::type_identity<const volatile T> { };
+struct add_cv : mstd::type_identity<const volatile T> { };
 
 template <typename T>
 using add_cv_t = typename add_cv<T>::type;
 
-/* remove_reference */
-template <typename T>
-struct remove_reference : mbed::type_identity<T> { };
-
-template <typename T>
-struct remove_reference<T &> : mbed::type_identity<T> { };
-
-template <typename T>
-struct remove_reference<T &&> : mbed::type_identity<T> { };
-
-template <typename T>
-using remove_reference_t = typename remove_reference<T>::type;
-
 /* add_lvalue_reference / add_value_reference */
 namespace impl {
 template <typename T> // Base test - objects and references
-struct is_referenceable : mbed::disjunction<is_object<T>, is_reference<T>> { };
+struct is_referenceable : mstd::disjunction<is_object<T>, is_reference<T>> { };
 template <typename R, typename... Args> // Specialisation - unqualified functions (non-variadic)
 struct is_referenceable<R(Args...)> : true_type { };
 template <typename R, typename... Args> // Specialisation - unqualified functions (variadic)
 struct is_referenceable<R(Args... ...)> : true_type { };
 
 template <typename T, bool = is_referenceable<T>::value>
-struct add_lvalue_reference : mbed::type_identity<T> { };
+struct add_lvalue_reference : mstd::type_identity<T> { };
 template <typename T>
-struct add_lvalue_reference<T, true> : mbed::type_identity<T &> { };
+struct add_lvalue_reference<T, true> : mstd::type_identity<T &> { };
 
 template <typename T, bool = is_referenceable<T>::value>
-struct add_rvalue_reference : mbed::type_identity<T> { };
+struct add_rvalue_reference : mstd::type_identity<T> { };
 template <typename T>
-struct add_rvalue_reference<T, true> : mbed::type_identity<T &&> { };
+struct add_rvalue_reference<T, true> : mstd::type_identity<T &&> { };
 } // namespace impl
 
 template <typename T>
@@ -358,22 +352,23 @@ struct add_rvalue_reference : impl::add_rvalue_reference<T> { };
 template <typename T>
 using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
 
-/* declval */
+// [declval]
 template <class T>
 add_rvalue_reference_t<T> declval() noexcept;
 
+// [meta.unary.cat]
 /* is_void */
 template <typename T>
 struct is_void : is_same<void, remove_cv_t<T>> { };
 
 /* is_null_pointer */
 template <typename T>
-struct is_null_pointer : is_same<nullptr_t, remove_cv_t<T>> { };
+struct is_null_pointer : is_same<decltype(nullptr), remove_cv_t<T>> { };
 
 /* is_integral */
 template <typename T>
 struct is_integral :
-    mbed::disjunction<
+    mstd::disjunction<
         is_same<bool, remove_cv_t<T>>,
         is_same<char, remove_cv_t<T>>,
         is_same<signed char, remove_cv_t<T>>,
@@ -393,7 +388,7 @@ struct is_integral :
 /* is_floating_point */
 template <typename T>
 struct is_floating_point :
-    mbed::disjunction<
+    mstd::disjunction<
         is_same<float, remove_cv_t<T>>,
         is_same<double, remove_cv_t<T>>,
         is_same<long double, remove_cv_t<T>>> { };
@@ -435,15 +430,15 @@ struct is_rvalue_reference<T &&> : true_type { };
 
 /* is_enum */
 template <typename T>
-struct is_enum : mbed::bool_constant<__is_enum(T)> { };
+struct is_enum : mstd::bool_constant<__is_enum(T)> { };
 
 /* is_union */
 template <typename T>
-struct is_union : mbed::bool_constant<__is_union(T)> { };
+struct is_union : mstd::bool_constant<__is_union(T)> { };
 
 /* is_class */
 template <typename T>
-struct is_class : mbed::bool_constant<__is_class(T)> { };
+struct is_class : mstd::bool_constant<__is_class(T)> { };
 
 /* is_function */
 template <typename T>
@@ -515,7 +510,7 @@ namespace impl {
 template <typename>
 using always_true = true_type;
 template <typename T>
-using is_not_function = mbed::negation<is_function<T>>;
+using is_not_function = mstd::negation<is_function<T>>;
 
 template <typename T, template<typename> class Filter = always_true>
 struct is_unqualified_member_pointer : false_type { };
@@ -543,15 +538,15 @@ struct is_reference<T &&> : true_type { };
 
 /* is_arithmetic */
 template <typename T>
-struct is_arithmetic : mbed::disjunction<is_integral<T>, is_floating_point<T>> { };
+struct is_arithmetic : mstd::disjunction<is_integral<T>, is_floating_point<T>> { };
 
 /* is_fundamental */
 template <typename T>
-struct is_fundamental : mbed::disjunction<is_arithmetic<T>, is_void<T>, is_null_pointer<T>> { };
+struct is_fundamental : mstd::disjunction<is_arithmetic<T>, is_void<T>, is_null_pointer<T>> { };
 
 /* is_compound */
 template <typename T>
-struct is_compound : mbed::negation<is_fundamental<T>> { };
+struct is_compound : mstd::negation<is_fundamental<T>> { };
 
 /* is_member_pointer */
 template <typename T>
@@ -559,12 +554,13 @@ struct is_member_pointer : impl::is_unqualified_member_pointer<remove_cv_t<T>> {
 
 /* is_scalar */
 template <typename T>
-struct is_scalar : mbed::disjunction<is_arithmetic<T>, is_enum<T>, is_pointer<T>, is_member_pointer<T>, is_null_pointer<T>> { };
+struct is_scalar : mstd::disjunction<is_arithmetic<T>, is_enum<T>, is_pointer<T>, is_member_pointer<T>, is_null_pointer<T>> { };
 
 /* is_object */
 template <typename T>
-struct is_object : mbed::disjunction<is_scalar<T>, is_array<T>, is_union<T>, is_class<T>> { };
+struct is_object : mstd::disjunction<is_scalar<T>, is_array<T>, is_union<T>, is_class<T>> { };
 
+// [meta.unary.prop]
 /* is_const */
 template <typename T>
 struct is_const : false_type { };
@@ -581,35 +577,35 @@ struct is_volatile<volatile T> : true_type { };
 
 /* is_trivial */
 template <typename T>
-struct is_trivial : mbed::bool_constant<__is_trivial(T)> { };
+struct is_trivial : mstd::bool_constant<__is_trivial(T)> { };
 
 /* is_trivially_copyable */
 template <typename T>
-struct is_trivially_copyable : mbed::bool_constant<__is_trivially_copyable(T)> { };
+struct is_trivially_copyable : mstd::bool_constant<__is_trivially_copyable(T)> { };
 
 /* is_standard_layout */
 template <typename T>
-struct is_standard_layout : mbed::bool_constant<__is_standard_layout(T)> { };
+struct is_standard_layout : mstd::bool_constant<__is_standard_layout(T)> { };
 
 /* is_pod */
 template <typename T>
-struct is_pod : mbed::bool_constant<__is_pod(T)> { };
+struct is_pod : mstd::bool_constant<__is_pod(T)> { };
 
 /* is_literal_type */
 template <typename T>
-struct is_literal_type : mbed::bool_constant<__is_literal_type(T)> { };
+struct is_literal_type : mstd::bool_constant<__is_literal_type(T)> { };
 
 /* is_empty */
 template <typename T>
-struct is_empty : mbed::bool_constant<__is_empty(T)> { };
+struct is_empty : mstd::bool_constant<__is_empty(T)> { };
 
 /* is_polymorphic */
 template <typename T>
-struct is_polymorphic : mbed::bool_constant<__is_polymorphic(T)> { };
+struct is_polymorphic : mstd::bool_constant<__is_polymorphic(T)> { };
 
 /* is_abstract */
 template <typename T>
-struct is_abstract : mbed::bool_constant<__is_abstract(T)> { };
+struct is_abstract : mstd::bool_constant<__is_abstract(T)> { };
 
 /* is_final (C++14) not supported */
 
@@ -618,7 +614,7 @@ namespace impl {
 template <typename T, bool = is_arithmetic<T>::value >
 struct is_signed : false_type { };
 template <typename T>
-struct is_signed<T, true> : mbed::bool_constant<T(-1) < T(0)> { };
+struct is_signed<T, true> : mstd::bool_constant<T(-1) < T(0)> { };
 } // namespace impl
 
 template <typename T>
@@ -629,7 +625,7 @@ namespace impl {
     template <typename T, bool = is_arithmetic<T>::value >
     struct is_unsigned : false_type { };
     template <typename T>
-    struct is_unsigned<T, true> : mbed::bool_constant<T(0) < T(-1)> { };
+    struct is_unsigned<T, true> : mstd::bool_constant<T(0) < T(-1)> { };
 }
 
 template <typename T>
@@ -637,7 +633,7 @@ struct is_unsigned : impl::is_unsigned<T> { };
 
 /* is_constructible */
 template <typename T, typename... Args>
-struct is_constructible : mbed::bool_constant<__is_constructible(T, Args...)> { };
+struct is_constructible : mstd::bool_constant<__is_constructible(T, Args...)> { };
 
 /* is_default_constructible */
 template <typename T>
@@ -657,7 +653,7 @@ template <typename To, typename From, typename = void>
 struct is_assignable : std::false_type { };
 
 template <typename To, typename From>
-struct is_assignable<To, From, mbed::void_t<decltype(std::declval<To>() = std::declval<From>())>> : std::true_type { };
+struct is_assignable<To, From, mstd::void_t<decltype(std::declval<To>() = std::declval<From>())>> : std::true_type { };
 } // namespace impl
 
 template <typename To, typename From>
@@ -675,11 +671,11 @@ struct is_move_assignable : is_assignable<add_lvalue_reference_t<T>,
 
 /* is_destructible */
 template <typename T>
-struct is_destructible : mbed::bool_constant<__is_destructible(T)> { };
+struct is_destructible : mstd::bool_constant<__is_destructible(T)> { };
 
 /* is_trivially_constructible */
 template <typename T, typename... Args>
-struct is_trivially_constructible : mbed::bool_constant<__is_trivially_constructible(T, Args...)> { };
+struct is_trivially_constructible : mstd::bool_constant<__is_trivially_constructible(T, Args...)> { };
 
 /* is_trivially_default_constructible */
 template <typename T>
@@ -695,7 +691,7 @@ struct is_trivially_move_constructible : is_trivially_constructible<T, add_rvalu
 
 /* is_trivially_assignable */
 template <typename To, typename From>
-struct is_trivially_assignable : mbed::bool_constant<__is_trivially_assignable(To, From)> { };
+struct is_trivially_assignable : mstd::bool_constant<__is_trivially_assignable(To, From)> { };
 
 /* is_trivially_copy_assignable */
 template <typename T>
@@ -709,11 +705,11 @@ struct is_trivially_move_assignable : is_trivially_assignable<add_lvalue_referen
 
 /* is_trivially_destructible */
 template <typename T>
-struct is_trivially_destructible : mbed::bool_constant<__is_trivially_destructible(T)> { };
+struct is_trivially_destructible : mstd::bool_constant<__is_trivially_destructible(T)> { };
 
 /* is_nothrow_constructible */
 template <typename T, typename... Args>
-struct is_nothrow_constructible : mbed::bool_constant<__is_nothrow_constructible(T, Args...)> { };
+struct is_nothrow_constructible : mstd::bool_constant<__is_nothrow_constructible(T, Args...)> { };
 
 /* is_nothrow_default_constructible */
 template <typename T>
@@ -729,7 +725,7 @@ struct is_nothrow_move_constructible : is_nothrow_constructible<T, add_rvalue_re
 
 /* is_nothrow_assignable */
 template <typename To, typename From>
-struct is_nothrow_assignable : mbed::bool_constant<__is_nothrow_assignable(To, From)> { };
+struct is_nothrow_assignable : mstd::bool_constant<__is_nothrow_assignable(To, From)> { };
 
 /* is_copy_assignable */
 template <typename T>
@@ -743,12 +739,13 @@ struct is_nothrow_move_assignable : is_nothrow_assignable<add_lvalue_reference_t
 
 /* is_nothrow_destructible */
 template <typename T>
-struct is_nothrow_destructible : mbed::bool_constant<__is_nothrow_destructible(T)> { };
+struct is_nothrow_destructible : mstd::bool_constant<__is_nothrow_destructible(T)> { };
 
 /* has_virtual_destructor */
 template <typename T>
-struct has_virtual_destructor : mbed::bool_constant<__has_virtual_destructor(T)> { };
+struct has_virtual_destructor : mstd::bool_constant<__has_virtual_destructor(T)> { };
 
+// [meta.unary.prop.query]
 /* alignment_of */
 template <typename T>
 struct alignment_of : integral_constant<size_t, alignof(T)> { };
@@ -779,68 +776,196 @@ struct extent<T[N], 0> : integral_constant<size_t, N> { };
 template <typename T, size_t N, unsigned I>
 struct extent<T[N], I> : extent<T, I - 1> { };
 
+// [meta.rel]
 /* is_convertible */
 /* __is_convertible_to apparently returns true for any From if To is void */
 template <typename From, typename To>
 struct is_convertible : conditional_t<is_void<To>::value,
                                is_void<From>,
-                               mbed::bool_constant<__is_convertible_to(From, To)>> { };
+                               mstd::bool_constant<__is_convertible_to(From, To)>> { };
 
 /* is_base_of */
 template <typename Base, typename Derived>
-struct is_base_of : mbed::bool_constant<__is_base_of(Base, Derived) && __is_class(Derived)> { };
+struct is_base_of : mstd::bool_constant<__is_base_of(Base, Derived) && __is_class(Derived)> { };
+
+
+/* make_signed */
+namespace impl
+{
+template <typename CV, typename T, bool = is_const<CV>::value, bool = is_volatile<CV>::value>
+struct copy_cv : mstd::type_identity<T> { };
+
+template <typename CV, typename T>
+struct copy_cv<CV, T, true, false> : add_const<T> { };
+
+template <typename CV, typename T>
+struct copy_cv<CV, T, false, true> : add_volatile<T> { };
+
+template <typename CV, typename T>
+struct copy_cv<CV, T, true, true> : add_cv<T> { };
+
+template <typename CV, typename T>
+using copy_cv_t = typename copy_cv<CV, T>::type;
+
+template <typename T>
+struct make_signed : mstd::type_identity<T> { };
+
+template <typename T>
+using make_signed_t = typename make_signed<T>::type;
+
+template <>
+struct make_signed<char> : mstd::type_identity<signed char> { };
+
+template <>
+struct make_signed<unsigned char> : mstd::type_identity<signed char> { };
+
+template <>
+struct make_signed<unsigned short> : mstd::type_identity<short> { };
+
+template <>
+struct make_signed<unsigned int> : mstd::type_identity<int> { };
+
+template <>
+struct make_signed<unsigned long> : mstd::type_identity<long> { };
+
+template <>
+struct make_signed<unsigned long long> : mstd::type_identity<long long> { };
+
+template <typename T>
+struct make_unsigned : mstd::type_identity<T> { };
+
+template <typename T>
+using make_unsigned_t = typename make_unsigned<T>::type;
+
+template <>
+struct make_unsigned<char> : mstd::type_identity<unsigned char> { };
+
+template <>
+struct make_unsigned<signed char> : mstd::type_identity<unsigned char> { };
+
+template <>
+struct make_unsigned<short> : mstd::type_identity<unsigned short> { };
+
+template <>
+struct make_unsigned<int> : mstd::type_identity<unsigned int> { };
+
+template <>
+struct make_unsigned<long> : mstd::type_identity<unsigned long> { };
+
+template <>
+struct make_unsigned<long long> : mstd::type_identity<unsigned long long> { };
+
+template <typename T, bool IsIntegral = is_integral<T>::value, bool IsEnum = is_enum<T>::value>
+struct make_signed_selector;
+
+template <typename T>
+class make_signed_selector<T, true, false> { // integral
+    using raw_signed_t = make_signed_t<remove_cv_t<T>>;
+public:
+    using type = copy_cv_t<T, raw_signed_t>;
+};
+
+template <typename T>
+class make_signed_selector<T, false, true> { // enum
+    using raw_signed_t = mstd::conditional_t<sizeof(T) <= 1, signed char,
+                         mstd::conditional_t<sizeof(T) <= sizeof(short), short,
+                         mstd::conditional_t<sizeof(T) <= sizeof(int), int,
+                         mstd::conditional_t<sizeof(T) <= sizeof(long), long, long long>>>>;
+public:
+    using type = copy_cv_t<T, raw_signed_t>;
+};
+
+template <typename T, bool IsIntegral = is_integral<T>::value, bool IsEnum = is_enum<T>::value>
+struct make_unsigned_selector;
+
+template <typename T>
+class make_unsigned_selector<T, true, false> { // integral
+    using raw_unsigned_t = make_unsigned_t<remove_cv_t<T>>;
+public:
+    using type = copy_cv_t<T, raw_unsigned_t>;
+};
+
+template <typename T>
+class make_unsigned_selector<T, false, true> { // enum
+    using raw_unsigned_t = mstd::conditional_t<sizeof(T) <= 1, unsigned char,
+                           mstd::conditional_t<sizeof(T) <= sizeof(short), unsigned short,
+                           mstd::conditional_t<sizeof(T) <= sizeof(int), unsigned int,
+                           mstd::conditional_t<sizeof(T) <= sizeof(long), unsigned long, unsigned long long>>>>;
+public:
+    using type = copy_cv_t<T, raw_unsigned_t>;
+};
+
+}
+
+template <typename T>
+struct make_signed : impl::make_signed_selector<T> { };
+
+template <>
+struct make_signed<bool>; // bool is integral, but make_signed does not apply
+
+template <typename T>
+using make_signed_t = typename make_signed<T>::type;
+
+template <typename T>
+struct make_unsigned : impl::make_unsigned_selector<T> { };
+
+template <>
+struct make_unsigned<bool>; // bool is integral, but make_unsigned does not apply
+
+template <typename T>
+using make_unsigned_t = typename make_unsigned<T>::type;
 
 /* remove_extent */
 template <typename T>
-struct remove_extent : mbed::type_identity<T> { };
+struct remove_extent : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_extent<T[]> : mbed::type_identity<T> { };
+struct remove_extent<T[]> : mstd::type_identity<T> { };
 
 template <typename T, size_t N>
-struct remove_extent<T[N]> : mbed::type_identity<T> { };
+struct remove_extent<T[N]> : mstd::type_identity<T> { };
 
 template <typename T>
 using remove_extent_t = typename remove_extent<T>::type;
 
 /* remove_all_extents */
 template <typename T>
-struct remove_all_extents : mbed::type_identity<T> { };
+struct remove_all_extents : mstd::type_identity<T> { };
 
 template <typename T>
 using remove_all_extents_t = typename remove_all_extents<T>::type;
 
 template <typename T>
-struct remove_all_extents<T[]> : mbed::type_identity<remove_all_extents_t<T>> { };
+struct remove_all_extents<T[]> : mstd::type_identity<remove_all_extents_t<T>> { };
 
 template <typename T, size_t N>
-struct remove_all_extents<T[N]> : mbed::type_identity<remove_all_extents_t<T>> { };
+struct remove_all_extents<T[N]> : mstd::type_identity<remove_all_extents_t<T>> { };
 
 /* remove_pointer */
 template <typename T>
-struct remove_pointer : mbed::type_identity<T> { };
+struct remove_pointer : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_pointer<T *> : mbed::type_identity<T> { };
+struct remove_pointer<T *> : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_pointer<T * const>  : mbed::type_identity<T> { };
+struct remove_pointer<T * const>  : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_pointer<T * volatile> : mbed::type_identity<T> { };
+struct remove_pointer<T * volatile> : mstd::type_identity<T> { };
 
 template <typename T>
-struct remove_pointer<T * const volatile> : mbed::type_identity<T> { };
+struct remove_pointer<T * const volatile> : mstd::type_identity<T> { };
 
 template <typename T>
 using remove_pointer_t = typename remove_pointer<T>::type;
 
 /* add_pointer */
 namespace impl {
-template <typename T, bool = mbed::disjunction<is_referenceable<T>, is_void<T>>::value>
-struct add_pointer : mbed::type_identity<T> { };
+template <typename T, bool = mstd::disjunction<is_referenceable<T>, is_void<T>>::value>
+struct add_pointer : mstd::type_identity<T> { };
 template <typename T>
-struct add_pointer<T, true> : mbed::type_identity<remove_reference_t<T> *> { };
+struct add_pointer<T, true> : mstd::type_identity<remove_reference_t<T> *> { };
 } // namespace impl
 
 template <typename T>
@@ -872,9 +997,9 @@ using aligned_storage_t = typename aligned_storage<Len, Align>::type;
 /* decay */
 namespace impl {
 template <typename T>
-struct decay : mbed::type_identity<
+struct decay : mstd::type_identity<
                     conditional_t<is_array<T>::value,
-                        remove_extent_t<T>,
+                        remove_extent_t<T> *,
                         conditional_t<is_function<T>::value,
                             add_pointer_t<T>,
                             remove_cv_t<T>
@@ -904,7 +1029,7 @@ template <typename T1, typename T2, typename=void>
 struct ct2_default { };
 
 template <typename T1, typename T2>
-struct ct2_default<T1, T2, mbed::void_t<ternary_t<T1, T2>>> : mbed::type_identity<decay_t<ternary_t<T1, T2>>> { };
+struct ct2_default<T1, T2, mstd::void_t<ternary_t<T1, T2>>> : mstd::type_identity<decay_t<ternary_t<T1, T2>>> { };
 
 template <typename T1, typename T2, typename D1 = decay_t<T1>, typename D2 = decay_t<T2>>
 struct ct2 : common_type<D1, D2> { };
@@ -916,7 +1041,7 @@ template <typename Void, typename T1, typename T2, typename... TN>
 struct ct_multi { };
 
 template <typename T1, typename T2, typename... TN>
-struct ct_multi<mbed::void_t<common_type<T1, T2>>, T1, T2, TN...> : common_type<common_type_t<T1, T2>, TN...> { };
+struct ct_multi<mstd::void_t<common_type<T1, T2>>, T1, T2, TN...> : common_type<common_type_t<T1, T2>, TN...> { };
 } // namespace impl
 
 /* common_type (1 type) */
@@ -933,7 +1058,7 @@ struct common_type<T1, T2, TN...> : impl::ct_multi<void, T1, T2, TN...> { };
 
 /* underlying_type */
 template <typename T>
-struct underlying_type : mbed::type_identity<__underlying_type(T)> { };
+struct underlying_type : mstd::type_identity<__underlying_type(T)> { };
 
 template <typename T>
 using underlying_type_t = typename underlying_type<T>::type;
@@ -943,305 +1068,156 @@ template <typename>
 struct result_of;
 
 template <typename F, typename... Args>
-struct result_of<F(Args...)> : mbed::invoke_result<F, Args...> { };
+struct result_of<F(Args...)> : mstd::invoke_result<F, Args...> { };
 
 template <typename T>
 using result_of_t = typename result_of<T>::type;
 
-/* addressof */
-template <typename T>
-T *addressof(T &arg) noexcept
-{
-    return reinterpret_cast<T *>(const_cast<char *>(&reinterpret_cast<const volatile char &>(arg)));
-}
-
-/* move */
-template <typename T>
-constexpr remove_reference_t<T> &&move(T &&a) noexcept
-{
-    return static_cast<remove_reference_t<T> &&>(a);
-}
-
-/* forward */
-template <typename T>
-constexpr T &&forward(remove_reference_t<T> &a) noexcept
-{
-    return static_cast<T &&>(a);
-}
-
-template <typename T>
-constexpr T &&forward(remove_reference_t<T> &&a) noexcept
-{
-    return static_cast<T &&>(a);
-}
-
-/* std::array is pretty useful */
-template <class T, size_t N>
-struct array {
-    T _elem[N];
-
-    using value_type = T;
-    using size_type = size_t;
-    using difference_type = ptrdiff_t;
-    using reference = T &;
-    using const_reference = const T &;
-    using pointer = T *;
-    using const_pointer = const T *;
-    using iterator = T *;
-    using const_iterator = const T *;
-    using reverse_iterator = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    T &at(size_t pos)
-    {
-        MBED_ASSERT(pos < size());
-        return _elem[pos];
-    }
-    const T &at(size_t pos) const
-    {
-        MBED_ASSERT(pos < size());
-        return _elem[pos];
-    }
-    T &operator[](size_t pos)
-    {
-        return _elem[pos];
-    }
-    const T &operator[](size_t pos) const
-    {
-        return _elem[pos];
-    }
-    T &front()
-    {
-        return _elem[0];
-    }
-    const T &front() const
-    {
-        return _elem[0];
-    }
-    T &back()
-    {
-        return _elem[N - 1];
-    }
-    const T &back() const
-    {
-        return _elem[N - 1];
-    }
-    T *data() noexcept
-    {
-        return _elem;
-    }
-    const T *data() const noexcept
-    {
-        return _elem;
-    }
-    constexpr bool empty() const noexcept
-    {
-        return false;
-    }
-    constexpr size_t size() const noexcept
-    {
-        return N;
-    }
-    constexpr size_t max_size() const noexcept
-    {
-        return N;
-    }
-    void fill(const T &value)
-    {
-        std::fill(begin(), end(), value);
-    }
-    iterator begin() noexcept
-    {
-        return _elem;
-    }
-    const_iterator begin() const noexcept
-    {
-        return _elem;
-    }
-    const_iterator cbegin() const noexcept
-    {
-        return _elem;
-    }
-    iterator end() noexcept
-    {
-        return _elem + N;
-    }
-    const_iterator end() const noexcept
-    {
-        return _elem + N;
-    }
-    const_iterator cend() const noexcept
-    {
-        return _elem + N;
-    }
-    reverse_iterator rbegin() noexcept
-    {
-        return reverse_iterator(end());
-    }
-    const_reverse_iterator rbegin() const noexcept
-    {
-        return const_reverse_iterator(end());
-    }
-    const_reverse_iterator crbegin() const noexcept
-    {
-        return const_reverse_iterator(end());
-    }
-    reverse_iterator rend() noexcept
-    {
-        return reverse_iterator(begin());
-    }
-    const_reverse_iterator rend() const noexcept
-    {
-        return const_reverse_iterator(begin());
-    }
-    const_reverse_iterator crend() const noexcept
-    {
-        return const_reverse_iterator(begin());
-    }
-};
-
-/* ARM Compiler 5 supports initializer lists, but is missing std::initializer_list */
-/* Implementation deduced experimentally */
-template <class T>
-struct initializer_list {
-    using value_type = T;
-    using reference = const T &;
-    using const_reference = const T &;
-    using size_type = size_t;
-    using iterator = const T *;
-    using const_iterator = const T *;
-    constexpr initializer_list() noexcept : _ptr(nullptr), _count(0)
-    {
-    }
-    constexpr initializer_list(const T *p, size_t n) noexcept : _ptr(p), _count(n)
-    {
-    }
-    constexpr size_t size() const noexcept
-    {
-        return _count;
-    }
-    const T *begin() const noexcept
-    {
-        return _ptr;
-    }
-    const T *end() const noexcept
-    {
-        return _ptr + _count;
-    }
-private:
-    const T *_ptr;
-    size_t _count;
-};
-
-/* begin */
-template <class C>
-auto begin(C &c) -> decltype(c.begin())
-{
-    return c.begin();
-}
-
-template <class C>
-auto begin(const C &c) -> decltype(c.begin())
-{
-    return c.begin();
-}
-
-template <class T, size_t N>
-T *begin(T (&array)[N]) noexcept
-{
-    return &array[0];
-}
-
-template <class C>
-auto cbegin(const C &c) noexcept(noexcept(begin(c))) -> decltype(begin(c))
-{
-    return begin(c);
-}
-
-/* begin(initializer_list<E>) */
-template <class E>
-const E begin(initializer_list<E> il) noexcept
-{
-    return il.begin();
-}
-
-/* end */
-template <class C>
-auto end(C &c) -> decltype(c.end())
-{
-    return c.end();
-}
-
-template <class C>
-auto end(const C &c) -> decltype(c.end())
-{
-    return c.end();
-}
-
-template <class T, size_t N>
-T *end(T (&array)[N]) noexcept
-{
-    return &array[N];
-}
-
-template <class C>
-auto cend(const C &c) noexcept(noexcept(end(c))) -> decltype(end(c))
-{
-    return end(c);
-}
-
-/* end(initializer_list<E>) */
-template <class E>
-const E end(initializer_list<E> il) noexcept
-{
-    return il.end();
-}
-
-/* align */
-inline void *align(size_t alignment, size_t size, void *&ptr, size_t &space) noexcept
-{
-    /* Behavior is undefined if alignment is not a power of 2 */
-    uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
-    uintptr_t new_addr = (addr + (alignment - 1)) & ~(alignment - 1);
-    uintptr_t pad = new_addr - addr;
-    if (pad + size <= space) {
-        space -= pad;
-        ptr = reinterpret_cast<void *>(new_addr);
-        return ptr;
-    } else {
-        return nullptr;
-    }
-}
-
 } // namespace std
 #endif // __CC_ARM
 
-/* More post-C++14 stuff */
-namespace mbed {
 
-/* C++17 as_const */
-#if __cplusplus >= 201703 || __cpp_lib_as_const >= 201510
-using std::as_const;
-#else
+/* More post-C++14 stuff */
+namespace mstd {
+
+using std::remove_const;
+using std::remove_const_t;
+using std::remove_volatile;
+using std::remove_volatile_t;
+using std::remove_cv;
+using std::remove_cv_t;
+using std::add_const;
+using std::add_const_t;
+using std::add_volatile;
+using std::add_volatile_t;
+using std::add_cv;
+using std::add_cv_t;
+using std::remove_reference;
+using std::remove_reference_t;
+using std::add_lvalue_reference;
+using std::add_rvalue_reference;
+using std::is_void;
+using std::is_null_pointer;
+using std::is_integral;
+using std::is_floating_point;
+using std::is_array;
+using std::is_pointer;
+using std::is_lvalue_reference;
+using std::is_rvalue_reference;
+using std::is_enum;
+using std::is_union;
+using std::is_class;
+using std::is_function;
+using std::is_member_function_pointer;
+using std::is_member_object_pointer;
+using std::is_reference;
+using std::is_arithmetic;
+using std::is_fundamental;
+using std::is_compound;
+using std::is_member_pointer;
+using std::is_scalar;
+using std::is_object;
+using std::is_const;
+using std::is_volatile;
+using std::is_trivial;
+using std::is_trivially_copyable;
+using std::is_standard_layout;
+using std::is_pod;
+using std::is_literal_type;
+using std::is_empty;
+using std::is_polymorphic;
+using std::is_abstract;
+using std::is_signed;
+using std::is_unsigned;
+using std::is_constructible;
+using std::is_default_constructible;
+using std::is_copy_constructible;
+using std::is_move_constructible;
+using std::is_assignable;
+using std::is_copy_assignable;
+using std::is_move_assignable;
+using std::is_destructible;
+using std::is_trivially_constructible;
+using std::is_trivially_default_constructible;
+using std::is_trivially_copy_constructible;
+using std::is_trivially_move_constructible;
+using std::is_trivially_assignable;
+using std::is_trivially_copy_assignable;
+using std::is_trivially_move_assignable;
+using std::is_trivially_destructible;
+// Exceptions are disabled in mbed, so short-circuit nothrow tests
+// (Compilers don't make noexcept() return false with exceptions
+// disabled, presumably to preserve binary compatibility, so the
+// std versions of these are unduly pessimistic).
+template <typename T, typename... Args>
+struct is_nothrow_constructible : is_constructible<T, Args...> { };
 template <typename T>
-constexpr std::add_const_t<T> &as_const(T &t) noexcept
-{
-    return t;
+struct is_nothrow_default_constructible : is_default_constructible<T> { };
+template <typename T>
+struct is_nothrow_copy_constructible : is_copy_constructible<T> { };
+template <typename T>
+struct is_nothrow_move_constructible : is_move_constructible<T> { };
+template <typename To, typename From>
+struct is_nothrow_assignable: is_assignable<To, From> { };
+template <typename T>
+struct is_nothrow_copy_assignable : is_copy_assignable<T> { };
+template <typename T>
+struct is_nothrow_move_assignable : is_move_assignable<T> { };
+using std::has_virtual_destructor;
+using std::alignment_of;
+using std::rank;
+using std::extent;
+using std::is_convertible;
+using std::is_base_of;
+using std::make_signed;
+using std::make_signed_t;
+using std::make_unsigned;
+using std::make_unsigned_t;
+using std::remove_extent;
+using std::remove_extent_t;
+using std::remove_all_extents;
+using std::remove_all_extents_t;
+using std::remove_pointer;
+using std::remove_pointer_t;
+using std::add_pointer;
+using std::add_pointer_t;
+using std::aligned_storage;
+using std::aligned_storage_t;
+using std::decay;
+using std::decay_t;
+using std::common_type;
+using std::common_type_t;
+using std::result_of;
+using std::result_of_t;
+
+/* C++20 remove_cvref */
+template <typename T>
+struct remove_cvref : type_identity<std::remove_cv_t<std::remove_reference_t<T>>> { };
+
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
 }
 
-template <typename T>
-void as_const(T &&) = delete;
+#ifndef __CC_ARM
+#if __cpp_lib_invoke < 201411
+#include <utility> // want std::forward
+#include <functional> // want std::reference_wrapper
+#elif __cpp_lib_is_invocable < 201703
+#include <functional> // want std::invoke
+#endif
 #endif
 
+namespace mstd {
 /* C++17 invoke_result, is_invocable, invoke */
-#if __cplusplus >= 201703 || __cpp_lib_is_invocable >= 201703
-/* Library has complete suite - pull it into mbed */
+#if __cpp_lib_is_invocable >= 201703
+/* Library has complete suite - pull it into mstd */
 using std::invoke_result;
 using std::invoke_result_t;
 using std::is_invocable;
 using std::is_nothrow_invocable;
 using std::is_invocable_r;
 using std::is_nothrow_invocable_r;
-using std::invoke;
 #else // __cpp_lib_is_invocable
 namespace impl {
 #if __cpp_lib_invoke >= 201411
@@ -1383,130 +1359,29 @@ template <typename R, typename F, typename... Args>
 struct is_nothrow_invocable_r : impl::is_invocable_r<R, invoke_result<F, Args...>> { };
 #endif
 
-#if __cpp_lib_invoke >= 201411
-using std::invoke;
-#else
-template <typename F, typename... Args>
-invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
-{
-    return impl::INVOKE(std::forward<F>(f), std::forward<Args>(args)...);
-}
-#endif // __cpp_lib_invoke
 #endif // __cpp_lib_is_invocable
 
-/* C++20 remove_cvref */
-template <typename T>
-struct remove_cvref : type_identity<std::remove_cv_t<std::remove_reference_t<T>>> { };
 
-template <typename T>
-using remove_cvref_t = typename remove_cvref<T>::type;
-
-/* C++20 unwrap_reference */
-template <typename T>
-struct unwrap_reference : type_identity<T> { };
-template <typename T>
-struct unwrap_reference<std::reference_wrapper<T>> : type_identity<T &> { };
-template <typename T>
-using unwrap_reference_t = typename unwrap_reference<T>::type;
-
-/* C++20 unwrap_ref_decay */
-template <typename T>
-struct unwrap_ref_decay : unwrap_reference<std::decay_t<T>> { };
-template <typename T>
-using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
-
-} // namespace mbed
+} // namespace mstd
 
 #ifdef __CC_ARM
-/* More C++11 functional stuff, using mbed::invoke */
+// And may as well give ourselves all the post C++14 stuff in std
+// to aid our implementations of std::tuple etc - not safe to do this for other toolchains
 namespace std {
-
-/* mem_fn */
-namespace impl {
-template <typename R, typename T>
-class mem_fn_t {
-    R T::* pm;
-public:
-    mem_fn_t(R T::* pm) : pm(pm) { }
-    template <typename... Args>
-    mbed::invoke_result_t<R T::*, Args...> operator()(Args&&... args) const
-    {
-        return mbed::invoke(pm, std::forward<Args>(args)...);
-    }
-};
+    using mstd::bool_constant;
+    using mstd::conjunction;
+    using mstd::disjunction;
+    using mstd::negation;
+    using mstd::void_t;
+    using mstd::type_identity;
+    using mstd::type_identity_t;
+    using mstd::is_invocable;
+    using mstd::is_invocable_r;
+    using mstd::invoke_result;
+    using mstd::invoke_result_t;
+    using mstd::remove_cvref;
+    using mstd::remove_cvref_t;
 }
-
-template <class R, class T>
-impl::mem_fn_t<R, T> mem_fn(R T::* pm)
-{
-    return impl::mem_fn_t<R, T>(pm);
-}
-
-/* reference_wrapper */
-template <typename T>
-class reference_wrapper {
-    T &FUN(T &x) noexcept { return x; }
-    void FUN(T &&x) = delete;
-    T *ptr;
-public:
-    using type = T;
-#if 0
-    // decltype doesn't seem to work well enough for this revised version
-    template <typename U,
-                typename = enable_if_t<!is_same<reference_wrapper, decay_t<U>>::value &&
-                                       !is_void<decltype(FUN(declval<U>()))>::value>>
-    reference_wrapper(U&& x) //noexcept(noexcept(FUN(declval<U>())))
-        : ptr(addressof(FUN(forward<U>(x)))) { }
-#else
-    reference_wrapper(T &x) noexcept : ptr(addressof(x)) { }
-    reference_wrapper(T &&x) = delete;
 #endif
 
-    reference_wrapper(const reference_wrapper &) noexcept = default;
-    reference_wrapper &operator=(const reference_wrapper &) noexcept = default;
-
-    operator T &() const noexcept { return *ptr; }
-    T &get() const noexcept { return *ptr; }
-
-    template <typename... ArgTypes>
-    mbed::invoke_result_t<T &, ArgTypes...> operator()(ArgTypes&&... args) const
-    {
-        return mbed::invoke(get(), forward<ArgTypes>(args)...);
-    }
-};
-
-/* ref, cref */
-template <typename T>
-reference_wrapper<T> ref(T &t) noexcept
-{
-    return reference_wrapper<T>(t);
-}
-
-template <typename T>
-reference_wrapper<T> ref(reference_wrapper<T> &t) noexcept
-{
-    return ref(t.get());
-}
-
-template <typename T>
-void ref(const T &&) = delete;
-
-template <typename T>
-reference_wrapper<const T> cref(const T &t) noexcept
-{
-    return reference_wrapper<const T>(t);
-}
-
-template <typename T>
-reference_wrapper<const T> cref(reference_wrapper<T> &t) noexcept
-{
-    return cref(t.get());
-}
-
-template <typename T>
-void cref(const T &&) = delete;
-
-} // namespace std
-#endif // _CC_ARM
-
-#endif // MBED_CXXSUPPORT_H
+#endif /* MSTD_TYPE_TRAITS_ */

--- a/platform/cxxsupport/mstd_utility
+++ b/platform/cxxsupport/mstd_utility
@@ -1,0 +1,337 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSTD_UTILITY_
+#define MSTD_UTILITY_
+
+/* <mstd_utility>
+ *
+ * - includes toolchain's <utility>
+ * - For ARM C 5, standard C++11/14 features:
+ *   - include <initializer_list>
+ *   - std::move, std::forward, std::exchange
+ *   - std::declval
+ *   - std::integer_sequence
+ *   - include <algorithm> to get default std::swap
+ *   - mstd::swap - substitute for std::swap that can move
+ *   - std::swap(array)
+ * - Swap assistance, to ensure moves happen on ARM C 5
+ *   - mstd::swap - alias for std::swap, or a local moving implementation for ARM C 5
+ * - For all toolchains, C++17/20 backports:
+ *   - mstd::as_const
+ */
+
+#include <utility>
+
+#ifdef __CC_ARM
+#include <_move.h>
+#include <algorithm> // to get std::swap
+#include <cstddef>
+#include <initializer_list>
+#include <cstdint> // uintmax_t
+#include <mstd_type_traits>
+#endif
+
+
+namespace mstd {
+// [utility.swap] - ARMC5's std::swap is not C++11, so make sure mstd::swap is
+// So to get ADL-aware lookup with good default swap, users should do `using mstd::swap; swap(x, y);`.
+#ifdef __CC_ARM
+template <class _TypeT>
+void swap(_TypeT &__a, _TypeT &__b)
+noexcept(__is_nothrow_constructible(_TypeT, _TypeT &&) && __is_nothrow_assignable(_TypeT &, _TypeT &&))
+{
+    _TypeT __tmp = std::move(__a);
+    __a = std::move(__b);
+    __b = std::move(__tmp);
+}
+
+template <class _TypeT, std::size_t _Size>
+void swap(_TypeT (&__a)[_Size], _TypeT (&__b)[_Size])
+noexcept(noexcept(swap(*__a, *__b)))
+{
+    _TypeT *__ptr_a = __a, *__ptr_b = __b;
+    const _TypeT * const __end_a = __a + _Size;
+    for (; __ptr_a != __end_a; ++__ptr_a, ++__ptr_b) {
+        swap(*__ptr_a, *__ptr_b);
+    }
+}
+#else
+using std::swap;
+#endif
+
+} // namespace mstd
+
+
+#ifdef __CC_ARM
+
+namespace std {
+
+template <typename _TypeT>
+constexpr conditional_t<!is_nothrow_move_constructible<_TypeT>::value && is_copy_constructible<_TypeT>::value,
+                        const _TypeT &, _TypeT &&>
+move_if_noexcept(_TypeT &__t) noexcept
+{
+    return std::move(__t);
+}
+
+// [declval]
+// is provided by mstd_type_traits, which we include
+
+// [utility.swap] - ARMC5's basic swap in <algorithm> does not move, but
+// we can add this std overload for arrays, and send it to our mstd moving version
+template <class _TypeT, std::size_t _Size>
+void swap(_TypeT (&__a)[_Size], _TypeT (&__b)[_Size])
+noexcept(noexcept(mstd::swap(*__a, *__b)))
+{
+    mstd::swap(__a, __b);
+}
+
+// [intseq.intseq]
+template <typename T, T... I>
+struct integer_sequence {
+    using value_type = T;
+    static constexpr size_t size() noexcept { return sizeof...(I); }
+};
+
+template <size_t... I>
+using index_sequence = integer_sequence<size_t, I...>;
+
+// [intseq.make]
+namespace impl {
+
+template <typename seq1, typename seq2>
+struct combine_umax_sequences;
+
+template <uintmax_t... seq1, uintmax_t... seq2>
+struct combine_umax_sequences<integer_sequence<uintmax_t, seq1...>, integer_sequence<uintmax_t, seq2...>>
+    : mstd::type_identity<integer_sequence<uintmax_t, seq1..., sizeof...(seq1) + seq2...>> { };
+
+template <uintmax_t N>
+struct make_umax_sequence : combine_umax_sequences<typename make_umax_sequence<N / 2>::type,
+                                                   typename make_umax_sequence<N - N / 2>::type> { };
+
+template <>
+struct make_umax_sequence<1> : mstd::type_identity<integer_sequence<uintmax_t, 0>> { };
+
+template <>
+struct make_umax_sequence<0> : mstd::type_identity<integer_sequence<uintmax_t>> { };
+
+
+template <typename T, T N, typename useq = typename make_umax_sequence<N>::type>
+struct make_integer_sequence;
+
+template <typename T, T N, uintmax_t... I>
+struct make_integer_sequence<T, N, integer_sequence<uintmax_t, I...>> {
+    static_assert(N >= 0, "negative integer sequence");
+    using type = integer_sequence<T, static_cast<T>(I)...>;
+};
+}
+
+template <typename T, T N>
+using make_integer_sequence = typename impl::make_integer_sequence<T, N>::type;
+
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+
+template <typename... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
+
+// [pair.astuple]
+template <typename>
+struct tuple_size;
+
+template <size_t, typename>
+struct tuple_element;
+
+template <size_t I, typename T>
+using tuple_element_t = typename tuple_element<I, T>::type;
+
+template <typename T1, typename T2>
+struct tuple_size<pair<T1, T2>> : integral_constant<size_t, 2> { };
+
+template <typename T1, typename T2>
+struct tuple_element<0, pair<T1, T2>> : mstd::type_identity<T1> { };
+
+template <typename T1, typename T2>
+struct tuple_element<1, pair<T1, T2>> : mstd::type_identity<T2> { };
+
+namespace impl{
+
+template <size_t I>
+struct pair_getter;
+
+template <>
+struct pair_getter<0> {
+    template <typename T1, typename T2>
+    static T1 &get(pair<T1, T2> &p)
+    {
+        return p.first;
+    }
+    template <typename T1, typename T2>
+    static const T1 &cget(const pair<T1, T2> &p)
+    {
+        return p.first;
+    }
+    template <typename T1, typename T2>
+    static T1 &&get_move(pair<T1, T2> &&p)
+    {
+        return std::forward<T1>(p.first);
+    }
+    template <typename T1, typename T2>
+    static const T1 &&cget_move(const pair<T1, T2> &&p)
+    {
+        return std::forward<T1>(p.first);
+    }
+};
+
+template <>
+struct pair_getter<1> {
+    template <typename T1, typename T2>
+    static T2 &get(pair<T1, T2> &p)
+    {
+        return p.second;
+    }
+    template <typename T1, typename T2>
+    static const T2 &cget(const pair<T1, T2> &p)
+    {
+        return p.second;
+    }
+    template <typename T1, typename T2>
+    static T2 &&get_move(pair<T1, T2> &&p)
+    {
+        return std::forward<T2>(p.second);
+    }
+    template <typename T1, typename T2>
+    static const T2 &&cget_move(const pair<T1, T2> &&p)
+    {
+        return std::forward<T2>(p.second);
+    }
+};
+}
+
+template <size_t I, typename T1, typename T2>
+constexpr tuple_element_t<I, pair<T1, T2>> &get(pair<T1, T2> &p) noexcept
+{
+    return impl::pair_getter<I>::get(p);
+}
+
+template <size_t I, typename T1, typename T2>
+constexpr const tuple_element_t<I, pair<T1, T2>> &get(const pair<T1, T2> &p) noexcept
+{
+    return impl::pair_getter<I>::cget(p);
+}
+
+template <size_t I, typename T1, typename T2>
+constexpr tuple_element_t<I, pair<T1, T2>> &&get(pair<T1, T2> &&p) noexcept
+{
+    return impl::pair_getter<I>::get_move(std::move(p));
+}
+
+template <size_t I, typename T1, typename T2>
+constexpr const tuple_element_t<I, pair<T1, T2>> &&get(const pair<T1, T2> &&p) noexcept
+{
+    return impl::pair_getter<I>::cget_move(std::move(p));
+}
+
+template <typename T1, typename T2>
+constexpr T1 &get(pair<T1, T2> &p) noexcept
+{
+    return p.first;
+}
+
+template <typename T1, typename T2>
+constexpr const T1 &get(const pair<T1, T2> &p) noexcept
+{
+    return p.first;
+}
+
+template <typename T1, typename T2>
+constexpr T1 &&get(pair<T1, T2> &&p) noexcept
+{
+    return p.first;
+}
+
+template <typename T1, typename T2>
+constexpr const T1 &&get(const pair<T1, T2> &&p) noexcept
+{
+    return p.first;
+}
+
+template <typename T2, typename T1>
+constexpr T2 &get(pair<T1, T2> &p) noexcept
+{
+    return p.second;
+}
+
+template <typename T2, typename T1>
+constexpr const T2 &get(const pair<T1, T2> &p) noexcept
+{
+    return p.second;
+}
+
+template <typename T2, typename T1>
+constexpr T2 &&get(pair<T1, T2> &&p) noexcept
+{
+    return p.second;
+}
+
+template <typename T2, typename T1>
+constexpr const T2 &&get(const pair<T1, T2> &&p) noexcept
+{
+    return p.second;
+}
+
+
+} // namespace std
+#endif
+
+namespace mstd {
+namespace rel_ops { using namespace std::rel_ops; }
+using std::initializer_list;
+using std::exchange;
+using std::forward;
+using std::move;
+// No exceptions in mbed OS
+template <typename T>
+T &&move_if_noexcept(T &t) noexcept
+{
+    return mstd::move(t);
+}
+using std::declval;
+using std::make_pair;
+using std::get;
+using std::pair;
+using std::integer_sequence;
+
+// C++17 [utility.as_const] */
+#if __cpp_lib_as_const >= 201510
+using std::as_const;
+#else
+template <typename _TypeT>
+constexpr std::add_const_t<_TypeT> &as_const(_TypeT &__t) noexcept
+{
+    return __t;
+}
+
+template <typename _TypeT>
+void as_const(_TypeT &&) = delete;
+#endif
+
+} // namespace mstd
+
+#endif // MSTD_UTILITY_

--- a/platform/internal/mbed_atomic_impl.h
+++ b/platform/internal/mbed_atomic_impl.h
@@ -1338,7 +1338,7 @@ DO_MBED_ATOMIC_OP_U_TEMPLATES(fetch_and)
 DO_MBED_ATOMIC_OP_U_TEMPLATES(fetch_or)
 DO_MBED_ATOMIC_OP_U_TEMPLATES(fetch_xor)
 
-namespace mbed {
+namespace mstd {
 namespace impl {
 
 // Use custom assembler forms for pre-ops where available, else construct from post-ops

--- a/platform/mbed_atomic.h
+++ b/platform/mbed_atomic.h
@@ -880,7 +880,7 @@ MBED_FORCEINLINE uint64_t core_util_atomic_fetch_xor_explicit_u64(volatile uint6
 #ifdef __cplusplus
 } // extern "C"
 
-#include "mbed_cxxsupport.h"
+#include <mstd_type_traits>
 
 // For each operation, two overloaded templates:
 // * one for non-pointer types, which has implementations based on the
@@ -900,65 +900,65 @@ template<typename T> T core_util_atomic_load(const volatile T *valuePtr) noexcep
 /** \copydoc core_util_atomic_load_u8 */
 template<typename T> T core_util_atomic_load(const T *valuePtr) noexcept;
 /** \copydoc core_util_atomic_store_u8 */
-template<typename T> void core_util_atomic_store(volatile T *valuePtr, mbed::type_identity_t<T> desiredValue) noexcept;
+template<typename T> void core_util_atomic_store(volatile T *valuePtr, mstd::type_identity_t<T> desiredValue) noexcept;
 /** \copydoc core_util_atomic_store_u8 */
-template<typename T> void core_util_atomic_store(T *valuePtr, mbed::type_identity_t<T> desiredValue) noexcept;
+template<typename T> void core_util_atomic_store(T *valuePtr, mstd::type_identity_t<T> desiredValue) noexcept;
 /** \copydoc core_util_atomic_exchange_u8 */
-template<typename T> T core_util_atomic_exchange(volatile T *ptr, mbed::type_identity_t<T> desiredValue) noexcept;
+template<typename T> T core_util_atomic_exchange(volatile T *ptr, mstd::type_identity_t<T> desiredValue) noexcept;
 /** \copydoc core_util_atomic_cas_u8 */
-template<typename T> bool core_util_atomic_compare_exchange_strong(volatile T *ptr, mbed::type_identity_t<T> *expectedCurrentValue, mbed::type_identity_t<T> desiredValue) noexcept;
+template<typename T> bool core_util_atomic_compare_exchange_strong(volatile T *ptr, mstd::type_identity_t<T> *expectedCurrentValue, mstd::type_identity_t<T> desiredValue) noexcept;
 /** \copydoc core_util_atomic_compare_exchange_weak_u8 */
-template<typename T> bool core_util_atomic_compare_exchange_weak(volatile T *ptr, mbed::type_identity_t<T> *expectedCurrentValue, mbed::type_identity_t<T> desiredValue) noexcept;
+template<typename T> bool core_util_atomic_compare_exchange_weak(volatile T *ptr, mstd::type_identity_t<T> *expectedCurrentValue, mstd::type_identity_t<T> desiredValue) noexcept;
 /** \copydoc core_util_fetch_add_u8 */
-template<typename T> T core_util_atomic_fetch_add(volatile T *valuePtr, mbed::type_identity_t<T> arg) noexcept;
+template<typename T> T core_util_atomic_fetch_add(volatile T *valuePtr, mstd::type_identity_t<T> arg) noexcept;
 /** \copydoc core_util_fetch_sub_u8 */
-template<typename T> T core_util_atomic_fetch_sub(volatile T *valuePtr, mbed::type_identity_t<T> arg) noexcept;
+template<typename T> T core_util_atomic_fetch_sub(volatile T *valuePtr, mstd::type_identity_t<T> arg) noexcept;
 /** \copydoc core_util_fetch_and_u8 */
-template<typename T> T core_util_atomic_fetch_and(volatile T *valuePtr, mbed::type_identity_t<T> arg) noexcept;
+template<typename T> T core_util_atomic_fetch_and(volatile T *valuePtr, mstd::type_identity_t<T> arg) noexcept;
 /** \copydoc core_util_fetch_or_u8 */
-template<typename T> T core_util_atomic_fetch_or(volatile T *valuePtr, mbed::type_identity_t<T> arg) noexcept;
+template<typename T> T core_util_atomic_fetch_or(volatile T *valuePtr, mstd::type_identity_t<T> arg) noexcept;
 /** \copydoc core_util_fetch_xor_u8 */
-template<typename T> T core_util_atomic_fetch_xor(volatile T *valuePtr, mbed::type_identity_t<T> arg) noexcept;
+template<typename T> T core_util_atomic_fetch_xor(volatile T *valuePtr, mstd::type_identity_t<T> arg) noexcept;
 
 /** \copydoc core_util_atomic_load_explicit_u8 */
 template<typename T> T core_util_atomic_load_explicit(const volatile T *valuePtr, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_load_explicit_u8 */
 template<typename T> T core_util_atomic_load_explicit(const T *valuePtr, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_store_explicit_u8 */
-template<typename T> void core_util_atomic_store_explicit(volatile T *valuePtr, mbed::type_identity_t<T> desiredValue, mbed_memory_order order) noexcept;
+template<typename T> void core_util_atomic_store_explicit(volatile T *valuePtr, mstd::type_identity_t<T> desiredValue, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_store_explicit_u8 */
-template<typename T> void core_util_atomic_store_explicit(T *valuePtr, mbed::type_identity_t<T> desiredValue, mbed_memory_order order) noexcept;
+template<typename T> void core_util_atomic_store_explicit(T *valuePtr, mstd::type_identity_t<T> desiredValue, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_exchange_explicit_u8 */
-template<typename T> T core_util_atomic_exchange_explicit(volatile T *ptr, mbed::type_identity_t<T> desiredValue, mbed_memory_order order) noexcept;
+template<typename T> T core_util_atomic_exchange_explicit(volatile T *ptr, mstd::type_identity_t<T> desiredValue, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_cas_explicit_u8 */
-template<typename T> bool core_util_atomic_compare_exchange_strong_explicit(volatile T *ptr, mbed::type_identity_t<T> *expectedCurrentValue, mbed::type_identity_t<T> desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
+template<typename T> bool core_util_atomic_compare_exchange_strong_explicit(volatile T *ptr, mstd::type_identity_t<T> *expectedCurrentValue, mstd::type_identity_t<T> desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
 /** \copydoc core_util_atomic_compare_exchange_weak_explicit_u8 */
-template<typename T> bool core_util_atomic_compare_exchange_weak_explicit(volatile T *ptr, mbed::type_identity_t<T> *expectedCurrentValue, mbed::type_identity_t<T> desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
+template<typename T> bool core_util_atomic_compare_exchange_weak_explicit(volatile T *ptr, mstd::type_identity_t<T> *expectedCurrentValue, mstd::type_identity_t<T> desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
 /** \copydoc core_util_fetch_add_explicit_u8 */
-template<typename T> T core_util_atomic_fetch_add_explicit(volatile T *valuePtr, mbed::type_identity_t<T> arg, mbed_memory_order order) noexcept;
+template<typename T> T core_util_atomic_fetch_add_explicit(volatile T *valuePtr, mstd::type_identity_t<T> arg, mbed_memory_order order) noexcept;
 /** \copydoc core_util_fetch_sub_explicit_u8 */
-template<typename T> T core_util_atomic_fetch_sub_explicit(volatile T *valuePtr, mbed::type_identity_t<T> arg, mbed_memory_order order) noexcept;
+template<typename T> T core_util_atomic_fetch_sub_explicit(volatile T *valuePtr, mstd::type_identity_t<T> arg, mbed_memory_order order) noexcept;
 /** \copydoc core_util_fetch_and_explicit_u8 */
-template<typename T> T core_util_atomic_fetch_and_explicit(volatile T *valuePtr, mbed::type_identity_t<T> arg, mbed_memory_order order) noexcept;
+template<typename T> T core_util_atomic_fetch_and_explicit(volatile T *valuePtr, mstd::type_identity_t<T> arg, mbed_memory_order order) noexcept;
 /** \copydoc core_util_fetch_or_explicit_u8 */
-template<typename T> T core_util_atomic_fetch_or_explicit(volatile T *valuePtr, mbed::type_identity_t<T> arg, mbed_memory_order order) noexcept;
+template<typename T> T core_util_atomic_fetch_or_explicit(volatile T *valuePtr, mstd::type_identity_t<T> arg, mbed_memory_order order) noexcept;
 /** \copydoc core_util_fetch_xor_explicit_u8 */
-template<typename T> T core_util_atomic_fetch_xor_explicit(volatile T *valuePtr, mbed::type_identity_t<T> arg, mbed_memory_order order) noexcept;
+template<typename T> T core_util_atomic_fetch_xor_explicit(volatile T *valuePtr, mstd::type_identity_t<T> arg, mbed_memory_order order) noexcept;
 
 /** \copydoc core_util_atomic_load_ptr */
 template<typename T> inline T *core_util_atomic_load(T *const volatile *valuePtr) noexcept;
 /** \copydoc core_util_atomic_load_ptr */
 template<typename T> inline T *core_util_atomic_load(T *const *valuePtr) noexcept;
 /** \copydoc core_util_atomic_store_ptr */
-template<typename T> inline void core_util_atomic_store(T *volatile *valuePtr, mbed::type_identity_t<T> *desiredValue) noexcept;
+template<typename T> inline void core_util_atomic_store(T *volatile *valuePtr, mstd::type_identity_t<T> *desiredValue) noexcept;
 /** \copydoc core_util_atomic_store_ptr */
-template<typename T> inline void core_util_atomic_store(T **valuePtr, mbed::type_identity_t<T> *desiredValue) noexcept;
+template<typename T> inline void core_util_atomic_store(T **valuePtr, mstd::type_identity_t<T> *desiredValue) noexcept;
 /** \copydoc core_util_atomic_exchange_ptr */
-template<typename T> inline T *core_util_atomic_exchange(T *volatile *valuePtr, mbed::type_identity_t<T> *desiredValue) noexcept;
+template<typename T> inline T *core_util_atomic_exchange(T *volatile *valuePtr, mstd::type_identity_t<T> *desiredValue) noexcept;
 /** \copydoc core_util_atomic_cas_ptr */
-template<typename T> inline bool core_util_atomic_compare_exchange_strong(T *volatile *ptr, mbed::type_identity_t<T> **expectedCurrentValue, mbed::type_identity_t<T> *desiredValue) noexcept;
+template<typename T> inline bool core_util_atomic_compare_exchange_strong(T *volatile *ptr, mstd::type_identity_t<T> **expectedCurrentValue, mstd::type_identity_t<T> *desiredValue) noexcept;
 /** \copydoc core_util_atomic_compare_exchange_weak_ptr */
-template<typename T> inline bool core_util_atomic_compare_exchange_weak(T *volatile *ptr, mbed::type_identity_t<T> **expectedCurrentValue, mbed::type_identity_t<T> *desiredValue) noexcept;
+template<typename T> inline bool core_util_atomic_compare_exchange_weak(T *volatile *ptr, mstd::type_identity_t<T> **expectedCurrentValue, mstd::type_identity_t<T> *desiredValue) noexcept;
 /** \copydoc core_util_fetch_add_ptr */
 template<typename T> inline T *core_util_atomic_fetch_add(T *volatile *valuePtr, ptrdiff_t arg) noexcept;
 /** \copydoc core_util_fetch_sub_ptr */
@@ -969,15 +969,15 @@ template<typename T> inline T *core_util_atomic_load_explicit(T *const volatile 
 /** \copydoc core_util_atomic_load_explicit_ptr */
 template<typename T> inline T *core_util_atomic_load_explicit(T *const *valuePtr, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_store_explicit_ptr */
-template<typename T> inline void core_util_atomic_store_explicit(T *volatile *valuePtr, mbed::type_identity_t<T> *desiredValue, mbed_memory_order order) noexcept;
+template<typename T> inline void core_util_atomic_store_explicit(T *volatile *valuePtr, mstd::type_identity_t<T> *desiredValue, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_store_explicit_ptr */
-template<typename T> inline void core_util_atomic_store_explicit(T **valuePtr, mbed::type_identity_t<T> *desiredValue, mbed_memory_order order) noexcept;
+template<typename T> inline void core_util_atomic_store_explicit(T **valuePtr, mstd::type_identity_t<T> *desiredValue, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_exchange_explicit_ptr */
-template<typename T> inline T *core_util_atomic_exchange_explicit(T *volatile *valuePtr, mbed::type_identity_t<T> *desiredValue, mbed_memory_order order) noexcept;
+template<typename T> inline T *core_util_atomic_exchange_explicit(T *volatile *valuePtr, mstd::type_identity_t<T> *desiredValue, mbed_memory_order order) noexcept;
 /** \copydoc core_util_atomic_cas_explicit_ptr */
-template<typename T> inline bool core_util_atomic_compare_exchange_strong_explicit(T *volatile *ptr, mbed::type_identity_t<T> **expectedCurrentValue, mbed::type_identity_t<T> *desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
+template<typename T> inline bool core_util_atomic_compare_exchange_strong_explicit(T *volatile *ptr, mstd::type_identity_t<T> **expectedCurrentValue, mstd::type_identity_t<T> *desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
 /** \copydoc core_util_atomic_compare_exchange_weak_explicit_ptr */
-template<typename T> inline bool core_util_atomic_compare_exchange_weak_explicit(T *volatile *ptr, mbed::type_identity_t<T> **expectedCurrentValue, mbed::type_identity_t<T> *desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
+template<typename T> inline bool core_util_atomic_compare_exchange_weak_explicit(T *volatile *ptr, mstd::type_identity_t<T> **expectedCurrentValue, mstd::type_identity_t<T> *desiredValue, mbed_memory_order success, mbed_memory_order failure) noexcept;
 /** \copydoc core_util_fetch_add_explicit_ptr */
 template<typename T> inline T *core_util_atomic_fetch_add_explicit(T *volatile *valuePtr, ptrdiff_t arg, mbed_memory_order order) noexcept;
 /** \copydoc core_util_fetch_sub_explicit_ptr */

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -524,8 +524,10 @@ class Resources(object):
             return
 
         _, ext = splitext(file_path)
-
-        file_type = self._EXT.get(ext.lower())
+        if ext == "" and "cxxsupport" in fake_path:
+            file_type = FileType.HEADER
+        else:
+            file_type = self._EXT.get(ext.lower())
         self.add_file_ref(file_type, fake_path, file_path)
         if file_type == FileType.HEADER:
             for name, path in self._all_parents(file_path, base_path, into_path):

--- a/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
+++ b/tools/test/travis-ci/doxy-spellchecker/ignore.en.pws
@@ -46,7 +46,9 @@ retval
 dequeue
 assertation
 destructor
+destructors
 constructor
+constructors
 ctor
 dtor
 dereference
@@ -71,6 +73,7 @@ deasserted
 getter
 setter
 preallocated
+excludable
 ascii
 IPv
 param

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -160,9 +160,9 @@ class ARM(mbedToolchain):
 
     def _get_toolchain_labels(self):
         if getattr(self.target, "default_toolchain", "ARM") == "uARM":
-            return ["ARM", "ARM_MICRO"]
+            return ["ARM", "ARM_MICRO", "ARMC5"]
         else:
-            return ["ARM", "ARM_STD"]
+            return ["ARM", "ARM_STD", "ARMC5"]
 
     def parse_dependencies(self, dep_path):
         dependencies = []


### PR DESCRIPTION
### Description

Restructure `mbed_cxxsupport.h` from #10868, to make it mirror the standard C library.

* `<mstd_xxxx>` is equivalent to C++14 or later `<xxxx>`
* Gets base toolchain header in to populate `namespace std` - some local implementation for ARM C 5.
* Imports all relevant stuff into `namespace mstd` - alternative implementations supplied where we want to bypass toolchain deficiencies. Eg `mstd::mutex` maps to `rtos::Mutex`.
* `namespace mstd` can also contain post-C++14 extensions not necessarily present in all toolchains.

Some C++11 library extensions and fixes, notably `invoke`, `<mstd_mutex>`.

`mbed::Atomic` in `platform/Atomic.h` moved to `mstd::atomic` in `<mstd_atomic>` to fit the general pattern.

Using separate namespace and filename gives us the ability to work around toolchain differences. In portable code, the following model could be used, assuming the choice between mbed OS and a fully C++11-compliant system.

    #ifdef TARGET_LIKE_MBED
    #include <mstd_atomic>
    #include <mstd_mutex>
    #else
    #include <atomic>
    #include <mutex>
    using namespace mstd = std;
    #endif

    using mstd::mutex;
     
    mutex m;
    mstd::atomic_int i;

This is a breaking change with respect to #10868 and #10274 now on master (reworking Atomic.h and mbed_cxxsupport.h), but they're new since 5.13. I'd like this change to go in before 5.14, so there's no visible released API breakage.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan-, @bulislaw 

### Release Notes

* A set of C++11/14 library support headers have been included in `platform/cxxsupport`. These include standard-C++-like APIs, eg `mstd::atomic` in `<mstd_atomic>`, to improve on implementations provided with toolchains. See `platform/cxxsupport/README.md` for more information.