### PR TITLE
IAR: Suppress "exceptions are disabled" warning

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -53,7 +53,7 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics",  "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r", "-DMBED_DEBUG",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082,Pe540", "-On", "-r", "-DMBED_DEBUG",
             "-DMBED_TRAP_ERRORS_ENABLED=1", "--enable_restrict"],
         "asm": [],
         "c": ["--vla", "--diag_suppress=Pe546"],

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -50,7 +50,7 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "--enable_restrict",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082,Pe540", "-Ohz", "--enable_restrict",
              "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--vla", "--diag_suppress=Pe546"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -49,7 +49,7 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "-DNDEBUG", "--enable_restrict"],
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082,Pe540", "-Ohz", "-DNDEBUG", "--enable_restrict"],
         "asm": [],
         "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],


### PR DESCRIPTION
### Description

IAR compiler is outputting lots of warnings about exceptions being
disabled whenever it sees a "noexcept" keyword. We know, we know.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

