### PR TITLE
M252KG: Fix kvstore-static_tests failing with OOM

### DIFF
--- a/features/storage/TESTS/kvstore/static_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/static_tests/main.cpp
@@ -34,7 +34,8 @@ static const size_t buffer_size = 20;
 static const int    num_of_threads = 3;
 static const char   num_of_keys = 3;
 
-static const int heap_alloc_threshold_size = 4096;
+/* Forked 3 threads plus misc, so minimum (4 * OS_STACK_SIZE) heap are required. */
+static const int heap_alloc_threshold_size = 4 * OS_STACK_SIZE;
 
 static const char *keys[] = {"key1", "key2", "key3"};
 


### PR DESCRIPTION
### Description

This PR is split from #11176 and to fix OOM error in `kvstore-static_tests` test on NUMAKER_M252KG target. NUMAKER_M252KG just has 32KiB and meets OOM error in this test. This PR fixes it by decreasing forked threads from 3 to 2.

#### Depends on

#11176 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
