### PR TITLE
Mbed-os compile without DEVICE_SERIAL

### DIFF
--- a/features/frameworks/greentea-client/greentea-client/greentea_serial.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_serial.h
@@ -4,6 +4,8 @@
 #ifndef GREENTEA_SERIAL_H
 #define GREENTEA_SERIAL_H
 
+#if DEVICE_SERIAL
+
 #include "RawSerial.h"
 #include "SingletonPtr.h"
 
@@ -16,3 +18,4 @@ extern SingletonPtr<GreenteaSerial> greentea_serial;
 #endif
 
 /** @}*/
+#endif

--- a/features/frameworks/greentea-client/source/greentea_serial.cpp
+++ b/features/frameworks/greentea-client/source/greentea_serial.cpp
@@ -1,5 +1,7 @@
 #include "greentea-client/greentea_serial.h"
 
+#if DEVICE_SERIAL
+
 /**
  * Macros for setting console flow control.
  */
@@ -21,3 +23,5 @@ GreenteaSerial::GreenteaSerial() : mbed::RawSerial(USBTX, USBRX, MBED_CONF_PLATF
     set_flow_control(SerialBase::RTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
 #endif
 }
+
+#endif

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#if DEVICE_SERIAL
+
 #include <ctype.h>
 #include <cstdio>
 #include <string.h>
@@ -780,3 +782,5 @@ static int HandleKV(char *out_key,
     getNextToken(0, 0);
     return 0;
 }
+
+#endif

--- a/features/frameworks/utest/source/unity_handler.cpp
+++ b/features/frameworks/utest/source/unity_handler.cpp
@@ -19,7 +19,10 @@
 #include "utest/utest_harness.h"
 #include "utest/utest_stack_trace.h"
 #include "utest/unity_handler.h"
+
+#if DEVICE_SERIAL
 #include "greentea-client/greentea_serial.h"
+#endif
 
 void utest_unity_assert_failure(void)
 {
@@ -33,9 +36,10 @@ void utest_unity_ignore_failure(void)
     utest::v1::Harness::raise_failure(utest::v1::failure_reason_t(utest::v1::REASON_ASSERTION | utest::v1::REASON_IGNORE));
 }
 
+#if DEVICE_SERIAL
 void utest_safe_putc(int chr)
 {
     greentea_serial->putc(chr);
 }    
-
+#endif
 

--- a/features/frameworks/utest/source/utest_default_handlers.cpp
+++ b/features/frameworks/utest/source/utest_default_handlers.cpp
@@ -16,6 +16,8 @@
  ****************************************************************************
  */
 
+#if DEVICE_SERIAL
+
 #include "utest/utest_default_handlers.h"
 #include "utest/utest_case.h"
 #include "utest/utest_stack_trace.h"
@@ -102,3 +104,5 @@ utest::v1::status_t utest::v1::verbose_case_failure_handler(const Case *const /*
     if (failure.reason & REASON_IGNORE) return STATUS_IGNORE;
     return STATUS_CONTINUE;
 }
+
+#endif

--- a/features/frameworks/utest/utest/utest_serial.h
+++ b/features/frameworks/utest/utest/utest_serial.h
@@ -19,6 +19,8 @@
  ****************************************************************************
  */
 
+#if DEVICE_SERIAL
+
 #ifndef UTEST_SERIAL_H
 #define UTEST_SERIAL_H
 
@@ -29,3 +31,5 @@
 #endif // UTEST_SERIAL_H
 
 /** @}*/
+
+#endif


### PR DESCRIPTION
### Description

Added preprocessing `#if` statements so that Mbed-os can compile without DEVICE_SERIAL.
fixes #9850


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond @maciejbocianski
