### PR TITLE
Add Arduino Nano 33 BLE target

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_ARDUINO_NANO33BLE/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_ARDUINO_NANO33BLE/PinNames.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2019 Arduino SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+#include "nrf_gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+///> define macro producing for example Px_y = NRF_GPIO_PIN_MAP(x, y)
+#define PinDef(port_num, pin_num) P##port_num##_##pin_num = NRF_GPIO_PIN_MAP(port_num, pin_num)
+
+
+typedef enum {
+    PinDef(0 , 0), // P0_0 = 0...
+    PinDef(0 , 1),
+    PinDef(0 , 2),
+    PinDef(0 , 3),
+    PinDef(0 , 4),
+    PinDef(0 , 5),
+    PinDef(0 , 6),
+    PinDef(0 , 7),
+    PinDef(0 , 8),
+    PinDef(0 , 9),
+    PinDef(0 , 10),
+    PinDef(0 , 11),
+    PinDef(0 , 12),
+    PinDef(0 , 13),
+    PinDef(0 , 14),
+    PinDef(0 , 15),
+    PinDef(0 , 16),
+    PinDef(0 , 17),
+    PinDef(0 , 18),
+    PinDef(0 , 19),
+    PinDef(0 , 20),
+    PinDef(0 , 21),
+    PinDef(0 , 22),
+    PinDef(0 , 23),
+    PinDef(0 , 24),
+    PinDef(0 , 25),
+    PinDef(0 , 26),
+    PinDef(0 , 27),
+    PinDef(0 , 28),
+    PinDef(0 , 29),
+    PinDef(0 , 30),
+    PinDef(0 , 31),
+
+    PinDef(1 , 0), //P1_1 = 32...
+    PinDef(1 , 1),
+    PinDef(1 , 2),
+    PinDef(1 , 3),
+    PinDef(1 , 4),
+    PinDef(1 , 5),
+    PinDef(1 , 6),
+    PinDef(1 , 7),
+    PinDef(1 , 8),
+    PinDef(1 , 9),
+    PinDef(1 , 10),
+    PinDef(1 , 11),
+    PinDef(1 , 12),
+    PinDef(1 , 13),
+    PinDef(1 , 14),
+    PinDef(1 , 15),
+
+    // Port0
+    p0  = P0_0,
+    p1  = P0_1,
+    p2  = P0_2,
+    p3  = P0_3,
+    p4  = P0_4,
+    p5  = P0_5,
+    p6  = P0_6,
+    p7  = P0_7,
+    p8  = P0_8,
+    p9  = P0_9,
+    p10 = P0_10,
+    p11 = P0_11,
+    p12 = P0_12,
+    p13 = P0_13,
+    p14 = P0_14,
+    p15 = P0_15,
+    p16 = P0_16,
+    p17 = P0_17,
+    p18 = P0_18,
+    p19 = P0_19,
+    p20 = P0_20,
+    p21 = P0_21,
+    p22 = P0_22,
+    p23 = P0_23,
+    p24 = P0_24,
+    p25 = P0_25,
+    p26 = P0_26,
+    p27 = P0_27,
+    p28 = P0_28,
+    p29 = P0_29,
+    p30 = P0_30,
+    p31 = P0_31,
+    
+    // Port1
+    p32 = P1_0,
+    p33 = P1_1,
+    p34 = P1_2,
+    p35 = P1_3,
+    p36 = P1_4,
+    p37 = P1_5,
+    p38 = P1_6,
+    p39 = P1_7,
+    p40 = P1_8,
+    p41 = P1_9,
+    p42 = P1_10,
+    p43 = P1_11,
+    p44 = P1_12,
+    p45 = P1_13,
+    p46 = P1_14,
+    p47 = P1_15,
+
+    RX_PIN_NUMBER  = p42,
+    TX_PIN_NUMBER  = p35,
+
+    LED1 = p13,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+    STDIO_UART_TX = TX_PIN_NUMBER,
+    STDIO_UART_RX = RX_PIN_NUMBER,
+
+    SPI_PSELMOSI0 = P1_1,
+    SPI_PSELMISO0 = P1_8,
+    SPI_PSELSCK0  = P0_13,
+
+    SPIS_PSELMOSI = P1_1,
+    SPIS_PSELMISO = P1_8,
+    SPIS_PSELSCK  = P0_13,
+
+    I2C_SDA0 = p26,
+    I2C_SCL0 = p27,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    STDIO_UART_RTS = NC,
+    STDIO_UART_CTS = NC,
+    SPI_PSELSS0   = NC,
+    SPIS_PSELSS   = NC,
+
+    LED2 = NC,
+    LED3 = NC,
+    LED4 = NC,
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_ARDUINO_NANO33BLE/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_ARDUINO_NANO33BLE/device.h
@@ -1,0 +1,38 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include "objects.h"
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/mbed_lib.json
@@ -200,6 +200,12 @@
                 "NRF52_ERRATA_20"
             ]
         },
+        "ARDUINO_NANO33BLE": {
+            "target.macros_add": [
+                "CONFIG_GPIO_AS_PINRESET",
+                "NRF52_ERRATA_20"
+            ]
+        },
         "MTB_LAIRD_BL654": {
             "target.macros_add": [
                 "CONFIG_GPIO_AS_PINRESET",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7350,6 +7350,16 @@
         "release_versions": ["5"],
         "device_name": "nRF52840_xxAA"
     },
+    "ARDUINO_NANO33BLE": {
+        "inherits": ["MCU_NRF52840"],
+        "release_versions": ["5"],
+        "device_name": "nRF52840_xxAA",
+        "features_add": ["BLE", "STORAGE"],
+        "components_remove": ["QSPIF"],
+        "components_add": ["FLASHIAP"],
+        "device_has_remove": ["QSPI"],
+        "device_has_add": ["FLASH"]
+    },
     "MTB_LAIRD_BL654": {
         "inherits": ["MCU_NRF52840"],
         "release_versions": ["5"],


### PR DESCRIPTION
### Description

Request to add Arduino Nano 33 BLE as an mbed target (under nRF52840 family)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
