### PR TITLE
Fix PSoC 6 inout pins

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_gpio_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_gpio_api.c
@@ -60,9 +60,16 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     }
 }
 
-void gpio_dir(MBED_UNUSED gpio_t *obj, MBED_UNUSED PinDirection direction)
+void gpio_dir(gpio_t *obj, PinDirection direction)
 {
-    // mbed reads from input buffer instead of DR even for output pins so always leave input buffer enabled
+    if (direction == PIN_INPUT) {
+        cyhal_gpio_direction(obj->pin, CYHAL_GPIO_DIR_INPUT);
+        gpio_mode(obj, CYHAL_GPIO_DRIVE_ANALOG);
+    } else if (direction == PIN_OUTPUT) {
+        // mbed reads from input buffer instead of DR even for output pins so always leave input buffer enabled
+        cyhal_gpio_direction(obj->pin, CYHAL_GPIO_DIR_BIDIRECTIONAL);
+        gpio_mode(obj, CYHAL_GPIO_DRIVE_STRONG);
+    }
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description

Update the drive mode when setting the GPIO direction so that inout pins function correctly.
Greentea test report: [GTEA_KIT_062S2_43012__GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3459195/GTEA_KIT_062S2_43012__GCC_ARM.txt)

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress

### Release Notes
