### PR TITLE
Add Mbed bootloader support to CY8CKIT_062_WIFI_BT and CY8CPROTO_062_4343W

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8400,6 +8400,10 @@
         "post_binary_hook": {
             "function": "PSOC6Code.complete"
         },
+        "bootloader_supported": true,
+        "mbed_rom_start": "0x10002000",
+        "mbed_rom_size": "0xFE000",
+        "sectors": [[268435456, 512]],                            
         "overrides": {
             "network-default-interface-type": "WIFI"
         },
@@ -8410,7 +8414,11 @@
         "detect_code": ["1901"],
         "post_binary_hook": {
             "function": "PSOC6Code.complete"
-        }
+        },
+        "bootloader_supported": true,
+        "mbed_rom_start": "0x10002000",
+        "mbed_rom_size": "0x1FE000",
+        "sectors": [[268435456, 512]]                    
     },
     "CY8CKIT_062_BLE": {
         "inherits": ["MCU_PSOC6_M4"],


### PR DESCRIPTION
### Description

Add Mbed bootloader support to CY8CKIT_062_WIFI_BT and CY8CPROTO_062_4343W targets.  

This is needed for Pelion device management testing on these targets.  It covers non-PSA targets.

Note, that the linker/scatter files already support the required defines.  

Also, the mbed_rom_start, mbed_rom_size, and sectors defines are needed because this target doesn't have CMSIS pack which is used to validate memory regions.

Fixes https://github.com/ARMmbed/mbed-os/issues/10892

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/team-cypress 

### Release Notes

N/A