### PR TITLE
TLSSocketWrapper::recvfrom sets SocketAddress output variable

### DIFF
--- a/UNITTESTS/features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
+++ b/UNITTESTS/features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
@@ -307,6 +307,7 @@ TEST_F(TestTLSSocketWrapper, recv_from)
     EXPECT_EQ(wrapper->connect(a), NSAPI_ERROR_OK);
     SocketAddress b;
     EXPECT_EQ(wrapper->recvfrom(&b, dataBuf, dataSize), NSAPI_ERROR_OK);
+    EXPECT_EQ(a, b);
 }
 
 TEST_F(TestTLSSocketWrapper, recv_from_null)

--- a/UNITTESTS/features/netsocket/TLSSocketWrapper/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TLSSocketWrapper/unittest.cmake
@@ -28,8 +28,6 @@ set(unittest-test-sources
   stubs/mbed_shared_queues_stub.cpp
   stubs/nsapi_dns_stub.cpp
   stubs/EventFlags_stub.cpp
-  stubs/stoip4_stub.c
-  stubs/ip4tos_stub.c
   stubs/SocketStats_Stub.cpp
 )
 

--- a/features/netsocket/TLSSocketWrapper.cpp
+++ b/features/netsocket/TLSSocketWrapper.cpp
@@ -398,6 +398,9 @@ nsapi_size_or_error_t TLSSocketWrapper::recv(void *data, nsapi_size_t size)
 
 nsapi_size_or_error_t TLSSocketWrapper::recvfrom(SocketAddress *address, void *data, nsapi_size_t size)
 {
+    if (address) {
+        getpeername(address);
+    }
     return recv(data, size);
 }
 


### PR DESCRIPTION
### Description

According to: https://github.com/ARMmbed/mbed-os/issues/10865 . In `TLSSocketWrapper::recvfrom` outputs `SocketAddress` the peer address. It is tested by UNITTEST.  `TLSSocketWrapper` unittest does not use stoip4_stub anymore.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@michalpasztamobica
@kjbracey-arm  