### PR TITLE
Cellular API shutdown to stop state machine

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -984,14 +984,14 @@ void AT_CellularContext::cellular_callback(nsapi_event_t ev, intptr_t ptr)
             } else if (ev == NSAPI_EVENT_CONNECTION_STATUS_CHANGE && ptr == NSAPI_STATUS_DISCONNECTED) {
                 tr_info("cellular_callback: PPP mode and NSAPI_STATUS_DISCONNECTED");
                 _cb_data.error = NSAPI_ERROR_NO_CONNECTION;
+                _is_connected = false;
             }
         }
 #else
-#if MBED_CONF_MBED_TRACE_ENABLE
         if (ev == NSAPI_EVENT_CONNECTION_STATUS_CHANGE && ptr == NSAPI_STATUS_DISCONNECTED) {
             tr_info("cb: CellularContext disconnected");
+            _is_connected = false;
         }
-#endif // MBED_CONF_MBED_TRACE_ENABLE
 #endif // NSAPI_PPP_AVAILABLE
         // forward status change events to application, call_network_cb will make sure that only changed event are forwarded
         call_network_cb((nsapi_connection_status_t)ptr);

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -437,9 +437,6 @@ nsapi_error_t AT_CellularDevice::init()
 
 nsapi_error_t AT_CellularDevice::shutdown()
 {
-    if (_state_machine) {
-        _state_machine->reset();
-    }
     CellularDevice::shutdown();
 
     return _at->at_cmd_discard("+CFUN", "=0");

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -229,6 +229,9 @@ void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularC
 
 nsapi_error_t CellularDevice::shutdown()
 {
+    if (_state_machine) {
+        _state_machine->stop();
+    }
     CellularContext *curr = get_context_list();
     while (curr) {
         curr->cellular_callback(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);


### PR DESCRIPTION
### Description

Fixed `CellularDevice::shutdown()` to stop cellular state machine and DISCONNECTED event handling in `AT_CellularContext`.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@mirelachirica 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
