### PR TITLE
Add a gpio-irq pinmap

### DIFF
--- a/TESTS/mbed_hal/pinmap/main.cpp
+++ b/TESTS/mbed_hal/pinmap/main.cpp
@@ -21,6 +21,7 @@
 using namespace utest::v1;
 
 #include "gpio_api.h"
+#include "gpio_irq_api.h"
 #include "analogin_api.h"
 #include "analogout_api.h"
 #include "can_api.h"
@@ -40,6 +41,9 @@ typedef struct {
 
 const pinmap_info_t pinmap_functions[] = {
     PINMAP_TEST_ENTRY(gpio_pinmap),
+#if DEVICE_INTERRUPTIN
+    PINMAP_TEST_ENTRY(gpio_irq_pinmap),
+#endif
 #if DEVICE_ANALOGIN
     PINMAP_TEST_ENTRY(analogin_pinmap),
 #endif

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -440,6 +440,18 @@ const char *const GPIOMaps::pin_type_names[] = { "IO" };
 const char *const GPIOMaps::name = "GPIO";
 typedef Port<1, GPIOMaps, DefaultFormFactor, TF1> GPIOPort;
 
+#if DEVICE_INTERRUPTIN
+struct GPIOIRQMaps {
+    static const PinMap *maps[];
+    static const char *const pin_type_names[];
+    static const char *const name;
+};
+const PinMap *GPIOIRQMaps::maps[] = { gpio_irq_pinmap() };
+const char *const GPIOIRQMaps::pin_type_names[] = { "IRQ_IN" };
+const char *const GPIOIRQMaps::name = "GPIO_IRQ";
+typedef Port<1, GPIOIRQMaps, DefaultFormFactor, TF1> GPIOIRQPort;
+#endif
+
 #if DEVICE_SPI
 #include "spi_api.h"
 struct SPIMaps {

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -441,6 +441,7 @@ const char *const GPIOMaps::name = "GPIO";
 typedef Port<1, GPIOMaps, DefaultFormFactor, TF1> GPIOPort;
 
 #if DEVICE_INTERRUPTIN
+#include "gpio_irq_api.h"
 struct GPIOIRQMaps {
     static const PinMap *maps[];
     static const char *const pin_type_names[];

--- a/hal/gpio_irq_api.h
+++ b/hal/gpio_irq_api.h
@@ -21,6 +21,7 @@
 #define MBED_GPIO_IRQ_API_H
 
 #include "device.h"
+#include "pinmap.h"
 
 #if DEVICE_INTERRUPTIN
 
@@ -84,6 +85,18 @@ void gpio_irq_enable(gpio_irq_t *obj);
  * @param obj The GPIO object
  */
 void gpio_irq_disable(gpio_irq_t *obj);
+
+/** Get the pins that support all GPIO IRQ tests
+ *
+ * Return a PinMap array of pins that support GPIO IRQ.
+ * The array is terminated with {NC, NC, 0}.
+ *
+ * Targets should override the weak implementation of this
+ * function to provide the actual pinmap for GPIO IRQ testing.
+ *
+ * @return PinMap array
+ */
+const PinMap *gpio_irq_pinmap(void);
 
 /**@}*/
 

--- a/hal/mbed_gpio_irq.c
+++ b/hal/mbed_gpio_irq.c
@@ -1,0 +1,31 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hal/gpio_irq_api.h"
+
+#if DEVICE_INTERRUPTIN
+
+#include "platform/mbed_toolchain.h"
+#include "hal/gpio_api.h"
+
+MBED_WEAK const PinMap *gpio_irq_pinmap()
+{
+    // Targets should override this weak implementation to provide correct data.
+    // By default, this is exactly the same as GPIO PinMap.
+    return gpio_pinmap();
+}
+
+#endif

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/gpio_irq_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/gpio_irq_api.c
@@ -49,7 +49,7 @@ static void gpio_irq_dispatcher(uint32_t port_id)
             MBED_ASSERT(obj);
             Cy_GPIO_ClearInterrupt(port, pin);
             event = (obj->mode == IRQ_FALL)? IRQ_FALL : IRQ_RISE;
-            obj->handler(obj->id_arg, event);
+            ((gpio_irq_handler) obj->handler)(obj->id_arg, event);
         }
     }
 }
@@ -202,7 +202,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
             MBED_ASSERT("Invalid pin ID!");
             return (-1);
         }
-        obj->handler = handler;
+        obj->handler = (uint32_t) handler;
         obj->id_arg = id;
         return gpio_irq_setup_channel(obj);
     } else {

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/objects.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/objects.h
@@ -23,7 +23,6 @@
 #include "PinNames.h"
 #include "PortNames.h"
 
-#include "gpio_irq_api.h"
 #include "gpio_object.h"
 #include "cy_sysclk.h"
 #include "cy_syspm.h"
@@ -37,8 +36,8 @@ struct gpio_irq_s {
     GPIO_PRT_Type*      port;
     uint32_t            port_id;
     uint32_t            pin;
-    gpio_irq_event      mode;
-    gpio_irq_handler    handler;
+    uint32_t            mode;
+    uint32_t            handler;
     uint32_t            id_arg;
 #if defined (TARGET_MCU_PSOC6_M0)
     cy_en_intr_t        cm0p_irq_src;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
This patch adds a `gpio_irq_pinmap()` function that is used for GPIO IRQ testing with the FPGA shield. This is a follow-up to #10644; the default implementation returns a PinMap that is exactly the same as GPIO PinMap. Every target has to override this weak implementation to provide a correct list of pins to test.

I also updated the `tests-mbed_hal_fpga_ci_test_shield-gpio_irq` test to make use of `gpio_irq_pinmap()`.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@mmahadevan108 @c1728p9 @maclobdell @maciejbocianski 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
Add a weak `gpio_irq_pinmap()`, that every target has to override, to provide a set of pins for GPIO IRQ testing.