### PR TITLE
__cplusplus guard fixed pwmout_device.h for STM32F4

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+    
 #endif


### PR DESCRIPTION
### Description

This bug prevented using this header in cpp code directly.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

