### PR TITLE
USBDevice: Avoid forcing end device to be derived from USBDevice class

### DIFF
--- a/drivers/USBKeyboard.h
+++ b/drivers/USBKeyboard.h
@@ -19,7 +19,7 @@
 #define USBKEYBOARD_H
 
 #include "USBHID.h"
-#include "Stream.h"
+#include "platform/Stream.h"
 #include "PlatformMutex.h"
 
 /* Modifiers, left keys then right keys. */

--- a/drivers/USBMouseKeyboard.h
+++ b/drivers/USBMouseKeyboard.h
@@ -24,7 +24,7 @@
 
 #include "USBMouse.h"
 #include "USBKeyboard.h"
-#include "Stream.h"
+#include "platform/Stream.h"
 #include "USBHID.h"
 #include "PlatformMutex.h"
 

--- a/drivers/USBSerial.h
+++ b/drivers/USBSerial.h
@@ -19,7 +19,7 @@
 #define USBSERIAL_H
 
 #include "USBCDC.h"
-#include "Stream.h"
+#include "platform/Stream.h"
 #include "Callback.h"
 
 /**

--- a/drivers/internal/USBDevice.h
+++ b/drivers/internal/USBDevice.h
@@ -22,6 +22,7 @@
 #include "USBDevice_Types.h"
 #include "USBPhy.h"
 #include "mbed_critical.h"
+#include "Callback.h"
 
 /**
  * \defgroup drivers_USBDevice USBDevice class
@@ -139,7 +140,7 @@ public:
     * @param callback Method pointer to be called when a packet is transferred
     * @returns true if successful, false otherwise
     */
-    bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type, ep_cb_t callback = NULL);
+    bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type, mbed::Callback<void()> callback = NULL);
 
     /**
     * Add an endpoint
@@ -153,7 +154,7 @@ public:
     template<typename T>
     bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type, void (T::*callback)())
     {
-        return endpoint_add(endpoint, max_packet, type, static_cast<ep_cb_t>(callback));
+        return endpoint_add(endpoint, max_packet, type, mbed::callback(this, static_cast<ep_cb_t>(callback)));
     }
 
     /**
@@ -540,7 +541,7 @@ private:
     void _complete_set_interface();
 
     struct endpoint_info_t {
-        ep_cb_t callback;
+        mbed::Callback<void()> callback;
         uint16_t max_packet_size;
         uint16_t transfer_size;
         uint8_t flags;

--- a/drivers/source/usb/USBDevice.cpp
+++ b/drivers/source/usb/USBDevice.cpp
@@ -937,7 +937,7 @@ void USBDevice::out(usb_ep_t endpoint)
     MBED_ASSERT(info->pending >= 1);
     info->pending -= 1;
     if (info->callback) {
-        (this->*(info->callback))();
+        info->callback();
     }
 }
 
@@ -955,7 +955,7 @@ void USBDevice::in(usb_ep_t endpoint)
     MBED_ASSERT(info->pending >= 1);
     info->pending -= 1;
     if (info->callback) {
-        (this->*(info->callback))();
+        info->callback();
     }
 }
 
@@ -1051,7 +1051,7 @@ void USBDevice::sof_disable()
     unlock();
 }
 
-bool USBDevice::endpoint_add(usb_ep_t endpoint, uint32_t max_packet_size, usb_ep_type_t type, ep_cb_t callback)
+bool USBDevice::endpoint_add(usb_ep_t endpoint, uint32_t max_packet_size, usb_ep_type_t type, mbed::Callback<void()> callback)
 {
     lock();
 


### PR DESCRIPTION
### Description

By replacing the existing callbacks with proper `mbed::callback` we can use the USBDevice infrastructure without deriving directly from USBDevice.

The patch could bring a (tiny, big ?) performance hit due to the indirection, but would make the USBDevice class usable as a singleton.

A usage example can be found here https://github.com/arduino/ArduinoCore-nRF528x-mbedos/tree/master/cores/arduino/USB and https://github.com/bcmi-labs/ArduinoCore-nRF528x-mbedos/tree/master/libraries/USBHID

PluggableUSBDevice implements USBDevice and calls phy init() just once; all device drivers (derived from mbed ones) plug on it to create a composite device but they don't derive from USBDevice.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes


<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
