### PR TITLE
Xpresso: qspi_write fix

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/qspi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/qspi_api.c
@@ -34,6 +34,7 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 #include "qspi_device.h"
+#include "platform/mbed_critical.h"
 
 /* Look-up table entry indices */
 #define LUT1_SEQ_INDEX   0   // Pre-defined read sequence
@@ -267,6 +268,7 @@ qspi_status_t qspi_write(qspi_t *obj, const qspi_command_t *command, const void 
         return QSPI_STATUS_INVALID_PARAMETER;
     }
 
+    core_util_critical_section_enter();
     /* Prepare the write command */
     qspi_prepare_command(obj, command, data, to_write, NULL, 0);
 
@@ -295,6 +297,7 @@ qspi_status_t qspi_write(qspi_t *obj, const qspi_command_t *command, const void 
     if (to_write) {
         QSPI_WriteBlocking(base, (uint32_t *)data_send, to_write);
     }
+    core_util_critical_section_exit();
 
     while (QSPI_GetStatusFlags(base) & (kQSPI_Busy | kQSPI_IPAccess)) {
     }


### PR DESCRIPTION
Due to the data buffer is loaded in two steps the whole block needs protection from being interrupted to prevent write fails.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-hal 
@mmahadevan108 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
