### PR TITLE
Fix MBED_ASSERT for UTs

### DIFF
--- a/UNITTESTS/target_h/platform/mbed_assert.h
+++ b/UNITTESTS/target_h/platform/mbed_assert.h
@@ -39,7 +39,12 @@ extern "C" {
  *  @param file File where assertation failed.
  *  @param line Failing assertation line number.
  */
-MBED_NORETURN void mbed_assert_internal(const char *expr, const char *file, int line);
+// mbed_assert_internal UT stub only prints an assert trace and returns, so therefore
+// MBED_NORETURN must not be defined for UTs.
+#ifndef UNITTEST
+MBED_NORETURN
+#endif
+void mbed_assert_internal(const char *expr, const char *file, int line);
 
 #ifdef __cplusplus
 }
@@ -132,4 +137,3 @@ do {                                                     \
 /**@}*/
 
 /**@}*/
-


### PR DESCRIPTION
### Description

For UTs mbed_assert_internal should not be declared as MBED_NORETURN
as UT stub for mbed_assert_internal only prints out the assert trace
and returns back to original code.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
