### PR TITLE
Cellular: failure when deleting created context is not considered error

### DIFF
--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -172,9 +172,8 @@ pdp_type_t AT_CellularContext::string_to_pdp_type(const char *pdp_type)
 }
 
 // PDP Context handling
-nsapi_error_t AT_CellularContext::delete_current_context()
+void AT_CellularContext::delete_current_context()
 {
-    return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t AT_CellularContext::do_user_authentication()

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -309,7 +309,7 @@ pdp_type_t AT_CellularContext::string_to_pdp_type(const char *pdp_type_str)
 }
 
 // PDP Context handling
-nsapi_error_t AT_CellularContext::delete_current_context()
+void AT_CellularContext::delete_current_context()
 {
     tr_info("Delete context %d", _cid);
     _at.clear_error();
@@ -321,7 +321,8 @@ nsapi_error_t AT_CellularContext::delete_current_context()
         _new_context_set = false;
     }
 
-    return _at.get_last_error();
+    // there is nothing we can do if deleting of context fails. No point reporting an error (for example disconnect).
+    _at.clear_error();
 }
 
 nsapi_error_t AT_CellularContext::do_user_authentication()

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -115,7 +115,7 @@ private:
     nsapi_error_t find_and_activate_context();
     nsapi_error_t activate_ip_context();
     void check_and_deactivate_context();
-    nsapi_error_t delete_current_context();
+    void delete_current_context();
     nsapi_error_t check_operation(nsapi_error_t err, ContextOperation op);
     void ciot_opt_cb(mbed::CellularNetwork::CIoT_Supported_Opt ciot_opt);
     virtual void do_connect_with_retry();


### PR DESCRIPTION
### Description

If context delete fails there is nothing we or application can do. There is no point
returning an error for this. This affects to CellularContext/AT_CellularContext::disconnect
not returning an error if context delete fails. No need for documentation update.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AriParkkila 