### PR TITLE
BLE: allow overriding event signal

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -80,7 +80,7 @@ extern "C" void hci_mbed_os_handle_reset_sequence(uint8_t* msg)
  * This function will signal to the user code by calling signalEventsToProcess.
  * It is registered and called into the Wsf Stack.
  */
-MBED_WEAK extern "C" void wsf_mbed_ble_signal_event(void)
+extern "C" MBED_WEAK void wsf_mbed_ble_signal_event(void)
 {
     ble::vendor::cordio::BLE::deviceInstance().signalEventsToProcess(::BLE::DEFAULT_INSTANCE);
 }

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioBLE.cpp
@@ -80,7 +80,7 @@ extern "C" void hci_mbed_os_handle_reset_sequence(uint8_t* msg)
  * This function will signal to the user code by calling signalEventsToProcess.
  * It is registered and called into the Wsf Stack.
  */
-extern "C" void wsf_mbed_ble_signal_event(void)
+MBED_WEAK extern "C" void wsf_mbed_ble_signal_event(void)
 {
     ble::vendor::cordio::BLE::deviceInstance().signalEventsToProcess(::BLE::DEFAULT_INSTANCE);
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Function that signals events from controller can not be overridden by porter. This changes makes it weak making it possible to decouple host from controller.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

This makes no change to existing code and users. Only affects future porters.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
