### PR TITLE
STM32F413 Crash Capture

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -208,6 +208,10 @@
         "DISCO_F407VG": {
             "crash-capture-enabled": true,
             "fatal-error-auto-reboot-enabled": true
+        },
+        "DISCO_F413ZH": {
+            "crash-capture-enabled": true,
+            "fatal-error-auto-reboot-enabled": true
         }
     }
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_MICRO/stm32f413xh.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_MICRO/stm32f413xh.sct
@@ -54,7 +54,12 @@
 ; Total: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM
 #define VECTOR_SIZE                 0x1D8
 
-#define RAM_FIXED_SIZE              (MBED_BOOT_STACK_SIZE+VECTOR_SIZE)
+#define MBED_CRASH_REPORT_RAM_SIZE  0x100
+
+#define MBED_IRAM1_START            (MBED_RAM_START + VECTOR_SIZE + MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_IRAM1_SIZE             (MBED_RAM_SIZE - VECTOR_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
+
+#define RAM_FIXED_SIZE              (MBED_BOOT_STACK_SIZE+VECTOR_SIZE+MBED_CRASH_REPORT_RAM_SIZE)
 
 LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {    ; load region size_region
 
@@ -64,7 +69,11 @@ LR_IROM1  MBED_APP_START  MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  RW_IRAM1  (MBED_RAM_START+VECTOR_SIZE)  (MBED_RAM_SIZE-VECTOR_SIZE)  {  ; RW data
+  RW_m_crash_data  (MBED_RAM_START+VECTOR_SIZE)  EMPTY  MBED_CRASH_REPORT_RAM_SIZE { ; RW data
+  }
+
+
+  RW_IRAM1  MBED_IRAM1_START  MBED_IRAM1_SIZE  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_STD/stm32f413xh.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_STD/stm32f413xh.sct
@@ -43,6 +43,17 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
+#define MBED_RAM_START              0x20000000
+; 320KB SRAM (0x50000)
+#define MBED_RAM_SIZE               0x50000
+#define MBED_VECTTABLE_RAM_START    (MBED_RAM_START)
+; Total: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM
+#define MBED_VECTTABLE_RAM_SIZE     0x1D8
+#define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
+#define MBED_CRASH_REPORT_RAM_SIZE  0x100
+#define MBED_RAM0_START             (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_RAM0_SIZE              (MBED_RAM_SIZE - MBED_VECTTABLE_RAM_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
+
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
   ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
@@ -51,13 +62,14 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 320KB SRAM (0x50000)
-  ; Total: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1D8) (0x50000-0x1D8-Stack_Size)  {  ; RW data
+  RW_m_crash_data MBED_CRASH_REPORT_RAM_START EMPTY MBED_CRASH_REPORT_RAM_SIZE { ; RW data
+  }
+
+  RW_IRAM1 (MBED_RAM0_START) (MBED_RAM0_SIZE-Stack_Size)  {  ; RW data
    .ANY (+RW +ZI)
   }
 
-  ARM_LIB_STACK (0x20000000+0x50000) EMPTY -Stack_Size { ; stack
+  ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_GCC_ARM/STM32F413xH.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_GCC_ARM/STM32F413xH.ld
@@ -12,6 +12,8 @@
 
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
+M_CRASH_DATA_RAM_SIZE = 0x100;
+
 /* Linker script to configure memory regions. */
 MEMORY
 { 
@@ -90,6 +92,18 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
+
+    .crash_data_ram :
+    {
+        . = ALIGN(8);
+        __CRASH_DATA_RAM__ = .;
+        __CRASH_DATA_RAM_START__ = .; /* Create a global symbol at data start */
+        KEEP(*(.keep.crash_data_ram))
+        *(.m_crash_data_ram)     /* This is a user defined section */
+        . += M_CRASH_DATA_RAM_SIZE;
+        . = ALIGN(8);
+        __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+    } > RAM
 
     .data : AT (__etext)
     {

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_IAR/stm32f413xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_IAR/stm32f413xx.icf
@@ -9,13 +9,20 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 /* [RAM = 320kb = 0x50000] Vector table dynamic copy: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
 define symbol __NVIC_end__            = 0x200001D7;
-define symbol __region_RAM_start__    = 0x200001D8; /* Aligned on 8 bytes */
+define symbol __region_CRASH_DATA_RAM_start__  = 0x200001D8;
+define symbol __region_CRASH_DATA_RAM_end__    = 0x200002D7;
+define symbol __region_RAM_start__    = 0x200002D8; /* Aligned on 8 bytes */
 define symbol __region_RAM_end__      = 0x2004FFFF;
 
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
+define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
+
+/* Define Crash Data Symbols */
+define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
+define exported symbol __CRASH_DATA_RAM_END__ = __region_CRASH_DATA_RAM_end__;
 
 /* Stack and Heap */
 if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {


### PR DESCRIPTION
### Description

This pull request adds crash capture support to STM32F413 targets.

```
[mbed] Working path "/fakepath/mbed-os-example-crash-reporting" (program)
[mbed] Detecting connected targets/boards to your system...
[mbed] Opening serial terminal to "DISCO_F413ZH"
--- Terminal on /dev/tty.usbmodem141103 - 9600,8,N,1 ---


Mbed-OS crash reporting test: main()

Forcing exception

++ MbedOS Fault Handler ++

FaultType: HardFault

Context:
R0   : 0800CE14
R1   : 0000000A
R2   : E000ED00
R3   : 0000AAA3
R4   : 00000000
R5   : 00000000
R6   : 00000000
R7   : 00000000
R8   : 00000000
R9   : 00000000
R10  : 00000000
R11  : 00000000
R12  : FFFFFFFF
SP   : 20002950
LR   : 080002ED
PC   : 080002C4
xPSR : 010F0000
PSP  : 20002930
MSP  : 2004FFC0
CPUID: 410FC241
HFSR : 40000000
MMFSR: 00000000
BFSR : 00000000
UFSR : 00000100
DFSR : 00000008
AFSR : 00000000
Mode : Thread
Priv : Privileged
Stack: PSP

-- MbedOS Fault Handler --



++ MbedOS Error Info ++
Error Status: 0x80FF013D Code: 317 Module: 255
Error Message: Fault exception
Location: 0x8001013
Error Value: 0x80002C4
Current Thread: main  Id: 0x20001120 Entry: 0x8001EB3 StackSize: 0x1000 StackMem: 0x20001960 SP: 0x2004FF58 
For more info, visit: https://mbed.com/s/error?error=0x80FF013D&tgt=DISCO_F413ZH
-- MbedOS Error Info --

= System will be rebooted due to a fatal error =
= Reboot count(=1) reached maximum, system will halt after rebooting =
mbed_error_reboot_callback: System rebooting, reboot error callback received

Mbed-OS crash reporting test: main()

Successfully read reboot info ==> 

  error status: 0x80FF013D
  error value: 0x080002C4
  error address: 0x08001013
  error reboot count: 0x00000001
  error crc: 0x77CB5C03

Crash Report data captured:
[0]: 0x0800CE14
[1]: 0x0000000A
[2]: 0xE000ED00
[3]: 0x0000AAA3
[4]: 0x00000000
[5]: 0x00000000
[6]: 0x00000000
[7]: 0x00000000
[8]: 0x00000000
[9]: 0x00000000
[10]: 0x00000000
[11]: 0x00000000
[12]: 0xFFFFFFFF
[13]: 0x20002950
[14]: 0x080002ED
[15]: 0x080002C4

Mbed-OS crash reporting test completed
```


<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->