### PR TITLE
Add padding up to restrict_size

### DIFF
--- a/tools/regions.py
+++ b/tools/regions.py
@@ -107,7 +107,8 @@ def merge_region_list(
         destination,
         notify,
         padding=b'\xFF',
-        restrict_size=None
+        restrict_size=None,
+        pad_to_restrict_size=False
 ):
     """Merge the region_list into a single image
 
@@ -116,6 +117,7 @@ def merge_region_list(
     destination - file name to write all regions to
     padding - bytes to fill gaps with
     restrict_size - check to ensure a region fits within the given size
+    pad_to_restrict_size - fill with padding up to restrict_size
     """
     merged = IntelHex()
     _, format = splitext(destination)
@@ -168,6 +170,9 @@ def merge_region_list(
             pad_size = start - begin
             merged.puts(begin, padding * pad_size)
             begin = stop + 1
+        if restrict_size is not None and pad_to_restrict_size:
+            pad_size = int(restrict_size, 0) - begin
+            merged.puts(begin, padding * pad_size)
 
     if not exists(dirname(destination)):
         makedirs(dirname(destination))

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -666,7 +666,8 @@ class mbedToolchain:
         res = "{}.{}".format(join(self.build_dir, name), ext)
         merge_region_list(
             region_list, res, self.notify,
-            restrict_size=self.config.target.restrict_size
+            restrict_size=self.config.target.restrict_size,
+            pad_to_restrict_size=True
         )
         update_regions = [
             r for r in region_list if r.name in UPDATE_WHITELIST


### PR DESCRIPTION
### Description

https://os.mbed.com/docs/mbed-os/v5.13/reference/bootloader-configuration.html section target.restrict_size states that:
"The postbuild merge process pads the resulting bootloader binary to its end address."
This padding is added for region merges that specify restrict_size. Additional pad_to_restrict_size boolean argument added to allow both full and 'update' outputs.

Fixes: #9949

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes
