### PR TITLE
NRF52840: remove align instructions from gcc linker for ARM.extab exi…

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -149,14 +149,12 @@ SECTIONS
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-        . = ALIGN(8);
     } > FLASH
 
     __exidx_start = .;
     .ARM.exidx :
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-        . = ALIGN(8);
     } > FLASH
     __exidx_end = .;
 


### PR DESCRIPTION
### Description

Remove the ALIGN instructions for ARM.extab and ARM.exidx sections for the GCC_ARM NRF52840 linker script.  These constraints were causing link failures for more complex mbed-os applications on this platform and this may be due to over constraining the linker.  I do not see any requirements for these sections to be aligned to 8-byte boundaries.

### Pull request type

    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

