### PR TITLE
Define I²C related pin names for the L-Tek FF_LPC546XX target

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_FF_LPC546XX/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MCU_LPC546XX/TARGET_FF_LPC546XX/PinNames.h
@@ -230,6 +230,13 @@ typedef enum {
     p30 = P0_1,
 
 
+    I2C_SCL2 = P0_27,
+    I2C_SDA2 = P0_26,
+    I2C_SCL7 = P1_30,
+    I2C_SDA7 = P1_29,
+    I2C_SCL  = I2C_SCL2,
+    I2C_SDA  = I2C_SDA2,
+
 
     // Not connected
     NC = (int)0xFFFFFFFF


### PR DESCRIPTION
### Description

Fixes #11115 .

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [*] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
