### PR TITLE
Cellular: Provide API to restart cellular device

### DIFF
--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -134,6 +134,11 @@ void AT_CellularDevice::delete_context(CellularContext *context)
 {
 }
 
+nsapi_error_t AT_CellularDevice::restart()
+{
+    return NSAPI_ERROR_OK;
+}
+
 AT_CellularNetwork *AT_CellularDevice::open_network_impl(ATHandler &at)
 {
     _network = new AT_CellularNetwork(at);

--- a/UNITTESTS/target_h/myCellularDevice.h
+++ b/UNITTESTS/target_h/myCellularDevice.h
@@ -125,6 +125,11 @@ public:
         return NSAPI_ERROR_OK;
     }
 
+    virtual nsapi_error_t restart()
+    {
+        return NSAPI_ERROR_OK;
+    }
+
     virtual nsapi_error_t shutdown()
     {
         return NSAPI_ERROR_OK;

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -207,6 +207,11 @@ public:
      */
     virtual void delete_context(CellularContext *context) = 0;
 
+    /** Restart the cellular device and its state machine and tries to reconnect.
+     *
+     */
+    virtual nsapi_error_t restart() = 0;
+
     /** Stop the current operation. Operations: set_device_ready, set_sim_ready, register_to_network, attach_to_network
      *
      */

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -318,6 +318,25 @@ void AT_CellularDevice::delete_context(CellularContext *context)
     release_at_handler(at);
 }
 
+nsapi_error_t AT_CellularDevice::restart()
+{
+    tr_debug("Restart cellular device and try to reconnect");
+
+    shutdown();
+    soft_power_off();
+    hard_power_off();
+
+    AT_CellularContext *curr = _context_list;
+    while (curr) {
+        nsapi_error_t error = curr->connect();
+        if (error != NSAPI_ERROR_OK) {
+            return error;
+        }
+        curr = (AT_CellularContext *)curr->_next;
+    }
+    return NSAPI_ERROR_OK;
+}
+
 CellularNetwork *AT_CellularDevice::open_network(FileHandle *fh)
 {
     if (!_network) {

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -59,6 +59,8 @@ public:
 
     virtual void delete_context(CellularContext *context);
 
+    virtual nsapi_error_t restart();
+
     virtual CellularNetwork *open_network(FileHandle *fh = NULL);
 
     virtual CellularSMS *open_sms(FileHandle *fh = NULL);


### PR DESCRIPTION
This API will restart the cellular device and its state machine and will try to reconnect again.
It can be used from error recovery which an error happened in the cellular device
This pull request depends on PR #11154 and should be merged after it.
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@AriParkkila 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
