### PR TITLE
freescale: fix i2c_byte_read function

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
@@ -192,10 +192,8 @@ int i2c_byte_read(i2c_t *obj, int last)
         base->C1 |= I2C_C1_TXAK_MASK; // NACK
     }
 
-    data = (base->D & 0xFF);
-
-    /* Change direction to Tx to avoid extra clocks. */
-    base->C1 |= I2C_C1_TX_MASK;
+    /* Read dummy to release the bus. */
+    data = base->D;
 
     /* Wait until data transfer complete. */
     while (!(base->S & kI2C_IntPendingFlag))
@@ -204,6 +202,11 @@ int i2c_byte_read(i2c_t *obj, int last)
 
     /* Clear the IICIF flag. */
     base->S = kI2C_IntPendingFlag;
+
+    /* Change direction to Tx to avoid extra clocks. */
+    base->C1 |= I2C_C1_TX_MASK;
+
+    data = (base->D & 0xFF);
 
     return data;
 }


### PR DESCRIPTION
### Description

Fix `i2c_byte_read` implementation for Freescale Xpresso targets
`single byte read` test  gets stuck in `i2c_byte_read` while reading first byte

```
before:
| target       | platform_name | test suite                             | result  | elapsed_time (sec) | copy_method |
|--------------|---------------|----------------------------------------|---------|--------------------|-------------|
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | TIMEOUT | 33.65              | default     |
mbedgt: test suite results: 1 TIMEOUT
mbedgt: test case report:
| target       | platform_name | test suite                             | test case                            | passed | failed | result | elapsed_time (sec) |
|--------------|---------------|----------------------------------------|--------------------------------------|--------|--------|--------|--------------------|
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - init/free test all pins        | 1      | 0      | OK     | 0.75               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test read i2c API              | 1      | 0      | OK     | 0.45               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test single byte read i2c API  | 0      | 0      | ERROR  | 0.0                |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test single byte write i2c API | 1      | 0      | OK     | 0.47               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test write i2c API             | 1      | 0      | OK     | 0.47               |

after:
| target       | platform_name | test suite                             | test case                            | passed | failed | result | elapsed_time (sec) |
|--------------|---------------|----------------------------------------|--------------------------------------|--------|--------|--------|--------------------|
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - init/free test all pins        | 1      | 0      | OK     | 0.75               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test read i2c API              | 1      | 0      | OK     | 0.45               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test single byte read i2c API  | 1      | 0      | OK     | 0.47               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test single byte write i2c API | 1      | 0      | OK     | 0.47               |
| K64F-GCC_ARM | K64F          | tests-mbed_hal_fpga_ci_test_shield-i2c | i2c - test write i2c API             | 1      | 0      | OK     | 0.47
```

![obraz](https://user-images.githubusercontent.com/17130713/62272438-5b56dc00-b43b-11e9-9ac1-3d5f37248bf1.png)


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/mbed-os-hal 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
