### PR TITLE
fix rom start & size for CY8CKIT_062_WIFI_BT & CY8CPROTO_062_4343W

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8455,8 +8455,8 @@
             "function": "PSOC6Code.complete"
         },
         "bootloader_supported": true,
-        "mbed_rom_start": "0x10002000",
-        "mbed_rom_size": "0xFE000",
+        "mbed_rom_start": "0x10000000",
+        "mbed_rom_size": "0x100000",
         "sectors": [[268435456, 512]],                            
         "overrides": {
             "network-default-interface-type": "WIFI"
@@ -8470,8 +8470,8 @@
             "function": "PSOC6Code.complete"
         },
         "bootloader_supported": true,
-        "mbed_rom_start": "0x10002000",
-        "mbed_rom_size": "0x1FE000",
+        "mbed_rom_start": "0x10000000",
+        "mbed_rom_size": "0x200000",
         "sectors": [[268435456, 512]]                    
     },
     "CY8CKIT_062S2_43012": {


### PR DESCRIPTION
### Description

This fixes a mistake that was merged to master in https://github.com/ARMmbed/mbed-os/pull/11053

This corrects the flash base address and size, and makes it compatible with the new method that was introduced in 5.13.1 for merging the Cortex M4 and Cortex M0+ images.  Essentially, instead of setting the rom start to be the start of the M4 area, it will now be set to the start of the M0+ area which precedes the M4.   The linker file handles adding the M0+ area instead of post-build scripts. 

This does not fix bootloader support.  That will be introduced in a future PR.  

This has been tested with CY8CKIT_062_WIFI_BT & CY8CPROTO_062_4343W, using GCC_ARM, and mbed-os-example-blinky.  The application starts up fine on each board after this change.

Please merge urgently as this fixes master for these targets and unblocks other PRs.

cc @ARMmbed/team-cypress 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


### Release Notes

