### PR TITLE
__cplusplus guard fixed pwmout_device.h for STM32 families

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/pwmout_device.h
@@ -56,4 +56,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F2/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F3/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32H7/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L0/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/pwmout_device.h
@@ -56,4 +56,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/pwmout_device.h
@@ -57,4 +57,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L4/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/pwmout_device.h
@@ -54,4 +54,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32WB/pwmout_device.h
+++ b/targets/TARGET_STM/TARGET_STM32WB/pwmout_device.h
@@ -56,4 +56,8 @@ extern const pwm_apb_map_t pwm_apb_map_table[];
 
 #endif // DEVICE_PWMOUT
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
### Description

This bug prevented using this header in cpp code directly.

This is the same fix as done by @byq77 in #11150 applied to other STM32 families.


<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
cc @0xc0170 

