### PR TITLE
make watchdog kick reset test pass CI (LSI problem)

### DIFF
--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -26,7 +26,21 @@
 #include "mbed.h"
 
 #define TIMEOUT_MS 100UL
-#define KICK_ADVANCE_MS 10UL
+
+/* This value is used to calculate the time to kick the watchdog.
+ * Given the watchdog timeout is set to TIMEOUT_MS, the kick will be performed
+ * with a delay of (TIMEOUT_MS - KICK_ADVANCE_MS), after the init.
+ *
+ * It is common for the watchdog peripheral to use a low precision clock source,
+ * e.g. the LSI RC acts as a clock source for the IWDG on ST targets.
+ * According to the ST spec, the 37 kHz LSI is guaranteed to have a frequency
+ * around 37-38 kHz, but the actual frequency range guaranteed by the production
+ * tests is 26 kHz up to 56 kHz.
+ * Bearing that in mind, a 100 ms timeout value may actually last as long as 142 ms
+ * and as short as 66 ms.
+ * The value of 35 ms is used to cover the worst case scenario (66 ms).
+ */
+#define KICK_ADVANCE_MS 35UL
 
 #define MSG_VALUE_DUMMY "0"
 #define CASE_DATA_INVALID 0xffffffffUL

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -26,7 +26,21 @@
 #include "mbed.h"
 
 #define TIMEOUT_MS 100UL
-#define KICK_ADVANCE_MS 10UL
+
+/* This value is used to calculate the time to kick the watchdog.
+ * Given the watchdog timeout is set to TIMEOUT_MS, the kick will be performed
+ * with a delay of (TIMEOUT_MS - KICK_ADVANCE_MS), after the init.
+ *
+ * It is common for the watchdog peripheral to use a low precision clock source,
+ * e.g. the LSI RC acts as a clock source for the IWDG on ST targets.
+ * According to the ST spec, the 37 kHz LSI is guaranteed to have a frequency
+ * around 37-38 kHz, but the actual frequency range guaranteed by the production
+ * tests is 26 kHz up to 56 kHz.
+ * Bearing that in mind, a 100 ms timeout value may actually last as long as 142 ms
+ * and as short as 66 ms.
+ * The value of 35 ms is used to cover the worst case scenario (66 ms).
+ */
+#define KICK_ADVANCE_MS 35UL
 
 #define MSG_VALUE_DUMMY "0"
 #define CASE_DATA_INVALID 0xffffffffUL


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This change makes the watchdog kick reset pass on device NUCLEO-L073RZ. 
https://github.com/ARMmbed/mbed-os/blob/3b0053c23444c7311a92858799fdffd81ba9df2f/TESTS/mbed_hal/watchdog_reset/main.cpp#L222-L251
According to documentation the LSI oscillator frequency might vary from 26 kHz to 56 kHz. So the test might still don't pass on some devices, but in worst case watchdog might fire half time sooner than specified. We have relaxed this test earlier: 

https://github.com/ARMmbed/mbed-os/blob/431c4c19ae2056785c85e2a119ed51dd35f79f3c/TESTS/mbed_hal/watchdog_timing/main.cpp#L50-L71

so it checks whether the watchdog restarts the device before 2*timeout. But we don't specify the lower limit. I think the lower limit should be checked too, but regarding to datasheets many devices have their LSI oscillators frequency differ very much. So it would be hard to choose good range of acceptable difference of timeouts.

I think it would be appropriate to write that test (watchdog kick reset) so it passes on all devices and write another test that checks the low limit of specific device.

Please review

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@maciejbocianski @mprse @jamesbeyond @fkjagodzinski 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
