### PR TITLE
NRF52 need to call TIMER_TASK_SHUTDOWN for current consumption

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/us_ticker.c
@@ -141,6 +141,7 @@ void us_ticker_clear_interrupt(void)
 void us_ticker_free(void)
 {
     nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_STOP);
+    nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_SHUTDOWN);
     nrf_timer_int_disable(NRF_TIMER1, nrf_timer_compare_int_get(NRF_TIMER_CC_CHANNEL0));
     NVIC_DisableIRQ(TIMER1_IRQn);
     us_ticker_initialized = false;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Since current consumption increased when the timer has been running and only the STOP task is used to stop on nRF52x, we need to call SHUTDOWN task after STOP task.

[reference for nRF52840](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrf52%2Fstruct%2Fnrf52840_errata.html
)
[reference for nRF52832](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrf52%2Fstruct%2Fnrf52840_errata.html)

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
