### PR TITLE
Optimize debug profile flags for size

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -5,7 +5,7 @@
                    "-fmessage-length=0", "-fno-exceptions",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG",
+                   "-fomit-frame-pointer", "-Og", "-g3", "-DMBED_DEBUG",
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu11"],

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -30,7 +30,7 @@
                "--any_contingency", "--keep=os_cb_sections"]
     },
     "ARM": {
-        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O0", "-g", "-DMBED_DEBUG",
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
@@ -40,7 +40,7 @@
         "ld": ["--show_full_path", "--any_contingency", "--keep=os_cb_sections"]
     },
     "uARM": {
-        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O0", "-D__MICROLIB", "-g",
                    "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DMBED_DEBUG",

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -53,7 +53,7 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics",  "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082,Pe540", "-On", "-r", "-DMBED_DEBUG",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082,Pe540", "-Ol", "-r", "-DMBED_DEBUG",
             "-DMBED_TRAP_ERRORS_ENABLED=1", "--enable_restrict"],
         "asm": [],
         "c": ["--vla", "--diag_suppress=Pe546"],


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Adjusts the debug profile to use similar size-optimized configurations.

This allows to compile also larger applications with debug profile. Especially on ROM constrained devices, it often is not possible to use the current speed-optimized profiles.

For example: device management client example with Thread stack (K64F + Thread + GCC)

With default GCC profile => does not fit.
With optimized GCC profile => 

16:01:13 Total Static RAM memory (data + bss): 70300(+70300) bytes
16:01:13 Total Flash memory (text + data): 657209(+657209) bytes

With Wisun stack this saves -321 KiB ROM.

This is similar to changes done for develop profile in #10813

Previously Client has been maintaining its own size-optimized compiler profiles as part of its delivery. It would be better for client to drop those, and Mbed OS to adopt more size-optimized profiles. (https://github.com/ARMmbed/mbed-cloud-client-example/tree/master/profiles).

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@TeroJaasko @kjbracey-arm @bulislaw 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

Changed the Debug compiler profile to favor size optimization over speed optimization.