### PR TITLE
BLE: fix public address being set incorrectly

### DIFF
--- a/features/FEATURE_BLE/ble/generic/GenericGap.h
+++ b/features/FEATURE_BLE/ble/generic/GenericGap.h
@@ -790,7 +790,6 @@ private:
     pal::GenericAccessService &_gap_service;
     PalSecurityManager &_pal_sm;
     BLEProtocol::AddressType_t _address_type;
-    ble::address_t _address;
     pal::initiator_policy_t _initiator_policy_mode;
     pal::scanning_filter_policy_t _scanning_filter_policy;
     pal::advertising_filter_policy_t _advertising_filter_policy;

--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -477,7 +477,6 @@ ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEve
 {
     switch (type) {
         case LegacyAddressType::PUBLIC:
-            // The public address cannot be set, just set the type to public
             _address_type = type;
             return BLE_ERROR_NONE;
 
@@ -494,7 +493,6 @@ ble_error_t GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEve
             }
 
             _address_type = type;
-            _address = ble::address_t(address);
             _random_static_identity_address = ble::address_t(address);
             return BLE_ERROR_NONE;
         }
@@ -2156,7 +2154,6 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
     }
 
     _address_type = LegacyAddressType::RANDOM_PRIVATE_NON_RESOLVABLE;
-    _address = address;
 }
 
 template <template<class> class PalGapImpl, class PalSecurityManager, class ConnectionEventMonitorEventHandler>

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -144,10 +144,25 @@ void CordioHCIDriver::handle_reset_sequence(uint8_t *pMsg)
                 /* parse and store event parameters */
                 BdaCpy(hciCoreCb.bdAddr, pMsg);
 
+                ble::address_t static_address;
+
+                if (get_random_static_address(static_address)) {
+                    // note: will send the HCI command to send the random address
+                    cordio::BLE::deviceInstance().getGap().setAddress(
+                        BLEProtocol::AddressType::RANDOM_STATIC,
+                        static_address.data()
+                    );
+                } else {
+                    /* send next command in sequence */
+                    HciLeReadBufSizeCmd();
+                }
+                break;
+            }
+
+            case HCI_OPCODE_LE_SET_RAND_ADDR:
                 /* send next command in sequence */
                 HciLeReadBufSizeCmd();
                 break;
-            }
 
             case HCI_OPCODE_LE_READ_BUF_SIZE:
                 /* parse and store event parameters */

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -144,25 +144,17 @@ void CordioHCIDriver::handle_reset_sequence(uint8_t *pMsg)
                 /* parse and store event parameters */
                 BdaCpy(hciCoreCb.bdAddr, pMsg);
 
-                ble::address_t static_address;
+                ble::address_t dummy;
+                /* public address cannot be set so this does not create an HCI command */
+                cordio::BLE::deviceInstance().getGap().setAddress(
+                    BLEProtocol::AddressType::PUBLIC,
+                    dummy
+                );
 
-                if (get_random_static_address(static_address)) {
-                    // note: will send the HCI command to send the random address
-                    cordio::BLE::deviceInstance().getGap().setAddress(
-                        BLEProtocol::AddressType::RANDOM_STATIC,
-                        static_address.data()
-                    );
-                } else {
-                    /* send next command in sequence */
-                    HciLeReadBufSizeCmd();
-                }
-                break;
-            }
-
-            case HCI_OPCODE_LE_SET_RAND_ADDR:
                 /* send next command in sequence */
                 HciLeReadBufSizeCmd();
                 break;
+            }
 
             case HCI_OPCODE_LE_READ_BUF_SIZE:
                 /* parse and store event parameters */

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.cpp
@@ -144,13 +144,6 @@ void CordioHCIDriver::handle_reset_sequence(uint8_t *pMsg)
                 /* parse and store event parameters */
                 BdaCpy(hciCoreCb.bdAddr, pMsg);
 
-                ble::address_t dummy;
-                /* public address cannot be set so this does not create an HCI command */
-                cordio::BLE::deviceInstance().getGap().setAddress(
-                    BLEProtocol::AddressType::PUBLIC,
-                    dummy
-                );
-
                 /* send next command in sequence */
                 HciLeReadBufSizeCmd();
                 break;

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -361,16 +361,15 @@ void NRFCordioHCIDriver::start_reset_sequence()
 
 bool NRFCordioHCIDriver::get_random_static_address(ble::address_t& address)
 {
-    /* address cannot have all bits set to 1 */
-    bool no_binary_zeros = true;
-    while (no_binary_zeros) {
-        for (uint8_t i = 0; i < 6; i++) {
-            if (LlGetRandNum(&address[i]) != LL_SUCCESS) return false;
-            /* Make static address (Vol C, Part 3, section 10.8.1) */
-            if (i == 5) address[5] |= 0xC0;
-            if (address[i] != 0xff) no_binary_zeros = false;
-        }
-    }
+    address[0] = (uint8_t)(NRF_FICR->DEVICEADDR[0] >> 0);
+    address[1] = (uint8_t)(NRF_FICR->DEVICEADDR[0] >> 8);
+    address[2] = (uint8_t)(NRF_FICR->DEVICEADDR[0] >> 16);
+    address[3] = (uint8_t)(NRF_FICR->DEVICEADDR[0] >> 24);
+    address[4] = (uint8_t)(NRF_FICR->DEVICEADDR[1] >> 0);
+    address[5] = (uint8_t)(NRF_FICR->DEVICEADDR[1] >> 8);
+
+    /* Make static address (Vol C, Part 3, section 10.8.1) */
+    address[5] |= 0xC0;
 
     return true;
 }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/NRFCordioHCIDriver.cpp
@@ -361,9 +361,16 @@ void NRFCordioHCIDriver::start_reset_sequence()
 
 bool NRFCordioHCIDriver::get_random_static_address(ble::address_t& address)
 {
-    PalCfgLoadData(PAL_CFG_ID_BD_ADDR, address.data(), sizeof(bdAddr_t));
-
-    MBED_ASSERT((address[5] & 0xC0) == 0xC0);
+    /* address cannot have all bits set to 1 */
+    bool no_binary_zeros = true;
+    while (no_binary_zeros) {
+        for (uint8_t i = 0; i < 6; i++) {
+            if (LlGetRandNum(&address[i]) != LL_SUCCESS) return false;
+            /* Make static address (Vol C, Part 3, section 10.8.1) */
+            if (i == 5) address[5] |= 0xC0;
+            if (address[i] != 0xff) no_binary_zeros = false;
+        }
+    }
 
     return true;
 }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/stack/sources/pal_cfg.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/stack/sources/pal_cfg.c
@@ -177,8 +177,8 @@ void palCfgLoadBdAddress(uint8_t *pDevAddr)
   unsigned int devAddrLen = 6;
 
   /* Load address from nRF configuration. */
-  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEADDR[0]) <<  0) |
-                     (((uint64_t)NRF_FICR->DEVICEADDR[1]) << 32);
+  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEID[0]) <<  0) |
+                     (((uint64_t)NRF_FICR->DEVICEID[1]) << 32);
 
   unsigned int i = 0;
   while (i < devAddrLen)
@@ -202,8 +202,8 @@ void palCfgLoadExtMac154Address(uint8_t *pDevAddr)
   unsigned int devAddrLen = 8;
 
   /* Load address from nRF configuration. */
-  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEADDR[0]) <<  0) |
-                     (((uint64_t)NRF_FICR->DEVICEADDR[1]) << 32);
+  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEID[0]) <<  0) |
+                     (((uint64_t)NRF_FICR->DEVICEID[1]) << 32);
 
   unsigned int i = 0;
   while (i < devAddrLen)

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/stack/sources/pal_cfg.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NORDIC_CORDIO/TARGET_NRF5x/stack/sources/pal_cfg.c
@@ -177,8 +177,8 @@ void palCfgLoadBdAddress(uint8_t *pDevAddr)
   unsigned int devAddrLen = 6;
 
   /* Load address from nRF configuration. */
-  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEID[0]) <<  0) |
-                     (((uint64_t)NRF_FICR->DEVICEID[1]) << 32);
+  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEADDR[0]) <<  0) |
+                     (((uint64_t)NRF_FICR->DEVICEADDR[1]) << 32);
 
   unsigned int i = 0;
   while (i < devAddrLen)
@@ -186,8 +186,6 @@ void palCfgLoadBdAddress(uint8_t *pDevAddr)
     pDevAddr[i] = devAddr >> (i * 8);
     i++;
   }
-
-  pDevAddr[5] |= 0xC0;     /* cf. "Static Address" (Vol C, Part 3, section 10.8.1) */
 }
 
 /*************************************************************************************************/
@@ -204,8 +202,8 @@ void palCfgLoadExtMac154Address(uint8_t *pDevAddr)
   unsigned int devAddrLen = 8;
 
   /* Load address from nRF configuration. */
-  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEID[0]) <<  0) |
-                     (((uint64_t)NRF_FICR->DEVICEID[1]) << 32);
+  uint64_t devAddr = (((uint64_t)NRF_FICR->DEVICEADDR[0]) <<  0) |
+                     (((uint64_t)NRF_FICR->DEVICEADDR[1]) << 32);
 
   unsigned int i = 0;
   while (i < devAddrLen)


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Two problems: init was using the wrong register for the source of the public address (although both are valid sources) and then was setting a random static as the public address.

The current behaviour is to set to correctly set the public address but still keep the default address the old static.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@pan- 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

The default BT address set on boot will change. The user is still able to set his own the same way as previously. The address will revert to what it was in 5.12.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
