### PR TITLE
Cellular: Fix cellular statemachine stop and BG96 power up

### DIFF
--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -124,19 +124,19 @@ nsapi_error_t CellularDevice::create_state_machine()
         _nw->attach(callback(this, &CellularDevice::stm_callback));
         _state_machine = new CellularStateMachine(*this, *get_queue(), *_nw);
         _state_machine->set_cellular_callback(callback(this, &CellularDevice::stm_callback));
-        err = _state_machine->start_dispatch();
-        if (err) {
-            tr_error("Start state machine failed.");
-            delete _state_machine;
-            _state_machine = NULL;
-        }
-
         if (strlen(_plmn)) {
             _state_machine->set_plmn(_plmn);
         }
         if (strlen(_sim_pin)) {
             _state_machine->set_sim_pin(_sim_pin);
         }
+    }
+    err = _state_machine->start_dispatch();
+    if (err) {
+        tr_error("Start state machine failed.");
+        delete _state_machine;
+        _state_machine = NULL;
+        return err;
     }
     return err;
 }


### PR DESCRIPTION
### Description

Fix statemachine stop() so that it can be restarted.

Fix BG96 power up sequence to cope with modem off right after connecting is started.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarvte @mirelachirica 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
