### PR TITLE
 Relax us ticker frequency requirement + test update

### DIFF
--- a/TESTS/mbed_hal/us_ticker/main.cpp
+++ b/TESTS/mbed_hal/us_ticker/main.cpp
@@ -32,7 +32,17 @@ void us_ticker_info_test()
     const ticker_info_t *p_ticker_info = us_ticker_get_info();
 
     TEST_ASSERT(p_ticker_info->frequency >= 250000);
-    TEST_ASSERT(p_ticker_info->frequency <= 8000000);
+
+    switch (p_ticker_info->bits) {
+        case 32:
+            TEST_ASSERT(p_ticker_info->frequency <= 100000000);
+            break;
+
+        default:
+            TEST_ASSERT(p_ticker_info->frequency <= 8000000);
+            break;
+    }
+
     TEST_ASSERT(p_ticker_info->bits >= 16);
 
 #ifdef US_TICKER_PERIOD_NUM

--- a/TESTS/mbed_hal/us_ticker/us_ticker_api_tests.h
+++ b/TESTS/mbed_hal/us_ticker/us_ticker_api_tests.h
@@ -31,7 +31,10 @@ extern "C" {
  *
  * Given ticker is available.
  * When ticker information data is obtained.
- * Then ticker information indicate that frequency between 250KHz and 8MHz and the counter is at least 16 bits wide.
+ * Then ticker information indicate that:
+ * - counter frequency is between 250KHz and 8MHz for counters which are less than 32 bits wide
+ * - counter frequency is up to 100MHz for counters which are 32 bits wide
+ * - the counter is at least 16 bits wide.
  */
 void us_ticker_info_test(void);
 

--- a/hal/us_ticker_api.h
+++ b/hal/us_ticker_api.h
@@ -32,7 +32,8 @@ extern "C" {
  * Low level interface to the microsecond ticker of a target
  *
  * # Defined behavior
- * * Has a reported frequency between 250KHz and 8MHz - Verified by test ::us_ticker_info_test
+ * * Has a reported frequency between 250KHz and 8MHz for counters which are less than 32 bits wide - Verified by test ::us_ticker_info_test
+ * * Has a reported frequency up to 100MHz for counters which are 32 bits wide - Verified by test ::us_ticker_info_test
  * * Has a counter that is at least 16 bits wide - Verified by test ::us_ticker_info_test
  * * All behavior defined by the @ref hal_ticker_shared "ticker specification"
  *


### PR DESCRIPTION
### Description

This change is required by the Samsung S111(S5JS100). On this board timer clock used for us ticker operates at 26MHz.
According to current requirements, 8 MHz is the top limit for us ticker timer.

This change relaxes top limit to 100 MHz, but only for 32-bit timers.

Ticker common layer schedules one interrupt per timer rollover to trace elapsed time. We need to ensure that this operation is not performed too frequently. I.e. in case of 16-bit timer at 32 MHz, the timer rollover will happen after ~2 ms. This may cause that there will be no time for other tasks. That is why we increase the top limit, but only for 32-bit timers.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@bulislaw @jamesbeyond @fkjagodzinski @maciejbocianski 


