### PR TITLE
STM32F7: Do not generate redundant IN tokens

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_hcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_hcd.c
@@ -969,6 +969,7 @@ static void HCD_HC_IN_IRQHandler   (HCD_HandleTypeDef *hhcd, uint8_t chnum)
       tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
       tmpreg |= USB_OTG_HCCHAR_CHENA;
       USBx_HC(chnum)->HCCHAR = tmpreg;
+      reactivate = 1;
     }
     __HAL_HCD_CLEAR_HC_INT(chnum, USB_OTG_HCINT_CHH);
     // MBED: changed


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

When STM32F746-DISCO board was being used in (unsupported) USBHost mode,
the communication was unreliable. Our investigation revealed that the
problem lied in redundant IN tokens that the host generated even though
it shouldn't. This could lead to endless high-frequency NAKs being
received from device, which caused watchdog reset as USBHost spent all
time in interrupt handlers.

In our application the clocks frequencies are:
  * HCLK = 48 MHz
  * APB1 = 6 MHz
  * APB2 = 12 MHz

We have captured the raw USB High-Speed traffic using OpenVizsla.
Without this change, when USB MSD device connected to the system
responded to IN with NAK, there were excessive IN tokens generated about
667 ns after the NAK. With this commit the IN tokens are generated no
sooner than 10 us after the NAK.

The high frequency of the IN/NAK pairs is not the biggest problem.
The biggest problem is that the USB Host did continue to send the IN token
after DATA and ACK packets were received from device - *without* any request
from upper layer (USB MSD).

The USB MSD devices won't have extra data available on Bulk IN endpoint
after the expected data was received by Host. In such case IN/NAK cycle
time is only houndreds of nanoseconds, the MCU has no time for anything else.

The problem manifested not only on Bulk endpoints, but also during
Control transfers. Example correct scenario (when this fix is applied):
  * SETUP stage
    * SETUP [host -> address 0 endpoint 0]
    * DATA0 [80 06 00 01 00 00 08 00] [CRC16: EB 94]
    * ACK
  * DATA stage
    * IN
    * NAK
    ... the IN/NAK repeated multiple time until device was ready
    * IN
    * DATA1 [12 01 10 02 00 00 00 40] [CRC16: 55 41]
    * ACK
  * STATUS stage
    * OUT
    * DATA1 ZLP
    * ACK

Without this commit, in DATA stage, after the ACK was received, the host
did send extra IN to which device responded with STALL. On bus it was:
  * DATA stage
    ...
    * IN
    * DATA1 [12 01 10 02 00 00 00 40] [CRC16: 55 41]
    * IN
    * STALL
    * IN
    * STALL
  * STATUS stage
    * OUT
    * DATA1 ZLP
    * STALL

In the fault case the next SETUP was sent only after 510 ms, which
indicates timeout in upper layer.

With this commit the next SETUP is sent 120 us after the STATUS stage ACK.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
