### PR TITLE
FATFileSystem::stat() enabled for all compilers

### DIFF
--- a/features/storage/TESTS/filesystem/fat_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/fat_filesystem/main.cpp
@@ -82,6 +82,10 @@ void test_read_write()
     err = file.close();
     TEST_ASSERT_EQUAL(0, err);
 
+    struct stat st;
+    err = fs.stat("test_read_write.dat", &st);
+    TEST_ASSERT_EQUAL(TEST_SIZE, st.st_size);
+
     err = file.open(&fs, "test_read_write.dat", O_RDONLY);
     TEST_ASSERT_EQUAL(0, err);
     size = file.read(buffer, TEST_SIZE);

--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -517,15 +517,12 @@ int FATFileSystem::stat(const char *path, struct stat *st)
         return fat_error_remap(res);
     }
 
-    /* ARMCC doesnt support stat(), and these symbols are not defined by the toolchain. */
-#ifdef TOOLCHAIN_GCC
     st->st_size = f.fsize;
     st->st_mode = 0;
     st->st_mode |= (f.fattrib & AM_DIR) ? S_IFDIR : S_IFREG;
     st->st_mode |= (f.fattrib & AM_RDO) ?
                    (S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) :
                    (S_IRWXU | S_IRWXG | S_IRWXO);
-#endif /* TOOLCHAIN_GCC */
     unlock();
 
     return 0;


### PR DESCRIPTION
### Description

Fixes https://github.com/ARMmbed/mbed-os/issues/10198
Macro which restricted compilation to GCC_ARM is removed.
Existing read_write() test is amended to call stat() and check that correct size is returned.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@geky 
@kjbracey-arm 