### PR TITLE
Allows placing KVStore and update images on separate storage devices - to internal and external flash

### DIFF
--- a/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
+++ b/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
@@ -53,11 +53,12 @@ static inline uint32_t align_down(uint64_t val, uint64_t size)
 int  get_virtual_TDBStore_position(uint32_t conf_start_address, uint32_t conf_size, bool is_conf_tdb_internal,
                                    uint32_t *tdb_start_address, uint32_t *tdb_end_address)
 {
-    uint32_t bd_final_size = conf_size;;
+    uint32_t bd_final_size = conf_size;
     uint32_t flash_end_address;
     uint32_t flash_start_address;
     uint32_t aligned_start_address;
     FlashIAP flash;
+    static const int STORE_SECTORS = 2;
 
     int ret = flash.init();
     if (ret != 0) {
@@ -92,34 +93,19 @@ int  get_virtual_TDBStore_position(uint32_t conf_start_address, uint32_t conf_si
             }
         }
     } else {
-        if (is_conf_tdb_internal == true) {
-            aligned_start_address = flash_first_writable_sector_address;
-            bd_size_t spare_size_for_app = 0;
-            bd_addr_t curr_addr = aligned_start_address;
-            int spare_sectors_for_app = 2;
-            int min_sectors_for_storage = 2;
-            for (int i = 0; i < spare_sectors_for_app + min_sectors_for_storage - 1; i++) {
-                bd_size_t sector_size = flash.get_sector_size(curr_addr);
-                curr_addr += sector_size;
-                if (curr_addr >= flash_end_address) {
-                    spare_size_for_app = 0;
-                    break;
-                }
+        // Assumption is that last two sectors are reserved for the TDBStore
+        aligned_start_address = flash.get_flash_start() + flash.get_flash_size();
 
-                if (i < spare_sectors_for_app) {
-                    spare_size_for_app += sector_size;
-                }
-            }
-            aligned_start_address += spare_size_for_app;
-            bd_final_size = (flash_end_address - aligned_start_address);
-        } else {
-            aligned_start_address = flash_end_address - (flash.get_sector_size(flash_end_address - 1) * 2);
-            if (aligned_start_address < flash_first_writable_sector_address) {
-                flash.deinit();
-                return -2;
-            }
-            bd_final_size = (flash_end_address - aligned_start_address);
+        for (int i = STORE_SECTORS; i; i--) {
+            bd_size_t sector_size = flash.get_sector_size(aligned_start_address - 1);
+            aligned_start_address -= sector_size;
         }
+
+        if (aligned_start_address < flash_first_writable_sector_address) {
+            flash.deinit();
+            return -2;
+        }
+        bd_final_size = (flash_end_address - aligned_start_address);
     }
 
     (*tdb_start_address) = aligned_start_address;

--- a/features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.cpp
+++ b/features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.cpp
@@ -123,6 +123,9 @@ int  get_expected_internal_TDBStore_position(uint32_t *out_tdb_start_offset, uin
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_EXTERNAL") == 0) {
         *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
         tdb_size = MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
+    } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_INTERNAL") == 0) {
+        *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
+        tdb_size = MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "default") == 0) {
 #if COMPONENT_QSPIF || COMPONENT_SPIF || COMPONENT_DATAFLASH
         *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;


### PR DESCRIPTION
Allows having KVStore in internal and update image in external flash

Fixes a bug where it has not been possible to have KVStore in internal
flash while an update image image has been kept in external storage.

[TDBStore] changes the default TDBStore location. Instead of placing the TDBStore after the application - plus two spare sectors if a new app image is bigger than the original - now it's kept at the end of the flash

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@yossi2le 
@teetak01 

### Release Notes

Fixes TDB_INTERNAL configuration - makes possible to have the KVStore inside internal flash while update images are kept in an external storage.
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
