### PR TITLE
Enterprise security support

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSTAInterface.cpp
@@ -113,6 +113,8 @@ static nsapi_security_t whd_tosecurity(whd_security_t sec)
             return NSAPI_SECURITY_WPA;
         case WHD_SECURITY_WPA2_MIXED_PSK:
             return NSAPI_SECURITY_WPA_WPA2;
+        case WHD_SECURITY_WPA2_MIXED_ENT:
+            return NSAPI_SECURITY_WPA2_ENT;
         case WHD_SECURITY_WPA2_AES_PSK:
         case WHD_SECURITY_WPA2_AES_ENT:
         case WHD_SECURITY_WPA2_FBT_PSK:
@@ -136,6 +138,8 @@ whd_security_t whd_fromsecurity(nsapi_security_t sec)
             return WHD_SECURITY_WPA2_AES_PSK;
         case NSAPI_SECURITY_WPA_WPA2:
             return WHD_SECURITY_WPA2_MIXED_PSK;
+        case NSAPI_SECURITY_WPA2_ENT:
+            return WHD_SECURITY_WPA2_MIXED_ENT;
         default:
             return WHD_SECURITY_UNKNOWN;
     }
@@ -179,8 +183,8 @@ nsapi_error_t WhdSTAInterface::set_credentials(const char *ssid, const char *pas
 {
     if ((ssid == NULL) ||
             (strlen(ssid) == 0) ||
-            (pass == NULL && (security != NSAPI_SECURITY_NONE)) ||
-            (strlen(pass) == 0 && (security != NSAPI_SECURITY_NONE)) ||
+            (pass == NULL && ( security != NSAPI_SECURITY_NONE && security != NSAPI_SECURITY_WPA2_ENT)) ||
+            (strlen(pass) == 0 && ( security != NSAPI_SECURITY_NONE && security != NSAPI_SECURITY_WPA2_ENT)) ||
             (strlen(pass) > 63 && (security == NSAPI_SECURITY_WPA2 || security == NSAPI_SECURITY_WPA || security == NSAPI_SECURITY_WPA_WPA2))
        ) {
         return NSAPI_ERROR_PARAMETER;

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -127,6 +127,7 @@ typedef enum nsapi_security {
     NSAPI_SECURITY_CHAP         = 0x6,      /*!< phrase conforms to PPP authentication context */
     NSAPI_SECURITY_EAP_TLS      = 0x7,      /*!< phrase conforms to EAP-TLS */
     NSAPI_SECURITY_PEAP         = 0x8,      /*!< phrase conforms to PEAP */
+    NSAPI_SECURITY_WPA2_ENT     = 0x9,      /*!< phrase conforms to WPA2-AES and WPA-TKIP with enterprise security */
     NSAPI_SECURITY_UNKNOWN      = 0xFF,     /*!< unknown/unsupported security in scan results */
 } nsapi_security_t;
 


### PR DESCRIPTION
### Description
This PR provides the capability to Cypress PSoC 6 targets to connect to 802.1x WiFi networks.
   Added NSAPI_SECURITY_WPA2_ENT type to nsapi_security enum.
  * Phrase helps to connect to an 802.1X capable network.
  * Phrase conforms to WPA2-AES and WPA-TKIP with enterprise security.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
Please suggest

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

Add NSAPI_SECURITY_WPA2_ENT type to nsapi_security enum.

- Phrase helps to connect to an 802.1X capable network.
- Phrase conforms to WPA2-AES and WPA-TKIP with enterprise security.