### PR TITLE
Update MCUXpresso AnalogIn driver for LPC devices

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/LPC54114_cm4_features.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/LPC54114_cm4_features.h
@@ -1,41 +1,19 @@
 /*
 ** ###################################################################
 **     Version:             rev. 1.0, 2016-05-09
-**     Build:               b160802
+**     Build:               b190225
 **
 **     Abstract:
 **         Chip specific module features.
 **
-**     Copyright (c) 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2019 NXP
 **     All rights reserved.
 **
-**     Redistribution and use in source and binary forms, with or without modification,
-**     are permitted provided that the following conditions are met:
+**     SPDX-License-Identifier: BSD-3-Clause
 **
-**     o Redistributions of source code must retain the above copyright notice, this list
-**       of conditions and the following disclaimer.
-**
-**     o Redistributions in binary form must reproduce the above copyright notice, this
-**       list of conditions and the following disclaimer in the documentation and/or
-**       other materials provided with the distribution.
-**
-**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-**       contributors may be used to endorse or promote products derived from this
-**       software without specific prior written permission.
-**
-**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-**
-**     http:                 www.freescale.com
-**     mail:                 support@freescale.com
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
 **
 **     Revisions:
 **     - rev. 1.0 (2016-05-09)
@@ -55,6 +33,8 @@
 #define FSL_FEATURE_SOC_ASYNC_SYSCON_COUNT (1)
 /* @brief CRC availability on the SoC. */
 #define FSL_FEATURE_SOC_CRC_COUNT (1)
+/* @brief CTIMER availability on the SoC. */
+#define FSL_FEATURE_SOC_CTIMER_COUNT (5)
 /* @brief DMA availability on the SoC. */
 #define FSL_FEATURE_SOC_DMA_COUNT (1)
 /* @brief DMIC availability on the SoC. */
@@ -89,8 +69,6 @@
 #define FSL_FEATURE_SOC_SPIFI_COUNT (1)
 /* @brief SYSCON availability on the SoC. */
 #define FSL_FEATURE_SOC_SYSCON_COUNT (1)
-/* @brief CTIMER availability on the SoC. */
-#define FSL_FEATURE_SOC_CTIMER_COUNT (5)
 /* @brief USART availability on the SoC. */
 #define FSL_FEATURE_SOC_USART_COUNT (8)
 /* @brief USB availability on the SoC. */
@@ -100,15 +78,138 @@
 /* @brief WWDT availability on the SoC. */
 #define FSL_FEATURE_SOC_WWDT_COUNT (1)
 
+/* ADC module features */
+
+/* @brief Do not has input select (register INSEL). */
+#define FSL_FEATURE_ADC_HAS_NO_INSEL  (0)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_RESOL (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_TSAMP (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE (0)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_CALMODE (0)
+/* @brief Has startup register. */
+#define FSL_FEATURE_ADC_HAS_STARTUP_REG (1)
+/* @brief Has ADTrim register */
+#define FSL_FEATURE_ADC_HAS_TRIM_REG (0)
+/* @brief Has Calibration register. */
+#define FSL_FEATURE_ADC_HAS_CALIB_REG (1)
+
 /* DMA module features */
 
 /* @brief Number of channels */
 #define FSL_FEATURE_DMA_NUMBER_OF_CHANNELS (20)
+/* @brief Align size of DMA descriptor */
+#define FSL_FEATURE_DMA_DESCRIPTOR_ALIGN_SIZE (512)
+/* @brief DMA head link descriptor table align size */
+#define FSL_FEATURE_DMA_LINK_DESCRIPTOR_ALIGN_SIZE (16U)
+
+/* FLEXCOMM module features */
+
+/* @brief FLEXCOMM0 USART INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM0_USART_INDEX  (0)
+/* @brief FLEXCOMM0 SPI INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM0_SPI_INDEX  (0)
+/* @brief FLEXCOMM0 I2C INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM0_I2C_INDEX  (0)
+/* @brief FLEXCOMM1 USART INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM1_USART_INDEX  (1)
+/* @brief FLEXCOMM1 SPI INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM1_SPI_INDEX  (1)
+/* @brief FLEXCOMM1 I2C INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM1_I2C_INDEX  (1)
+/* @brief FLEXCOMM2 USART INDEX 2 */
+#define FSL_FEATURE_FLEXCOMM2_USART_INDEX  (2)
+/* @brief FLEXCOMM2 SPI INDEX 2 */
+#define FSL_FEATURE_FLEXCOMM2_SPI_INDEX  (2)
+/* @brief FLEXCOMM2 I2C INDEX 2 */
+#define FSL_FEATURE_FLEXCOMM2_I2C_INDEX  (2)
+/* @brief FLEXCOMM3 USART INDEX 3 */
+#define FSL_FEATURE_FLEXCOMM3_USART_INDEX  (3)
+/* @brief FLEXCOMM3 SPI INDEX 3 */
+#define FSL_FEATURE_FLEXCOMM3_SPI_INDEX  (3)
+/* @brief FLEXCOMM3 I2C INDEX 3 */
+#define FSL_FEATURE_FLEXCOMM3_I2C_INDEX  (3)
+/* @brief FLEXCOMM4 USART INDEX 4 */
+#define FSL_FEATURE_FLEXCOMM4_USART_INDEX  (4)
+/* @brief FLEXCOMM4 SPI INDEX 4 */
+#define FSL_FEATURE_FLEXCOMM4_SPI_INDEX  (4)
+/* @brief FLEXCOMM4 I2C INDEX 4 */
+#define FSL_FEATURE_FLEXCOMM4_I2C_INDEX  (4)
+/* @brief FLEXCOMM5 USART INDEX 5 */
+#define FSL_FEATURE_FLEXCOMM5_USART_INDEX  (5)
+/* @brief FLEXCOMM5 SPI INDEX 5 */
+#define FSL_FEATURE_FLEXCOMM5_SPI_INDEX  (5)
+/* @brief FLEXCOMM5 I2C INDEX 5 */
+#define FSL_FEATURE_FLEXCOMM5_I2C_INDEX  (5)
+/* @brief FLEXCOMM6 USART INDEX 6 */
+#define FSL_FEATURE_FLEXCOMM6_USART_INDEX  (6)
+/* @brief FLEXCOMM6 SPI INDEX 6 */
+#define FSL_FEATURE_FLEXCOMM6_SPI_INDEX  (6)
+/* @brief FLEXCOMM6 I2C INDEX 6 */
+#define FSL_FEATURE_FLEXCOMM6_I2C_INDEX  (6)
+/* @brief FLEXCOMM7 I2S INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM6_I2S_INDEX  (0)
+/* @brief FLEXCOMM7 USART INDEX 7 */
+#define FSL_FEATURE_FLEXCOMM7_USART_INDEX  (7)
+/* @brief FLEXCOMM7 SPI INDEX 7 */
+#define FSL_FEATURE_FLEXCOMM7_SPI_INDEX  (7)
+/* @brief FLEXCOMM7 I2C INDEX 7 */
+#define FSL_FEATURE_FLEXCOMM7_I2C_INDEX  (7)
+/* @brief FLEXCOMM7 I2S INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM7_I2S_INDEX  (1)
+/* @brief I2S has DMIC interconnection */
+#define FSL_FEATURE_FLEXCOMM_INSTANCE_I2S_HAS_DMIC_INTERCONNECTIONn(x) \
+    (((x) == FLEXCOMM0) ? (0) : \
+    (((x) == FLEXCOMM1) ? (0) : \
+    (((x) == FLEXCOMM2) ? (0) : \
+    (((x) == FLEXCOMM3) ? (0) : \
+    (((x) == FLEXCOMM4) ? (0) : \
+    (((x) == FLEXCOMM5) ? (0) : \
+    (((x) == FLEXCOMM6) ? (0) : \
+    (((x) == FLEXCOMM7) ? (1) : (-1)))))))))
+
+/* I2S module features */
+
+/* @brief I2S support dual channel transfer */
+#define FSL_FEATURE_I2S_SUPPORT_SECONDARY_CHANNEL (0)
+/* @brief I2S has DMIC interconnection */
+#define FSL_FEATURE_FLEXCOMM_I2S_HAS_DMIC_INTERCONNECTION  (1)
+
+/* MAILBOX module features */
+
+/* @brief Mailbox side for current core */
+#define FSL_FEATURE_MAILBOX_SIDE_A (1)
+/* @brief Mailbox has no reset control */
+#define FSL_FEATURE_MAILBOX_HAS_NO_RESET (1)
+
+/* MRT module features */
+
+/* @brief number of channels. */
+#define FSL_FEATURE_MRT_NUMBER_OF_CHANNELS  (4)
+
+/* interrupt module features */
+
+/* @brief Lowest interrupt request number. */
+#define FSL_FEATURE_INTERRUPT_IRQ_MIN (-14)
+/* @brief Highest interrupt request number. */
+#define FSL_FEATURE_INTERRUPT_IRQ_MAX (105)
 
 /* PINT module features */
 
 /* @brief Number of connected outputs */
 #define FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS (8)
+
+/* RTC module features */
+
+/* @brief RTC has no reset control */
+#define FSL_FEATURE_RTC_HAS_NO_RESET (1)
 
 /* SCT module features */
 
@@ -118,6 +219,8 @@
 #define FSL_FEATURE_SCT_NUMBER_OF_STATES (10)
 /* @brief Number of match capture */
 #define FSL_FEATURE_SCT_NUMBER_OF_MATCH_CAPTURE (10)
+/* @brief Number of outputs */
+#define FSL_FEATURE_SCT_NUMBER_OF_OUTPUTS (8)
 
 /* SYSCON module features */
 
@@ -129,6 +232,24 @@
 #define FSL_FEATURE_SYSCON_FLASH_SECTOR_SIZE_BYTES (32768)
 /* @brief Flash size in bytes */
 #define FSL_FEATURE_SYSCON_FLASH_SIZE_BYTES (262144)
+/* @brief IAP has Flash read & write function */
+#define FSL_FEATURE_IAP_HAS_FLASH_FUNCTION (1)
+/* @brief IAP has read Flash signature function  */
+#define FSL_FEATURE_IAP_HAS_FLASH_SIGNATURE_READ (1)
+/* @brief IAP has read extended Flash signature function */
+#define FSL_FEATURE_IAP_HAS_FLASH_EXTENDED_SIGNATURE_READ (0)
+
+/* SysTick module features */
+
+/* @brief Systick has external reference clock. */
+#define FSL_FEATURE_SYSTICK_HAS_EXT_REF (0)
+/* @brief Systick external reference clock is core clock divided by this value. */
+#define FSL_FEATURE_SYSTICK_EXT_REF_CORE_DIV (0)
+
+/* USB module features */
+
+/* @brief Number of the endpoint in USB FS */
+#define FSL_FEATURE_USB_EP_NUM (5)
 
 #endif /* _LPC54114_cm4_FEATURES_H_ */
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_adc.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_adc.c
@@ -1,45 +1,32 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_adc.h"
 #include "fsl_clock.h"
 
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.lpc_adc"
+#endif
+
 static ADC_Type *const s_adcBases[] = ADC_BASE_PTRS;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static const clock_ip_name_t s_adcClocks[] = ADC_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+#define FREQUENCY_1MHZ (1000000U)
 
 static uint32_t ADC_GetInstance(ADC_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_ADC_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_adcBases); instance++)
     {
         if (s_adcBases[instance] == base)
         {
@@ -47,19 +34,27 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_ADC_COUNT);
+    assert(instance < ARRAY_SIZE(s_adcBases));
 
     return instance;
 }
 
+/*!
+ * brief Initialize the ADC module.
+ *
+ * param base ADC peripheral base address.
+ * param config Pointer to configuration structure, see to #adc_config_t.
+ */
 void ADC_Init(ADC_Type *base, const adc_config_t *config)
 {
     assert(config != NULL);
 
     uint32_t tmp32 = 0U;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Enable clock. */
     CLOCK_EnableClock(s_adcClocks[ADC_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     /* Disable the interrupts. */
     base->INTEN = 0U; /* Quickly disable all the interrupts. */
@@ -67,6 +62,7 @@ void ADC_Init(ADC_Type *base, const adc_config_t *config)
     /* Configure the ADC block. */
     tmp32 = ADC_CTRL_CLKDIV(config->clockDividerNumber);
 
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
     /* Async or Sync clock mode. */
     switch (config->clockMode)
     {
@@ -76,84 +72,236 @@ void ADC_Init(ADC_Type *base, const adc_config_t *config)
         default: /* kADC_ClockSynchronousMode */
             break;
     }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
 
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
     /* Resolution. */
-    tmp32 |= ADC_CTRL_RESOL(config->resolution);
 
+    tmp32 |= ADC_CTRL_RESOL(config->resolution);
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_RESOL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL) & FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL
     /* Bypass calibration. */
     if (config->enableBypassCalibration)
     {
         tmp32 |= ADC_CTRL_BYPASSCAL_MASK;
     }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL. */
 
-    /* Sample time clock count. */
-    tmp32 |= ADC_CTRL_TSAMP(config->sampleTimeNumber);
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_TSAMP) & FSL_FEATURE_ADC_HAS_CTRL_TSAMP
+/* Sample time clock count. */
+#if (defined(FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL) && FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL)
+    if (config->clockMode == kADC_ClockAsynchronousMode)
+    {
+#endif /* FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL */
+        tmp32 |= ADC_CTRL_TSAMP(config->sampleTimeNumber);
+#if (defined(FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL) && FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL)
+    }
+#endif /* FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL */
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_TSAMP. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE) & FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE
+    if (config->enableLowPowerMode)
+    {
+        tmp32 |= ADC_CTRL_LPWRMODE_MASK;
+    }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE. */
 
     base->CTRL = tmp32;
+
+#if defined(FSL_FEATURE_ADC_HAS_GPADC_CTRL0_LDO_POWER_EN) && FSL_FEATURE_ADC_HAS_GPADC_CTRL0_LDO_POWER_EN
+    base->GPADC_CTRL0 |= ADC_GPADC_CTRL0_LDO_POWER_EN_MASK;
+    if (config->clockMode == kADC_ClockSynchronousMode)
+    {
+        base->GPADC_CTRL0 |= ADC_GPADC_CTRL0_PASS_ENABLE(config->sampleTimeNumber);
+    }
+#endif /* FSL_FEATURE_ADC_HAS_GPADC_CTRL0_LDO_POWER_EN */
+
+#if defined(FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL) && FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL
+    tmp32 = *(uint32_t *)FSL_FEATURE_FLASH_ADDR_OF_TEMP_CAL;
+    if (tmp32 & FSL_FEATURE_FLASH_ADDR_OF_TEMP_CAL_VALID)
+    {
+        base->GPADC_CTRL1 = (tmp32 >> 1);
+    }
+#if !(defined(FSL_FEATURE_ADC_HAS_STARTUP_ADC_INIT) && FSL_FEATURE_ADC_HAS_STARTUP_ADC_INIT)
+    base->STARTUP = ADC_STARTUP_ADC_ENA_MASK; /* Set the ADC Start bit */
+#endif                                        /* FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL */
+#endif                                        /* FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL */
+
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+    base->TRM &= ~ADC_TRM_VRANGE_MASK;
+    base->TRM |= ADC_TRM_VRANGE(config->voltageRange);
+#endif /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 }
 
+/*!
+ * brief Gets an available pre-defined settings for initial configuration.
+ *
+ * This function initializes the initial configuration structure with an available settings. The default values are:
+ * code
+ *   config->clockMode = kADC_ClockSynchronousMode;
+ *   config->clockDividerNumber = 0U;
+ *   config->resolution = kADC_Resolution12bit;
+ *   config->enableBypassCalibration = false;
+ *   config->sampleTimeNumber = 0U;
+ * endcode
+ * param config Pointer to configuration structure.
+ */
 void ADC_GetDefaultConfig(adc_config_t *config)
 {
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
+
     config->clockMode = kADC_ClockSynchronousMode;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
+
     config->clockDividerNumber = 0U;
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
     config->resolution = kADC_Resolution12bit;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_RESOL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL) & FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL
     config->enableBypassCalibration = false;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_TSAMP) & FSL_FEATURE_ADC_HAS_CTRL_TSAMP
     config->sampleTimeNumber = 0U;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_TSAMP. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE) & FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE
+    config->enableLowPowerMode = false;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE. */
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+    config->voltageRange = kADC_HighVoltageRange;
+#endif /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 }
 
+/*!
+ * brief Deinitialize the ADC module.
+ *
+ * param base ADC peripheral base address.
+ */
 void ADC_Deinit(ADC_Type *base)
 {
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable the clock. */
     CLOCK_DisableClock(s_adcClocks[ADC_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
+#if !(defined(FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC) && FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC)
+#if defined(FSL_FEATURE_ADC_HAS_CALIB_REG) & FSL_FEATURE_ADC_HAS_CALIB_REG
+/*!
+ * brief Do the self calibration. To calibrate the ADC, set the ADC clock to 1 mHz.
+ *        In order to achieve the specified ADC accuracy, the A/D converter must be recalibrated, at a minimum,
+ *        following every chip reset before initiating normal ADC operation.
+ *
+ * param base ADC peripheral base address.
+ * retval true  Calibration succeed.
+ * retval false Calibration failed.
+ */
 bool ADC_DoSelfCalibration(ADC_Type *base)
 {
-    uint32_t i;
+    uint32_t frequency = 0U;
+    uint32_t delayUs = 0U;
 
     /* Enable the converter. */
     /* This bit acn only be set 1 by software. It is cleared automatically whenever the ADC is powered down.
        This bit should be set after at least 10 ms after the ADC is powered on. */
     base->STARTUP = ADC_STARTUP_ADC_ENA_MASK;
-    for (i = 0U; i < 0x10; i++) /* Wait a few clocks to startup up. */
-    {
-        __ASM("NOP");
-    }
+    SDK_DelayAtLeastUs(1U);
     if (!(base->STARTUP & ADC_STARTUP_ADC_ENA_MASK))
     {
         return false; /* ADC is not powered up. */
     }
 
+    /* Get the ADC clock frequency in synchronous mode. */
+    frequency = CLOCK_GetFreq(kCLOCK_BusClk) / (((base->CTRL & ADC_CTRL_CLKDIV_MASK) >> ADC_CTRL_CLKDIV_SHIFT) + 1);
+    base->CTRL |= ADC_CTRL_CLKDIV((frequency / 1000000U) - 1U);
+    frequency = 1000000U;
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) && FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
+    /* Get the ADC clock frequency in asynchronous mode. */
+    if (ADC_CTRL_ASYNMODE_MASK == (base->CTRL & ADC_CTRL_ASYNMODE_MASK))
+    {
+        frequency = CLOCK_GetAdcClkFreq();
+    }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE */
+    assert(0U != frequency);
+
     /* If not in by-pass mode, do the calibration. */
     if ((ADC_CALIB_CALREQD_MASK == (base->CALIB & ADC_CALIB_CALREQD_MASK)) &&
         (0U == (base->CTRL & ADC_CTRL_BYPASSCAL_MASK)))
     {
+        /* A calibration cycle requires approximately 81 ADC clocks to complete. */
+        delayUs = (120 * FREQUENCY_1MHZ) / frequency + 1;
         /* Calibration is needed, do it now. */
         base->CALIB = ADC_CALIB_CALIB_MASK;
-        i = 0xF0000;
-        while ((ADC_CALIB_CALIB_MASK == (base->CALIB & ADC_CALIB_CALIB_MASK)) && (--i))
-        {
-        }
-        if (i == 0U)
+        SDK_DelayAtLeastUs(delayUs);
+        if (ADC_CALIB_CALIB_MASK == (base->CALIB & ADC_CALIB_CALIB_MASK))
         {
             return false; /* Calibration timeout. */
         }
     }
 
-    /* A dummy conversion cycle will be performed. */
+    /* A “dummy” conversion cycle requires approximately 6 ADC clocks */
+    delayUs = (10 * FREQUENCY_1MHZ) / frequency + 1;
     base->STARTUP |= ADC_STARTUP_ADC_INIT_MASK;
-    i = 0x7FFFF;
-    while ((ADC_STARTUP_ADC_INIT_MASK == (base->STARTUP & ADC_STARTUP_ADC_INIT_MASK)) && (--i))
-    {
-    }
-    if (i == 0U)
+    SDK_DelayAtLeastUs(delayUs);
+    if (ADC_STARTUP_ADC_INIT_MASK == (base->STARTUP & ADC_STARTUP_ADC_INIT_MASK))
     {
         return false;
     }
 
     return true;
 }
+#else
+/*!
+ * brief Do the self calibration. To calibrate the ADC, set the ADC clock to 1 mHz.
+ *        In order to achieve the specified ADC accuracy, the A/D converter must be recalibrated, at a minimum,
+ *        following every chip reset before initiating normal ADC operation.
+ *
+ * param base ADC peripheral base address.
+ * param frequency The ststem clock frequency to ADC.
+ * retval true  Calibration succeed.
+ * retval false Calibration failed.
+ */
+bool ADC_DoSelfCalibration(ADC_Type *base, uint32_t frequency)
+{
+    uint32_t tmp32;
 
+    /* Store the current contents of the ADC CTRL register. */
+    tmp32 = base->CTRL;
+
+    /* Start ADC self-calibration. */
+    base->CTRL |= ADC_CTRL_CALMODE_MASK;
+
+    /* Divide the system clock to yield an ADC clock of about 1 mHz. */
+    base->CTRL &= ~ADC_CTRL_CLKDIV_MASK;
+    base->CTRL |= ADC_CTRL_CLKDIV((frequency / 1000000U) - 1U);
+
+    /* Clear the LPWR bit. */
+    base->CTRL &= ~ADC_CTRL_LPWRMODE_MASK;
+    /* Delay for 120 uSec @ 1 mHz ADC clock */
+    SDK_DelayAtLeastUs(120U);
+
+    /* Check the completion of calibration. */
+    if (ADC_CTRL_CALMODE_MASK == (base->CTRL & ADC_CTRL_CALMODE_MASK))
+    {
+        /* Restore the contents of the ADC CTRL register. */
+        base->CTRL = tmp32;
+        return false; /* Calibration timeout. */
+    }
+    /* Restore the contents of the ADC CTRL register. */
+    base->CTRL = tmp32;
+
+    return true;
+}
+#endif /* FSL_FEATURE_ADC_HAS_CALIB_REG */
+#endif /* FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC*/
+
+/*!
+ * brief Configure the conversion sequence A.
+ *
+ * param base ADC peripheral base address.
+ * param config Pointer to configuration structure, see to #adc_conv_seq_config_t.
+ */
 void ADC_SetConvSeqAConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
 {
     assert(config != NULL);
@@ -198,6 +346,12 @@ void ADC_SetConvSeqAConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
     base->SEQ_CTRL[0] = tmp32;
 }
 
+/*!
+ * brief Configure the conversion sequence B.
+ *
+ * param base ADC peripheral base address.
+ * param config Pointer to configuration structure, see to #adc_conv_seq_config_t.
+ */
 void ADC_SetConvSeqBConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
 {
     assert(config != NULL);
@@ -242,6 +396,14 @@ void ADC_SetConvSeqBConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
     base->SEQ_CTRL[1] = tmp32;
 }
 
+/*!
+ * brief Get the global ADC conversion infomation of sequence A.
+ *
+ * param base ADC peripheral base address.
+ * param info Pointer to information structure, see to #adc_result_info_t;
+ * retval true  The conversion result is ready.
+ * retval false The conversion result is not ready yet.
+ */
 bool ADC_GetConvSeqAGlobalConversionResult(ADC_Type *base, adc_result_info_t *info)
 {
     assert(info != NULL);
@@ -259,11 +421,19 @@ bool ADC_GetConvSeqAGlobalConversionResult(ADC_Type *base, adc_result_info_t *in
     info->thresholdCorssingStatus =
         (adc_threshold_crossing_status_t)((tmp32 & ADC_SEQ_GDAT_THCMPCROSS_MASK) >> ADC_SEQ_GDAT_THCMPCROSS_SHIFT);
     info->channelNumber = (tmp32 & ADC_SEQ_GDAT_CHN_MASK) >> ADC_SEQ_GDAT_CHN_SHIFT;
-    info->overrunFlag = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
+    info->overrunFlag   = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
 
     return true;
 }
 
+/*!
+ * brief Get the global ADC conversion infomation of sequence B.
+ *
+ * param base ADC peripheral base address.
+ * param info Pointer to information structure, see to #adc_result_info_t;
+ * retval true  The conversion result is ready.
+ * retval false The conversion result is not ready yet.
+ */
 bool ADC_GetConvSeqBGlobalConversionResult(ADC_Type *base, adc_result_info_t *info)
 {
     assert(info != NULL);
@@ -281,11 +451,20 @@ bool ADC_GetConvSeqBGlobalConversionResult(ADC_Type *base, adc_result_info_t *in
     info->thresholdCorssingStatus =
         (adc_threshold_crossing_status_t)((tmp32 & ADC_SEQ_GDAT_THCMPCROSS_MASK) >> ADC_SEQ_GDAT_THCMPCROSS_SHIFT);
     info->channelNumber = (tmp32 & ADC_SEQ_GDAT_CHN_MASK) >> ADC_SEQ_GDAT_CHN_SHIFT;
-    info->overrunFlag = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
+    info->overrunFlag   = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
 
     return true;
 }
 
+/*!
+ * brief Get the channel's ADC conversion completed under each conversion sequence.
+ *
+ * param base ADC peripheral base address.
+ * param channel The indicated channel number.
+ * param info Pointer to information structure, see to #adc_result_info_t;
+ * retval true  The conversion result is ready.
+ * retval false The conversion result is not ready yet.
+ */
 bool ADC_GetChannelConversionResult(ADC_Type *base, uint32_t channel, adc_result_info_t *info)
 {
     assert(info != NULL);
@@ -299,12 +478,51 @@ bool ADC_GetChannelConversionResult(ADC_Type *base, uint32_t channel, adc_result
     }
 
     info->result = (tmp32 & ADC_DAT_RESULT_MASK) >> ADC_DAT_RESULT_SHIFT;
+#if (defined(FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT) && FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT)
+    switch ((base->CTRL & ADC_CTRL_RESOL_MASK) >> ADC_CTRL_RESOL_SHIFT)
+    {
+        case kADC_Resolution10bit:
+            info->result >>= kADC_Resolution10bitInfoResultShift;
+            break;
+        case kADC_Resolution8bit:
+            info->result >>= kADC_Resolution8bitInfoResultShift;
+            break;
+        case kADC_Resolution6bit:
+            info->result >>= kADC_Resolution6bitInfoResultShift;
+            break;
+        default:
+            break;
+    }
+#endif
     info->thresholdCompareStatus =
         (adc_threshold_compare_status_t)((tmp32 & ADC_DAT_THCMPRANGE_MASK) >> ADC_DAT_THCMPRANGE_SHIFT);
     info->thresholdCorssingStatus =
         (adc_threshold_crossing_status_t)((tmp32 & ADC_DAT_THCMPCROSS_MASK) >> ADC_DAT_THCMPCROSS_SHIFT);
     info->channelNumber = (tmp32 & ADC_DAT_CHANNEL_MASK) >> ADC_DAT_CHANNEL_SHIFT;
-    info->overrunFlag = ((tmp32 & ADC_DAT_OVERRUN_MASK) == ADC_DAT_OVERRUN_MASK);
+    info->overrunFlag   = ((tmp32 & ADC_DAT_OVERRUN_MASK) == ADC_DAT_OVERRUN_MASK);
 
     return true;
 }
+#if defined(FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP) && (FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP)
+void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        SYSCON->ASYNCAPBCTRL         = SYSCON_ASYNCAPBCTRL_ENABLE_MASK;
+        ASYNC_SYSCON->TEMPSENSORCTRL = kADC_NoOffsetAdded;
+        ASYNC_SYSCON->TEMPSENSORCTRL |= ASYNC_SYSCON_TEMPSENSORCTRL_ENABLE_MASK;
+        base->GPADC_CTRL0 |= (kADC_ADCInUnityGainMode | kADC_Impedance87kOhm);
+    }
+    else
+    {
+        /* if the temperature sensor is not turned on then ASYNCAPBCTRL is likely to be zero
+         * and accessing the registers will cause a memory access error. Test for this */
+        if (SYSCON->ASYNCAPBCTRL == SYSCON_ASYNCAPBCTRL_ENABLE_MASK)
+        {
+            ASYNC_SYSCON->TEMPSENSORCTRL = 0x0;
+            base->GPADC_CTRL0 &= ~(kADC_ADCInUnityGainMode | kADC_Impedance87kOhm);
+            base->GPADC_CTRL0 |= kADC_Impedance55kOhm;
+        }
+    }
+}
+#endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_adc.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_adc.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef __FSL_ADC_H__
@@ -46,25 +24,26 @@
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief ADC driver version 1.0.0. */
-#define LPC_ADC_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*! @brief ADC driver version 2.3.1. */
+#define FSL_ADC_DRIVER_VERSION (MAKE_VERSION(2, 3, 1))
 /*@}*/
 
 /*!
  * @brief Flags
  */
+
 enum _adc_status_flags
 {
-    kADC_ThresholdCompareFlagOnChn0 = 1U << 0U,   /*!< Threshold comparison event on Channel 0. */
-    kADC_ThresholdCompareFlagOnChn1 = 1U << 1U,   /*!< Threshold comparison event on Channel 1. */
-    kADC_ThresholdCompareFlagOnChn2 = 1U << 2U,   /*!< Threshold comparison event on Channel 2. */
-    kADC_ThresholdCompareFlagOnChn3 = 1U << 3U,   /*!< Threshold comparison event on Channel 3. */
-    kADC_ThresholdCompareFlagOnChn4 = 1U << 4U,   /*!< Threshold comparison event on Channel 4. */
-    kADC_ThresholdCompareFlagOnChn5 = 1U << 5U,   /*!< Threshold comparison event on Channel 5. */
-    kADC_ThresholdCompareFlagOnChn6 = 1U << 6U,   /*!< Threshold comparison event on Channel 6. */
-    kADC_ThresholdCompareFlagOnChn7 = 1U << 7U,   /*!< Threshold comparison event on Channel 7. */
-    kADC_ThresholdCompareFlagOnChn8 = 1U << 8U,   /*!< Threshold comparison event on Channel 8. */
-    kADC_ThresholdCompareFlagOnChn9 = 1U << 9U,   /*!< Threshold comparison event on Channel 9. */
+    kADC_ThresholdCompareFlagOnChn0  = 1U << 0U,  /*!< Threshold comparison event on Channel 0. */
+    kADC_ThresholdCompareFlagOnChn1  = 1U << 1U,  /*!< Threshold comparison event on Channel 1. */
+    kADC_ThresholdCompareFlagOnChn2  = 1U << 2U,  /*!< Threshold comparison event on Channel 2. */
+    kADC_ThresholdCompareFlagOnChn3  = 1U << 3U,  /*!< Threshold comparison event on Channel 3. */
+    kADC_ThresholdCompareFlagOnChn4  = 1U << 4U,  /*!< Threshold comparison event on Channel 4. */
+    kADC_ThresholdCompareFlagOnChn5  = 1U << 5U,  /*!< Threshold comparison event on Channel 5. */
+    kADC_ThresholdCompareFlagOnChn6  = 1U << 6U,  /*!< Threshold comparison event on Channel 6. */
+    kADC_ThresholdCompareFlagOnChn7  = 1U << 7U,  /*!< Threshold comparison event on Channel 7. */
+    kADC_ThresholdCompareFlagOnChn8  = 1U << 8U,  /*!< Threshold comparison event on Channel 8. */
+    kADC_ThresholdCompareFlagOnChn9  = 1U << 9U,  /*!< Threshold comparison event on Channel 9. */
     kADC_ThresholdCompareFlagOnChn10 = 1U << 10U, /*!< Threshold comparison event on Channel 10. */
     kADC_ThresholdCompareFlagOnChn11 = 1U << 11U, /*!< Threshold comparison event on Channel 11. */
     kADC_OverrunFlagForChn0 =
@@ -93,10 +72,10 @@ enum _adc_status_flags
         1U << 23U, /*!< Mirror the OVERRUN status flag from the result register for ADC channel 11. */
     kADC_GlobalOverrunFlagForSeqA = 1U << 24U, /*!< Mirror the glabal OVERRUN status flag for conversion sequence A. */
     kADC_GlobalOverrunFlagForSeqB = 1U << 25U, /*!< Mirror the global OVERRUN status flag for conversion sequence B. */
-    kADC_ConvSeqAInterruptFlag = 1U << 28U,    /*!< Sequence A interrupt/DMA trigger. */
-    kADC_ConvSeqBInterruptFlag = 1U << 29U,    /*!< Sequence B interrupt/DMA trigger. */
-    kADC_ThresholdCompareInterruptFlag = 1U << 30U, /*!< Threshold comparision interrupt flag. */
-    kADC_OverrunInterruptFlag = 1U << 31U,          /*!< Overrun interrupt flag. */
+    kADC_ConvSeqAInterruptFlag    = 1U << 28U, /*!< Sequence A interrupt/DMA trigger. */
+    kADC_ConvSeqBInterruptFlag    = 1U << 29U, /*!< Sequence B interrupt/DMA trigger. */
+    kADC_ThresholdCompareInterruptFlag = 1U << 30U,        /*!< Threshold comparision interrupt flag. */
+    kADC_OverrunInterruptFlag          = (int)(1U << 31U), /*!< Overrun interrupt flag. */
 };
 
 /*!
@@ -110,10 +89,11 @@ enum _adc_interrupt_enable
     kADC_ConvSeqBInterruptEnable = ADC_INTEN_SEQB_INTEN_MASK, /*!< Enable interrupt upon completion of each individual
                                                                    conversion in sequence B, or entire sequence. */
     kADC_OverrunInterruptEnable = ADC_INTEN_OVR_INTEN_MASK, /*!< Enable the detection of an overrun condition on any of
-                                                                 the channel data registers will cause an overrun
-                                                                 interrupt/DMA trigger. */
+                                                               the channel data registers will cause an overrun
+                                                               interrupt/DMA trigger. */
 };
 
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
 /*!
  * @brief Define selection of clock mode.
  */
@@ -123,17 +103,44 @@ typedef enum _adc_clock_mode
         0U, /*!< The ADC clock would be derived from the system clock based on "clockDividerNumber". */
     kADC_ClockAsynchronousMode = 1U, /*!< The ADC clock would be based on the SYSCON block's divider. */
 } adc_clock_mode_t;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
 
+#if defined(FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT) && (FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT)
 /*!
  * @brief Define selection of resolution.
  */
 typedef enum _adc_resolution
 {
-    kADC_Resolution6bit = 0U,  /*!< 6-bit resolution. */
-    kADC_Resolution8bit = 1U,  /*!< 8-bit resolution. */
+    kADC_Resolution6bit = 3U,
+    /*!< 6-bit resolution. */  /* This is a HW issue that the ADC resolution enum configure not align with HW implement,
+                                  ES2 chip already fixed the issue, Currently, update ADC enum define as a workaround */
+    kADC_Resolution8bit  = 2U, /*!< 8-bit resolution. */
+    kADC_Resolution10bit = 1U, /*!< 10-bit resolution. */
+    kADC_Resolution12bit = 0U, /*!< 12-bit resolution. */
+} adc_resolution_t;
+#elif defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
+/*!
+ * @brief Define selection of resolution.
+ */
+typedef enum _adc_resolution
+{
+    kADC_Resolution6bit  = 0U, /*!< 6-bit resolution. */
+    kADC_Resolution8bit  = 1U, /*!< 8-bit resolution. */
     kADC_Resolution10bit = 2U, /*!< 10-bit resolution. */
     kADC_Resolution12bit = 3U, /*!< 12-bit resolution. */
 } adc_resolution_t;
+#endif
+
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+/*!
+ * @brief Definfe range of the analog supply voltage VDDA.
+ */
+typedef enum _adc_voltage_range
+{
+    kADC_HighVoltageRange = 0U, /* High voltage. VDD = 2.7 V to 3.6 V. */
+    kADC_LowVoltageRange  = 1U, /* Low voltage. VDD = 2.4 V to 2.7 V. */
+} adc_vdda_range_t;
+#endif /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 
 /*!
  * @brief Define selection of polarity of selected input trigger for conversion sequence.
@@ -149,8 +156,8 @@ typedef enum _adc_trigger_polarity
  */
 typedef enum _adc_priority
 {
-    kADC_PriorityLow = 0U,  /*!< This sequence would be preempted when another sequence is started. */
-    kADC_PriorityHigh = 1U, /*!< This sequence would preempt other sequence even when is is started. */
+    kADC_PriorityLow  = 0U, /*!< This sequence would be preempted when another sequence is started. */
+    kADC_PriorityHigh = 1U, /*!< This sequence would preempt other sequence even when it is started. */
 } adc_priority_t;
 
 /*!
@@ -169,7 +176,7 @@ typedef enum _adc_seq_interrupt_mode
  */
 typedef enum _adc_threshold_compare_status
 {
-    kADC_ThresholdCompareInRange = 0U,    /*!< LOW threshold <= conversion value <= HIGH threshold. */
+    kADC_ThresholdCompareInRange    = 0U, /*!< LOW threshold <= conversion value <= HIGH threshold. */
     kADC_ThresholdCompareBelowRange = 1U, /*!< conversion value < LOW threshold. */
     kADC_ThresholdCompareAboveRange = 2U, /*!< conversion value > HIGH threshold. */
 } adc_threshold_compare_status_t;
@@ -199,27 +206,84 @@ typedef enum _adc_threshold_crossing_status
  */
 typedef enum _adc_threshold_interrupt_mode
 {
-    kADC_ThresholdInterruptDisabled = 0U,   /*!< Threshold comparison interrupt is disabled. */
-    kADC_ThresholdInterruptOnOutside = 1U,  /*!< Threshold comparison interrupt is enabled on outside threshold. */
+    kADC_ThresholdInterruptDisabled   = 0U, /*!< Threshold comparison interrupt is disabled. */
+    kADC_ThresholdInterruptOnOutside  = 1U, /*!< Threshold comparison interrupt is enabled on outside threshold. */
     kADC_ThresholdInterruptOnCrossing = 2U, /*!< Threshold comparison interrupt is enabled on crossing threshold. */
 } adc_threshold_interrupt_mode_t;
+
+/*!
+ * @brief Define the info result mode of different resolution.
+ */
+typedef enum _adc_inforesultshift
+{
+    kADC_Resolution12bitInfoResultShift = 0U, /*!< Info result shift of Resolution12bit. */
+    kADC_Resolution10bitInfoResultShift = 2U, /*!< Info result shift of Resolution10bit. */
+    kADC_Resolution8bitInfoResultShift  = 4U, /*!< Info result shift of Resolution8bit. */
+    kADC_Resolution6bitInfoResultShift  = 6U, /*!< Info result shift of Resolution6bit. */
+} adc_inforesult_t;
+
+/*!
+ * @brief Define common modes for Temerature sensor.
+ */
+typedef enum _adc_tempsensor_common_mode
+{
+    kADC_HighNegativeOffsetAdded = 0x0U, /*!< Temerature sensor common mode: high negative offset added. */
+    kADC_IntermediateNegativeOffsetAdded =
+        0x4U,                           /*!< Temerature sensor common mode: intermediate negative offset added. */
+    kADC_NoOffsetAdded          = 0x8U, /*!< Temerature sensor common mode: no offset added. */
+    kADC_LowPositiveOffsetAdded = 0xcU, /*!< Temerature sensor common mode: low positive offset added. */
+} adc_tempsensor_common_mode_t;
+
+/*!
+ * @brief Define source impedance modes for GPADC control.
+ */
+typedef enum _adc_second_control
+{
+    kADC_Impedance621Ohm = 0x1U << 9U, /*!< Extand ADC sampling time according to source impedance 1: 0.621 kOhm. */
+    kADC_Impedance55kOhm =
+        0x14U << 9U, /*!< Extand ADC sampling time according to source impedance 20 (default): 55 kOhm. */
+    kADC_Impedance87kOhm = 0x1fU << 9U, /*!< Extand ADC sampling time according to source impedance 31: 87 kOhm. */
+
+    kADC_NormalFunctionalMode = 0x0U << 14U, /*!< TEST mode: Normal functional mode. */
+    kADC_MultiplexeTestMode   = 0x1U << 14U, /*!< TEST mode: Multiplexer test mode. */
+    kADC_ADCInUnityGainMode   = 0x2U << 14U, /*!< TEST mode: ADC in unity gain mode. */
+} adc_second_control_t;
 
 /*!
  * @brief Define structure for configuring the block.
  */
 typedef struct _adc_config
 {
-    adc_clock_mode_t clockMode;   /*!< Select the clock mode for ADC converter. */
-    uint32_t clockDividerNumber;  /*!< This field is only available when using kADC_ClockSynchronousMode for "clockMode"
-                                       field. The divider would be plused by 1 based on the value in this field. The
-                                       available range is in 8 bits. */
-    adc_resolution_t resolution;  /*!< Select the conversion bits. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
+    adc_clock_mode_t clockMode;  /*!< Select the clock mode for ADC converter. */
+#endif                           /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
+    uint32_t clockDividerNumber; /*!< This field is only available when using kADC_ClockSynchronousMode for "clockMode"
+                                      field. The divider would be plused by 1 based on the value in this field. The
+                                      available range is in 8 bits. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
+    adc_resolution_t resolution; /*!< Select the conversion bits. */
+#endif                           /* FSL_FEATURE_ADC_HAS_CTRL_RESOL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL) & FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL
     bool enableBypassCalibration; /*!< By default, a calibration cycle must be performed each time the chip is
                                        powered-up. Re-calibration may be warranted periodically - especially if
                                        operating conditions have changed. To enable this option would avoid the need to
                                        calibrate if offset error is not a concern in the application. */
-    uint32_t sampleTimeNumber;    /*!< By default, with value as "0U", the sample period would be 2.5 ADC clocks. Then,
-                                       to plus the "sampleTimeNumber" value here. The available value range is in 3 bits.*/
+#endif                            /* FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_TSAMP) & FSL_FEATURE_ADC_HAS_CTRL_TSAMP
+    uint32_t sampleTimeNumber; /*!< By default, with value as "0U", the sample period would be 2.5 ADC clocks. Then,
+                                    to plus the "sampleTimeNumber" value here. The available value range is in 3 bits.*/
+#endif                         /* FSL_FEATURE_ADC_HAS_CTRL_TSAMP. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE) & FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE
+    bool enableLowPowerMode; /*!< If disable low-power mode, ADC remains activated even when no conversions are
+                              requested.
+                              If enable low-power mode, The ADC is automatically powered-down when no conversions are
+                              taking place. */
+#endif                       /* FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE. */
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+    adc_vdda_range_t
+        voltageRange; /*!<  Configure the ADC for the appropriate operating range of the analog supply voltage VDDA.
+                            Failure to set the area correctly causes the ADC to return incorrect conversion results. */
+#endif                /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 } adc_config_t;
 
 /*!
@@ -228,17 +292,17 @@ typedef struct _adc_config
 typedef struct _adc_conv_seq_config
 {
     uint32_t channelMask; /*!< Selects which one or more of the ADC channels will be sampled and converted when this
-                               sequence is launched. The masked channels would be involved in current conversion
-                               sequence, beginning with the lowest-order. The available range is in 12-bit. */
+             sequence is launched. The masked channels would be involved in current conversion
+             sequence, beginning with the lowest-order. The available range is in 12-bit. */
     uint32_t triggerMask; /*!< Selects which one or more of the available hardware trigger sources will cause this
-                               conversion sequence to be initiated. The available range is 6-bit.*/
+             conversion sequence to be initiated. The available range is 6-bit.*/
     adc_trigger_polarity_t triggerPolarity; /*!< Select the trigger to lauch conversion sequence. */
     bool enableSyncBypass; /*!< To enable this feature allows the hardware trigger input to bypass synchronization
-                                flip-flop stages and therefore shorten the time between the trigger input signal and the
-                                start of a conversion. */
+               flip-flop stages and therefore shorten the time between the trigger input signal and the
+               start of a conversion. */
     bool enableSingleStep; /*!< When enabling this feature, a trigger will launch a single conversion on the next
-                                channel in the sequence instead of the default response of launching an entire sequence
-                                of conversions. */
+               channel in the sequence instead of the default response of launching an entire sequence
+               of conversions. */
     adc_seq_interrupt_mode_t interruptMode; /*!< Select the interrpt/DMA trigger mode. */
 } adc_conv_seq_config_t;
 
@@ -247,7 +311,7 @@ typedef struct _adc_conv_seq_config
  */
 typedef struct _adc_result_info
 {
-    uint32_t result;                                         /*!< Keey the conversion data value. */
+    uint32_t result;                                         /*!< Keep the conversion data value. */
     adc_threshold_compare_status_t thresholdCompareStatus;   /*!< Keep the threshold compare status. */
     adc_threshold_crossing_status_t thresholdCorssingStatus; /*!< Keep the threshold crossing status. */
     uint32_t channelNumber;                                  /*!< Keep the channel number for this conversion. */
@@ -298,6 +362,8 @@ void ADC_Deinit(ADC_Type *base);
  */
 void ADC_GetDefaultConfig(adc_config_t *config);
 
+#if !(defined(FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC) && FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC)
+#if defined(FSL_FEATURE_ADC_HAS_CALIB_REG) && FSL_FEATURE_ADC_HAS_CALIB_REG
 /*!
  * @brief Do the self hardware calibration.
  *
@@ -306,7 +372,22 @@ void ADC_GetDefaultConfig(adc_config_t *config);
  * @retval false Calibration failed.
  */
 bool ADC_DoSelfCalibration(ADC_Type *base);
+#else
+/*!
+ * @brief Do the self calibration. To calibrate the ADC, set the ADC clock to 500 kHz.
+ *        In order to achieve the specified ADC accuracy, the A/D converter must be recalibrated, at a minimum,
+ *        following every chip reset before initiating normal ADC operation.
+ *
+ * @param base ADC peripheral base address.
+ * @param frequency The ststem clock frequency to ADC.
+ * @retval true  Calibration succeed.
+ * @retval false Calibration failed.
+ */
+bool ADC_DoSelfCalibration(ADC_Type *base, uint32_t frequency);
+#endif /* FSL_FEATURE_ADC_HAS_CALIB_REG */
+#endif /* FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC */
 
+#if !(defined(FSL_FEATURE_ADC_HAS_NO_INSEL) && FSL_FEATURE_ADC_HAS_NO_INSEL)
 /*!
  * @brief Enable the internal temperature sensor measurement.
  *
@@ -316,6 +397,9 @@ bool ADC_DoSelfCalibration(ADC_Type *base);
  * @param base ADC peripheral base address.
  * @param enable Switcher to enable the feature or not.
  */
+#if defined(FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP) && (FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP)
+void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable);
+#else
 static inline void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable)
 {
     if (enable)
@@ -327,8 +411,9 @@ static inline void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable)
         base->INSEL = (base->INSEL & ~ADC_INSEL_SEL_MASK) | ADC_INSEL_SEL(0);
     }
 }
-
-/* @} */
+#endif /* FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP. */
+#endif /* FSL_FEATURE_ADC_HAS_NO_INSEL. */
+       /* @} */
 
 /*!
  * @name Control conversion sequence A.
@@ -542,7 +627,7 @@ bool ADC_GetChannelConversionResult(ADC_Type *base, uint32_t channel, adc_result
  */
 static inline void ADC_SetThresholdPair0(ADC_Type *base, uint32_t lowValue, uint32_t highValue)
 {
-    base->THR0_LOW = ADC_THR0_LOW_THRLOW(lowValue);
+    base->THR0_LOW  = ADC_THR0_LOW_THRLOW(lowValue);
     base->THR0_HIGH = ADC_THR0_HIGH_THRHIGH(highValue);
 }
 
@@ -555,7 +640,7 @@ static inline void ADC_SetThresholdPair0(ADC_Type *base, uint32_t lowValue, uint
  */
 static inline void ADC_SetThresholdPair1(ADC_Type *base, uint32_t lowValue, uint32_t highValue)
 {
-    base->THR1_LOW = ADC_THR1_LOW_THRLOW(lowValue);
+    base->THR1_LOW  = ADC_THR1_LOW_THRLOW(lowValue);
     base->THR1_HIGH = ADC_THR1_HIGH_THRHIGH(highValue);
 }
 
@@ -611,13 +696,24 @@ static inline void ADC_DisableInterrupts(ADC_Type *base, uint32_t mask)
 }
 
 /*!
- * @brief Enable the interrupt of shreshold compare event for each channel.
+ * @brief Enable the interrupt of threshold compare event for each channel.
+ * @deprecated Do not use this function.  It has been superceded by @ADC_EnableThresholdCompareInterrupt
+ */
+static inline void ADC_EnableShresholdCompareInterrupt(ADC_Type *base,
+                                                       uint32_t channel,
+                                                       adc_threshold_interrupt_mode_t mode)
+{
+    base->INTEN = (base->INTEN & ~(0x3U << ((channel << 1U) + 3U))) | ((uint32_t)(mode) << ((channel << 1U) + 3U));
+}
+
+/*!
+ * @brief Enable the interrupt of threshold compare event for each channel.
  *
  * @param base ADC peripheral base address.
  * @param channel Channel number.
  * @param mode Interrupt mode for threshold compare event, see to #adc_threshold_interrupt_mode_t.
  */
-static inline void ADC_EnableShresholdCompareInterrupt(ADC_Type *base,
+static inline void ADC_EnableThresholdCompareInterrupt(ADC_Type *base,
                                                        uint32_t channel,
                                                        adc_threshold_interrupt_mode_t mode)
 {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_clock.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_clock.h
@@ -1,40 +1,16 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
+ * Copyright 2016 - 2019 , NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
  *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _FSL_CLOCK_H_
 #define _FSL_CLOCK_H_
 
-#include "fsl_device_registers.h"
-#include <stdint.h>
-#include <stdbool.h>
-#include <assert.h>
+#include "fsl_common.h"
 
 /*! @addtogroup clock */
 /*! @{ */
@@ -44,11 +20,34 @@
 /*******************************************************************************
  * Definitions
  *****************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief CLOCK driver version 2.2.0. */
+#define FSL_CLOCK_DRIVER_VERSION (MAKE_VERSION(2, 2, 0))
+/*@}*/
+
+/*!
+ * @brief User-defined the size of cache for CLOCK_PllGetConfig() function.
+ *
+ * Once define this MACRO to be non-zero value, CLOCK_PllGetConfig() function
+ * would cache the recent calulation and accelerate the execution to get the
+ * right settings.
+ */
+#ifndef CLOCK_USR_CFG_PLL_CONFIG_CACHE_COUNT
+#define CLOCK_USR_CFG_PLL_CONFIG_CACHE_COUNT 2U
+#endif
+
+/* Definition for delay API in clock driver, users can redefine it to the real application. */
+#ifndef SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY
+#define SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY (96000000UL)
+#endif
+
 /*! @brief Clock ip name array for FLEXCOMM. */
-#define FLEXCOMM_CLOCKS                                                        \
-    {                                                                          \
-        kCLOCK_FlexComm0, kCLOCK_FlexComm1, kCLOCK_FlexComm2, kCLOCK_FlexComm3, \
-					kCLOCK_FlexComm4, kCLOCK_FlexComm5, kCLOCK_FlexComm6, kCLOCK_FlexComm7 \
+#define FLEXCOMM_CLOCKS                                                                                             \
+    {                                                                                                               \
+        kCLOCK_FlexComm0, kCLOCK_FlexComm1, kCLOCK_FlexComm2, kCLOCK_FlexComm3, kCLOCK_FlexComm4, kCLOCK_FlexComm5, \
+            kCLOCK_FlexComm6, kCLOCK_FlexComm7                                                                      \
     }
 /*! @brief Clock ip name array for LPUART. */
 #define LPUART_CLOCKS                                                                                         \
@@ -166,31 +165,31 @@
 typedef enum _clock_ip_name
 {
     kCLOCK_IpInvalid = 0U,
-    kCLOCK_Rom = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 1),
-    kCLOCK_Sram1 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 3),
-    kCLOCK_Sram2 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 4),
-    kCLOCK_Regfile = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 6),
-    kCLOCK_Flash = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 7),
-    kCLOCK_Fmc = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 8),
-    kCLOCK_InputMux = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 11),
-    kCLOCK_Iocon = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 13),
-    kCLOCK_Gpio0 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 14),
-    kCLOCK_Gpio1 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 15),
-    kCLOCK_Gpio2 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 16),
-    kCLOCK_Gpio3 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 17),
-    kCLOCK_Pint = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 18),
-    kCLOCK_Gint = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 19), /* GPIO_GLOBALINT0 and GPIO_GLOBALINT1 share the same slot  */
-    kCLOCK_Dma = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 20),
-    kCLOCK_Crc = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 21),
-    kCLOCK_Wwdt = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 22),
-    kCLOCK_Rtc = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 23),
+    kCLOCK_Rom       = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 1),
+    kCLOCK_Sram1     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 3),
+    kCLOCK_Sram2     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 4),
+    kCLOCK_Regfile   = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 6),
+    kCLOCK_Flash     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 7),
+    kCLOCK_Fmc       = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 8),
+    kCLOCK_InputMux  = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 11),
+    kCLOCK_Iocon     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 13),
+    kCLOCK_Gpio0     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 14),
+    kCLOCK_Gpio1     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 15),
+    kCLOCK_Gpio2     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 16),
+    kCLOCK_Gpio3     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 17),
+    kCLOCK_Pint      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 18),
+    kCLOCK_Gint    = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 19), /* GPIO_GLOBALINT0 and GPIO_GLOBALINT1 share the same slot  */
+    kCLOCK_Dma     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 20),
+    kCLOCK_Crc     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 21),
+    kCLOCK_Wwdt    = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 22),
+    kCLOCK_Rtc     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 23),
     kCLOCK_Mailbox = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 26),
-    kCLOCK_Adc0 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 27),
-    kCLOCK_Mrt = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 0),
-    kCLOCK_Sct0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 2),
+    kCLOCK_Adc0    = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 27),
+    kCLOCK_Mrt     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 0),
+    kCLOCK_Sct0    = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 2),
     kCLOCK_SctIpu0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 6),
-    kCLOCK_Utick = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 10),
-	kCLOCK_FlexComm0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_Utick   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 10),
+    kCLOCK_FlexComm0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
     kCLOCK_FlexComm1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
     kCLOCK_FlexComm2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
     kCLOCK_FlexComm3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
@@ -198,45 +197,45 @@ typedef enum _clock_ip_name
     kCLOCK_FlexComm5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
     kCLOCK_FlexComm6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
     kCLOCK_FlexComm7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_MinUart0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_MinUart1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_MinUart2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_MinUart3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_MinUart4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_MinUart5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_MinUart6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_MinUart7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_LSpi0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_LSpi1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_LSpi2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_LSpi3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_LSpi4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_LSpi5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_LSpi6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_LSpi7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_BI2c0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_BI2c1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_BI2c2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_BI2c3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_BI2c4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_BI2c5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_BI2c6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_BI2c7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_FlexI2s0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_FlexI2s1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_FlexI2s2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_FlexI2s3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_FlexI2s4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_FlexI2s5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_FlexI2s6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_FlexI2s7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_DMic = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 19),
-    kCLOCK_Ct32b2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 22),
-    kCLOCK_Usbd0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 25),
-    kCLOCK_Ct32b0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 26),
-    kCLOCK_Ct32b1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 27),
-    kCLOCK_Pvtvf0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 28),
-    kCLOCK_Pvtvf1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 28),
+    kCLOCK_MinUart0  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_MinUart1  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_MinUart2  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_MinUart3  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_MinUart4  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_MinUart5  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_MinUart6  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_MinUart7  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_LSpi0     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_LSpi1     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_LSpi2     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_LSpi3     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_LSpi4     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_LSpi5     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_LSpi6     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_LSpi7     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_BI2c0     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_BI2c1     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_BI2c2     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_BI2c3     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_BI2c4     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_BI2c5     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_BI2c6     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_BI2c7     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_FlexI2s0  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_FlexI2s1  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_FlexI2s2  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_FlexI2s3  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_FlexI2s4  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_FlexI2s5  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_FlexI2s6  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_FlexI2s7  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_DMic      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 19),
+    kCLOCK_Ct32b2    = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 22),
+    kCLOCK_Usbd0     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 25),
+    kCLOCK_Ct32b0    = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 26),
+    kCLOCK_Ct32b1    = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 27),
+    kCLOCK_Pvtvf0    = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 28),
+    kCLOCK_Pvtvf1    = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 28),
     kCLOCK_BodyBias0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 29),
     kCLOCK_EzhArchB0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 31),
 
@@ -254,7 +253,7 @@ typedef enum _clock_name
     kCLOCK_ExtClk,      /*!< External Clock                                          */
     kCLOCK_PllOut,      /*!< PLL Output                                              */
     kCLOCK_UsbClk,      /*!< USB input                                               */
-    kClock_WdtOsc,      /*!< Watchdog Oscillator                                     */
+    kCLOCK_WdtOsc,      /*!< Watchdog Oscillator                                     */
     kCLOCK_Frg,         /*!< Frg Clock                                               */
     kCLOCK_Dmic,        /*!< Digital Mic clock                                       */
     kCLOCK_AsyncApbClk, /*!< Async APB clock																			    */
@@ -279,18 +278,22 @@ typedef enum _async_clock_src
 } async_clock_src_t;
 
 /*! @brief Clock Mux Switches
-*  The encoding is as follows each connection identified is 64bits wide
-*  starting from LSB upwards
-*
-*  [4 bits for choice, where 1 is A, 2 is B, 3 is C and 4 is D, 0 means end of descriptor] [8 bits mux ID]*
-*
-*/
+ *  The encoding is as follows each connection identified is 32bits wide while 24bits are valuable
+ *  starting from LSB upwards
+ *
+ *  [4 bits for choice, 0 means invalid choice] [8 bits mux ID]*
+ *
+ */
 
-#define MUX_A(m, choice) (((m) << 0) | ((choice + 1) << 8))
-#define MUX_B(m, choice) (((m) << 12) | ((choice + 1) << 20))
-#define MUX_C(m, choice) (((m) << 24) | ((choice + 1) << 32))
-#define MUX_D(m, choice) (((m) << 36) | ((choice + 1) << 44))
-#define MUX_E(m, choice) (((m) << 48) | ((choice + 1) << 56))
+#define CLK_ATTACH_ID(mux, sel, pos) (((mux << 0U) | ((sel + 1) & 0xFU) << 8U) << (pos * 12U))
+#define MUX_A(mux, sel) CLK_ATTACH_ID(mux, sel, 0U)
+#define MUX_B(mux, sel, selector) (CLK_ATTACH_ID(mux, sel, 1U) | (selector << 24U))
+
+#define GET_ID_ITEM(connection) ((connection)&0xFFFU)
+#define GET_ID_NEXT_ITEM(connection) ((connection) >> 12U)
+#define GET_ID_ITEM_MUX(connection) ((connection)&0xFFU)
+#define GET_ID_ITEM_SEL(connection) ((((connection)&0xF00U) >> 8U) - 1U)
+#define GET_ID_SELECTOR(connection) ((connection)&0xF000000U)
 
 #define CM_MAINCLKSELA 0
 #define CM_MAINCLKSELB 1
@@ -326,134 +329,136 @@ typedef enum _async_clock_src
 typedef enum _clock_attach_id
 {
 
-    kFRO12M_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 0),
-    kEXT_CLK_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 1) | MUX_B(CM_MAINCLKSELB, 0),
-    kWDT_OSC_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 2) | MUX_B(CM_MAINCLKSELB, 0),
-    kFRO_HF_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 3) | MUX_B(CM_MAINCLKSELB, 0),
-    kSYS_PLL_to_MAIN_CLK = MUX_A(CM_MAINCLKSELB, 2),
-    kOSC32K_to_MAIN_CLK = MUX_A(CM_MAINCLKSELB, 3),
+    kFRO12M_to_MAIN_CLK  = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kEXT_CLK_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 1) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kWDT_OSC_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 2) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kFRO_HF_to_MAIN_CLK  = MUX_A(CM_MAINCLKSELA, 3) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kSYS_PLL_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 2, 0),
+    kOSC32K_to_MAIN_CLK  = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 3, 0),
 
-    kFRO12M_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 0),
+    kFRO12M_to_SYS_PLL  = MUX_A(CM_SYSPLLCLKSEL, 0),
     kEXT_CLK_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 1),
     kWDT_OSC_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 2),
-    kOSC32K_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 3),
-    kNONE_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 7),
+    kOSC32K_to_SYS_PLL  = MUX_A(CM_SYSPLLCLKSEL, 3),
+    kNONE_to_SYS_PLL    = MUX_A(CM_SYSPLLCLKSEL, 7),
 
     kMAIN_CLK_to_ASYNC_APB = MUX_A(CM_ASYNCAPB, 0),
-    kFRO12M_to_ASYNC_APB = MUX_A(CM_ASYNCAPB, 1),
+    kFRO12M_to_ASYNC_APB   = MUX_A(CM_ASYNCAPB, 1),
 
     kMAIN_CLK_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 0),
-    kSYS_PLL_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 1),
-    kFRO_HF_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 2),
-    kNONE_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 7),
+    kSYS_PLL_to_ADC_CLK  = MUX_A(CM_ADCASYNCCLKSEL, 1),
+    kFRO_HF_to_ADC_CLK   = MUX_A(CM_ADCASYNCCLKSEL, 2),
+    kNONE_to_ADC_CLK     = MUX_A(CM_ADCASYNCCLKSEL, 7),
 
     kMAIN_CLK_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 0),
-    kSYS_PLL_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 1),
-    kFRO_HF_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 3),
-    kNONE_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 7),
+    kSYS_PLL_to_SPIFI_CLK  = MUX_A(CM_SPIFICLKSEL, 1),
+    kFRO_HF_to_SPIFI_CLK   = MUX_A(CM_SPIFICLKSEL, 3),
+    kNONE_to_SPIFI_CLK     = MUX_A(CM_SPIFICLKSEL, 7),
 
-    kFRO12M_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 0),
-    kFRO_HF_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 1),
+    kFRO12M_to_FLEXCOMM0  = MUX_A(CM_FXCOMCLKSEL0, 0),
+    kFRO_HF_to_FLEXCOMM0  = MUX_A(CM_FXCOMCLKSEL0, 1),
     kSYS_PLL_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 2),
-    kMCLK_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 3),
-    kFRG_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 4),
-    kNONE_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 7),
+    kMCLK_to_FLEXCOMM0    = MUX_A(CM_FXCOMCLKSEL0, 3),
+    kFRG_to_FLEXCOMM0     = MUX_A(CM_FXCOMCLKSEL0, 4),
+    kNONE_to_FLEXCOMM0    = MUX_A(CM_FXCOMCLKSEL0, 7),
 
-    kFRO12M_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 0),
-    kFRO_HF_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 1),
+    kFRO12M_to_FLEXCOMM1  = MUX_A(CM_FXCOMCLKSEL1, 0),
+    kFRO_HF_to_FLEXCOMM1  = MUX_A(CM_FXCOMCLKSEL1, 1),
     kSYS_PLL_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 2),
-    kMCLK_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 3),
-    kFRG_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 4),
-    kNONE_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 7),
+    kMCLK_to_FLEXCOMM1    = MUX_A(CM_FXCOMCLKSEL1, 3),
+    kFRG_to_FLEXCOMM1     = MUX_A(CM_FXCOMCLKSEL1, 4),
+    kNONE_to_FLEXCOMM1    = MUX_A(CM_FXCOMCLKSEL1, 7),
 
-    kFRO12M_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 0),
-    kFRO_HF_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 1),
+    kFRO12M_to_FLEXCOMM2  = MUX_A(CM_FXCOMCLKSEL2, 0),
+    kFRO_HF_to_FLEXCOMM2  = MUX_A(CM_FXCOMCLKSEL2, 1),
     kSYS_PLL_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 2),
-    kMCLK_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 3),
-    kFRG_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 4),
-    kNONE_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 7),
+    kMCLK_to_FLEXCOMM2    = MUX_A(CM_FXCOMCLKSEL2, 3),
+    kFRG_to_FLEXCOMM2     = MUX_A(CM_FXCOMCLKSEL2, 4),
+    kNONE_to_FLEXCOMM2    = MUX_A(CM_FXCOMCLKSEL2, 7),
 
-    kFRO12M_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 0),
-    kFRO_HF_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 1),
+    kFRO12M_to_FLEXCOMM3  = MUX_A(CM_FXCOMCLKSEL3, 0),
+    kFRO_HF_to_FLEXCOMM3  = MUX_A(CM_FXCOMCLKSEL3, 1),
     kSYS_PLL_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 2),
-    kMCLK_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 3),
-    kFRG_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 4),
-    kNONE_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 7),
+    kMCLK_to_FLEXCOMM3    = MUX_A(CM_FXCOMCLKSEL3, 3),
+    kFRG_to_FLEXCOMM3     = MUX_A(CM_FXCOMCLKSEL3, 4),
+    kNONE_to_FLEXCOMM3    = MUX_A(CM_FXCOMCLKSEL3, 7),
 
-    kFRO12M_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 0),
-    kFRO_HF_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 1),
+    kFRO12M_to_FLEXCOMM4  = MUX_A(CM_FXCOMCLKSEL4, 0),
+    kFRO_HF_to_FLEXCOMM4  = MUX_A(CM_FXCOMCLKSEL4, 1),
     kSYS_PLL_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 2),
-    kMCLK_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 3),
-    kFRG_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 4),
-    kNONE_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 7),
+    kMCLK_to_FLEXCOMM4    = MUX_A(CM_FXCOMCLKSEL4, 3),
+    kFRG_to_FLEXCOMM4     = MUX_A(CM_FXCOMCLKSEL4, 4),
+    kNONE_to_FLEXCOMM4    = MUX_A(CM_FXCOMCLKSEL4, 7),
 
-    kFRO12M_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 0),
-    kFRO_HF_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 1),
+    kFRO12M_to_FLEXCOMM5  = MUX_A(CM_FXCOMCLKSEL5, 0),
+    kFRO_HF_to_FLEXCOMM5  = MUX_A(CM_FXCOMCLKSEL5, 1),
     kSYS_PLL_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 2),
-    kMCLK_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 3),
-    kFRG_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 4),
-    kNONE_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 7),
+    kMCLK_to_FLEXCOMM5    = MUX_A(CM_FXCOMCLKSEL5, 3),
+    kFRG_to_FLEXCOMM5     = MUX_A(CM_FXCOMCLKSEL5, 4),
+    kNONE_to_FLEXCOMM5    = MUX_A(CM_FXCOMCLKSEL5, 7),
 
-    kFRO12M_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 0),
-    kFRO_HF_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 1),
+    kFRO12M_to_FLEXCOMM6  = MUX_A(CM_FXCOMCLKSEL6, 0),
+    kFRO_HF_to_FLEXCOMM6  = MUX_A(CM_FXCOMCLKSEL6, 1),
     kSYS_PLL_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 2),
-    kMCLK_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 3),
-    kFRG_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 4),
-    kNONE_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 7),
+    kMCLK_to_FLEXCOMM6    = MUX_A(CM_FXCOMCLKSEL6, 3),
+    kFRG_to_FLEXCOMM6     = MUX_A(CM_FXCOMCLKSEL6, 4),
+    kNONE_to_FLEXCOMM6    = MUX_A(CM_FXCOMCLKSEL6, 7),
 
-    kFRO12M_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 0),
-    kFRO_HF_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 1),
+    kFRO12M_to_FLEXCOMM7  = MUX_A(CM_FXCOMCLKSEL7, 0),
+    kFRO_HF_to_FLEXCOMM7  = MUX_A(CM_FXCOMCLKSEL7, 1),
     kSYS_PLL_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 2),
-    kMCLK_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 3),
-    kFRG_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 4),
-    kNONE_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 7),
+    kMCLK_to_FLEXCOMM7    = MUX_A(CM_FXCOMCLKSEL7, 3),
+    kFRG_to_FLEXCOMM7     = MUX_A(CM_FXCOMCLKSEL7, 4),
+    kNONE_to_FLEXCOMM7    = MUX_A(CM_FXCOMCLKSEL7, 7),
 
     kMAIN_CLK_to_FRG = MUX_A(CM_FRGCLKSEL, 0),
-    kSYS_PLL_to_FRG = MUX_A(CM_FRGCLKSEL, 1),
-    kFRO12M_to_FRG = MUX_A(CM_FRGCLKSEL, 2),
-    kFRO_HF_to_FRG = MUX_A(CM_FRGCLKSEL, 3),
-    kNONE_to_FRG = MUX_A(CM_FRGCLKSEL, 7),
+    kSYS_PLL_to_FRG  = MUX_A(CM_FRGCLKSEL, 1),
+    kFRO12M_to_FRG   = MUX_A(CM_FRGCLKSEL, 2),
+    kFRO_HF_to_FRG   = MUX_A(CM_FRGCLKSEL, 3),
+    kNONE_to_FRG     = MUX_A(CM_FRGCLKSEL, 7),
 
-    kFRO_HF_to_MCLK = MUX_A(CM_FXI2S0MCLKCLKSEL, 0),
-    kSYS_PLL_to_MCLK = MUX_A(CM_FXI2S0MCLKCLKSEL, 1),
-    kNONE_to_MCLK = MUX_A(CM_FXI2S0MCLKCLKSEL, 7),
+    kFRO_HF_to_MCLK   = MUX_A(CM_FXI2S0MCLKCLKSEL, 0),
+    kSYS_PLL_to_MCLK  = MUX_A(CM_FXI2S0MCLKCLKSEL, 1),
+    kMAIN_CLK_to_MCLK = MUX_A(CM_FXI2S0MCLKCLKSEL, 2),
+    kNONE_to_MCLK     = MUX_A(CM_FXI2S0MCLKCLKSEL, 7),
 
-    kFRO12M_to_DMIC = MUX_A(CM_DMICCLKSEL, 0),
-    kFRO_HF_to_DMIC = MUX_A(CM_DMICCLKSEL, 1),
-    kSYS_PLL_to_DMIC = MUX_A(CM_DMICCLKSEL, 2),
-    kMCLK_to_DMIC = MUX_A(CM_DMICCLKSEL, 3),
+    kFRO12M_to_DMIC   = MUX_A(CM_DMICCLKSEL, 0),
+    kFRO_HF_to_DMIC   = MUX_A(CM_DMICCLKSEL, 1),
+    kSYS_PLL_to_DMIC  = MUX_A(CM_DMICCLKSEL, 2),
+    kMCLK_to_DMIC     = MUX_A(CM_DMICCLKSEL, 3),
     kMAIN_CLK_to_DMIC = MUX_A(CM_DMICCLKSEL, 4),
-    kWDT_CLK_to_DMIC = MUX_A(CM_DMICCLKSEL, 5),
-    kNONE_to_DMIC = MUX_A(CM_DMICCLKSEL, 7),
+    kWDT_CLK_to_DMIC  = MUX_A(CM_DMICCLKSEL, 5),
+    kNONE_to_DMIC     = MUX_A(CM_DMICCLKSEL, 7),
 
-    kFRO_HF_to_USB_CLK = MUX_A(CM_USBCLKSEL, 0),
-    kSYS_PLL_to_USB_CLK = MUX_A(CM_USBCLKSEL, 1),
-    kNONE_to_USB_CLK = MUX_A(CM_USBCLKSEL, 7),
+    kFRO_HF_to_USB_CLK   = MUX_A(CM_USBCLKSEL, 0),
+    kSYS_PLL_to_USB_CLK  = MUX_A(CM_USBCLKSEL, 1),
+    kMAIN_CLK_to_USB_CLK = MUX_A(CM_USBCLKSEL, 2),
+    kNONE_to_USB_CLK     = MUX_A(CM_USBCLKSEL, 7),
 
     kMAIN_CLK_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 0),
-    kEXT_CLK_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 1),
-    kWDT_OSC_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 2),
-    kFRO_HF_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 3),
-    kSYS_PLL_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 4),
-    kFRO12M_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 5),
-    kOSC32K_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 6),
-    kNONE_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 7),
-    kNONE_to_NONE = 0x80000000U,
+    kEXT_CLK_to_CLKOUT  = MUX_A(CM_CLKOUTCLKSELA, 1),
+    kWDT_OSC_to_CLKOUT  = MUX_A(CM_CLKOUTCLKSELA, 2),
+    kFRO_HF_to_CLKOUT   = MUX_A(CM_CLKOUTCLKSELA, 3),
+    kSYS_PLL_to_CLKOUT  = MUX_A(CM_CLKOUTCLKSELA, 4),
+    kFRO12M_to_CLKOUT   = MUX_A(CM_CLKOUTCLKSELA, 5),
+    kOSC32K_to_CLKOUT   = MUX_A(CM_CLKOUTCLKSELA, 6),
+    kNONE_to_CLKOUT     = MUX_A(CM_CLKOUTCLKSELA, 7),
+    kNONE_to_NONE       = (int)0x80000000U,
 } clock_attach_id_t;
 
 /*  Clock dividers */
 typedef enum _clock_div_name
 {
-    kCLOCK_DivSystickClk = 0,
-    kCLOCK_DivTraceClk = 1,
-    kCLOCK_DivAhbClk = 32,
-    kCLOCK_DivClkOut = 33,
-    kCLOCK_DivSpifiClk = 36,
+    kCLOCK_DivSystickClk  = 0,
+    kCLOCK_DivTraceClk    = 1,
+    kCLOCK_DivAhbClk      = 32,
+    kCLOCK_DivClkOut      = 33,
+    kCLOCK_DivSpifiClk    = 36,
     kCLOCK_DivAdcAsyncClk = 37,
-    kCLOCK_DivUsbClk = 38,
-    kCLOCK_DivFrg = 40,
-    kCLOCK_DivDmicClk = 42,
-    kCLOCK_DivFxI2s0MClk = 43
+    kCLOCK_DivUsbClk      = 38,
+    kCLOCK_DivFrg         = 40,
+    kCLOCK_DivDmicClk     = 42,
+    kCLOCK_DivFxI2s0MClk  = 43
 } clock_div_name_t;
 
 /*******************************************************************************
@@ -500,8 +505,6 @@ typedef enum _clock_flashtim
     kCLOCK_Flash4Cycle,     /*!< Flash accesses use 4 CPU clocks */
     kCLOCK_Flash5Cycle,     /*!< Flash accesses use 5 CPU clocks */
     kCLOCK_Flash6Cycle,     /*!< Flash accesses use 6 CPU clocks */
-    kCLOCK_Flash7Cycle,     /*!< Flash accesses use 7 CPU clocks */
-    kCLOCK_Flash8Cycle      /*!< Flash accesses use 8 CPU clocks */
 } clock_flashtim_t;
 
 /**
@@ -534,6 +537,14 @@ status_t CLOCK_SetupFROClocking(uint32_t iFreq);
  */
 void CLOCK_AttachClk(clock_attach_id_t connection);
 /**
+ * @brief   Get the actual clock attach id.
+ * This fuction uses the offset in input attach id, then it reads the actual source value in
+ * the register and combine the offset to obtain an actual attach id.
+ * @param   attachId  : Clock attach id to get.
+ * @return  Clock source value.
+ */
+clock_attach_id_t CLOCK_GetClockAttachId(clock_attach_id_t attachId);
+/**
  * @brief	Setup peripheral clock dividers.
  * @param	div_name	: Clock divider name
  * @param divided_by_value: Value to be divided
@@ -556,13 +567,23 @@ uint32_t CLOCK_GetFreq(clock_name_t clockName);
  *  @return	Input Frequency for FRG
  */
 uint32_t CLOCK_GetFRGInputClock(void);
-    
+
+/*! @brief  Return Input frequency for the DMIC
+ *  @return Input Frequency for DMIC
+ */
+uint32_t CLOCK_GetDmicClkFreq(void);
+
+/*! @brief  Return Input frequency for the FRG
+ *  @return Input Frequency for FRG
+ */
+uint32_t CLOCK_GetFrgClkFreq(void);
+
 /*! @brief	Set output of the Fractional baud rate generator
  * @param	freq	: Desired output frequency
  * @return	Error Code 0 - fail 1 - success
  */
 uint32_t CLOCK_SetFRGClock(uint32_t freq);
-    
+
 /*! @brief	Return Frequency of FRO 12MHz
  *  @return	Frequency of FRO 12MHz
  */
@@ -579,6 +600,10 @@ uint32_t CLOCK_GetWdtOscFreq(void);
  *  @return	Frequency of High-Freq output of FRO
  */
 uint32_t CLOCK_GetFroHfFreq(void);
+/*! @brief  Return Frequency of USB
+ *  @return Frequency of USB
+ */
+uint32_t CLOCK_GetUsbClkFreq(void);
 /*! @brief	Return Frequency of PLL
  *  @return	Frequency of PLL
  */
@@ -599,6 +624,10 @@ uint32_t CLOCK_GetI2SMClkFreq(void);
  *  @return	Frequency of Flexcomm functional Clock
  */
 uint32_t CLOCK_GetFlexCommClkFreq(uint32_t id);
+/*! @brief	Return Frequency of Adc Clock
+ *  @return	Frequency of Adc Clock.
+ */
+uint32_t CLOCK_GetAdcClkFreq(void);
 /*! @brief	Return Asynchronous APB Clock source
  *  @return	Asynchronous APB CLock source
  */
@@ -670,12 +699,14 @@ void CLOCK_SetStoredPLLClockRate(uint32_t rate);
  */
 #define PLL_CONFIGFLAG_USEINRATE (1 << 0) /*!< Flag to use InputRate in PLL configuration structure for setup */
 #define PLL_CONFIGFLAG_FORCENOFRACT                                                                                    \
-    (1                                                                                                                 \
-     << 2) /*!< Force non-fractional output mode, PLL output will not use the fractional, automatic bandwidth, or SS \ \
-                \ \ \                                                                                                                     \
-                  \ \ \ \ \                                                                                                                     \
-                    \ \ \ \ \ \ \                                                                                                                     \
-                      hardware */
+    (1 << 2) /*!< Force non-fractional output mode, PLL output will not use the fractional, automatic bandwidth, or SS \
+                \ \                                                                                                    \
+                  \ \ \ \                                                                                              \
+                    \ \ \ \ \ \                                                                                        \
+                       \ \ \ \ \ \ \ \                                                                                 \
+                         \ \ \ \ \ \ \ \ \ \                                                                           \
+                           \ \ \ \ \ \ \ \ \ \ \ \                                                                     \
+                             hardware */
 
 /*! @brief PLL Spread Spectrum (SS) Programmable modulation frequency
  * See (MF) field in the SYSPLLSSCTRL1 register in the UM.
@@ -686,10 +717,10 @@ typedef enum _ss_progmodfm
     kSS_MF_384 = (1 << 20), /*!< Nss ?= 384 (fm ? 5.2 - 10.4 kHz) */
     kSS_MF_256 = (2 << 20), /*!< Nss = 256 (fm ? 7.8 - 15.6 kHz) */
     kSS_MF_128 = (3 << 20), /*!< Nss = 128 (fm ? 15.6 - 31.3 kHz) */
-    kSS_MF_64 = (4 << 20),  /*!< Nss = 64 (fm ? 32.3 - 64.5 kHz) */
-    kSS_MF_32 = (5 << 20),  /*!< Nss = 32 (fm ? 62.5- 125 kHz) */
-    kSS_MF_24 = (6 << 20),  /*!< Nss ?= 24 (fm ? 83.3- 166.6 kHz) */
-    kSS_MF_16 = (7 << 20)   /*!< Nss = 16 (fm ? 125- 250 kHz) */
+    kSS_MF_64  = (4 << 20), /*!< Nss = 64 (fm ? 32.3 - 64.5 kHz) */
+    kSS_MF_32  = (5 << 20), /*!< Nss = 32 (fm ? 62.5- 125 kHz) */
+    kSS_MF_24  = (6 << 20), /*!< Nss ?= 24 (fm ? 83.3- 166.6 kHz) */
+    kSS_MF_16  = (7 << 20)  /*!< Nss = 16 (fm ? 125- 250 kHz) */
 } ss_progmodfm_t;
 
 /*! @brief PLL Spread Spectrum (SS) Programmable frequency modulation depth
@@ -697,14 +728,14 @@ typedef enum _ss_progmodfm
  */
 typedef enum _ss_progmoddp
 {
-    kSS_MR_K0 = (0 << 23),   /*!< k = 0 (no spread spectrum) */
-    kSS_MR_K1 = (1 << 23),   /*!< k = 1 */
+    kSS_MR_K0   = (0 << 23), /*!< k = 0 (no spread spectrum) */
+    kSS_MR_K1   = (1 << 23), /*!< k = 1 */
     kSS_MR_K1_5 = (2 << 23), /*!< k = 1.5 */
-    kSS_MR_K2 = (3 << 23),   /*!< k = 2 */
-    kSS_MR_K3 = (4 << 23),   /*!< k = 3 */
-    kSS_MR_K4 = (5 << 23),   /*!< k = 4 */
-    kSS_MR_K6 = (6 << 23),   /*!< k = 6 */
-    kSS_MR_K8 = (7 << 23)    /*!< k = 8 */
+    kSS_MR_K2   = (3 << 23), /*!< k = 2 */
+    kSS_MR_K3   = (4 << 23), /*!< k = 3 */
+    kSS_MR_K4   = (5 << 23), /*!< k = 4 */
+    kSS_MR_K6   = (6 << 23), /*!< k = 6 */
+    kSS_MR_K8   = (7 << 23)  /*!< k = 8 */
 } ss_progmoddp_t;
 
 /*! @brief PLL Spread Spectrum (SS) Modulation waveform control
@@ -714,7 +745,7 @@ typedef enum _ss_progmoddp
  */
 typedef enum _ss_modwvctrl
 {
-    kSS_MC_NOC = (0 << 26),  /*!< no compensation */
+    kSS_MC_NOC  = (0 << 26), /*!< no compensation */
     kSS_MC_RECC = (2 << 26), /*!< recommended setting */
     kSS_MC_MAXC = (3 << 26), /*!< max. compensation */
 } ss_modwvctrl_t;
@@ -742,19 +773,20 @@ typedef struct _pll_config
 } pll_config_t;
 
 /*! @brief PLL setup structure flags for 'flags' field
-* These flags control how the PLL setup function sets up the PLL
-*/
-#define PLL_SETUPFLAG_POWERUP (1 << 0)  /*!< Setup will power on the PLL after setup */
-#define PLL_SETUPFLAG_WAITLOCK (1 << 1) /*!< Setup will wait for PLL lock, implies the PLL will be pwoered on */
-#define PLL_SETUPFLAG_ADGVOLT (1 << 2)  /*!< Optimize system voltage for the new PLL rate */
+ * These flags control how the PLL setup function sets up the PLL
+ */
+#define PLL_SETUPFLAG_POWERUP (1 << 0)         /*!< Setup will power on the PLL after setup */
+#define PLL_SETUPFLAG_WAITLOCK (1 << 1)        /*!< Setup will wait for PLL lock, implies the PLL will be pwoered on */
+#define PLL_SETUPFLAG_ADGVOLT (1 << 2)         /*!< Optimize system voltage for the new PLL rate */
+#define PLL_SETUPFLAG_USEFEEDBACKDIV2 (1 << 3) /*!< Use feedback divider by 2 in divider path */
 
 /*! @brief PLL setup structure
-* This structure can be used to pre-build a PLL setup configuration
-* at run-time and quickly set the PLL to the configuration. It can be
-* populated with the PLL setup function. If powering up or waiting
-* for PLL lock, the PLL input clock source should be configured prior
-* to PLL setup.
-*/
+ * This structure can be used to pre-build a PLL setup configuration
+ * at run-time and quickly set the PLL to the configuration. It can be
+ * populated with the PLL setup function. If powering up or waiting
+ * for PLL lock, the PLL input clock source should be configured prior
+ * to PLL setup.
+ */
 typedef struct _pll_setup
 {
     uint32_t syspllctrl;      /*!< PLL control register SYSPLLCTRL */
@@ -769,21 +801,21 @@ typedef struct _pll_setup
  */
 typedef enum _pll_error
 {
-    kStatus_PLL_Success = MAKE_STATUS(kStatusGroup_Generic, 0),        /*!< PLL operation was successful */
-    kStatus_PLL_OutputTooLow = MAKE_STATUS(kStatusGroup_Generic, 1),   /*!< PLL output rate request was too low */
-    kStatus_PLL_OutputTooHigh = MAKE_STATUS(kStatusGroup_Generic, 2),  /*!< PLL output rate request was too high */
-    kStatus_PLL_InputTooLow = MAKE_STATUS(kStatusGroup_Generic, 3),    /*!< PLL input rate is too low */
-    kStatus_PLL_InputTooHigh = MAKE_STATUS(kStatusGroup_Generic, 4),   /*!< PLL input rate is too high */
-    kStatus_PLL_OutsideIntLimit = MAKE_STATUS(kStatusGroup_Generic, 5) /*!< Requested output rate isn't possible */
+    kStatus_PLL_Success         = MAKE_STATUS(kStatusGroup_Generic, 0), /*!< PLL operation was successful */
+    kStatus_PLL_OutputTooLow    = MAKE_STATUS(kStatusGroup_Generic, 1), /*!< PLL output rate request was too low */
+    kStatus_PLL_OutputTooHigh   = MAKE_STATUS(kStatusGroup_Generic, 2), /*!< PLL output rate request was too high */
+    kStatus_PLL_InputTooLow     = MAKE_STATUS(kStatusGroup_Generic, 3), /*!< PLL input rate is too low */
+    kStatus_PLL_InputTooHigh    = MAKE_STATUS(kStatusGroup_Generic, 4), /*!< PLL input rate is too high */
+    kStatus_PLL_OutsideIntLimit = MAKE_STATUS(kStatusGroup_Generic, 5)  /*!< Requested output rate isn't possible */
 } pll_error_t;
 
 /*! @brief USB clock source definition. */
 typedef enum _clock_usb_src
 {
-    kCLOCK_UsbSrcFro = (uint32_t)kCLOCK_FroHf,            /*!< Use FRO 96 or 48 MHz. */
+    kCLOCK_UsbSrcFro       = (uint32_t)kCLOCK_FroHf,      /*!< Use FRO 96 or 48 MHz. */
     kCLOCK_UsbSrcSystemPll = (uint32_t)kCLOCK_PllOut,     /*!< Use System PLL output. */
     kCLOCK_UsbSrcMainClock = (uint32_t)kCLOCK_CoreSysClk, /*!< Use Main clock.    */
-    kCLOCK_UsbSrcNone = SYSCON_USBCLKSEL_SEL(
+    kCLOCK_UsbSrcNone      = SYSCON_USBCLKSEL_SEL(
         7) /*!< Use None, this may be selected in order to reduce power when no output is needed. */
 } clock_usb_src_t;
 
@@ -804,7 +836,7 @@ pll_error_t CLOCK_SetupPLLData(pll_config_t *pControl, pll_setup_t *pSetup);
 
 /*! @brief	Set PLL output from PLL setup structure (precise frequency)
  * @param	pSetup	: Pointer to populated PLL setup structure
-* @param flagcfg : Flag configuration for PLL config structure
+ * @param flagcfg : Flag configuration for PLL config structure
  * @return	PLL_ERROR_SUCCESS on success, or PLL setup error code
  * @note	This function will power off the PLL, setup the PLL with the
  * new setup data, and then optionally powerup the PLL, wait for PLL lock,
@@ -848,6 +880,17 @@ static inline void CLOCK_DisableUsbfs0Clock(void)
     CLOCK_DisableClock(kCLOCK_Usbd0);
 }
 bool CLOCK_EnableUsbfs0Clock(clock_usb_src_t src, uint32_t freq);
+
+/*!
+ * @brief Use DWT to delay at least for some time.
+ *  Please note that, this API will calculate the microsecond period with the maximum
+ *  supported CPU frequency, so this API will only delay for at least the given microseconds, if precise
+ *  delay count was needed, please implement a new timer count to achieve this function.
+ *
+ * @param delay_us  Delay time in unit of microsecond.
+ */
+void SDK_DelayAtLeastUs(uint32_t delay_us);
+
 #if defined(__cplusplus)
 }
 #endif /* __cplusplus */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_LPCXpresso/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_LPCXpresso/mbed_overrides.c
@@ -135,6 +135,7 @@ void ADC_ClockPower_Configuration(void)
      * The divider would be set when configuring the converter.
      */
     CLOCK_EnableClock(kCLOCK_Adc0); /* SYSCON->AHBCLKCTRL[0] |= SYSCON_AHBCLKCTRL_ADC0_MASK; */
+    RESET_PeripheralReset(kADC0_RST_SHIFT_RSTn);
 }
 
 /* Initialize the external memory. */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/LPC54628_features.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/device/LPC54628_features.h
@@ -1,37 +1,16 @@
 /*
 ** ###################################################################
 **     Version:             rev. 1.2, 2017-06-08
-**     Build:               b170609
+**     Build:               b190225
 **
 **     Abstract:
 **         Chip specific module features.
 **
 **     Copyright 2016 Freescale Semiconductor, Inc.
-**     Copyright 2016-2017 NXP
-**     Redistribution and use in source and binary forms, with or without modification,
-**     are permitted provided that the following conditions are met:
+**     Copyright 2016-2019 NXP
+**     All rights reserved.
 **
-**     1. Redistributions of source code must retain the above copyright notice, this list
-**       of conditions and the following disclaimer.
-**
-**     2. Redistributions in binary form must reproduce the above copyright notice, this
-**       list of conditions and the following disclaimer in the documentation and/or
-**       other materials provided with the distribution.
-**
-**     3. Neither the name of the copyright holder nor the names of its
-**       contributors may be used to endorse or promote products derived from this
-**       software without specific prior written permission.
-**
-**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**     SPDX-License-Identifier: BSD-3-Clause
 **
 **     http:                 www.nxp.com
 **     mail:                 support@nxp.com
@@ -55,502 +34,105 @@
 
 /* SOC module features */
 
-/* @brief ACMP availability on the SoC. */
-#define FSL_FEATURE_SOC_ACMP_COUNT (0)
 /* @brief ADC availability on the SoC. */
 #define FSL_FEATURE_SOC_ADC_COUNT (1)
-/* @brief ADC12 availability on the SoC. */
-#define FSL_FEATURE_SOC_ADC12_COUNT (0)
-/* @brief ADC16 availability on the SoC. */
-#define FSL_FEATURE_SOC_ADC16_COUNT (0)
-/* @brief ADC_5HC availability on the SoC. */
-#define FSL_FEATURE_SOC_ADC_5HC_COUNT (0)
-/* @brief AES availability on the SoC. */
-#define FSL_FEATURE_SOC_AES_COUNT (0)
-/* @brief AFE availability on the SoC. */
-#define FSL_FEATURE_SOC_AFE_COUNT (0)
-/* @brief AGC availability on the SoC. */
-#define FSL_FEATURE_SOC_AGC_COUNT (0)
-/* @brief AIPS availability on the SoC. */
-#define FSL_FEATURE_SOC_AIPS_COUNT (0)
-/* @brief AIPSTZ availability on the SoC. */
-#define FSL_FEATURE_SOC_AIPSTZ_COUNT (0)
-/* @brief ANATOP availability on the SoC. */
-#define FSL_FEATURE_SOC_ANATOP_COUNT (0)
-/* @brief AOI availability on the SoC. */
-#define FSL_FEATURE_SOC_AOI_COUNT (0)
-/* @brief APBH availability on the SoC. */
-#define FSL_FEATURE_SOC_APBH_COUNT (0)
-/* @brief ASMC availability on the SoC. */
-#define FSL_FEATURE_SOC_ASMC_COUNT (0)
-/* @brief ASRC availability on the SoC. */
-#define FSL_FEATURE_SOC_ASRC_COUNT (0)
 /* @brief ASYNC_SYSCON availability on the SoC. */
 #define FSL_FEATURE_SOC_ASYNC_SYSCON_COUNT (1)
-/* @brief ATX availability on the SoC. */
-#define FSL_FEATURE_SOC_ATX_COUNT (0)
-/* @brief AXBS availability on the SoC. */
-#define FSL_FEATURE_SOC_AXBS_COUNT (0)
-/* @brief BCH availability on the SoC. */
-#define FSL_FEATURE_SOC_BCH_COUNT (0)
-/* @brief BLEDP availability on the SoC. */
-#define FSL_FEATURE_SOC_BLEDP_COUNT (0)
-/* @brief BOD availability on the SoC. */
-#define FSL_FEATURE_SOC_BOD_COUNT (0)
-/* @brief CAAM availability on the SoC. */
-#define FSL_FEATURE_SOC_CAAM_COUNT (0)
-/* @brief CADC availability on the SoC. */
-#define FSL_FEATURE_SOC_CADC_COUNT (0)
-/* @brief CALIB availability on the SoC. */
-#define FSL_FEATURE_SOC_CALIB_COUNT (0)
 /* @brief CAN availability on the SoC. */
 #define FSL_FEATURE_SOC_LPC_CAN_COUNT (2)
-/* @brief CAU availability on the SoC. */
-#define FSL_FEATURE_SOC_CAU_COUNT (0)
-/* @brief CAU3 availability on the SoC. */
-#define FSL_FEATURE_SOC_CAU3_COUNT (0)
-/* @brief CCM availability on the SoC. */
-#define FSL_FEATURE_SOC_CCM_COUNT (0)
-/* @brief CCM_ANALOG availability on the SoC. */
-#define FSL_FEATURE_SOC_CCM_ANALOG_COUNT (0)
-/* @brief CHRG availability on the SoC. */
-#define FSL_FEATURE_SOC_CHRG_COUNT (0)
-/* @brief CMP availability on the SoC. */
-#define FSL_FEATURE_SOC_CMP_COUNT (0)
-/* @brief CMT availability on the SoC. */
-#define FSL_FEATURE_SOC_CMT_COUNT (0)
-/* @brief CNC availability on the SoC. */
-#define FSL_FEATURE_SOC_CNC_COUNT (0)
-/* @brief COP availability on the SoC. */
-#define FSL_FEATURE_SOC_COP_COUNT (0)
 /* @brief CRC availability on the SoC. */
 #define FSL_FEATURE_SOC_CRC_COUNT (1)
-/* @brief CS availability on the SoC. */
-#define FSL_FEATURE_SOC_CS_COUNT (0)
-/* @brief CSI availability on the SoC. */
-#define FSL_FEATURE_SOC_CSI_COUNT (0)
-/* @brief CT32B availability on the SoC. */
-#define FSL_FEATURE_SOC_CT32B_COUNT (0)
-/* @brief CTI availability on the SoC. */
-#define FSL_FEATURE_SOC_CTI_COUNT (0)
 /* @brief CTIMER availability on the SoC. */
 #define FSL_FEATURE_SOC_CTIMER_COUNT (5)
-/* @brief DAC availability on the SoC. */
-#define FSL_FEATURE_SOC_DAC_COUNT (0)
-/* @brief DAC32 availability on the SoC. */
-#define FSL_FEATURE_SOC_DAC32_COUNT (0)
-/* @brief DCDC availability on the SoC. */
-#define FSL_FEATURE_SOC_DCDC_COUNT (0)
-/* @brief DCP availability on the SoC. */
-#define FSL_FEATURE_SOC_DCP_COUNT (0)
-/* @brief DDR availability on the SoC. */
-#define FSL_FEATURE_SOC_DDR_COUNT (0)
-/* @brief DDRC availability on the SoC. */
-#define FSL_FEATURE_SOC_DDRC_COUNT (0)
-/* @brief DDRC_MP availability on the SoC. */
-#define FSL_FEATURE_SOC_DDRC_MP_COUNT (0)
-/* @brief DDR_PHY availability on the SoC. */
-#define FSL_FEATURE_SOC_DDR_PHY_COUNT (0)
 /* @brief DMA availability on the SoC. */
 #define FSL_FEATURE_SOC_DMA_COUNT (1)
-/* @brief DMAMUX availability on the SoC. */
-#define FSL_FEATURE_SOC_DMAMUX_COUNT (0)
 /* @brief DMIC availability on the SoC. */
 #define FSL_FEATURE_SOC_DMIC_COUNT (1)
-/* @brief DRY availability on the SoC. */
-#define FSL_FEATURE_SOC_DRY_COUNT (0)
-/* @brief DSPI availability on the SoC. */
-#define FSL_FEATURE_SOC_DSPI_COUNT (0)
-/* @brief ECSPI availability on the SoC. */
-#define FSL_FEATURE_SOC_ECSPI_COUNT (0)
-/* @brief EDMA availability on the SoC. */
-#define FSL_FEATURE_SOC_EDMA_COUNT (0)
 /* @brief EEPROM availability on the SoC. */
 #define FSL_FEATURE_SOC_EEPROM_COUNT (1)
-/* @brief EIM availability on the SoC. */
-#define FSL_FEATURE_SOC_EIM_COUNT (0)
 /* @brief EMC availability on the SoC. */
 #define FSL_FEATURE_SOC_EMC_COUNT (1)
-/* @brief EMVSIM availability on the SoC. */
-#define FSL_FEATURE_SOC_EMVSIM_COUNT (0)
-/* @brief ENC availability on the SoC. */
-#define FSL_FEATURE_SOC_ENC_COUNT (0)
 /* @brief ENET availability on the SoC. */
 #define FSL_FEATURE_SOC_LPC_ENET_COUNT (1)
-/* @brief EPDC availability on the SoC. */
-#define FSL_FEATURE_SOC_EPDC_COUNT (0)
-/* @brief EPIT availability on the SoC. */
-#define FSL_FEATURE_SOC_EPIT_COUNT (0)
-/* @brief ESAI availability on the SoC. */
-#define FSL_FEATURE_SOC_ESAI_COUNT (0)
-/* @brief EWM availability on the SoC. */
-#define FSL_FEATURE_SOC_EWM_COUNT (0)
-/* @brief FB availability on the SoC. */
-#define FSL_FEATURE_SOC_FB_COUNT (0)
-/* @brief FGPIO availability on the SoC. */
-#define FSL_FEATURE_SOC_FGPIO_COUNT (0)
-/* @brief FLASH availability on the SoC. */
-#define FSL_FEATURE_SOC_FLASH_COUNT (0)
-/* @brief FLEXCAN availability on the SoC. */
-#define FSL_FEATURE_SOC_FLEXCAN_COUNT (0)
 /* @brief FLEXCOMM availability on the SoC. */
 #define FSL_FEATURE_SOC_FLEXCOMM_COUNT (10)
-/* @brief FLEXIO availability on the SoC. */
-#define FSL_FEATURE_SOC_FLEXIO_COUNT (0)
-/* @brief FLEXRAM availability on the SoC. */
-#define FSL_FEATURE_SOC_FLEXRAM_COUNT (0)
-/* @brief FLEXSPI availability on the SoC. */
-#define FSL_FEATURE_SOC_FLEXSPI_COUNT (0)
 /* @brief FMC availability on the SoC. */
 #define FSL_FEATURE_SOC_FMC_COUNT (1)
-/* @brief FSKDT availability on the SoC. */
-#define FSL_FEATURE_SOC_FSKDT_COUNT (0)
-/* @brief FSP availability on the SoC. */
-#define FSL_FEATURE_SOC_FSP_COUNT (0)
-/* @brief FTFA availability on the SoC. */
-#define FSL_FEATURE_SOC_FTFA_COUNT (0)
-/* @brief FTFE availability on the SoC. */
-#define FSL_FEATURE_SOC_FTFE_COUNT (0)
-/* @brief FTFL availability on the SoC. */
-#define FSL_FEATURE_SOC_FTFL_COUNT (0)
-/* @brief FTM availability on the SoC. */
-#define FSL_FEATURE_SOC_FTM_COUNT (0)
-/* @brief FTMRA availability on the SoC. */
-#define FSL_FEATURE_SOC_FTMRA_COUNT (0)
-/* @brief FTMRE availability on the SoC. */
-#define FSL_FEATURE_SOC_FTMRE_COUNT (0)
-/* @brief FTMRH availability on the SoC. */
-#define FSL_FEATURE_SOC_FTMRH_COUNT (0)
 /* @brief GINT availability on the SoC. */
 #define FSL_FEATURE_SOC_GINT_COUNT (2)
-/* @brief GPC availability on the SoC. */
-#define FSL_FEATURE_SOC_GPC_COUNT (0)
-/* @brief GPC_PGC availability on the SoC. */
-#define FSL_FEATURE_SOC_GPC_PGC_COUNT (0)
 /* @brief GPIO availability on the SoC. */
 #define FSL_FEATURE_SOC_GPIO_COUNT (1)
-/* @brief GPMI availability on the SoC. */
-#define FSL_FEATURE_SOC_GPMI_COUNT (0)
-/* @brief GPT availability on the SoC. */
-#define FSL_FEATURE_SOC_GPT_COUNT (0)
-/* @brief HSADC availability on the SoC. */
-#define FSL_FEATURE_SOC_HSADC_COUNT (0)
 /* @brief I2C availability on the SoC. */
 #define FSL_FEATURE_SOC_I2C_COUNT (10)
 /* @brief I2S availability on the SoC. */
 #define FSL_FEATURE_SOC_I2S_COUNT (2)
-/* @brief ICS availability on the SoC. */
-#define FSL_FEATURE_SOC_ICS_COUNT (0)
-/* @brief IEE availability on the SoC. */
-#define FSL_FEATURE_SOC_IEE_COUNT (0)
-/* @brief IEER availability on the SoC. */
-#define FSL_FEATURE_SOC_IEER_COUNT (0)
-/* @brief IGPIO availability on the SoC. */
-#define FSL_FEATURE_SOC_IGPIO_COUNT (0)
-/* @brief II2C availability on the SoC. */
-#define FSL_FEATURE_SOC_II2C_COUNT (0)
 /* @brief INPUTMUX availability on the SoC. */
 #define FSL_FEATURE_SOC_INPUTMUX_COUNT (1)
-/* @brief INTMUX availability on the SoC. */
-#define FSL_FEATURE_SOC_INTMUX_COUNT (0)
 /* @brief IOCON availability on the SoC. */
 #define FSL_FEATURE_SOC_IOCON_COUNT (1)
-/* @brief IOMUXC availability on the SoC. */
-#define FSL_FEATURE_SOC_IOMUXC_COUNT (0)
-/* @brief IOMUXC_GPR availability on the SoC. */
-#define FSL_FEATURE_SOC_IOMUXC_GPR_COUNT (0)
-/* @brief IOMUXC_LPSR availability on the SoC. */
-#define FSL_FEATURE_SOC_IOMUXC_LPSR_COUNT (0)
-/* @brief IOMUXC_LPSR_GPR availability on the SoC. */
-#define FSL_FEATURE_SOC_IOMUXC_LPSR_GPR_COUNT (0)
-/* @brief IOMUXC_SNVS availability on the SoC. */
-#define FSL_FEATURE_SOC_IOMUXC_SNVS_COUNT (0)
-/* @brief IPWM availability on the SoC. */
-#define FSL_FEATURE_SOC_IPWM_COUNT (0)
-/* @brief IRQ availability on the SoC. */
-#define FSL_FEATURE_SOC_IRQ_COUNT (0)
-/* @brief IUART availability on the SoC. */
-#define FSL_FEATURE_SOC_IUART_COUNT (0)
-/* @brief KBI availability on the SoC. */
-#define FSL_FEATURE_SOC_KBI_COUNT (0)
-/* @brief KPP availability on the SoC. */
-#define FSL_FEATURE_SOC_KPP_COUNT (0)
-/* @brief L2CACHEC availability on the SoC. */
-#define FSL_FEATURE_SOC_L2CACHEC_COUNT (0)
 /* @brief LCD availability on the SoC. */
 #define FSL_FEATURE_SOC_LCD_COUNT (1)
-/* @brief LCDC availability on the SoC. */
-#define FSL_FEATURE_SOC_LCDC_COUNT (0)
-/* @brief LCDIF availability on the SoC. */
-#define FSL_FEATURE_SOC_LCDIF_COUNT (0)
-/* @brief LDO availability on the SoC. */
-#define FSL_FEATURE_SOC_LDO_COUNT (0)
-/* @brief LLWU availability on the SoC. */
-#define FSL_FEATURE_SOC_LLWU_COUNT (0)
-/* @brief LMEM availability on the SoC. */
-#define FSL_FEATURE_SOC_LMEM_COUNT (0)
-/* @brief LPADC availability on the SoC. */
-#define FSL_FEATURE_SOC_LPADC_COUNT (0)
-/* @brief LPCMP availability on the SoC. */
-#define FSL_FEATURE_SOC_LPCMP_COUNT (0)
-/* @brief LPDAC availability on the SoC. */
-#define FSL_FEATURE_SOC_LPDAC_COUNT (0)
-/* @brief LPI2C availability on the SoC. */
-#define FSL_FEATURE_SOC_LPI2C_COUNT (0)
-/* @brief LPIT availability on the SoC. */
-#define FSL_FEATURE_SOC_LPIT_COUNT (0)
-/* @brief LPSCI availability on the SoC. */
-#define FSL_FEATURE_SOC_LPSCI_COUNT (0)
-/* @brief LPSPI availability on the SoC. */
-#define FSL_FEATURE_SOC_LPSPI_COUNT (0)
-/* @brief LPTMR availability on the SoC. */
-#define FSL_FEATURE_SOC_LPTMR_COUNT (0)
-/* @brief LPTPM availability on the SoC. */
-#define FSL_FEATURE_SOC_LPTPM_COUNT (0)
-/* @brief LPUART availability on the SoC. */
-#define FSL_FEATURE_SOC_LPUART_COUNT (0)
-/* @brief LTC availability on the SoC. */
-#define FSL_FEATURE_SOC_LTC_COUNT (0)
-/* @brief MAILBOX availability on the SoC. */
-#define FSL_FEATURE_SOC_MAILBOX_COUNT (0)
-/* @brief MC availability on the SoC. */
-#define FSL_FEATURE_SOC_MC_COUNT (0)
-/* @brief MCG availability on the SoC. */
-#define FSL_FEATURE_SOC_MCG_COUNT (0)
-/* @brief MCGLITE availability on the SoC. */
-#define FSL_FEATURE_SOC_MCGLITE_COUNT (0)
-/* @brief MCM availability on the SoC. */
-#define FSL_FEATURE_SOC_MCM_COUNT (0)
-/* @brief MIPI_CSI2 availability on the SoC. */
-#define FSL_FEATURE_SOC_MIPI_CSI2_COUNT (0)
-/* @brief MIPI_DSI availability on the SoC. */
-#define FSL_FEATURE_SOC_MIPI_DSI_COUNT (0)
-/* @brief MIPI_DSI_HOST availability on the SoC. */
-#define FSL_FEATURE_SOC_MIPI_DSI_HOST_COUNT (0)
-/* @brief MMAU availability on the SoC. */
-#define FSL_FEATURE_SOC_MMAU_COUNT (0)
-/* @brief MMCAU availability on the SoC. */
-#define FSL_FEATURE_SOC_MMCAU_COUNT (0)
-/* @brief MMDC availability on the SoC. */
-#define FSL_FEATURE_SOC_MMDC_COUNT (0)
-/* @brief MMDVSQ availability on the SoC. */
-#define FSL_FEATURE_SOC_MMDVSQ_COUNT (0)
-/* @brief MPU availability on the SoC. */
-#define FSL_FEATURE_SOC_MPU_COUNT (0)
 /* @brief MRT availability on the SoC. */
 #define FSL_FEATURE_SOC_MRT_COUNT (1)
-/* @brief MSCAN availability on the SoC. */
-#define FSL_FEATURE_SOC_MSCAN_COUNT (0)
-/* @brief MSCM availability on the SoC. */
-#define FSL_FEATURE_SOC_MSCM_COUNT (0)
-/* @brief MTB availability on the SoC. */
-#define FSL_FEATURE_SOC_MTB_COUNT (0)
-/* @brief MTBDWT availability on the SoC. */
-#define FSL_FEATURE_SOC_MTBDWT_COUNT (0)
-/* @brief MU availability on the SoC. */
-#define FSL_FEATURE_SOC_MU_COUNT (0)
-/* @brief NFC availability on the SoC. */
-#define FSL_FEATURE_SOC_NFC_COUNT (0)
-/* @brief OCOTP availability on the SoC. */
-#define FSL_FEATURE_SOC_OCOTP_COUNT (0)
-/* @brief OPAMP availability on the SoC. */
-#define FSL_FEATURE_SOC_OPAMP_COUNT (0)
-/* @brief OSC availability on the SoC. */
-#define FSL_FEATURE_SOC_OSC_COUNT (0)
-/* @brief OSC32 availability on the SoC. */
-#define FSL_FEATURE_SOC_OSC32_COUNT (0)
-/* @brief OTFAD availability on the SoC. */
-#define FSL_FEATURE_SOC_OTFAD_COUNT (0)
-/* @brief PCC availability on the SoC. */
-#define FSL_FEATURE_SOC_PCC_COUNT (0)
-/* @brief PCIE_PHY_CMN availability on the SoC. */
-#define FSL_FEATURE_SOC_PCIE_PHY_CMN_COUNT (0)
-/* @brief PCIE_PHY_TRSV availability on the SoC. */
-#define FSL_FEATURE_SOC_PCIE_PHY_TRSV_COUNT (0)
-/* @brief PDB availability on the SoC. */
-#define FSL_FEATURE_SOC_PDB_COUNT (0)
-/* @brief PGA availability on the SoC. */
-#define FSL_FEATURE_SOC_PGA_COUNT (0)
 /* @brief PINT availability on the SoC. */
 #define FSL_FEATURE_SOC_PINT_COUNT (1)
-/* @brief PIT availability on the SoC. */
-#define FSL_FEATURE_SOC_PIT_COUNT (0)
-/* @brief PMC availability on the SoC. */
-#define FSL_FEATURE_SOC_PMC_COUNT (0)
-/* @brief PMU availability on the SoC. */
-#define FSL_FEATURE_SOC_PMU_COUNT (0)
-/* @brief PORT availability on the SoC. */
-#define FSL_FEATURE_SOC_PORT_COUNT (0)
-/* @brief PROP availability on the SoC. */
-#define FSL_FEATURE_SOC_PROP_COUNT (0)
-/* @brief PWM availability on the SoC. */
-#define FSL_FEATURE_SOC_PWM_COUNT (0)
-/* @brief PWT availability on the SoC. */
-#define FSL_FEATURE_SOC_PWT_COUNT (0)
-/* @brief PXP availability on the SoC. */
-#define FSL_FEATURE_SOC_PXP_COUNT (0)
-/* @brief QDEC availability on the SoC. */
-#define FSL_FEATURE_SOC_QDEC_COUNT (0)
-/* @brief QuadSPI availability on the SoC. */
-#define FSL_FEATURE_SOC_QuadSPI_COUNT (0)
-/* @brief RCM availability on the SoC. */
-#define FSL_FEATURE_SOC_RCM_COUNT (0)
-/* @brief RDC availability on the SoC. */
-#define FSL_FEATURE_SOC_RDC_COUNT (0)
-/* @brief RDC_SEMAPHORE availability on the SoC. */
-#define FSL_FEATURE_SOC_RDC_SEMAPHORE_COUNT (0)
-/* @brief RFSYS availability on the SoC. */
-#define FSL_FEATURE_SOC_RFSYS_COUNT (0)
-/* @brief RFVBAT availability on the SoC. */
-#define FSL_FEATURE_SOC_RFVBAT_COUNT (0)
 /* @brief RIT availability on the SoC. */
 #define FSL_FEATURE_SOC_RIT_COUNT (1)
 /* @brief RNG availability on the SoC. */
 #define FSL_FEATURE_SOC_LPC_RNG_COUNT (1)
-/* @brief RNGB availability on the SoC. */
-#define FSL_FEATURE_SOC_RNGB_COUNT (0)
-/* @brief ROM availability on the SoC. */
-#define FSL_FEATURE_SOC_ROM_COUNT (0)
-/* @brief ROMC availability on the SoC. */
-#define FSL_FEATURE_SOC_ROMC_COUNT (0)
-/* @brief RSIM availability on the SoC. */
-#define FSL_FEATURE_SOC_RSIM_COUNT (0)
 /* @brief RTC availability on the SoC. */
 #define FSL_FEATURE_SOC_RTC_COUNT (1)
-/* @brief SCG availability on the SoC. */
-#define FSL_FEATURE_SOC_SCG_COUNT (0)
-/* @brief SCI availability on the SoC. */
-#define FSL_FEATURE_SOC_SCI_COUNT (0)
 /* @brief SCT availability on the SoC. */
 #define FSL_FEATURE_SOC_SCT_COUNT (1)
-/* @brief SDHC availability on the SoC. */
-#define FSL_FEATURE_SOC_SDHC_COUNT (0)
 /* @brief SDIF availability on the SoC. */
 #define FSL_FEATURE_SOC_SDIF_COUNT (1)
-/* @brief SDIO availability on the SoC. */
-#define FSL_FEATURE_SOC_SDIO_COUNT (0)
-/* @brief SDMA availability on the SoC. */
-#define FSL_FEATURE_SOC_SDMA_COUNT (0)
-/* @brief SDMAARM availability on the SoC. */
-#define FSL_FEATURE_SOC_SDMAARM_COUNT (0)
-/* @brief SDMABP availability on the SoC. */
-#define FSL_FEATURE_SOC_SDMABP_COUNT (0)
-/* @brief SDMACORE availability on the SoC. */
-#define FSL_FEATURE_SOC_SDMACORE_COUNT (0)
-/* @brief SDMCORE availability on the SoC. */
-#define FSL_FEATURE_SOC_SDMCORE_COUNT (0)
-/* @brief SDRAM availability on the SoC. */
-#define FSL_FEATURE_SOC_SDRAM_COUNT (0)
-/* @brief SEMA4 availability on the SoC. */
-#define FSL_FEATURE_SOC_SEMA4_COUNT (0)
-/* @brief SEMA42 availability on the SoC. */
-#define FSL_FEATURE_SOC_SEMA42_COUNT (0)
 /* @brief SHA availability on the SoC. */
 #define FSL_FEATURE_SOC_SHA_COUNT (1)
-/* @brief SIM availability on the SoC. */
-#define FSL_FEATURE_SOC_SIM_COUNT (0)
-/* @brief SJC availability on the SoC. */
-#define FSL_FEATURE_SOC_SJC_COUNT (0)
-/* @brief SLCD availability on the SoC. */
-#define FSL_FEATURE_SOC_SLCD_COUNT (0)
 /* @brief SMARTCARD availability on the SoC. */
 #define FSL_FEATURE_SOC_SMARTCARD_COUNT (2)
-/* @brief SMC availability on the SoC. */
-#define FSL_FEATURE_SOC_SMC_COUNT (0)
-/* @brief SNVS availability on the SoC. */
-#define FSL_FEATURE_SOC_SNVS_COUNT (0)
-/* @brief SPBA availability on the SoC. */
-#define FSL_FEATURE_SOC_SPBA_COUNT (0)
-/* @brief SPDIF availability on the SoC. */
-#define FSL_FEATURE_SOC_SPDIF_COUNT (0)
 /* @brief SPI availability on the SoC. */
 #define FSL_FEATURE_SOC_SPI_COUNT (10)
 /* @brief SPIFI availability on the SoC. */
 #define FSL_FEATURE_SOC_SPIFI_COUNT (1)
-/* @brief SPM availability on the SoC. */
-#define FSL_FEATURE_SOC_SPM_COUNT (0)
-/* @brief SRC availability on the SoC. */
-#define FSL_FEATURE_SOC_SRC_COUNT (0)
 /* @brief SYSCON availability on the SoC. */
 #define FSL_FEATURE_SOC_SYSCON_COUNT (1)
-/* @brief TEMPMON availability on the SoC. */
-#define FSL_FEATURE_SOC_TEMPMON_COUNT (0)
-/* @brief TMR availability on the SoC. */
-#define FSL_FEATURE_SOC_TMR_COUNT (0)
-/* @brief TPM availability on the SoC. */
-#define FSL_FEATURE_SOC_TPM_COUNT (0)
-/* @brief TRGMUX availability on the SoC. */
-#define FSL_FEATURE_SOC_TRGMUX_COUNT (0)
-/* @brief TRIAMP availability on the SoC. */
-#define FSL_FEATURE_SOC_TRIAMP_COUNT (0)
-/* @brief TRNG availability on the SoC. */
-#define FSL_FEATURE_SOC_TRNG_COUNT (0)
-/* @brief TSC availability on the SoC. */
-#define FSL_FEATURE_SOC_TSC_COUNT (0)
-/* @brief TSI availability on the SoC. */
-#define FSL_FEATURE_SOC_TSI_COUNT (0)
-/* @brief TSTMR availability on the SoC. */
-#define FSL_FEATURE_SOC_TSTMR_COUNT (0)
-/* @brief UART availability on the SoC. */
-#define FSL_FEATURE_SOC_UART_COUNT (0)
 /* @brief USART availability on the SoC. */
 #define FSL_FEATURE_SOC_USART_COUNT (10)
 /* @brief USB availability on the SoC. */
 #define FSL_FEATURE_SOC_USB_COUNT (1)
-/* @brief USBHS availability on the SoC. */
-#define FSL_FEATURE_SOC_USBHS_COUNT (0)
-/* @brief USBDCD availability on the SoC. */
-#define FSL_FEATURE_SOC_USBDCD_COUNT (0)
 /* @brief USBFSH availability on the SoC. */
 #define FSL_FEATURE_SOC_USBFSH_COUNT (1)
 /* @brief USBHSD availability on the SoC. */
 #define FSL_FEATURE_SOC_USBHSD_COUNT (1)
-/* @brief USBHSDCD availability on the SoC. */
-#define FSL_FEATURE_SOC_USBHSDCD_COUNT (0)
 /* @brief USBHSH availability on the SoC. */
 #define FSL_FEATURE_SOC_USBHSH_COUNT (1)
-/* @brief USBNC availability on the SoC. */
-#define FSL_FEATURE_SOC_USBNC_COUNT (0)
-/* @brief USBPHY availability on the SoC. */
-#define FSL_FEATURE_SOC_USBPHY_COUNT (0)
-/* @brief USB_HSIC availability on the SoC. */
-#define FSL_FEATURE_SOC_USB_HSIC_COUNT (0)
-/* @brief USB_OTG availability on the SoC. */
-#define FSL_FEATURE_SOC_USB_OTG_COUNT (0)
-/* @brief USBVREG availability on the SoC. */
-#define FSL_FEATURE_SOC_USBVREG_COUNT (0)
-/* @brief USDHC availability on the SoC. */
-#define FSL_FEATURE_SOC_USDHC_COUNT (0)
 /* @brief UTICK availability on the SoC. */
 #define FSL_FEATURE_SOC_UTICK_COUNT (1)
-/* @brief VIU availability on the SoC. */
-#define FSL_FEATURE_SOC_VIU_COUNT (0)
-/* @brief VREF availability on the SoC. */
-#define FSL_FEATURE_SOC_VREF_COUNT (0)
-/* @brief VFIFO availability on the SoC. */
-#define FSL_FEATURE_SOC_VFIFO_COUNT (0)
-/* @brief WDOG availability on the SoC. */
-#define FSL_FEATURE_SOC_WDOG_COUNT (0)
-/* @brief WKPU availability on the SoC. */
-#define FSL_FEATURE_SOC_WKPU_COUNT (0)
 /* @brief WWDT availability on the SoC. */
 #define FSL_FEATURE_SOC_WWDT_COUNT (1)
-/* @brief XBAR availability on the SoC. */
-#define FSL_FEATURE_SOC_XBAR_COUNT (0)
-/* @brief XBARA availability on the SoC. */
-#define FSL_FEATURE_SOC_XBARA_COUNT (0)
-/* @brief XBARB availability on the SoC. */
-#define FSL_FEATURE_SOC_XBARB_COUNT (0)
-/* @brief XCVR availability on the SoC. */
-#define FSL_FEATURE_SOC_XCVR_COUNT (0)
-/* @brief XRDC availability on the SoC. */
-#define FSL_FEATURE_SOC_XRDC_COUNT (0)
-/* @brief XTALOSC availability on the SoC. */
-#define FSL_FEATURE_SOC_XTALOSC_COUNT (0)
-/* @brief XTALOSC24M availability on the SoC. */
-#define FSL_FEATURE_SOC_XTALOSC24M_COUNT (0)
-/* @brief ZLL availability on the SoC. */
-#define FSL_FEATURE_SOC_ZLL_COUNT (0)
+
+/* ADC module features */
+
+/* @brief Do not has input select (register INSEL). */
+#define FSL_FEATURE_ADC_HAS_NO_INSEL  (0)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_RESOL (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_TSAMP (1)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE (0)
+/* @brief Has ASYNMODE bitfile in CTRL reigster. */
+#define FSL_FEATURE_ADC_HAS_CTRL_CALMODE (0)
+/* @brief Has startup register. */
+#define FSL_FEATURE_ADC_HAS_STARTUP_REG (1)
+/* @brief Has ADTrim register */
+#define FSL_FEATURE_ADC_HAS_TRIM_REG (0)
+/* @brief Has Calibration register. */
+#define FSL_FEATURE_ADC_HAS_CALIB_REG (1)
 
 /* CAN module features */
 
@@ -561,6 +143,10 @@
 
 /* @brief Number of channels */
 #define FSL_FEATURE_DMA_NUMBER_OF_CHANNELS (30)
+/* @brief Align size of DMA descriptor */
+#define FSL_FEATURE_DMA_DESCRIPTOR_ALIGN_SIZE (512)
+/* @brief DMA head link descriptor table align size */
+#define FSL_FEATURE_DMA_LINK_DESCRIPTOR_ALIGN_SIZE (16U)
 
 /* EEPROM module features */
 
@@ -575,15 +161,123 @@
 /* @brief EEPROM internal clock freqency */
 #define FSL_FEATURE_EEPROM_INTERNAL_FREQ (1500000)
 
+/* FLEXCOMM module features */
+
+/* @brief FLEXCOMM0 USART INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM0_USART_INDEX  (0)
+/* @brief FLEXCOMM0 SPI INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM0_SPI_INDEX  (0)
+/* @brief FLEXCOMM0 I2C INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM0_I2C_INDEX  (0)
+/* @brief FLEXCOMM1 USART INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM1_USART_INDEX  (1)
+/* @brief FLEXCOMM1 SPI INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM1_SPI_INDEX  (1)
+/* @brief FLEXCOMM1 I2C INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM1_I2C_INDEX  (1)
+/* @brief FLEXCOMM2 USART INDEX 2 */
+#define FSL_FEATURE_FLEXCOMM2_USART_INDEX  (2)
+/* @brief FLEXCOMM2 SPI INDEX 2 */
+#define FSL_FEATURE_FLEXCOMM2_SPI_INDEX  (2)
+/* @brief FLEXCOMM2 I2C INDEX 2 */
+#define FSL_FEATURE_FLEXCOMM2_I2C_INDEX  (2)
+/* @brief FLEXCOMM3 USART INDEX 3 */
+#define FSL_FEATURE_FLEXCOMM3_USART_INDEX  (3)
+/* @brief FLEXCOMM3 SPI INDEX 3 */
+#define FSL_FEATURE_FLEXCOMM3_SPI_INDEX  (3)
+/* @brief FLEXCOMM3 I2C INDEX 3 */
+#define FSL_FEATURE_FLEXCOMM3_I2C_INDEX  (3)
+/* @brief FLEXCOMM4 USART INDEX 4 */
+#define FSL_FEATURE_FLEXCOMM4_USART_INDEX  (4)
+/* @brief FLEXCOMM4 SPI INDEX 4 */
+#define FSL_FEATURE_FLEXCOMM4_SPI_INDEX  (4)
+/* @brief FLEXCOMM4 I2C INDEX 4 */
+#define FSL_FEATURE_FLEXCOMM4_I2C_INDEX  (4)
+/* @brief FLEXCOMM5 USART INDEX 5 */
+#define FSL_FEATURE_FLEXCOMM5_USART_INDEX  (5)
+/* @brief FLEXCOMM5 SPI INDEX 5 */
+#define FSL_FEATURE_FLEXCOMM5_SPI_INDEX  (5)
+/* @brief FLEXCOMM5 I2C INDEX 5 */
+#define FSL_FEATURE_FLEXCOMM5_I2C_INDEX  (5)
+/* @brief FLEXCOMM6 USART INDEX 6 */
+#define FSL_FEATURE_FLEXCOMM6_USART_INDEX  (6)
+/* @brief FLEXCOMM6 SPI INDEX 6 */
+#define FSL_FEATURE_FLEXCOMM6_SPI_INDEX  (6)
+/* @brief FLEXCOMM6 I2C INDEX 6 */
+#define FSL_FEATURE_FLEXCOMM6_I2C_INDEX  (6)
+/* @brief FLEXCOMM7 I2S INDEX 0 */
+#define FSL_FEATURE_FLEXCOMM6_I2S_INDEX  (0)
+/* @brief FLEXCOMM7 USART INDEX 7 */
+#define FSL_FEATURE_FLEXCOMM7_USART_INDEX  (7)
+/* @brief FLEXCOMM7 SPI INDEX 7 */
+#define FSL_FEATURE_FLEXCOMM7_SPI_INDEX  (7)
+/* @brief FLEXCOMM7 I2C INDEX 7 */
+#define FSL_FEATURE_FLEXCOMM7_I2C_INDEX  (7)
+/* @brief FLEXCOMM7 I2S INDEX 1 */
+#define FSL_FEATURE_FLEXCOMM7_I2S_INDEX  (1)
+/* @brief FLEXCOMM4 USART INDEX 8 */
+#define FSL_FEATURE_FLEXCOMM8_USART_INDEX  (8)
+/* @brief FLEXCOMM4 SPI INDEX 8 */
+#define FSL_FEATURE_FLEXCOMM8_SPI_INDEX  (8)
+/* @brief FLEXCOMM4 I2C INDEX 8 */
+#define FSL_FEATURE_FLEXCOMM8_I2C_INDEX  (8)
+/* @brief FLEXCOMM5 USART INDEX 9 */
+#define FSL_FEATURE_FLEXCOMM9_USART_INDEX  (9)
+/* @brief FLEXCOMM5 SPI INDEX 9 */
+#define FSL_FEATURE_FLEXCOMM9_SPI_INDEX  (9)
+/* @brief FLEXCOMM5 I2C INDEX 9 */
+#define FSL_FEATURE_FLEXCOMM9_I2C_INDEX  (9)
+/* @brief I2S has DMIC interconnection */
+#define FSL_FEATURE_FLEXCOMM_INSTANCE_I2S_HAS_DMIC_INTERCONNECTIONn(x) \
+    (((x) == FLEXCOMM0) ? (0) : \
+    (((x) == FLEXCOMM1) ? (0) : \
+    (((x) == FLEXCOMM2) ? (0) : \
+    (((x) == FLEXCOMM3) ? (0) : \
+    (((x) == FLEXCOMM4) ? (0) : \
+    (((x) == FLEXCOMM5) ? (0) : \
+    (((x) == FLEXCOMM6) ? (0) : \
+    (((x) == FLEXCOMM7) ? (1) : \
+    (((x) == FLEXCOMM8) ? (0) : \
+    (((x) == FLEXCOMM9) ? (0) : (-1)))))))))))
+
+/* I2S module features */
+
+/* @brief I2S support dual channel transfer */
+#define FSL_FEATURE_I2S_SUPPORT_SECONDARY_CHANNEL (1)
+/* @brief I2S has DMIC interconnection */
+#define FSL_FEATURE_FLEXCOMM_I2S_HAS_DMIC_INTERCONNECTION  (1)
+
 /* IOCON module features */
 
 /* @brief Func bit field width */
 #define FSL_FEATURE_IOCON_FUNC_FIELD_WIDTH (4)
 
+/* MRT module features */
+
+/* @brief number of channels. */
+#define FSL_FEATURE_MRT_NUMBER_OF_CHANNELS  (4)
+
+/* interrupt module features */
+
+/* @brief Lowest interrupt request number. */
+#define FSL_FEATURE_INTERRUPT_IRQ_MIN (-14)
+/* @brief Highest interrupt request number. */
+#define FSL_FEATURE_INTERRUPT_IRQ_MAX (105)
+
 /* PINT module features */
 
 /* @brief Number of connected outputs */
 #define FSL_FEATURE_PINT_NUMBER_OF_CONNECTED_OUTPUTS (8)
+
+/* RIT module features */
+
+/* @brief RIT has no reset control */
+#define FSL_FEATURE_RIT_HAS_NO_RESET (1)
+
+/* RTC module features */
+
+/* @brief RTC has no reset control */
+#define FSL_FEATURE_RTC_HAS_NO_RESET (1)
 
 /* SCT module features */
 
@@ -593,6 +287,8 @@
 #define FSL_FEATURE_SCT_NUMBER_OF_STATES (10)
 /* @brief Number of match capture */
 #define FSL_FEATURE_SCT_NUMBER_OF_MATCH_CAPTURE (10)
+/* @brief Number of outputs */
+#define FSL_FEATURE_SCT_NUMBER_OF_OUTPUTS (10)
 
 /* SDIF module features */
 
@@ -620,6 +316,21 @@
 #define FSL_FEATURE_SYSCON_FLASH_SECTOR_SIZE_BYTES (32768)
 /* @brief Flash size in bytes */
 #define FSL_FEATURE_SYSCON_FLASH_SIZE_BYTES (524288)
+/* @brief IAP has Flash read & write function */
+#define FSL_FEATURE_IAP_HAS_FLASH_FUNCTION (1)
+/* @brief IAP has EEPROM read & write function */
+#define FSL_FEATURE_IAP_HAS_EEPROM_FUNCTION (1)
+/* @brief IAP has read Flash signature function  */
+#define FSL_FEATURE_IAP_HAS_FLASH_SIGNATURE_READ (0)
+/* @brief IAP has read extended Flash signature function */
+#define FSL_FEATURE_IAP_HAS_FLASH_EXTENDED_SIGNATURE_READ (1)
+
+/* SysTick module features */
+
+/* @brief Systick has external reference clock. */
+#define FSL_FEATURE_SYSTICK_HAS_EXT_REF (0)
+/* @brief Systick external reference clock is core clock divided by this value. */
+#define FSL_FEATURE_SYSTICK_EXT_REF_CORE_DIV (0)
 
 /* USB module features */
 
@@ -627,6 +338,8 @@
 #define FSL_FEATURE_USB_USB_RAM (0x00002000)
 /* @brief Base address of the USB dedicated RAM */
 #define FSL_FEATURE_USB_USB_RAM_BASE_ADDRESS (0x40100000)
+/* @brief Number of the endpoint in USB FS */
+#define FSL_FEATURE_USB_EP_NUM (5)
 
 /* USBFSH module features */
 
@@ -641,6 +354,8 @@
 #define FSL_FEATURE_USBHSD_USB_RAM (0x00002000)
 /* @brief Base address of the USB dedicated RAM */
 #define FSL_FEATURE_USBHSD_USB_RAM_BASE_ADDRESS (0x40100000)
+/* @brief Number of the endpoint in USB HS */
+#define FSL_FEATURE_USBHSD_EP_NUM (6)
 
 /* USBHSH module features */
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/drivers/fsl_adc.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/drivers/fsl_adc.c
@@ -1,44 +1,25 @@
 /*
- * The Clear BSD License
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted (subject to the limitations in the disclaimer below) provided
- * that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_adc.h"
 #include "fsl_clock.h"
 
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.lpc_adc"
+#endif
+
 static ADC_Type *const s_adcBases[] = ADC_BASE_PTRS;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static const clock_ip_name_t s_adcClocks[] = ADC_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+#define FREQUENCY_1MHZ (1000000U)
 
 static uint32_t ADC_GetInstance(ADC_Type *base)
 {
@@ -58,6 +39,12 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
     return instance;
 }
 
+/*!
+ * brief Initialize the ADC module.
+ *
+ * param base ADC peripheral base address.
+ * param config Pointer to configuration structure, see to #adc_config_t.
+ */
 void ADC_Init(ADC_Type *base, const adc_config_t *config)
 {
     assert(config != NULL);
@@ -75,6 +62,7 @@ void ADC_Init(ADC_Type *base, const adc_config_t *config)
     /* Configure the ADC block. */
     tmp32 = ADC_CTRL_CLKDIV(config->clockDividerNumber);
 
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
     /* Async or Sync clock mode. */
     switch (config->clockMode)
     {
@@ -84,31 +72,112 @@ void ADC_Init(ADC_Type *base, const adc_config_t *config)
         default: /* kADC_ClockSynchronousMode */
             break;
     }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
 
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
     /* Resolution. */
-    tmp32 |= ADC_CTRL_RESOL(config->resolution);
 
+    tmp32 |= ADC_CTRL_RESOL(config->resolution);
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_RESOL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL) & FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL
     /* Bypass calibration. */
     if (config->enableBypassCalibration)
     {
         tmp32 |= ADC_CTRL_BYPASSCAL_MASK;
     }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL. */
 
-    /* Sample time clock count. */
-    tmp32 |= ADC_CTRL_TSAMP(config->sampleTimeNumber);
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_TSAMP) & FSL_FEATURE_ADC_HAS_CTRL_TSAMP
+/* Sample time clock count. */
+#if (defined(FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL) && FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL)
+    if (config->clockMode == kADC_ClockAsynchronousMode)
+    {
+#endif /* FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL */
+        tmp32 |= ADC_CTRL_TSAMP(config->sampleTimeNumber);
+#if (defined(FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL) && FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL)
+    }
+#endif /* FSL_FEATURE_ADC_SYNCHRONOUS_USE_GPADC_CTRL */
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_TSAMP. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE) & FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE
+    if (config->enableLowPowerMode)
+    {
+        tmp32 |= ADC_CTRL_LPWRMODE_MASK;
+    }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE. */
 
     base->CTRL = tmp32;
+
+#if defined(FSL_FEATURE_ADC_HAS_GPADC_CTRL0_LDO_POWER_EN) && FSL_FEATURE_ADC_HAS_GPADC_CTRL0_LDO_POWER_EN
+    base->GPADC_CTRL0 |= ADC_GPADC_CTRL0_LDO_POWER_EN_MASK;
+    if (config->clockMode == kADC_ClockSynchronousMode)
+    {
+        base->GPADC_CTRL0 |= ADC_GPADC_CTRL0_PASS_ENABLE(config->sampleTimeNumber);
+    }
+#endif /* FSL_FEATURE_ADC_HAS_GPADC_CTRL0_LDO_POWER_EN */
+
+#if defined(FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL) && FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL
+    tmp32 = *(uint32_t *)FSL_FEATURE_FLASH_ADDR_OF_TEMP_CAL;
+    if (tmp32 & FSL_FEATURE_FLASH_ADDR_OF_TEMP_CAL_VALID)
+    {
+        base->GPADC_CTRL1 = (tmp32 >> 1);
+    }
+#if !(defined(FSL_FEATURE_ADC_HAS_STARTUP_ADC_INIT) && FSL_FEATURE_ADC_HAS_STARTUP_ADC_INIT)
+    base->STARTUP = ADC_STARTUP_ADC_ENA_MASK; /* Set the ADC Start bit */
+#endif                                        /* FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL */
+#endif                                        /* FSL_FEATURE_ADC_HAS_GPADC_CTRL1_OFFSET_CAL */
+
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+    base->TRM &= ~ADC_TRM_VRANGE_MASK;
+    base->TRM |= ADC_TRM_VRANGE(config->voltageRange);
+#endif /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 }
 
+/*!
+ * brief Gets an available pre-defined settings for initial configuration.
+ *
+ * This function initializes the initial configuration structure with an available settings. The default values are:
+ * code
+ *   config->clockMode = kADC_ClockSynchronousMode;
+ *   config->clockDividerNumber = 0U;
+ *   config->resolution = kADC_Resolution12bit;
+ *   config->enableBypassCalibration = false;
+ *   config->sampleTimeNumber = 0U;
+ * endcode
+ * param config Pointer to configuration structure.
+ */
 void ADC_GetDefaultConfig(adc_config_t *config)
 {
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
+
     config->clockMode = kADC_ClockSynchronousMode;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
+
     config->clockDividerNumber = 0U;
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
     config->resolution = kADC_Resolution12bit;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_RESOL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL) & FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL
     config->enableBypassCalibration = false;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_TSAMP) & FSL_FEATURE_ADC_HAS_CTRL_TSAMP
     config->sampleTimeNumber = 0U;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_TSAMP. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE) & FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE
+    config->enableLowPowerMode = false;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE. */
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+    config->voltageRange = kADC_HighVoltageRange;
+#endif /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 }
 
+/*!
+ * brief Deinitialize the ADC module.
+ *
+ * param base ADC peripheral base address.
+ */
 void ADC_Deinit(ADC_Type *base)
 {
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -117,53 +186,122 @@ void ADC_Deinit(ADC_Type *base)
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
+#if !(defined(FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC) && FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC)
+#if defined(FSL_FEATURE_ADC_HAS_CALIB_REG) & FSL_FEATURE_ADC_HAS_CALIB_REG
+/*!
+ * brief Do the self calibration. To calibrate the ADC, set the ADC clock to 1 mHz.
+ *        In order to achieve the specified ADC accuracy, the A/D converter must be recalibrated, at a minimum,
+ *        following every chip reset before initiating normal ADC operation.
+ *
+ * param base ADC peripheral base address.
+ * retval true  Calibration succeed.
+ * retval false Calibration failed.
+ */
 bool ADC_DoSelfCalibration(ADC_Type *base)
 {
-    uint32_t i;
+    uint32_t frequency = 0U;
+    uint32_t delayUs = 0U;
 
     /* Enable the converter. */
     /* This bit acn only be set 1 by software. It is cleared automatically whenever the ADC is powered down.
        This bit should be set after at least 10 ms after the ADC is powered on. */
     base->STARTUP = ADC_STARTUP_ADC_ENA_MASK;
-    for (i = 0U; i < 0x10; i++) /* Wait a few clocks to startup up. */
-    {
-        __ASM("NOP");
-    }
+    SDK_DelayAtLeastUs(1U);
     if (!(base->STARTUP & ADC_STARTUP_ADC_ENA_MASK))
     {
         return false; /* ADC is not powered up. */
     }
 
+    /* Get the ADC clock frequency in synchronous mode. */
+    frequency = CLOCK_GetFreq(kCLOCK_BusClk) / (((base->CTRL & ADC_CTRL_CLKDIV_MASK) >> ADC_CTRL_CLKDIV_SHIFT) + 1);
+    base->CTRL |= ADC_CTRL_CLKDIV((frequency / 1000000U) - 1U);
+    frequency = 1000000U;
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) && FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
+    /* Get the ADC clock frequency in asynchronous mode. */
+    if (ADC_CTRL_ASYNMODE_MASK == (base->CTRL & ADC_CTRL_ASYNMODE_MASK))
+    {
+        frequency = CLOCK_GetAdcClkFreq();
+    }
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE */
+    assert(0U != frequency);
+
     /* If not in by-pass mode, do the calibration. */
     if ((ADC_CALIB_CALREQD_MASK == (base->CALIB & ADC_CALIB_CALREQD_MASK)) &&
         (0U == (base->CTRL & ADC_CTRL_BYPASSCAL_MASK)))
     {
+        /* A calibration cycle requires approximately 81 ADC clocks to complete. */
+        delayUs = (120 * FREQUENCY_1MHZ) / frequency + 1;
         /* Calibration is needed, do it now. */
         base->CALIB = ADC_CALIB_CALIB_MASK;
-        i = 0xF0000;
-        while ((ADC_CALIB_CALIB_MASK == (base->CALIB & ADC_CALIB_CALIB_MASK)) && (--i))
-        {
-        }
-        if (i == 0U)
+        SDK_DelayAtLeastUs(delayUs);
+        if (ADC_CALIB_CALIB_MASK == (base->CALIB & ADC_CALIB_CALIB_MASK))
         {
             return false; /* Calibration timeout. */
         }
     }
 
-    /* A dummy conversion cycle will be performed. */
+    /* A “dummy” conversion cycle requires approximately 6 ADC clocks */
+    delayUs = (10 * FREQUENCY_1MHZ) / frequency + 1;
     base->STARTUP |= ADC_STARTUP_ADC_INIT_MASK;
-    i = 0x7FFFF;
-    while ((ADC_STARTUP_ADC_INIT_MASK == (base->STARTUP & ADC_STARTUP_ADC_INIT_MASK)) && (--i))
-    {
-    }
-    if (i == 0U)
+    SDK_DelayAtLeastUs(delayUs);
+    if (ADC_STARTUP_ADC_INIT_MASK == (base->STARTUP & ADC_STARTUP_ADC_INIT_MASK))
     {
         return false;
     }
 
     return true;
 }
+#else
+/*!
+ * brief Do the self calibration. To calibrate the ADC, set the ADC clock to 1 mHz.
+ *        In order to achieve the specified ADC accuracy, the A/D converter must be recalibrated, at a minimum,
+ *        following every chip reset before initiating normal ADC operation.
+ *
+ * param base ADC peripheral base address.
+ * param frequency The ststem clock frequency to ADC.
+ * retval true  Calibration succeed.
+ * retval false Calibration failed.
+ */
+bool ADC_DoSelfCalibration(ADC_Type *base, uint32_t frequency)
+{
+    uint32_t tmp32;
 
+    /* Store the current contents of the ADC CTRL register. */
+    tmp32 = base->CTRL;
+
+    /* Start ADC self-calibration. */
+    base->CTRL |= ADC_CTRL_CALMODE_MASK;
+
+    /* Divide the system clock to yield an ADC clock of about 1 mHz. */
+    base->CTRL &= ~ADC_CTRL_CLKDIV_MASK;
+    base->CTRL |= ADC_CTRL_CLKDIV((frequency / 1000000U) - 1U);
+
+    /* Clear the LPWR bit. */
+    base->CTRL &= ~ADC_CTRL_LPWRMODE_MASK;
+    /* Delay for 120 uSec @ 1 mHz ADC clock */
+    SDK_DelayAtLeastUs(120U);
+
+    /* Check the completion of calibration. */
+    if (ADC_CTRL_CALMODE_MASK == (base->CTRL & ADC_CTRL_CALMODE_MASK))
+    {
+        /* Restore the contents of the ADC CTRL register. */
+        base->CTRL = tmp32;
+        return false; /* Calibration timeout. */
+    }
+    /* Restore the contents of the ADC CTRL register. */
+    base->CTRL = tmp32;
+
+    return true;
+}
+#endif /* FSL_FEATURE_ADC_HAS_CALIB_REG */
+#endif /* FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC*/
+
+/*!
+ * brief Configure the conversion sequence A.
+ *
+ * param base ADC peripheral base address.
+ * param config Pointer to configuration structure, see to #adc_conv_seq_config_t.
+ */
 void ADC_SetConvSeqAConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
 {
     assert(config != NULL);
@@ -208,6 +346,12 @@ void ADC_SetConvSeqAConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
     base->SEQ_CTRL[0] = tmp32;
 }
 
+/*!
+ * brief Configure the conversion sequence B.
+ *
+ * param base ADC peripheral base address.
+ * param config Pointer to configuration structure, see to #adc_conv_seq_config_t.
+ */
 void ADC_SetConvSeqBConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
 {
     assert(config != NULL);
@@ -252,6 +396,14 @@ void ADC_SetConvSeqBConfig(ADC_Type *base, const adc_conv_seq_config_t *config)
     base->SEQ_CTRL[1] = tmp32;
 }
 
+/*!
+ * brief Get the global ADC conversion infomation of sequence A.
+ *
+ * param base ADC peripheral base address.
+ * param info Pointer to information structure, see to #adc_result_info_t;
+ * retval true  The conversion result is ready.
+ * retval false The conversion result is not ready yet.
+ */
 bool ADC_GetConvSeqAGlobalConversionResult(ADC_Type *base, adc_result_info_t *info)
 {
     assert(info != NULL);
@@ -269,11 +421,19 @@ bool ADC_GetConvSeqAGlobalConversionResult(ADC_Type *base, adc_result_info_t *in
     info->thresholdCorssingStatus =
         (adc_threshold_crossing_status_t)((tmp32 & ADC_SEQ_GDAT_THCMPCROSS_MASK) >> ADC_SEQ_GDAT_THCMPCROSS_SHIFT);
     info->channelNumber = (tmp32 & ADC_SEQ_GDAT_CHN_MASK) >> ADC_SEQ_GDAT_CHN_SHIFT;
-    info->overrunFlag = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
+    info->overrunFlag   = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
 
     return true;
 }
 
+/*!
+ * brief Get the global ADC conversion infomation of sequence B.
+ *
+ * param base ADC peripheral base address.
+ * param info Pointer to information structure, see to #adc_result_info_t;
+ * retval true  The conversion result is ready.
+ * retval false The conversion result is not ready yet.
+ */
 bool ADC_GetConvSeqBGlobalConversionResult(ADC_Type *base, adc_result_info_t *info)
 {
     assert(info != NULL);
@@ -291,11 +451,20 @@ bool ADC_GetConvSeqBGlobalConversionResult(ADC_Type *base, adc_result_info_t *in
     info->thresholdCorssingStatus =
         (adc_threshold_crossing_status_t)((tmp32 & ADC_SEQ_GDAT_THCMPCROSS_MASK) >> ADC_SEQ_GDAT_THCMPCROSS_SHIFT);
     info->channelNumber = (tmp32 & ADC_SEQ_GDAT_CHN_MASK) >> ADC_SEQ_GDAT_CHN_SHIFT;
-    info->overrunFlag = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
+    info->overrunFlag   = ((tmp32 & ADC_SEQ_GDAT_OVERRUN_MASK) == ADC_SEQ_GDAT_OVERRUN_MASK);
 
     return true;
 }
 
+/*!
+ * brief Get the channel's ADC conversion completed under each conversion sequence.
+ *
+ * param base ADC peripheral base address.
+ * param channel The indicated channel number.
+ * param info Pointer to information structure, see to #adc_result_info_t;
+ * retval true  The conversion result is ready.
+ * retval false The conversion result is not ready yet.
+ */
 bool ADC_GetChannelConversionResult(ADC_Type *base, uint32_t channel, adc_result_info_t *info)
 {
     assert(info != NULL);
@@ -309,12 +478,51 @@ bool ADC_GetChannelConversionResult(ADC_Type *base, uint32_t channel, adc_result
     }
 
     info->result = (tmp32 & ADC_DAT_RESULT_MASK) >> ADC_DAT_RESULT_SHIFT;
+#if (defined(FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT) && FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT)
+    switch ((base->CTRL & ADC_CTRL_RESOL_MASK) >> ADC_CTRL_RESOL_SHIFT)
+    {
+        case kADC_Resolution10bit:
+            info->result >>= kADC_Resolution10bitInfoResultShift;
+            break;
+        case kADC_Resolution8bit:
+            info->result >>= kADC_Resolution8bitInfoResultShift;
+            break;
+        case kADC_Resolution6bit:
+            info->result >>= kADC_Resolution6bitInfoResultShift;
+            break;
+        default:
+            break;
+    }
+#endif
     info->thresholdCompareStatus =
         (adc_threshold_compare_status_t)((tmp32 & ADC_DAT_THCMPRANGE_MASK) >> ADC_DAT_THCMPRANGE_SHIFT);
     info->thresholdCorssingStatus =
         (adc_threshold_crossing_status_t)((tmp32 & ADC_DAT_THCMPCROSS_MASK) >> ADC_DAT_THCMPCROSS_SHIFT);
     info->channelNumber = (tmp32 & ADC_DAT_CHANNEL_MASK) >> ADC_DAT_CHANNEL_SHIFT;
-    info->overrunFlag = ((tmp32 & ADC_DAT_OVERRUN_MASK) == ADC_DAT_OVERRUN_MASK);
+    info->overrunFlag   = ((tmp32 & ADC_DAT_OVERRUN_MASK) == ADC_DAT_OVERRUN_MASK);
 
     return true;
 }
+#if defined(FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP) && (FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP)
+void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        SYSCON->ASYNCAPBCTRL         = SYSCON_ASYNCAPBCTRL_ENABLE_MASK;
+        ASYNC_SYSCON->TEMPSENSORCTRL = kADC_NoOffsetAdded;
+        ASYNC_SYSCON->TEMPSENSORCTRL |= ASYNC_SYSCON_TEMPSENSORCTRL_ENABLE_MASK;
+        base->GPADC_CTRL0 |= (kADC_ADCInUnityGainMode | kADC_Impedance87kOhm);
+    }
+    else
+    {
+        /* if the temperature sensor is not turned on then ASYNCAPBCTRL is likely to be zero
+         * and accessing the registers will cause a memory access error. Test for this */
+        if (SYSCON->ASYNCAPBCTRL == SYSCON_ASYNCAPBCTRL_ENABLE_MASK)
+        {
+            ASYNC_SYSCON->TEMPSENSORCTRL = 0x0;
+            base->GPADC_CTRL0 &= ~(kADC_ADCInUnityGainMode | kADC_Impedance87kOhm);
+            base->GPADC_CTRL0 |= kADC_Impedance55kOhm;
+        }
+    }
+}
+#endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/drivers/fsl_adc.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/drivers/fsl_adc.h
@@ -1,35 +1,9 @@
 /*
- * The Clear BSD License
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted (subject to the limitations in the disclaimer below) provided
- * that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef __FSL_ADC_H__
@@ -50,25 +24,26 @@
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief ADC driver version 2.1.0. */
-#define LPC_ADC_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*! @brief ADC driver version 2.3.1. */
+#define FSL_ADC_DRIVER_VERSION (MAKE_VERSION(2, 3, 1))
 /*@}*/
 
 /*!
  * @brief Flags
  */
+
 enum _adc_status_flags
 {
-    kADC_ThresholdCompareFlagOnChn0 = 1U << 0U,   /*!< Threshold comparison event on Channel 0. */
-    kADC_ThresholdCompareFlagOnChn1 = 1U << 1U,   /*!< Threshold comparison event on Channel 1. */
-    kADC_ThresholdCompareFlagOnChn2 = 1U << 2U,   /*!< Threshold comparison event on Channel 2. */
-    kADC_ThresholdCompareFlagOnChn3 = 1U << 3U,   /*!< Threshold comparison event on Channel 3. */
-    kADC_ThresholdCompareFlagOnChn4 = 1U << 4U,   /*!< Threshold comparison event on Channel 4. */
-    kADC_ThresholdCompareFlagOnChn5 = 1U << 5U,   /*!< Threshold comparison event on Channel 5. */
-    kADC_ThresholdCompareFlagOnChn6 = 1U << 6U,   /*!< Threshold comparison event on Channel 6. */
-    kADC_ThresholdCompareFlagOnChn7 = 1U << 7U,   /*!< Threshold comparison event on Channel 7. */
-    kADC_ThresholdCompareFlagOnChn8 = 1U << 8U,   /*!< Threshold comparison event on Channel 8. */
-    kADC_ThresholdCompareFlagOnChn9 = 1U << 9U,   /*!< Threshold comparison event on Channel 9. */
+    kADC_ThresholdCompareFlagOnChn0  = 1U << 0U,  /*!< Threshold comparison event on Channel 0. */
+    kADC_ThresholdCompareFlagOnChn1  = 1U << 1U,  /*!< Threshold comparison event on Channel 1. */
+    kADC_ThresholdCompareFlagOnChn2  = 1U << 2U,  /*!< Threshold comparison event on Channel 2. */
+    kADC_ThresholdCompareFlagOnChn3  = 1U << 3U,  /*!< Threshold comparison event on Channel 3. */
+    kADC_ThresholdCompareFlagOnChn4  = 1U << 4U,  /*!< Threshold comparison event on Channel 4. */
+    kADC_ThresholdCompareFlagOnChn5  = 1U << 5U,  /*!< Threshold comparison event on Channel 5. */
+    kADC_ThresholdCompareFlagOnChn6  = 1U << 6U,  /*!< Threshold comparison event on Channel 6. */
+    kADC_ThresholdCompareFlagOnChn7  = 1U << 7U,  /*!< Threshold comparison event on Channel 7. */
+    kADC_ThresholdCompareFlagOnChn8  = 1U << 8U,  /*!< Threshold comparison event on Channel 8. */
+    kADC_ThresholdCompareFlagOnChn9  = 1U << 9U,  /*!< Threshold comparison event on Channel 9. */
     kADC_ThresholdCompareFlagOnChn10 = 1U << 10U, /*!< Threshold comparison event on Channel 10. */
     kADC_ThresholdCompareFlagOnChn11 = 1U << 11U, /*!< Threshold comparison event on Channel 11. */
     kADC_OverrunFlagForChn0 =
@@ -97,10 +72,10 @@ enum _adc_status_flags
         1U << 23U, /*!< Mirror the OVERRUN status flag from the result register for ADC channel 11. */
     kADC_GlobalOverrunFlagForSeqA = 1U << 24U, /*!< Mirror the glabal OVERRUN status flag for conversion sequence A. */
     kADC_GlobalOverrunFlagForSeqB = 1U << 25U, /*!< Mirror the global OVERRUN status flag for conversion sequence B. */
-    kADC_ConvSeqAInterruptFlag = 1U << 28U,    /*!< Sequence A interrupt/DMA trigger. */
-    kADC_ConvSeqBInterruptFlag = 1U << 29U,    /*!< Sequence B interrupt/DMA trigger. */
-    kADC_ThresholdCompareInterruptFlag = 1U << 30U, /*!< Threshold comparision interrupt flag. */
-    kADC_OverrunInterruptFlag = 1U << 31U,          /*!< Overrun interrupt flag. */
+    kADC_ConvSeqAInterruptFlag    = 1U << 28U, /*!< Sequence A interrupt/DMA trigger. */
+    kADC_ConvSeqBInterruptFlag    = 1U << 29U, /*!< Sequence B interrupt/DMA trigger. */
+    kADC_ThresholdCompareInterruptFlag = 1U << 30U,        /*!< Threshold comparision interrupt flag. */
+    kADC_OverrunInterruptFlag          = (int)(1U << 31U), /*!< Overrun interrupt flag. */
 };
 
 /*!
@@ -114,10 +89,11 @@ enum _adc_interrupt_enable
     kADC_ConvSeqBInterruptEnable = ADC_INTEN_SEQB_INTEN_MASK, /*!< Enable interrupt upon completion of each individual
                                                                    conversion in sequence B, or entire sequence. */
     kADC_OverrunInterruptEnable = ADC_INTEN_OVR_INTEN_MASK, /*!< Enable the detection of an overrun condition on any of
-                                                                 the channel data registers will cause an overrun
-                                                                 interrupt/DMA trigger. */
+                                                               the channel data registers will cause an overrun
+                                                               interrupt/DMA trigger. */
 };
 
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
 /*!
  * @brief Define selection of clock mode.
  */
@@ -127,17 +103,44 @@ typedef enum _adc_clock_mode
         0U, /*!< The ADC clock would be derived from the system clock based on "clockDividerNumber". */
     kADC_ClockAsynchronousMode = 1U, /*!< The ADC clock would be based on the SYSCON block's divider. */
 } adc_clock_mode_t;
+#endif /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
 
+#if defined(FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT) && (FSL_FEATURE_ADC_DAT_OF_HIGH_ALIGNMENT)
 /*!
  * @brief Define selection of resolution.
  */
 typedef enum _adc_resolution
 {
-    kADC_Resolution6bit = 0U,  /*!< 6-bit resolution. */
-    kADC_Resolution8bit = 1U,  /*!< 8-bit resolution. */
+    kADC_Resolution6bit = 3U,
+    /*!< 6-bit resolution. */  /* This is a HW issue that the ADC resolution enum configure not align with HW implement,
+                                  ES2 chip already fixed the issue, Currently, update ADC enum define as a workaround */
+    kADC_Resolution8bit  = 2U, /*!< 8-bit resolution. */
+    kADC_Resolution10bit = 1U, /*!< 10-bit resolution. */
+    kADC_Resolution12bit = 0U, /*!< 12-bit resolution. */
+} adc_resolution_t;
+#elif defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
+/*!
+ * @brief Define selection of resolution.
+ */
+typedef enum _adc_resolution
+{
+    kADC_Resolution6bit  = 0U, /*!< 6-bit resolution. */
+    kADC_Resolution8bit  = 1U, /*!< 8-bit resolution. */
     kADC_Resolution10bit = 2U, /*!< 10-bit resolution. */
     kADC_Resolution12bit = 3U, /*!< 12-bit resolution. */
 } adc_resolution_t;
+#endif
+
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+/*!
+ * @brief Definfe range of the analog supply voltage VDDA.
+ */
+typedef enum _adc_voltage_range
+{
+    kADC_HighVoltageRange = 0U, /* High voltage. VDD = 2.7 V to 3.6 V. */
+    kADC_LowVoltageRange  = 1U, /* Low voltage. VDD = 2.4 V to 2.7 V. */
+} adc_vdda_range_t;
+#endif /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 
 /*!
  * @brief Define selection of polarity of selected input trigger for conversion sequence.
@@ -153,7 +156,7 @@ typedef enum _adc_trigger_polarity
  */
 typedef enum _adc_priority
 {
-    kADC_PriorityLow = 0U,  /*!< This sequence would be preempted when another sequence is started. */
+    kADC_PriorityLow  = 0U, /*!< This sequence would be preempted when another sequence is started. */
     kADC_PriorityHigh = 1U, /*!< This sequence would preempt other sequence even when it is started. */
 } adc_priority_t;
 
@@ -173,7 +176,7 @@ typedef enum _adc_seq_interrupt_mode
  */
 typedef enum _adc_threshold_compare_status
 {
-    kADC_ThresholdCompareInRange = 0U,    /*!< LOW threshold <= conversion value <= HIGH threshold. */
+    kADC_ThresholdCompareInRange    = 0U, /*!< LOW threshold <= conversion value <= HIGH threshold. */
     kADC_ThresholdCompareBelowRange = 1U, /*!< conversion value < LOW threshold. */
     kADC_ThresholdCompareAboveRange = 2U, /*!< conversion value > HIGH threshold. */
 } adc_threshold_compare_status_t;
@@ -203,27 +206,84 @@ typedef enum _adc_threshold_crossing_status
  */
 typedef enum _adc_threshold_interrupt_mode
 {
-    kADC_ThresholdInterruptDisabled = 0U,   /*!< Threshold comparison interrupt is disabled. */
-    kADC_ThresholdInterruptOnOutside = 1U,  /*!< Threshold comparison interrupt is enabled on outside threshold. */
+    kADC_ThresholdInterruptDisabled   = 0U, /*!< Threshold comparison interrupt is disabled. */
+    kADC_ThresholdInterruptOnOutside  = 1U, /*!< Threshold comparison interrupt is enabled on outside threshold. */
     kADC_ThresholdInterruptOnCrossing = 2U, /*!< Threshold comparison interrupt is enabled on crossing threshold. */
 } adc_threshold_interrupt_mode_t;
+
+/*!
+ * @brief Define the info result mode of different resolution.
+ */
+typedef enum _adc_inforesultshift
+{
+    kADC_Resolution12bitInfoResultShift = 0U, /*!< Info result shift of Resolution12bit. */
+    kADC_Resolution10bitInfoResultShift = 2U, /*!< Info result shift of Resolution10bit. */
+    kADC_Resolution8bitInfoResultShift  = 4U, /*!< Info result shift of Resolution8bit. */
+    kADC_Resolution6bitInfoResultShift  = 6U, /*!< Info result shift of Resolution6bit. */
+} adc_inforesult_t;
+
+/*!
+ * @brief Define common modes for Temerature sensor.
+ */
+typedef enum _adc_tempsensor_common_mode
+{
+    kADC_HighNegativeOffsetAdded = 0x0U, /*!< Temerature sensor common mode: high negative offset added. */
+    kADC_IntermediateNegativeOffsetAdded =
+        0x4U,                           /*!< Temerature sensor common mode: intermediate negative offset added. */
+    kADC_NoOffsetAdded          = 0x8U, /*!< Temerature sensor common mode: no offset added. */
+    kADC_LowPositiveOffsetAdded = 0xcU, /*!< Temerature sensor common mode: low positive offset added. */
+} adc_tempsensor_common_mode_t;
+
+/*!
+ * @brief Define source impedance modes for GPADC control.
+ */
+typedef enum _adc_second_control
+{
+    kADC_Impedance621Ohm = 0x1U << 9U, /*!< Extand ADC sampling time according to source impedance 1: 0.621 kOhm. */
+    kADC_Impedance55kOhm =
+        0x14U << 9U, /*!< Extand ADC sampling time according to source impedance 20 (default): 55 kOhm. */
+    kADC_Impedance87kOhm = 0x1fU << 9U, /*!< Extand ADC sampling time according to source impedance 31: 87 kOhm. */
+
+    kADC_NormalFunctionalMode = 0x0U << 14U, /*!< TEST mode: Normal functional mode. */
+    kADC_MultiplexeTestMode   = 0x1U << 14U, /*!< TEST mode: Multiplexer test mode. */
+    kADC_ADCInUnityGainMode   = 0x2U << 14U, /*!< TEST mode: ADC in unity gain mode. */
+} adc_second_control_t;
 
 /*!
  * @brief Define structure for configuring the block.
  */
 typedef struct _adc_config
 {
-    adc_clock_mode_t clockMode;   /*!< Select the clock mode for ADC converter. */
-    uint32_t clockDividerNumber;  /*!< This field is only available when using kADC_ClockSynchronousMode for "clockMode"
-                                       field. The divider would be plused by 1 based on the value in this field. The
-                                       available range is in 8 bits. */
-    adc_resolution_t resolution;  /*!< Select the conversion bits. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE) & FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE
+    adc_clock_mode_t clockMode;  /*!< Select the clock mode for ADC converter. */
+#endif                           /* FSL_FEATURE_ADC_HAS_CTRL_ASYNMODE. */
+    uint32_t clockDividerNumber; /*!< This field is only available when using kADC_ClockSynchronousMode for "clockMode"
+                                      field. The divider would be plused by 1 based on the value in this field. The
+                                      available range is in 8 bits. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_RESOL) & FSL_FEATURE_ADC_HAS_CTRL_RESOL
+    adc_resolution_t resolution; /*!< Select the conversion bits. */
+#endif                           /* FSL_FEATURE_ADC_HAS_CTRL_RESOL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL) & FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL
     bool enableBypassCalibration; /*!< By default, a calibration cycle must be performed each time the chip is
                                        powered-up. Re-calibration may be warranted periodically - especially if
                                        operating conditions have changed. To enable this option would avoid the need to
                                        calibrate if offset error is not a concern in the application. */
-    uint32_t sampleTimeNumber;    /*!< By default, with value as "0U", the sample period would be 2.5 ADC clocks. Then,
-                                       to plus the "sampleTimeNumber" value here. The available value range is in 3 bits.*/
+#endif                            /* FSL_FEATURE_ADC_HAS_CTRL_BYPASSCAL. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_TSAMP) & FSL_FEATURE_ADC_HAS_CTRL_TSAMP
+    uint32_t sampleTimeNumber; /*!< By default, with value as "0U", the sample period would be 2.5 ADC clocks. Then,
+                                    to plus the "sampleTimeNumber" value here. The available value range is in 3 bits.*/
+#endif                         /* FSL_FEATURE_ADC_HAS_CTRL_TSAMP. */
+#if defined(FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE) & FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE
+    bool enableLowPowerMode; /*!< If disable low-power mode, ADC remains activated even when no conversions are
+                              requested.
+                              If enable low-power mode, The ADC is automatically powered-down when no conversions are
+                              taking place. */
+#endif                       /* FSL_FEATURE_ADC_HAS_CTRL_LPWRMODE. */
+#if defined(FSL_FEATURE_ADC_HAS_TRIM_REG) & FSL_FEATURE_ADC_HAS_TRIM_REG
+    adc_vdda_range_t
+        voltageRange; /*!<  Configure the ADC for the appropriate operating range of the analog supply voltage VDDA.
+                            Failure to set the area correctly causes the ADC to return incorrect conversion results. */
+#endif                /* FSL_FEATURE_ADC_HAS_TRIM_REG. */
 } adc_config_t;
 
 /*!
@@ -232,17 +292,17 @@ typedef struct _adc_config
 typedef struct _adc_conv_seq_config
 {
     uint32_t channelMask; /*!< Selects which one or more of the ADC channels will be sampled and converted when this
-                               sequence is launched. The masked channels would be involved in current conversion
-                               sequence, beginning with the lowest-order. The available range is in 12-bit. */
+             sequence is launched. The masked channels would be involved in current conversion
+             sequence, beginning with the lowest-order. The available range is in 12-bit. */
     uint32_t triggerMask; /*!< Selects which one or more of the available hardware trigger sources will cause this
-                               conversion sequence to be initiated. The available range is 6-bit.*/
+             conversion sequence to be initiated. The available range is 6-bit.*/
     adc_trigger_polarity_t triggerPolarity; /*!< Select the trigger to lauch conversion sequence. */
     bool enableSyncBypass; /*!< To enable this feature allows the hardware trigger input to bypass synchronization
-                                flip-flop stages and therefore shorten the time between the trigger input signal and the
-                                start of a conversion. */
+               flip-flop stages and therefore shorten the time between the trigger input signal and the
+               start of a conversion. */
     bool enableSingleStep; /*!< When enabling this feature, a trigger will launch a single conversion on the next
-                                channel in the sequence instead of the default response of launching an entire sequence
-                                of conversions. */
+               channel in the sequence instead of the default response of launching an entire sequence
+               of conversions. */
     adc_seq_interrupt_mode_t interruptMode; /*!< Select the interrpt/DMA trigger mode. */
 } adc_conv_seq_config_t;
 
@@ -302,6 +362,8 @@ void ADC_Deinit(ADC_Type *base);
  */
 void ADC_GetDefaultConfig(adc_config_t *config);
 
+#if !(defined(FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC) && FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC)
+#if defined(FSL_FEATURE_ADC_HAS_CALIB_REG) && FSL_FEATURE_ADC_HAS_CALIB_REG
 /*!
  * @brief Do the self hardware calibration.
  *
@@ -310,6 +372,20 @@ void ADC_GetDefaultConfig(adc_config_t *config);
  * @retval false Calibration failed.
  */
 bool ADC_DoSelfCalibration(ADC_Type *base);
+#else
+/*!
+ * @brief Do the self calibration. To calibrate the ADC, set the ADC clock to 500 kHz.
+ *        In order to achieve the specified ADC accuracy, the A/D converter must be recalibrated, at a minimum,
+ *        following every chip reset before initiating normal ADC operation.
+ *
+ * @param base ADC peripheral base address.
+ * @param frequency The ststem clock frequency to ADC.
+ * @retval true  Calibration succeed.
+ * @retval false Calibration failed.
+ */
+bool ADC_DoSelfCalibration(ADC_Type *base, uint32_t frequency);
+#endif /* FSL_FEATURE_ADC_HAS_CALIB_REG */
+#endif /* FSL_FEATURE_ADC_HAS_NO_CALIB_FUNC */
 
 #if !(defined(FSL_FEATURE_ADC_HAS_NO_INSEL) && FSL_FEATURE_ADC_HAS_NO_INSEL)
 /*!
@@ -321,6 +397,9 @@ bool ADC_DoSelfCalibration(ADC_Type *base);
  * @param base ADC peripheral base address.
  * @param enable Switcher to enable the feature or not.
  */
+#if defined(FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP) && (FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP)
+void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable);
+#else
 static inline void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable)
 {
     if (enable)
@@ -332,8 +411,9 @@ static inline void ADC_EnableTemperatureSensor(ADC_Type *base, bool enable)
         base->INSEL = (base->INSEL & ~ADC_INSEL_SEL_MASK) | ADC_INSEL_SEL(0);
     }
 }
+#endif /* FSL_FEATURE_ADC_ASYNC_SYSCON_TEMP. */
 #endif /* FSL_FEATURE_ADC_HAS_NO_INSEL. */
-/* @} */
+       /* @} */
 
 /*!
  * @name Control conversion sequence A.
@@ -547,7 +627,7 @@ bool ADC_GetChannelConversionResult(ADC_Type *base, uint32_t channel, adc_result
  */
 static inline void ADC_SetThresholdPair0(ADC_Type *base, uint32_t lowValue, uint32_t highValue)
 {
-    base->THR0_LOW = ADC_THR0_LOW_THRLOW(lowValue);
+    base->THR0_LOW  = ADC_THR0_LOW_THRLOW(lowValue);
     base->THR0_HIGH = ADC_THR0_HIGH_THRHIGH(highValue);
 }
 
@@ -560,7 +640,7 @@ static inline void ADC_SetThresholdPair0(ADC_Type *base, uint32_t lowValue, uint
  */
 static inline void ADC_SetThresholdPair1(ADC_Type *base, uint32_t lowValue, uint32_t highValue)
 {
-    base->THR1_LOW = ADC_THR1_LOW_THRLOW(lowValue);
+    base->THR1_LOW  = ADC_THR1_LOW_THRLOW(lowValue);
     base->THR1_HIGH = ADC_THR1_HIGH_THRHIGH(highValue);
 }
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/drivers/fsl_clock.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/drivers/fsl_clock.h
@@ -1,45 +1,16 @@
 /*
- * The Clear BSD License
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright (c) 2016 - 2017 , NXP
+ * Copyright 2016 - 2019 , NXP
  * All rights reserved.
  *
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted (subject to the limitations in the disclaimer below) provided
- * that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name ofcopyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _FSL_CLOCK_H_
 #define _FSL_CLOCK_H_
 
-#include "fsl_device_registers.h"
-#include <stdint.h>
-#include <stdbool.h>
-#include <assert.h>
+#include "fsl_common.h"
 
 /*! @addtogroup clock */
 /*! @{ */
@@ -52,15 +23,15 @@
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief CLOCK driver version 2.0.0. */
-#define FSL_CLOCK_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*! @brief CLOCK driver version 2.2.0. */
+#define FSL_CLOCK_DRIVER_VERSION (MAKE_VERSION(2, 2, 0))
 /*@}*/
 
 /*! @brief Configure whether driver controls clock
  *
  * When set to 0, peripheral drivers will enable clock in initialize function
  * and disable clock in de-initialize function. When set to 1, peripheral
- * driver will not control the clock, application could contol the clock out of
+ * driver will not control the clock, application could control the clock out of
  * the driver.
  *
  * @note All drivers share this feature switcher. If it is set to 1, application
@@ -78,12 +49,29 @@
  * right settings.
  */
 #ifndef CLOCK_USR_CFG_PLL_CONFIG_CACHE_COUNT
-#define CLOCK_USR_CFG_PLL_CONFIG_CACHE_COUNT  2U
+#define CLOCK_USR_CFG_PLL_CONFIG_CACHE_COUNT 2U
 #endif
 
+/*! @brief FROHF clock setting API address in ROM. */
+#define CLOCK_FROHF_SETTING_API_ROM_ADDRESS (0x030091DFU)
+
+/* Definition for delay API in clock driver, users can redefine it to the real application. */
+#ifndef SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY
+#define SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY (220000000UL)
+#endif
+
+/**
+ *  Initialize the Core clock to given frequency (12, 48 or 96 MHz), this API is implememnt in ROM code.
+ *  Turns on FRO and uses default CCO, if freq is 12000000, then high speed output is off, else high speed
+ *  output is enabled.
+ *  Usage: set_fro_frequency(frequency), (frequency must be one of 12, 48 or 96 MHz)
+ */
+
+#define set_fro_frequency(iFreq) (*((void (*)(uint32_t iFreq))(CLOCK_FROHF_SETTING_API_ROM_ADDRESS)))(iFreq)
+
 /*! @brief Clock ip name array for ROM. */
-#define ADC_CLOCKS \
-    {              \
+#define ADC_CLOCKS  \
+    {               \
         kCLOCK_Adc0 \
     }
 /*! @brief Clock ip name array for ROM. */
@@ -92,8 +80,8 @@
         kCLOCK_Rom \
     }
 /*! @brief Clock ip name array for SRAM. */
-#define SRAM_CLOCKS \
-    {               \
+#define SRAM_CLOCKS                              \
+    {                                            \
         kCLOCK_Sram1, kCLOCK_Sram2, kCLOCK_Sram3 \
     }
 /*! @brief Clock ip name array for FLASH. */
@@ -107,121 +95,120 @@
         kCLOCK_Fmc \
     }
 /*! @brief Clock ip name array for EEPROM. */
-#define EEPROM_CLOCKS  \
-    {                  \
-        kCLOCK_Eeprom  \
+#define EEPROM_CLOCKS \
+    {                 \
+        kCLOCK_Eeprom \
     }
 /*! @brief Clock ip name array for SPIFI. */
-#define SPIFI_CLOCKS  \
-    {                 \
-        kCLOCK_Spifi  \
+#define SPIFI_CLOCKS \
+    {                \
+        kCLOCK_Spifi \
     }
 /*! @brief Clock ip name array for INPUTMUX. */
-#define INPUTMUX_CLOCKS      \
-    {                        \
-        kCLOCK_InputMux      \
+#define INPUTMUX_CLOCKS \
+    {                   \
+        kCLOCK_InputMux \
     }
 /*! @brief Clock ip name array for IOCON. */
-#define IOCON_CLOCKS         \
-    {                        \
-        kCLOCK_Iocon         \
+#define IOCON_CLOCKS \
+    {                \
+        kCLOCK_Iocon \
     }
 /*! @brief Clock ip name array for GPIO. */
-#define GPIO_CLOCKS          \
-    {                        \
-        kCLOCK_Gpio0,kCLOCK_Gpio1, kCLOCK_Gpio2, kCLOCK_Gpio3, kCLOCK_Gpio4, kCLOCK_Gpio5     \
+#define GPIO_CLOCKS                                                                        \
+    {                                                                                      \
+        kCLOCK_Gpio0, kCLOCK_Gpio1, kCLOCK_Gpio2, kCLOCK_Gpio3, kCLOCK_Gpio4, kCLOCK_Gpio5 \
     }
 /*! @brief Clock ip name array for PINT. */
-#define PINT_CLOCKS          \
-    {                        \
-        kCLOCK_Pint          \
+#define PINT_CLOCKS \
+    {               \
+        kCLOCK_Pint \
     }
 /*! @brief Clock ip name array for GINT. */
-#define GINT_CLOCKS          \
-    {                        \
-        kCLOCK_Gint, kCLOCK_Gint          \
+#define GINT_CLOCKS              \
+    {                            \
+        kCLOCK_Gint, kCLOCK_Gint \
     }
 /*! @brief Clock ip name array for DMA. */
-#define DMA_CLOCKS          \
-    {                       \
-        kCLOCK_Dma          \
+#define DMA_CLOCKS \
+    {              \
+        kCLOCK_Dma \
     }
 /*! @brief Clock ip name array for CRC. */
-#define CRC_CLOCKS          \
-    {                       \
-        kCLOCK_Crc          \
+#define CRC_CLOCKS \
+    {              \
+        kCLOCK_Crc \
     }
 /*! @brief Clock ip name array for WWDT. */
-#define WWDT_CLOCKS          \
-    {                        \
-        kCLOCK_Wwdt          \
+#define WWDT_CLOCKS \
+    {               \
+        kCLOCK_Wwdt \
     }
 /*! @brief Clock ip name array for RTC. */
-#define RTC_CLOCKS          \
-    {                       \
-        kCLOCK_Rtc          \
+#define RTC_CLOCKS \
+    {              \
+        kCLOCK_Rtc \
     }
 /*! @brief Clock ip name array for ADC0. */
-#define ADC0_CLOCKS          \
-    {                        \
-        kCLOCK_Adc0          \
+#define ADC0_CLOCKS \
+    {               \
+        kCLOCK_Adc0 \
     }
 /*! @brief Clock ip name array for MRT. */
-#define MRT_CLOCKS           \
-    {                        \
-        kCLOCK_Mrt           \
+#define MRT_CLOCKS \
+    {              \
+        kCLOCK_Mrt \
     }
 /*! @brief Clock ip name array for RIT. */
-#define RIT_CLOCKS           \
-    {                        \
-        kCLOCK_Rit           \
+#define RIT_CLOCKS \
+    {              \
+        kCLOCK_Rit \
     }
 /*! @brief Clock ip name array for SCT0. */
-#define SCT_CLOCKS          \
-    {                        \
-        kCLOCK_Sct0          \
+#define SCT_CLOCKS  \
+    {               \
+        kCLOCK_Sct0 \
     }
 /*! @brief Clock ip name array for MCAN. */
-#define MCAN_CLOCKS          \
-    {                        \
-        kCLOCK_Mcan0, kCLOCK_Mcan1          \
+#define MCAN_CLOCKS                \
+    {                              \
+        kCLOCK_Mcan0, kCLOCK_Mcan1 \
     }
 /*! @brief Clock ip name array for UTICK. */
-#define UTICK_CLOCKS         \
-    {                        \
-        kCLOCK_Utick         \
+#define UTICK_CLOCKS \
+    {                \
+        kCLOCK_Utick \
     }
 /*! @brief Clock ip name array for FLEXCOMM. */
-#define FLEXCOMM_CLOCKS                                                        \
-    {                                                                          \
-        kCLOCK_FlexComm0, kCLOCK_FlexComm1, kCLOCK_FlexComm2, kCLOCK_FlexComm3, \
-					kCLOCK_FlexComm4, kCLOCK_FlexComm5, kCLOCK_FlexComm6, kCLOCK_FlexComm7, \
-                                        kCLOCK_FlexComm8, kCLOCK_FlexComm9 \
+#define FLEXCOMM_CLOCKS                                                                                             \
+    {                                                                                                               \
+        kCLOCK_FlexComm0, kCLOCK_FlexComm1, kCLOCK_FlexComm2, kCLOCK_FlexComm3, kCLOCK_FlexComm4, kCLOCK_FlexComm5, \
+            kCLOCK_FlexComm6, kCLOCK_FlexComm7, kCLOCK_FlexComm8, kCLOCK_FlexComm9                                  \
     }
 /*! @brief Clock ip name array for LPUART. */
 #define LPUART_CLOCKS                                                                                         \
     {                                                                                                         \
         kCLOCK_MinUart0, kCLOCK_MinUart1, kCLOCK_MinUart2, kCLOCK_MinUart3, kCLOCK_MinUart4, kCLOCK_MinUart5, \
-            kCLOCK_MinUart6, kCLOCK_MinUart7, kCLOCK_MinUart8,kCLOCK_MinUart9     \
+            kCLOCK_MinUart6, kCLOCK_MinUart7, kCLOCK_MinUart8, kCLOCK_MinUart9                                \
     }
 
 /*! @brief Clock ip name array for BI2C. */
-#define BI2C_CLOCKS                                                                                                     \
-    {                                                                                                                   \
-        kCLOCK_BI2c0, kCLOCK_BI2c1, kCLOCK_BI2c2, kCLOCK_BI2c3, kCLOCK_BI2c4, kCLOCK_BI2c5, kCLOCK_BI2c6, kCLOCK_BI2c7, \
-        kCLOCK_BI2c8, kCLOCK_BI2c9  \
+#define BI2C_CLOCKS                                                                                       \
+    {                                                                                                     \
+        kCLOCK_BI2c0, kCLOCK_BI2c1, kCLOCK_BI2c2, kCLOCK_BI2c3, kCLOCK_BI2c4, kCLOCK_BI2c5, kCLOCK_BI2c6, \
+            kCLOCK_BI2c7, kCLOCK_BI2c8, kCLOCK_BI2c9                                                      \
     }
 /*! @brief Clock ip name array for LSPI. */
-#define LPSI_CLOCKS                                                                                                     \
-    {                                                                                                                   \
-        kCLOCK_LSpi0, kCLOCK_LSpi1, kCLOCK_LSpi2, kCLOCK_LSpi3, kCLOCK_LSpi4, kCLOCK_LSpi5, kCLOCK_LSpi6, kCLOCK_LSpi7, \
-        kCLOCK_LSpi8, kCLOCK_LSpi9  \
+#define LPSI_CLOCKS                                                                                       \
+    {                                                                                                     \
+        kCLOCK_LSpi0, kCLOCK_LSpi1, kCLOCK_LSpi2, kCLOCK_LSpi3, kCLOCK_LSpi4, kCLOCK_LSpi5, kCLOCK_LSpi6, \
+            kCLOCK_LSpi7, kCLOCK_LSpi8, kCLOCK_LSpi9                                                      \
     }
 /*! @brief Clock ip name array for FLEXI2S. */
 #define FLEXI2S_CLOCKS                                                                                        \
     {                                                                                                         \
         kCLOCK_FlexI2s0, kCLOCK_FlexI2s1, kCLOCK_FlexI2s2, kCLOCK_FlexI2s3, kCLOCK_FlexI2s4, kCLOCK_FlexI2s5, \
-            kCLOCK_FlexI2s6, kCLOCK_FlexI2s7, kCLOCK_FlexI2s8, kCLOCK_FlexI2s9                                                                  \
+            kCLOCK_FlexI2s6, kCLOCK_FlexI2s7, kCLOCK_FlexI2s8, kCLOCK_FlexI2s9                                \
     }
 /*! @brief Clock ip name array for DMIC. */
 #define DMIC_CLOCKS \
@@ -229,73 +216,73 @@
         kCLOCK_DMic \
     }
 /*! @brief Clock ip name array for CT32B. */
-#define CTIMER_CLOCKS                                                               \
-    {                                                                               \
-        kCLOCK_Ct32b0, kCLOCK_Ct32b1, kCLOCK_Ct32b2, kCLOCK_Ct32b3, kCLOCK_Ct32b4   \
+#define CTIMER_CLOCKS                                                             \
+    {                                                                             \
+        kCLOCK_Ct32b0, kCLOCK_Ct32b1, kCLOCK_Ct32b2, kCLOCK_Ct32b3, kCLOCK_Ct32b4 \
     }
 /*! @brief Clock ip name array for LCD. */
-#define LCD_CLOCKS  \
-    {               \
-        kCLOCK_Lcd  \
+#define LCD_CLOCKS \
+    {              \
+        kCLOCK_Lcd \
     }
 /*! @brief Clock ip name array for SDIO. */
-#define SDIO_CLOCKS  \
-    {                \
-        kCLOCK_Sdio  \
+#define SDIO_CLOCKS \
+    {               \
+        kCLOCK_Sdio \
     }
 /*! @brief Clock ip name array for USBRAM. */
-#define USBRAM_CLOCKS    \
-    {                    \
-        kCLOCK_UsbRam1   \
+#define USBRAM_CLOCKS  \
+    {                  \
+        kCLOCK_UsbRam1 \
     }
 /*! @brief Clock ip name array for EMC. */
-#define EMC_CLOCKS       \
-    {                    \
-        kCLOCK_Emc       \
+#define EMC_CLOCKS \
+    {              \
+        kCLOCK_Emc \
     }
 /*! @brief Clock ip name array for ETH. */
-#define ETH_CLOCKS       \
-    {                    \
-        kCLOCK_Eth       \
+#define ETH_CLOCKS \
+    {              \
+        kCLOCK_Eth \
     }
 /*! @brief Clock ip name array for AES. */
-#define AES_CLOCKS       \
-    {                    \
-        kCLOCK_Aes       \
+#define AES_CLOCKS \
+    {              \
+        kCLOCK_Aes \
     }
 /*! @brief Clock ip name array for OTP. */
-#define OTP_CLOCKS       \
-    {                    \
-        kCLOCK_Otp       \
+#define OTP_CLOCKS \
+    {              \
+        kCLOCK_Otp \
     }
 /*! @brief Clock ip name array for RNG. */
-#define RNG_CLOCKS       \
-    {                    \
-        kCLOCK_Rng       \
+#define RNG_CLOCKS \
+    {              \
+        kCLOCK_Rng \
     }
 /*! @brief Clock ip name array for USBHMR0. */
-#define USBHMR0_CLOCKS       \
-    {                        \
-        kCLOCK_Usbhmr0       \
+#define USBHMR0_CLOCKS \
+    {                  \
+        kCLOCK_Usbhmr0 \
     }
 /*! @brief Clock ip name array for USBHSL0. */
-#define USBHSL0_CLOCKS       \
-    {                        \
-        kCLOCK_Usbhsl0       \
+#define USBHSL0_CLOCKS \
+    {                  \
+        kCLOCK_Usbhsl0 \
     }
 /*! @brief Clock ip name array for SHA0. */
-#define SHA0_CLOCKS       \
-    {                     \
-        kCLOCK_Sha0       \
+#define SHA0_CLOCKS \
+    {               \
+        kCLOCK_Sha0 \
     }
 /*! @brief Clock ip name array for SMARTCARD. */
-#define SMARTCARD_CLOCKS  \
-    {                     \
+#define SMARTCARD_CLOCKS                     \
+    {                                        \
         kCLOCK_SmartCard0, kCLOCK_SmartCard1 \
     }
 /*! @brief Clock ip name array for USBD. */
-#define USBD_CLOCKS  \
-    {                \
+#define USBD_CLOCKS                              \
+    {                                            \
         kCLOCK_Usbd0, kCLOCK_Usbh1, kCLOCK_Usbd1 \
     }
 /*! @brief Clock ip name array for USBH. */
@@ -328,106 +315,106 @@
 /*! @brief Clock gate name used for CLOCK_EnableClock/CLOCK_DisableClock. */
 typedef enum _clock_ip_name
 {
-    kCLOCK_IpInvalid = 0U,
-    kCLOCK_Rom = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 1),
-    kCLOCK_Sram1 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 3),
-    kCLOCK_Sram2 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 4),
-    kCLOCK_Sram3 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 5),
-    kCLOCK_Flash = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 7),
-    kCLOCK_Fmc = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 8),
-    kCLOCK_Eeprom = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 9),
-    kCLOCK_Spifi = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 10),
-    kCLOCK_InputMux = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 11),
-    kCLOCK_Iocon = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 13),
-    kCLOCK_Gpio0 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 14),
-    kCLOCK_Gpio1 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 15),
-    kCLOCK_Gpio2 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 16),
-    kCLOCK_Gpio3 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 17),
-    kCLOCK_Pint = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 18),
-    kCLOCK_Gint = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 19),
-    kCLOCK_Dma = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 20),
-    kCLOCK_Crc = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 21),
-    kCLOCK_Wwdt = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 22),
-    kCLOCK_Rtc = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 23),
-    kCLOCK_Adc0 = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 27),
-    kCLOCK_Mrt = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 0),
-    kCLOCK_Rit = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 1),
-    kCLOCK_Sct0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 2),
-    kCLOCK_Mcan0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 7),
-    kCLOCK_Mcan1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 8),
-    kCLOCK_Utick = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 10),
-    kCLOCK_FlexComm0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_FlexComm1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_FlexComm2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_FlexComm3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_FlexComm4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_FlexComm5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_FlexComm6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_FlexComm7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_MinUart0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_MinUart1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_MinUart2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_MinUart3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_MinUart4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_MinUart5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_MinUart6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_MinUart7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_LSpi0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_LSpi1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_LSpi2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_LSpi3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_LSpi4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_LSpi5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_LSpi6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_LSpi7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_BI2c0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_BI2c1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_BI2c2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_BI2c3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_BI2c4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_BI2c5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_BI2c6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_BI2c7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_FlexI2s0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
-    kCLOCK_FlexI2s1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
-    kCLOCK_FlexI2s2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
-    kCLOCK_FlexI2s3 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
-    kCLOCK_FlexI2s4 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
-    kCLOCK_FlexI2s5 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
-    kCLOCK_FlexI2s6 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
-    kCLOCK_FlexI2s7 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
-    kCLOCK_DMic = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 19),
-    kCLOCK_Ct32b2 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 22),
-    kCLOCK_Usbd0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 25),
-    kCLOCK_Ct32b0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 26),
-    kCLOCK_Ct32b1 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 27),
-    kCLOCK_BodyBias0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 29),
-    kCLOCK_EzhArchB0 = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 31),
-    kCLOCK_Lcd = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 2),
-    kCLOCK_Sdio = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 3),
-    kCLOCK_Usbh1 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 4),
-    kCLOCK_Usbd1 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 5),
-    kCLOCK_UsbRam1 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 6),
-    kCLOCK_Emc = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 7),
-    kCLOCK_Eth = CLK_GATE_DEFINE(AHB_CLK_CTRL2,8),
-    kCLOCK_Gpio4 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 9),
-    kCLOCK_Gpio5 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 10),
-    kCLOCK_Aes = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 11),
-    kCLOCK_Otp = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 12),
-    kCLOCK_Rng = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 13),
-    kCLOCK_FlexComm8 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
-    kCLOCK_FlexComm9 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
-    kCLOCK_MinUart8 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
-    kCLOCK_MinUart9 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
-    kCLOCK_LSpi8 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
-    kCLOCK_LSpi9 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
-    kCLOCK_BI2c8 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
-    kCLOCK_BI2c9 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
-    kCLOCK_FlexI2s8 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
-    kCLOCK_FlexI2s9 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
-    kCLOCK_Usbhmr0 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 16),
-    kCLOCK_Usbhsl0 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 17),
-    kCLOCK_Sha0 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 18),
+    kCLOCK_IpInvalid  = 0U,
+    kCLOCK_Rom        = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 1),
+    kCLOCK_Sram1      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 3),
+    kCLOCK_Sram2      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 4),
+    kCLOCK_Sram3      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 5),
+    kCLOCK_Flash      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 7),
+    kCLOCK_Fmc        = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 8),
+    kCLOCK_Eeprom     = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 9),
+    kCLOCK_Spifi      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 10),
+    kCLOCK_InputMux   = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 11),
+    kCLOCK_Iocon      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 13),
+    kCLOCK_Gpio0      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 14),
+    kCLOCK_Gpio1      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 15),
+    kCLOCK_Gpio2      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 16),
+    kCLOCK_Gpio3      = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 17),
+    kCLOCK_Pint       = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 18),
+    kCLOCK_Gint       = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 19),
+    kCLOCK_Dma        = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 20),
+    kCLOCK_Crc        = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 21),
+    kCLOCK_Wwdt       = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 22),
+    kCLOCK_Rtc        = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 23),
+    kCLOCK_Adc0       = CLK_GATE_DEFINE(AHB_CLK_CTRL0, 27),
+    kCLOCK_Mrt        = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 0),
+    kCLOCK_Rit        = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 1),
+    kCLOCK_Sct0       = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 2),
+    kCLOCK_Mcan0      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 7),
+    kCLOCK_Mcan1      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 8),
+    kCLOCK_Utick      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 10),
+    kCLOCK_FlexComm0  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_FlexComm1  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_FlexComm2  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_FlexComm3  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_FlexComm4  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_FlexComm5  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_FlexComm6  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_FlexComm7  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_MinUart0   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_MinUart1   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_MinUart2   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_MinUart3   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_MinUart4   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_MinUart5   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_MinUart6   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_MinUart7   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_LSpi0      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_LSpi1      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_LSpi2      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_LSpi3      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_LSpi4      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_LSpi5      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_LSpi6      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_LSpi7      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_BI2c0      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_BI2c1      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_BI2c2      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_BI2c3      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_BI2c4      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_BI2c5      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_BI2c6      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_BI2c7      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_FlexI2s0   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 11),
+    kCLOCK_FlexI2s1   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 12),
+    kCLOCK_FlexI2s2   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 13),
+    kCLOCK_FlexI2s3   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 14),
+    kCLOCK_FlexI2s4   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 15),
+    kCLOCK_FlexI2s5   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 16),
+    kCLOCK_FlexI2s6   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 17),
+    kCLOCK_FlexI2s7   = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 18),
+    kCLOCK_DMic       = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 19),
+    kCLOCK_Ct32b2     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 22),
+    kCLOCK_Usbd0      = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 25),
+    kCLOCK_Ct32b0     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 26),
+    kCLOCK_Ct32b1     = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 27),
+    kCLOCK_BodyBias0  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 29),
+    kCLOCK_EzhArchB0  = CLK_GATE_DEFINE(AHB_CLK_CTRL1, 31),
+    kCLOCK_Lcd        = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 2),
+    kCLOCK_Sdio       = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 3),
+    kCLOCK_Usbh1      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 4),
+    kCLOCK_Usbd1      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 5),
+    kCLOCK_UsbRam1    = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 6),
+    kCLOCK_Emc        = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 7),
+    kCLOCK_Eth        = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 8),
+    kCLOCK_Gpio4      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 9),
+    kCLOCK_Gpio5      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 10),
+    kCLOCK_Aes        = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 11),
+    kCLOCK_Otp        = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 12),
+    kCLOCK_Rng        = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 13),
+    kCLOCK_FlexComm8  = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
+    kCLOCK_FlexComm9  = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
+    kCLOCK_MinUart8   = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
+    kCLOCK_MinUart9   = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
+    kCLOCK_LSpi8      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
+    kCLOCK_LSpi9      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
+    kCLOCK_BI2c8      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
+    kCLOCK_BI2c9      = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
+    kCLOCK_FlexI2s8   = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 14),
+    kCLOCK_FlexI2s9   = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 15),
+    kCLOCK_Usbhmr0    = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 16),
+    kCLOCK_Usbhsl0    = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 17),
+    kCLOCK_Sha0       = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 18),
     kCLOCK_SmartCard0 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 19),
     kCLOCK_SmartCard1 = CLK_GATE_DEFINE(AHB_CLK_CTRL2, 20),
 
@@ -458,7 +445,7 @@ typedef enum _clock_name
     kCLOCK_ExtClk,      /*!< External Clock                                          */
     kCLOCK_PllOut,      /*!< PLL Output                                              */
     kCLOCK_UsbClk,      /*!< USB input                                               */
-    kClock_WdtOsc,      /*!< Watchdog Oscillator                                     */
+    kCLOCK_WdtOsc,      /*!< Watchdog Oscillator                                     */
     kCLOCK_Frg,         /*!< Frg Clock                                               */
     kCLOCK_Dmic,        /*!< Digital Mic clock                                       */
     kCLOCK_AsyncApbClk, /*!< Async APB clock										 */
@@ -489,18 +476,22 @@ typedef enum _async_clock_src
 } async_clock_src_t;
 
 /*! @brief Clock Mux Switches
-*  The encoding is as follows each connection identified is 64bits wide
-*  starting from LSB upwards
-*
-*  [4 bits for choice, where 1 is A, 2 is B, 3 is C and 4 is D, 0 means end of descriptor] [8 bits mux ID]*
-*
-*/
+ *  The encoding is as follows each connection identified is 32bits wide while 24bits are valuable
+ *  starting from LSB upwards
+ *
+ *  [4 bits for choice, 0 means invalid choice] [8 bits mux ID]*
+ *
+ */
 
-#define MUX_A(m, choice) (((m) << 0) | ((choice + 1) << 8))
-#define MUX_B(m, choice) (((m) << 12) | ((choice + 1) << 20))
-#define MUX_C(m, choice) (((m) << 24) | ((choice + 1) << 32))
-#define MUX_D(m, choice) (((m) << 36) | ((choice + 1) << 44))
-#define MUX_E(m, choice) (((m) << 48) | ((choice + 1) << 56))
+#define CLK_ATTACH_ID(mux, sel, pos) (((mux << 0U) | ((sel + 1) & 0xFU) << 8U) << (pos * 12U))
+#define MUX_A(mux, sel) CLK_ATTACH_ID(mux, sel, 0U)
+#define MUX_B(mux, sel, selector) (CLK_ATTACH_ID(mux, sel, 1U) | (selector << 24U))
+
+#define GET_ID_ITEM(connection) ((connection)&0xFFFU)
+#define GET_ID_NEXT_ITEM(connection) ((connection) >> 12U)
+#define GET_ID_ITEM_MUX(connection) ((connection)&0xFFU)
+#define GET_ID_ITEM_SEL(connection) ((((connection)&0xF00U) >> 8U) - 1U)
+#define GET_ID_SELECTOR(connection) ((connection)&0xF000000U)
 
 #define CM_MAINCLKSELA 0
 #define CM_MAINCLKSELB 1
@@ -524,8 +515,8 @@ typedef enum _async_clock_src
 #define CM_MCLKCLKSEL 24
 #define CM_FRGCLKSEL 26
 #define CM_DMICCLKSEL 27
-#define CM_SCTCLKSEL  28
-#define CM_LCDCLKSEL  29
+#define CM_SCTCLKSEL 28
+#define CM_LCDCLKSEL 29
 #define CM_SDIOCLKSEL 30
 
 #define CM_ASYNCAPB 31
@@ -533,189 +524,189 @@ typedef enum _async_clock_src
 typedef enum _clock_attach_id
 {
 
-    kFRO12M_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 0),
-    kEXT_CLK_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 1) | MUX_B(CM_MAINCLKSELB, 0),
-    kWDT_OSC_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 2) | MUX_B(CM_MAINCLKSELB, 0),
-    kFRO_HF_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 3) | MUX_B(CM_MAINCLKSELB, 0),
-    kSYS_PLL_to_MAIN_CLK = MUX_A(CM_MAINCLKSELB, 2),
-    kOSC32K_to_MAIN_CLK = MUX_A(CM_MAINCLKSELB, 3),
+    kFRO12M_to_MAIN_CLK  = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kEXT_CLK_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 1) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kWDT_OSC_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 2) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kFRO_HF_to_MAIN_CLK  = MUX_A(CM_MAINCLKSELA, 3) | MUX_B(CM_MAINCLKSELB, 0, 0),
+    kSYS_PLL_to_MAIN_CLK = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 2, 0),
+    kOSC32K_to_MAIN_CLK  = MUX_A(CM_MAINCLKSELA, 0) | MUX_B(CM_MAINCLKSELB, 3, 0),
 
-    kMAIN_CLK_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 0),
-    kEXT_CLK_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 1),
-    kWDT_OSC_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 2),
-    kFRO_HF_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 3),
-    kSYS_PLL_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 4),
-    kUSB_PLL_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 5),
-    kAUDIO_PLL_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 6),
+    kMAIN_CLK_to_CLKOUT   = MUX_A(CM_CLKOUTCLKSELA, 0),
+    kEXT_CLK_to_CLKOUT    = MUX_A(CM_CLKOUTCLKSELA, 1),
+    kWDT_OSC_to_CLKOUT    = MUX_A(CM_CLKOUTCLKSELA, 2),
+    kFRO_HF_to_CLKOUT     = MUX_A(CM_CLKOUTCLKSELA, 3),
+    kSYS_PLL_to_CLKOUT    = MUX_A(CM_CLKOUTCLKSELA, 4),
+    kUSB_PLL_to_CLKOUT    = MUX_A(CM_CLKOUTCLKSELA, 5),
+    kAUDIO_PLL_to_CLKOUT  = MUX_A(CM_CLKOUTCLKSELA, 6),
     kOSC32K_OSC_to_CLKOUT = MUX_A(CM_CLKOUTCLKSELA, 7),
 
-    kFRO12M_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 0),
+    kFRO12M_to_SYS_PLL  = MUX_A(CM_SYSPLLCLKSEL, 0),
     kEXT_CLK_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 1),
     kWDT_OSC_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 2),
-    kOSC32K_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 3),
-    kNONE_to_SYS_PLL = MUX_A(CM_SYSPLLCLKSEL, 7),
+    kOSC32K_to_SYS_PLL  = MUX_A(CM_SYSPLLCLKSEL, 3),
+    kNONE_to_SYS_PLL    = MUX_A(CM_SYSPLLCLKSEL, 7),
 
-    kFRO12M_to_AUDIO_PLL = MUX_A(CM_AUDPLLCLKSEL, 0),
+    kFRO12M_to_AUDIO_PLL  = MUX_A(CM_AUDPLLCLKSEL, 0),
     kEXT_CLK_to_AUDIO_PLL = MUX_A(CM_AUDPLLCLKSEL, 1),
-    kNONE_to_AUDIO_PLL = MUX_A(CM_AUDPLLCLKSEL, 7),
+    kNONE_to_AUDIO_PLL    = MUX_A(CM_AUDPLLCLKSEL, 7),
 
-    kMAIN_CLK_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 0),
-    kSYS_PLL_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 1),
-    kUSB_PLL_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 2),
-    kFRO_HF_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 3),
+    kMAIN_CLK_to_SPIFI_CLK  = MUX_A(CM_SPIFICLKSEL, 0),
+    kSYS_PLL_to_SPIFI_CLK   = MUX_A(CM_SPIFICLKSEL, 1),
+    kUSB_PLL_to_SPIFI_CLK   = MUX_A(CM_SPIFICLKSEL, 2),
+    kFRO_HF_to_SPIFI_CLK    = MUX_A(CM_SPIFICLKSEL, 3),
     kAUDIO_PLL_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 4),
-    kNONE_to_SPIFI_CLK = MUX_A(CM_SPIFICLKSEL, 7),
+    kNONE_to_SPIFI_CLK      = MUX_A(CM_SPIFICLKSEL, 7),
 
-    kFRO_HF_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 0),
-    kSYS_PLL_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 1),
-    kUSB_PLL_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 2),
+    kFRO_HF_to_ADC_CLK    = MUX_A(CM_ADCASYNCCLKSEL, 0),
+    kSYS_PLL_to_ADC_CLK   = MUX_A(CM_ADCASYNCCLKSEL, 1),
+    kUSB_PLL_to_ADC_CLK   = MUX_A(CM_ADCASYNCCLKSEL, 2),
     kAUDIO_PLL_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 3),
-    kNONE_to_ADC_CLK = MUX_A(CM_ADCASYNCCLKSEL, 7),
+    kNONE_to_ADC_CLK      = MUX_A(CM_ADCASYNCCLKSEL, 7),
 
-    kFRO_HF_to_USB0_CLK = MUX_A(CM_USB0CLKSEL, 0),
+    kFRO_HF_to_USB0_CLK  = MUX_A(CM_USB0CLKSEL, 0),
     kSYS_PLL_to_USB0_CLK = MUX_A(CM_USB0CLKSEL, 1),
     kUSB_PLL_to_USB0_CLK = MUX_A(CM_USB0CLKSEL, 2),
-    kNONE_to_USB0_CLK = MUX_A(CM_USB0CLKSEL, 7),
+    kNONE_to_USB0_CLK    = MUX_A(CM_USB0CLKSEL, 7),
 
-    kFRO_HF_to_USB1_CLK = MUX_A(CM_USB1CLKSEL, 0),
+    kFRO_HF_to_USB1_CLK  = MUX_A(CM_USB1CLKSEL, 0),
     kSYS_PLL_to_USB1_CLK = MUX_A(CM_USB1CLKSEL, 1),
     kUSB_PLL_to_USB1_CLK = MUX_A(CM_USB1CLKSEL, 2),
-    kNONE_to_USB1_CLK = MUX_A(CM_USB1CLKSEL, 7),
+    kNONE_to_USB1_CLK    = MUX_A(CM_USB1CLKSEL, 7),
 
-    kFRO12M_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 0),
-    kFRO_HF_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 1),
+    kFRO12M_to_FLEXCOMM0    = MUX_A(CM_FXCOMCLKSEL0, 0),
+    kFRO_HF_to_FLEXCOMM0    = MUX_A(CM_FXCOMCLKSEL0, 1),
     kAUDIO_PLL_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 2),
-    kMCLK_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 3),
-    kFRG_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 4),
-    kNONE_to_FLEXCOMM0 = MUX_A(CM_FXCOMCLKSEL0, 7),
+    kMCLK_to_FLEXCOMM0      = MUX_A(CM_FXCOMCLKSEL0, 3),
+    kFRG_to_FLEXCOMM0       = MUX_A(CM_FXCOMCLKSEL0, 4),
+    kNONE_to_FLEXCOMM0      = MUX_A(CM_FXCOMCLKSEL0, 7),
 
-    kFRO12M_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 0),
-    kFRO_HF_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 1),
+    kFRO12M_to_FLEXCOMM1    = MUX_A(CM_FXCOMCLKSEL1, 0),
+    kFRO_HF_to_FLEXCOMM1    = MUX_A(CM_FXCOMCLKSEL1, 1),
     kAUDIO_PLL_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 2),
-    kMCLK_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 3),
-    kFRG_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 4),
-    kNONE_to_FLEXCOMM1 = MUX_A(CM_FXCOMCLKSEL1, 7),
+    kMCLK_to_FLEXCOMM1      = MUX_A(CM_FXCOMCLKSEL1, 3),
+    kFRG_to_FLEXCOMM1       = MUX_A(CM_FXCOMCLKSEL1, 4),
+    kNONE_to_FLEXCOMM1      = MUX_A(CM_FXCOMCLKSEL1, 7),
 
-    kFRO12M_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 0),
-    kFRO_HF_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 1),
+    kFRO12M_to_FLEXCOMM2    = MUX_A(CM_FXCOMCLKSEL2, 0),
+    kFRO_HF_to_FLEXCOMM2    = MUX_A(CM_FXCOMCLKSEL2, 1),
     kAUDIO_PLL_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 2),
-    kMCLK_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 3),
-    kFRG_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 4),
-    kNONE_to_FLEXCOMM2 = MUX_A(CM_FXCOMCLKSEL2, 7),
+    kMCLK_to_FLEXCOMM2      = MUX_A(CM_FXCOMCLKSEL2, 3),
+    kFRG_to_FLEXCOMM2       = MUX_A(CM_FXCOMCLKSEL2, 4),
+    kNONE_to_FLEXCOMM2      = MUX_A(CM_FXCOMCLKSEL2, 7),
 
-    kFRO12M_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 0),
-    kFRO_HF_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 1),
+    kFRO12M_to_FLEXCOMM3    = MUX_A(CM_FXCOMCLKSEL3, 0),
+    kFRO_HF_to_FLEXCOMM3    = MUX_A(CM_FXCOMCLKSEL3, 1),
     kAUDIO_PLL_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 2),
-    kMCLK_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 3),
-    kFRG_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 4),
-    kNONE_to_FLEXCOMM3 = MUX_A(CM_FXCOMCLKSEL3, 7),
+    kMCLK_to_FLEXCOMM3      = MUX_A(CM_FXCOMCLKSEL3, 3),
+    kFRG_to_FLEXCOMM3       = MUX_A(CM_FXCOMCLKSEL3, 4),
+    kNONE_to_FLEXCOMM3      = MUX_A(CM_FXCOMCLKSEL3, 7),
 
-    kFRO12M_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 0),
-    kFRO_HF_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 1),
+    kFRO12M_to_FLEXCOMM4    = MUX_A(CM_FXCOMCLKSEL4, 0),
+    kFRO_HF_to_FLEXCOMM4    = MUX_A(CM_FXCOMCLKSEL4, 1),
     kAUDIO_PLL_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 2),
-    kMCLK_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 3),
-    kFRG_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 4),
-    kNONE_to_FLEXCOMM4 = MUX_A(CM_FXCOMCLKSEL4, 7),
+    kMCLK_to_FLEXCOMM4      = MUX_A(CM_FXCOMCLKSEL4, 3),
+    kFRG_to_FLEXCOMM4       = MUX_A(CM_FXCOMCLKSEL4, 4),
+    kNONE_to_FLEXCOMM4      = MUX_A(CM_FXCOMCLKSEL4, 7),
 
-    kFRO12M_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 0),
-    kFRO_HF_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 1),
+    kFRO12M_to_FLEXCOMM5    = MUX_A(CM_FXCOMCLKSEL5, 0),
+    kFRO_HF_to_FLEXCOMM5    = MUX_A(CM_FXCOMCLKSEL5, 1),
     kAUDIO_PLL_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 2),
-    kMCLK_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 3),
-    kFRG_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 4),
-    kNONE_to_FLEXCOMM5 = MUX_A(CM_FXCOMCLKSEL5, 7),
+    kMCLK_to_FLEXCOMM5      = MUX_A(CM_FXCOMCLKSEL5, 3),
+    kFRG_to_FLEXCOMM5       = MUX_A(CM_FXCOMCLKSEL5, 4),
+    kNONE_to_FLEXCOMM5      = MUX_A(CM_FXCOMCLKSEL5, 7),
 
-    kFRO12M_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 0),
-    kFRO_HF_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 1),
+    kFRO12M_to_FLEXCOMM6    = MUX_A(CM_FXCOMCLKSEL6, 0),
+    kFRO_HF_to_FLEXCOMM6    = MUX_A(CM_FXCOMCLKSEL6, 1),
     kAUDIO_PLL_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 2),
-    kMCLK_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 3),
-    kFRG_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 4),
-    kNONE_to_FLEXCOMM6 = MUX_A(CM_FXCOMCLKSEL6, 7),
+    kMCLK_to_FLEXCOMM6      = MUX_A(CM_FXCOMCLKSEL6, 3),
+    kFRG_to_FLEXCOMM6       = MUX_A(CM_FXCOMCLKSEL6, 4),
+    kNONE_to_FLEXCOMM6      = MUX_A(CM_FXCOMCLKSEL6, 7),
 
-    kFRO12M_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 0),
-    kFRO_HF_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 1),
+    kFRO12M_to_FLEXCOMM7    = MUX_A(CM_FXCOMCLKSEL7, 0),
+    kFRO_HF_to_FLEXCOMM7    = MUX_A(CM_FXCOMCLKSEL7, 1),
     kAUDIO_PLL_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 2),
-    kMCLK_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 3),
-    kFRG_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 4),
-    kNONE_to_FLEXCOMM7 = MUX_A(CM_FXCOMCLKSEL7, 7),
+    kMCLK_to_FLEXCOMM7      = MUX_A(CM_FXCOMCLKSEL7, 3),
+    kFRG_to_FLEXCOMM7       = MUX_A(CM_FXCOMCLKSEL7, 4),
+    kNONE_to_FLEXCOMM7      = MUX_A(CM_FXCOMCLKSEL7, 7),
 
-    kFRO12M_to_FLEXCOMM8 = MUX_A(CM_FXCOMCLKSEL8, 0),
-    kFRO_HF_to_FLEXCOMM8 = MUX_A(CM_FXCOMCLKSEL8, 1),
+    kFRO12M_to_FLEXCOMM8    = MUX_A(CM_FXCOMCLKSEL8, 0),
+    kFRO_HF_to_FLEXCOMM8    = MUX_A(CM_FXCOMCLKSEL8, 1),
     kAUDIO_PLL_to_FLEXCOMM8 = MUX_A(CM_FXCOMCLKSEL8, 2),
-    kMCLK_to_FLEXCOMM8 = MUX_A(CM_FXCOMCLKSEL8, 3),
-    kFRG_to_FLEXCOMM8 = MUX_A(CM_FXCOMCLKSEL8, 4),
-    kNONE_to_FLEXCOMM8 = MUX_A(CM_FXCOMCLKSEL8, 7),
+    kMCLK_to_FLEXCOMM8      = MUX_A(CM_FXCOMCLKSEL8, 3),
+    kFRG_to_FLEXCOMM8       = MUX_A(CM_FXCOMCLKSEL8, 4),
+    kNONE_to_FLEXCOMM8      = MUX_A(CM_FXCOMCLKSEL8, 7),
 
-    kFRO12M_to_FLEXCOMM9 = MUX_A(CM_FXCOMCLKSEL9, 0),
-    kFRO_HF_to_FLEXCOMM9 = MUX_A(CM_FXCOMCLKSEL9, 1),
+    kFRO12M_to_FLEXCOMM9    = MUX_A(CM_FXCOMCLKSEL9, 0),
+    kFRO_HF_to_FLEXCOMM9    = MUX_A(CM_FXCOMCLKSEL9, 1),
     kAUDIO_PLL_to_FLEXCOMM9 = MUX_A(CM_FXCOMCLKSEL9, 2),
-    kMCLK_to_FLEXCOMM9 = MUX_A(CM_FXCOMCLKSEL9, 3),
-    kFRG_to_FLEXCOMM9 = MUX_A(CM_FXCOMCLKSEL9, 4),
-    kNONE_to_FLEXCOMM9 = MUX_A(CM_FXCOMCLKSEL9, 7),
+    kMCLK_to_FLEXCOMM9      = MUX_A(CM_FXCOMCLKSEL9, 3),
+    kFRG_to_FLEXCOMM9       = MUX_A(CM_FXCOMCLKSEL9, 4),
+    kNONE_to_FLEXCOMM9      = MUX_A(CM_FXCOMCLKSEL9, 7),
 
-    kFRO_HF_to_MCLK = MUX_A(CM_MCLKCLKSEL, 0),
+    kFRO_HF_to_MCLK    = MUX_A(CM_MCLKCLKSEL, 0),
     kAUDIO_PLL_to_MCLK = MUX_A(CM_MCLKCLKSEL, 1),
-    kNONE_to_MCLK = MUX_A(CM_MCLKCLKSEL, 7),
+    kNONE_to_MCLK      = MUX_A(CM_MCLKCLKSEL, 7),
 
     kMAIN_CLK_to_FRG = MUX_A(CM_FRGCLKSEL, 0),
-    kSYS_PLL_to_FRG = MUX_A(CM_FRGCLKSEL, 1),
-    kFRO12M_to_FRG = MUX_A(CM_FRGCLKSEL, 2),
-    kFRO_HF_to_FRG = MUX_A(CM_FRGCLKSEL, 3),
-    kNONE_to_FRG = MUX_A(CM_FRGCLKSEL, 7),
+    kSYS_PLL_to_FRG  = MUX_A(CM_FRGCLKSEL, 1),
+    kFRO12M_to_FRG   = MUX_A(CM_FRGCLKSEL, 2),
+    kFRO_HF_to_FRG   = MUX_A(CM_FRGCLKSEL, 3),
+    kNONE_to_FRG     = MUX_A(CM_FRGCLKSEL, 7),
 
-    kFRO12M_to_DMIC = MUX_A(CM_DMICCLKSEL, 0),
+    kFRO12M_to_DMIC     = MUX_A(CM_DMICCLKSEL, 0),
     kFRO_HF_DIV_to_DMIC = MUX_A(CM_DMICCLKSEL, 1),
-    kAUDIO_PLL_to_DMIC = MUX_A(CM_DMICCLKSEL, 2),
-    kMCLK_to_DMIC = MUX_A(CM_DMICCLKSEL, 3),
-    kNONE_to_DMIC = MUX_A(CM_DMICCLKSEL, 7),
+    kAUDIO_PLL_to_DMIC  = MUX_A(CM_DMICCLKSEL, 2),
+    kMCLK_to_DMIC       = MUX_A(CM_DMICCLKSEL, 3),
+    kNONE_to_DMIC       = MUX_A(CM_DMICCLKSEL, 7),
 
-    kMCLK_to_SCT_CLK = MUX_A(CM_SCTCLKSEL, 0),
-    kSYS_PLL_to_SCT_CLK = MUX_A(CM_SCTCLKSEL, 1),
-    kFRO_HF_to_SCT_CLK = MUX_A(CM_SCTCLKSEL, 2),
+    kMAIN_CLK_to_SCT_CLK  = MUX_A(CM_SCTCLKSEL, 0),
+    kSYS_PLL_to_SCT_CLK   = MUX_A(CM_SCTCLKSEL, 1),
+    kFRO_HF_to_SCT_CLK    = MUX_A(CM_SCTCLKSEL, 2),
     kAUDIO_PLL_to_SCT_CLK = MUX_A(CM_SCTCLKSEL, 3),
-    kNONE_to_SCT_CLK = MUX_A(CM_SCTCLKSEL, 7),
+    kNONE_to_SCT_CLK      = MUX_A(CM_SCTCLKSEL, 7),
 
-    kMCLK_to_SDIO_CLK = MUX_A(CM_SDIOCLKSEL, 0),
-    kSYS_PLL_to_SDIO_CLK = MUX_A(CM_SDIOCLKSEL, 1),
-    kUSB_PLL_to_SDIO_CLK = MUX_A(CM_SDIOCLKSEL, 2),
-    kFRO_HF_to_SDIO_CLK = MUX_A(CM_SDIOCLKSEL, 3),
+    kMAIN_CLK_to_SDIO_CLK  = MUX_A(CM_SDIOCLKSEL, 0),
+    kSYS_PLL_to_SDIO_CLK   = MUX_A(CM_SDIOCLKSEL, 1),
+    kUSB_PLL_to_SDIO_CLK   = MUX_A(CM_SDIOCLKSEL, 2),
+    kFRO_HF_to_SDIO_CLK    = MUX_A(CM_SDIOCLKSEL, 3),
     kAUDIO_PLL_to_SDIO_CLK = MUX_A(CM_SDIOCLKSEL, 4),
-    kNONE_to_SDIO_CLK = MUX_A(CM_SDIOCLKSEL, 7),
-    
-    kMCLK_to_LCD_CLK = MUX_A(CM_LCDCLKSEL, 0),
+    kNONE_to_SDIO_CLK      = MUX_A(CM_SDIOCLKSEL, 7),
+
+    kMAIN_CLK_to_LCD_CLK = MUX_A(CM_LCDCLKSEL, 0),
     kLCDCLKIN_to_LCD_CLK = MUX_A(CM_LCDCLKSEL, 1),
-    kFRO_HF_to_LCD_CLK = MUX_A(CM_LCDCLKSEL, 2),
-    kNONE_to_LCD_CLK = MUX_A(CM_LCDCLKSEL, 3),
-    
-    kMAIN_CLK_to_ASYNC_APB = MUX_A(CM_ASYNCAPB, 0),
-    kFRO12M_to_ASYNC_APB = MUX_A(CM_ASYNCAPB, 1),
-    kAUDIO_PLL_to_ASYNC_APB = MUX_A(CM_ASYNCAPB, 2),
+    kFRO_HF_to_LCD_CLK   = MUX_A(CM_LCDCLKSEL, 2),
+    kNONE_to_LCD_CLK     = MUX_A(CM_LCDCLKSEL, 3),
+
+    kMAIN_CLK_to_ASYNC_APB    = MUX_A(CM_ASYNCAPB, 0),
+    kFRO12M_to_ASYNC_APB      = MUX_A(CM_ASYNCAPB, 1),
+    kAUDIO_PLL_to_ASYNC_APB   = MUX_A(CM_ASYNCAPB, 2),
     kI2C_CLK_FC6_to_ASYNC_APB = MUX_A(CM_ASYNCAPB, 3),
-    kNONE_to_NONE = 0x80000000U,
+    kNONE_to_NONE             = (int)0x80000000U,
 } clock_attach_id_t;
 
 /*  Clock dividers */
 typedef enum _clock_div_name
 {
-    kCLOCK_DivSystickClk = 0,
-    kCLOCK_DivArmTrClkDiv = 1,
-    kCLOCK_DivCan0Clk = 2,
-    kCLOCK_DivCan1Clk = 3,
+    kCLOCK_DivSystickClk    = 0,
+    kCLOCK_DivArmTrClkDiv   = 1,
+    kCLOCK_DivCan0Clk       = 2,
+    kCLOCK_DivCan1Clk       = 3,
     kCLOCK_DivSmartCard0Clk = 4,
     kCLOCK_DivSmartCard1Clk = 5,
-    kCLOCK_DivAhbClk = 32,
-    kCLOCK_DivClkOut = 33,
-    kCLOCK_DivFrohfClk = 34,
-    kCLOCK_DivSpifiClk = 36,
-    kCLOCK_DivAdcAsyncClk = 37,
-    kCLOCK_DivUsb0Clk = 38,
-    kCLOCK_DivUsb1Clk = 39,
-    kCLOCK_DivFrg = 40,
-    kCLOCK_DivDmicClk = 42,
-    kCLOCK_DivMClk = 43,
-    kCLOCK_DivLcdClk = 44,
-    kCLOCK_DivSctClk = 45,
-    kCLOCK_DivEmcClk = 46,
-    kCLOCK_DivSdioClk = 47
+    kCLOCK_DivAhbClk        = 32,
+    kCLOCK_DivClkOut        = 33,
+    kCLOCK_DivFrohfClk      = 34,
+    kCLOCK_DivSpifiClk      = 36,
+    kCLOCK_DivAdcAsyncClk   = 37,
+    kCLOCK_DivUsb0Clk       = 38,
+    kCLOCK_DivUsb1Clk       = 39,
+    kCLOCK_DivFrg           = 40,
+    kCLOCK_DivDmicClk       = 42,
+    kCLOCK_DivMClk          = 43,
+    kCLOCK_DivLcdClk        = 44,
+    kCLOCK_DivSctClk        = 45,
+    kCLOCK_DivEmcClk        = 46,
+    kCLOCK_DivSdioClk       = 47
 } clock_div_name_t;
 
 /*******************************************************************************
@@ -735,7 +726,7 @@ static inline void CLOCK_EnableClock(clock_ip_name_t clk)
     }
     else
     {
-        SYSCON->ASYNCAPBCTRL = SYSCON_ASYNCAPBCTRL_ENABLE(1);
+        SYSCON->ASYNCAPBCTRL             = SYSCON_ASYNCAPBCTRL_ENABLE(1);
         ASYNC_SYSCON->ASYNCAPBCLKCTRLSET = (1U << CLK_GATE_ABSTRACT_BITS_SHIFT(clk));
     }
 }
@@ -750,8 +741,7 @@ static inline void CLOCK_DisableClock(clock_ip_name_t clk)
     else
     {
         ASYNC_SYSCON->ASYNCAPBCLKCTRLCLR = (1U << CLK_GATE_ABSTRACT_BITS_SHIFT(clk));
-        SYSCON->ASYNCAPBCTRL = SYSCON_ASYNCAPBCTRL_ENABLE(0);
-
+        SYSCON->ASYNCAPBCTRL             = SYSCON_ASYNCAPBCTRL_ENABLE(0);
     }
 }
 /**
@@ -800,6 +790,14 @@ status_t CLOCK_SetupFROClocking(uint32_t iFreq);
  */
 void CLOCK_AttachClk(clock_attach_id_t connection);
 /**
+ * @brief   Get the actual clock attach id.
+ * This fuction uses the offset in input attach id, then it reads the actual source value in
+ * the register and combine the offset to obtain an actual attach id.
+ * @param   attachId  : Clock attach id to get.
+ * @return  Clock source value.
+ */
+clock_attach_id_t CLOCK_GetClockAttachId(clock_attach_id_t attachId);
+/**
  * @brief	Setup peripheral clock dividers.
  * @param	div_name	: Clock divider name
  * @param divided_by_value: Value to be divided
@@ -813,6 +811,20 @@ void CLOCK_SetClkDiv(clock_div_name_t div_name, uint32_t divided_by_value, bool 
  * @return	Nothing
  */
 void CLOCK_SetFLASHAccessCyclesForFreq(uint32_t iFreq);
+
+/**
+ * @brief	Set the frg output frequency.
+ * @param	freq	: output frequency
+ * @return	0   : the frequency range is out of range.
+ *          1   : switch successfully.
+ */
+uint32_t CLOCK_SetFRGClock(uint32_t freq);
+
+/*! @brief	Return Frequency of FRG input clock
+ *  @return	Frequency value
+ */
+uint32_t CLOCK_GetFRGInputClock(void);
+
 /*! @brief	Return Frequency of selected clock
  *  @return	Frequency of selected clock
  */
@@ -833,6 +845,11 @@ uint32_t CLOCK_GetSpifiClkFreq(void);
  *  @return	Frequency of Adc Clock.
  */
 uint32_t CLOCK_GetAdcClkFreq(void);
+/*! brief	Return Frequency of MCAN Clock
+ *  param	MCanSel : 0U: MCAN0; 1U: MCAN1
+ *  return	Frequency of MCAN Clock
+ */
+uint32_t CLOCK_GetMCanClkFreq(uint32_t MCanSel);
 /*! @brief	Return Frequency of Usb0 Clock
  *  @return	Frequency of Usb0 Clock.
  */
@@ -873,6 +890,14 @@ uint32_t CLOCK_GetWdtOscFreq(void);
  *  @return	Frequency of High-Freq output of FRO
  */
 uint32_t CLOCK_GetFroHfFreq(void);
+/*! @brief  Return Frequency of frg
+ *  @return Frequency of FRG
+ */
+uint32_t CLOCK_GetFrgClkFreq(void);
+/*! @brief  Return Frequency of dmic
+ *  @return Frequency of DMIC
+ */
+uint32_t CLOCK_GetDmicClkFreq(void);
 /*! @brief	Return Frequency of PLL
  *  @return	Frequency of PLL
  */
@@ -912,6 +937,13 @@ __STATIC_INLINE async_clock_src_t CLOCK_GetAsyncApbClkSrc(void)
  *  @return	Frequency of Asynchronous APB Clock Clock
  */
 uint32_t CLOCK_GetAsyncApbClkFreq(void);
+/*! @brief	Return EMC source
+ *  @return	EMC source
+ */
+__STATIC_INLINE uint32_t CLOCK_GetEmcClkFreq(void)
+{
+    return CLOCK_GetCoreSysClkFreq() / ((SYSCON->AHBCLKDIV & 0xffU) + 1U) / ((SYSCON->EMCCLKDIV & 0xffU) + 1U);
+}
 /*! @brief	Return Audio PLL input clock rate
  *  @return	Audio PLL input clock rate
  */
@@ -946,7 +978,7 @@ uint32_t CLOCK_GetAudioPLLOutClockRate(bool recompute);
  *  the rate computation function can take some time to perform. It
  *  is recommended to use 'false' with the 'recompute' parameter.
  */
-uint32_t CLOCK_GetUSbPLLOutClockRate(bool recompute);
+uint32_t CLOCK_GetUsbPLLOutClockRate(bool recompute);
 
 /*! @brief	Enables and disables PLL bypass mode
  *  @brief	bypass	: true to bypass PLL (PLL output = PLL input, false to disable bypass
@@ -990,20 +1022,19 @@ __STATIC_INLINE bool CLOCK_IsAudioPLLLocked(void)
 
 /*! @brief	Enables and disables SYS OSC
  *  @brief	enable	: true to enable SYS OSC, false to disable SYS OSC
-*/
-__STATIC_INLINE  void CLOCK_Enable_SysOsc(bool enable)
+ */
+__STATIC_INLINE void CLOCK_Enable_SysOsc(bool enable)
 {
-    if(enable)
+    if (enable)
     {
         SYSCON->PDRUNCFGCLR[0] |= SYSCON_PDRUNCFG_PDEN_VD2_ANA_MASK;
         SYSCON->PDRUNCFGCLR[1] |= SYSCON_PDRUNCFG_PDEN_SYSOSC_MASK;
     }
-    
+
     else
     {
-        SYSCON->PDRUNCFGSET[0] = SYSCON_PDRUNCFG_PDEN_VD2_ANA_MASK; 
+        SYSCON->PDRUNCFGSET[0] = SYSCON_PDRUNCFG_PDEN_VD2_ANA_MASK;
         SYSCON->PDRUNCFGSET[1] = SYSCON_PDRUNCFG_PDEN_SYSOSC_MASK;
-
     }
 }
 
@@ -1035,12 +1066,13 @@ void CLOCK_SetStoredAudioPLLClockRate(uint32_t rate);
  */
 #define PLL_CONFIGFLAG_USEINRATE (1 << 0) /*!< Flag to use InputRate in PLL configuration structure for setup */
 #define PLL_CONFIGFLAG_FORCENOFRACT                                                                                    \
-    (1                                                                                                                 \
-     << 2) /*!< Force non-fractional output mode, PLL output will not use the fractional, automatic bandwidth, or SS \ \
-                \ \ \                                                                                                                     \
-                  \ \ \ \ \                                                                                                                     \
-                    \ \ \ \ \ \ \                                                                                                                     \
-                      hardware */
+    (1 << 2) /*!< Force non-fractional output mode, PLL output will not use the fractional, automatic bandwidth, or SS \
+                \ \                                                                                                    \
+                  \ \ \ \                                                                                              \
+                     \ \ \ \ \ \                                                                                       \
+                       \ \ \ \ \ \ \ \                                                                                 \
+                         \ \ \ \ \ \ \ \ \ \                                                                           \
+                           hardware */
 
 /*! @brief PLL configuration structure
  *
@@ -1056,53 +1088,54 @@ typedef struct _pll_config
 } pll_config_t;
 
 /*! @brief PLL setup structure flags for 'flags' field
-* These flags control how the PLL setup function sets up the PLL
-*/
+ * These flags control how the PLL setup function sets up the PLL
+ */
 #define PLL_SETUPFLAG_POWERUP (1 << 0)  /*!< Setup will power on the PLL after setup */
 #define PLL_SETUPFLAG_WAITLOCK (1 << 1) /*!< Setup will wait for PLL lock, implies the PLL will be pwoered on */
 #define PLL_SETUPFLAG_ADGVOLT (1 << 2)  /*!< Optimize system voltage for the new PLL rate */
 
 /*! @brief PLL setup structure
-* This structure can be used to pre-build a PLL setup configuration
-* at run-time and quickly set the PLL to the configuration. It can be
-* populated with the PLL setup function. If powering up or waiting
-* for PLL lock, the PLL input clock source should be configured prior
-* to PLL setup.
-*/
+ * This structure can be used to pre-build a PLL setup configuration
+ * at run-time and quickly set the PLL to the configuration. It can be
+ * populated with the PLL setup function. If powering up or waiting
+ * for PLL lock, the PLL input clock source should be configured prior
+ * to PLL setup.
+ */
 typedef struct _pll_setup
 {
-    uint32_t pllctrl;         /*!< PLL control register SYSPLLCTRL */
-    uint32_t pllndec;         /*!< PLL NDEC register SYSPLLNDEC */
-    uint32_t pllpdec;         /*!< PLL PDEC register SYSPLLPDEC */
-    uint32_t pllmdec;         /*!< PLL MDEC registers SYSPLLPDEC */
-    uint32_t pllRate;         /*!< Acutal PLL rate */
-    uint32_t audpllfrac;      /*!< only aduio PLL has this function*/
-    uint32_t flags;           /*!< PLL setup flags, Or'ed value of PLL_SETUPFLAG_* definitions */
+    uint32_t pllctrl;    /*!< PLL control register SYSPLLCTRL */
+    uint32_t pllndec;    /*!< PLL NDEC register SYSPLLNDEC */
+    uint32_t pllpdec;    /*!< PLL PDEC register SYSPLLPDEC */
+    uint32_t pllmdec;    /*!< PLL MDEC registers SYSPLLPDEC */
+    uint32_t pllRate;    /*!< Acutal PLL rate */
+    uint32_t audpllfrac; /*!< only aduio PLL has this function*/
+    uint32_t flags;      /*!< PLL setup flags, Or'ed value of PLL_SETUPFLAG_* definitions */
 } pll_setup_t;
 
 /*! @brief PLL status definitions
  */
 typedef enum _pll_error
 {
-    kStatus_PLL_Success = MAKE_STATUS(kStatusGroup_Generic, 0),         /*!< PLL operation was successful */
-    kStatus_PLL_OutputTooLow = MAKE_STATUS(kStatusGroup_Generic, 1),    /*!< PLL output rate request was too low */
-    kStatus_PLL_OutputTooHigh = MAKE_STATUS(kStatusGroup_Generic, 2),   /*!< PLL output rate request was too high */
-    kStatus_PLL_InputTooLow = MAKE_STATUS(kStatusGroup_Generic, 3),     /*!< PLL input rate is too low */
-    kStatus_PLL_InputTooHigh = MAKE_STATUS(kStatusGroup_Generic, 4),    /*!< PLL input rate is too high */
+    kStatus_PLL_Success         = MAKE_STATUS(kStatusGroup_Generic, 0), /*!< PLL operation was successful */
+    kStatus_PLL_OutputTooLow    = MAKE_STATUS(kStatusGroup_Generic, 1), /*!< PLL output rate request was too low */
+    kStatus_PLL_OutputTooHigh   = MAKE_STATUS(kStatusGroup_Generic, 2), /*!< PLL output rate request was too high */
+    kStatus_PLL_InputTooLow     = MAKE_STATUS(kStatusGroup_Generic, 3), /*!< PLL input rate is too low */
+    kStatus_PLL_InputTooHigh    = MAKE_STATUS(kStatusGroup_Generic, 4), /*!< PLL input rate is too high */
     kStatus_PLL_OutsideIntLimit = MAKE_STATUS(kStatusGroup_Generic, 5), /*!< Requested output rate isn't possible */
-    kStatus_PLL_CCOTooLow = MAKE_STATUS(kStatusGroup_Generic, 6),       /*!< Requested CCO rate isn't possible */
-    kStatus_PLL_CCOTooHigh = MAKE_STATUS(kStatusGroup_Generic, 7)       /*!< Requested CCO rate isn't possible */
+    kStatus_PLL_CCOTooLow       = MAKE_STATUS(kStatusGroup_Generic, 6), /*!< Requested CCO rate isn't possible */
+    kStatus_PLL_CCOTooHigh      = MAKE_STATUS(kStatusGroup_Generic, 7)  /*!< Requested CCO rate isn't possible */
 } pll_error_t;
 
 /*! @brief USB clock source definition. */
 typedef enum _clock_usb_src
 {
-    kCLOCK_UsbSrcFro = (uint32_t)kCLOCK_FroHf,            /*!< Use FRO 96 or 48 MHz. */
+    kCLOCK_UsbSrcFro       = (uint32_t)kCLOCK_FroHf,      /*!< Use FRO 96 or 48 MHz. */
     kCLOCK_UsbSrcSystemPll = (uint32_t)kCLOCK_PllOut,     /*!< Use System PLL output. */
     kCLOCK_UsbSrcMainClock = (uint32_t)kCLOCK_CoreSysClk, /*!< Use Main clock.    */
-    kCLOCK_UsbSrcUsbPll = (uint32_t)kCLOCK_UsbPll,        /*!< Use USB PLL clock.    */
+    kCLOCK_UsbSrcUsbPll    = (uint32_t)kCLOCK_UsbPll,     /*!< Use USB PLL clock.    */
 
-    kCLOCK_UsbSrcNone = SYSCON_USB0CLKSEL_SEL(7)          /*!< Use None, this may be selected in order to reduce power when no output is needed.. */
+    kCLOCK_UsbSrcNone = SYSCON_USB0CLKSEL_SEL(
+        7) /*!< Use None, this may be selected in order to reduce power when no output is needed.. */
 } clock_usb_src_t;
 
 /*! @brief USB PDEL Divider. */
@@ -1112,24 +1145,24 @@ typedef enum _usb_pll_psel
     pSel_Divide_2,
     pSel_Divide_4,
     pSel_Divide_8
-}usb_pll_psel;
+} usb_pll_psel;
 
 /*! @brief PLL setup structure
-* This structure can be used to pre-build a USB PLL setup configuration
-* at run-time and quickly set the usb PLL to the configuration. It can be
-* populated with the USB PLL setup function. If powering up or waiting
-* for USB PLL lock, the PLL input clock source should be configured prior
-* to USB PLL setup.
-*/
+ * This structure can be used to pre-build a USB PLL setup configuration
+ * at run-time and quickly set the usb PLL to the configuration. It can be
+ * populated with the USB PLL setup function. If powering up or waiting
+ * for USB PLL lock, the PLL input clock source should be configured prior
+ * to USB PLL setup.
+ */
 typedef struct _usb_pll_setup
 {
-  uint8_t msel;           /*!< USB PLL control register msel:1U-256U */
-  uint8_t psel;           /*!< USB PLL control register psel:only support inter 1U 2U 4U 8U */
-  uint8_t nsel;           /*!< USB PLL control register nsel:only suppoet inter 1U 2U 3U 4U */
-  bool direct;            /*!< USB PLL CCO output control */
-  bool bypass;            /*!< USB PLL inout clock bypass control  */
-  bool fbsel;             /*!< USB PLL ineter mode and non-integer mode control*/
-  uint32_t inputRate;     /*!< USB PLL input rate */
+    uint8_t msel;       /*!< USB PLL control register msel:1U-256U */
+    uint8_t psel;       /*!< USB PLL control register psel:only support inter 1U 2U 4U 8U */
+    uint8_t nsel;       /*!< USB PLL control register nsel:only suppoet inter 1U 2U 3U 4U */
+    bool direct;        /*!< USB PLL CCO output control */
+    bool bypass;        /*!< USB PLL inout clock bypass control  */
+    bool fbsel;         /*!< USB PLL ineter mode and non-integer mode control*/
+    uint32_t inputRate; /*!< USB PLL input rate */
 } usb_pll_setup_t;
 
 /*! @brief	Return System PLL output clock rate from setup structure
@@ -1156,6 +1189,11 @@ uint32_t CLOCK_GetAudioPLLOutFromFractSetup(pll_setup_t *pSetup);
  */
 uint32_t CLOCK_GetUsbPLLOutFromSetup(const usb_pll_setup_t *pSetup);
 
+/*! @brief	Set USB PLL output frequency
+ *  @param	rate		: frequency value
+ *
+ */
+void CLOCK_SetStoredUsbPLLClockRate(uint32_t rate);
 /*! @brief	Set PLL output based on the passed PLL setup data
  *  @param	pControl	: Pointer to populated PLL control structure to generate setup with
  *  @param	pSetup		: Pointer to PLL setup structure to be filled
@@ -1176,7 +1214,7 @@ pll_error_t CLOCK_SetupAudioPLLData(pll_config_t *pControl, pll_setup_t *pSetup)
 
 /*! @brief	Set PLL output from PLL setup structure (precise frequency)
  * @param	pSetup	: Pointer to populated PLL setup structure
-* @param flagcfg : Flag configuration for PLL config structure
+ * @param flagcfg : Flag configuration for PLL config structure
  * @return	PLL_ERROR_SUCCESS on success, or PLL setup error code
  * @note	This function will power off the PLL, setup the PLL with the
  * new setup data, and then optionally powerup the PLL, wait for PLL lock,
@@ -1188,7 +1226,7 @@ pll_error_t CLOCK_SetupSystemPLLPrec(pll_setup_t *pSetup, uint32_t flagcfg);
 
 /*! @brief	Set AUDIO PLL output from AUDIOPLL setup structure (precise frequency)
  * @param	pSetup	: Pointer to populated PLL setup structure
-* @param flagcfg : Flag configuration for PLL config structure
+ * @param flagcfg : Flag configuration for PLL config structure
  * @return	PLL_ERROR_SUCCESS on success, or PLL setup error code
  * @note	This function will power off the PLL, setup the PLL with the
  * new setup data, and then optionally powerup the AUDIO PLL, wait for PLL lock,
@@ -1198,9 +1236,10 @@ pll_error_t CLOCK_SetupSystemPLLPrec(pll_setup_t *pSetup, uint32_t flagcfg);
  */
 pll_error_t CLOCK_SetupAudioPLLPrec(pll_setup_t *pSetup, uint32_t flagcfg);
 
-/*! @brief	Set AUDIO PLL output from AUDIOPLL setup structure using the Audio Fractional divider register(precise frequency)
+/*! @brief	Set AUDIO PLL output from AUDIOPLL setup structure using the Audio Fractional divider register(precise
+ * frequency)
  * @param	pSetup	: Pointer to populated PLL setup structure
-* @param flagcfg : Flag configuration for PLL config structure
+ * @param flagcfg : Flag configuration for PLL config structure
  * @return	PLL_ERROR_SUCCESS on success, or PLL setup error code
  * @note	This function will power off the PLL, setup the PLL with the
  * new setup data, and then optionally powerup the AUDIO PLL, wait for PLL lock,
@@ -1295,6 +1334,16 @@ bool CLOCK_EnableUsbhs0DeviceClock(clock_usb_src_t src, uint32_t freq);
  * Enable USB HOST High Speed clock.
  */
 bool CLOCK_EnableUsbhs0HostClock(clock_usb_src_t src, uint32_t freq);
+
+/*!
+ * @brief Use DWT to delay at least for some time.
+ *  Please note that, this API will calculate the microsecond period with the maximum
+ *  supported CPU frequency, so this API will only delay for at least the given microseconds, if precise
+ *  delay count was needed, please implement a new timer count to achieve this function.
+ *
+ * @param delay_us  Delay time in unit of microsecond.
+ */
+void SDK_DelayAtLeastUs(uint32_t delay_us);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
### Description
Update the MCUXpresso AnalogIn driver to pass the FPGA test shield tests. Below are updates

1. Updated the ADC SDK driver for LPC546XX and LPC54114 
2. Update the Analogin HAL driver to fix clock setup and the return of conversion results. The ADC has 12-bit resolution and the API expects results in 16-bit format.

FPGA test result below:
mbedgt: test on hardware with target id: 105600001984a78e00000000000000000000000097969905
mbedgt: test suite 'mbed-os-tests-mbed_hal_fpga_ci_test_shield-analogin' ............................. OK in 15.02 sec
        test case: 'AnalogIn - init test' ............................................................ OK in 0.40 sec
        test case: 'AnalogIn - read test' ............................................................ OK in 0.40 sec
mbedgt: test case summary: 2 passes, 0 failures

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

