### PR TITLE
NVStore.cpp (and KVStore) - run-time failure handling missing

### DIFF
--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -736,6 +736,9 @@ int SecureStore::init()
     int ret = MBED_SUCCESS;
 
     MBED_ASSERT(!(scratch_buf_size % enc_block_size));
+    if (scratch_buf_size % enc_block_size) {
+        return MBED_SYSTEM_ERROR_BASE;
+    }
 
     _mutex.lock();
 #if defined(MBEDTLS_PLATFORM_C)


### PR DESCRIPTION
### Description

Against to using MBED_ASSERT (works only for DEBUG build, not working with release build) implemented valid failure handling for NVStore nad KVStore.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@JanneKiiskila 
@SeppoTakalo 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
