### PR TITLE
Greentea testing wifi connect nonblocked

### DIFF
--- a/TESTS/network/wifi/README.md
+++ b/TESTS/network/wifi/README.md
@@ -62,15 +62,16 @@ Please refer to the following table for priorities of test cases. Priorities are
 | 9   | WIFI_CONNECT_PARAMS_CHANNEL             |                            | SHOULD   |
 | 10  | WIFI_CONNECT_PARAMS_CHANNEL_FAIL        |                            | SHOULD   |
 | 11  | WIFI_CONNECT                            |                            | MUST     |
-| 12  | WIFI_CONNECT_SECURE                     | With security type:        |          |
+| 12  | WIFI_CONNECT_NONBLOCK                   |                            | SHOULD   |
+| 13  | WIFI_CONNECT_SECURE                     | With security type:        |          |
 |     |                                         | NSAPI_SECURITY_WEP         | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA         | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA2        | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA_WPA2    | MUST     |
-| 13  | WIFI_CONNECT_SECURE_FAIL                |                            | MUST     |
-| 14  | WIFI_CONNECT_DISCONNECT_REPEAT          |                            | MUST     |
-| 15  | WIFI_SCAN_NULL                          |                            | SHOULD   |
-| 16  | WIFI_SCAN                               |                            | SHOULD   |
+| 14  | WIFI_CONNECT_SECURE_FAIL                |                            | MUST     |
+| 15  | WIFI_CONNECT_DISCONNECT_REPEAT          |                            | MUST     |
+| 16  | WIFI_SCAN_NULL                          |                            | SHOULD   |
+| 17  | WIFI_SCAN                               |                            | SHOULD   |
 
 Building test binaries
 ----------------------
@@ -372,7 +373,7 @@ Test `WiFiInterface::connect()` without parameters. Use `set_credentials()` for 
 2.  `Call WiFiInterface::set_credentials( <ssid:unsecure>, NULL)`.
 3.  `Call WiFiInterface::connect()`.
 4.  `disconnect()`.
-5.  `Call WiFiInterface::set_credentials( <ssid:unsecure>, "")`.
+5.  `Call WiFiInterface::set_credentials( <ssid:unsecure>, "")`.
 6.  `Call WiFiInterface::connect()`.
 7.  `disconnect()`.
 8.  Trash the memory storing SSID.
@@ -383,6 +384,33 @@ Test `WiFiInterface::connect()` without parameters. Use `set_credentials()` for 
 **Expected result:**
 
 `connect()` calls return `NSAPI_ERROR_OK`.
+
+### WIFI_CONNECT_NONBLOCK
+
+**Description:**
+
+Test `WiFiInterface::connect()` and `WiFiInterface::disconnect()` in non-blocking mode. It checks that driver can connect and disconnect in nonblocking mode. 
+
+**Preconditions:**
+
+1.  Test enviroment is set up as specified in the "Test Environment" chapter.
+
+**Test steps:**
+
+1.  Initialize the driver.
+2.  `Call WiFiInterface::set_credentials( <ssid:unsecure>, NULL)`.
+3.  `Call WiFiInterface::connect()`.
+4.  `Call WiFiInterface::set_blocking(false)`
+5.  `Call WiFiInterface::get_connection_status()`
+6.  `disconnect()`
+7.  `Call WiFiInterface::get_connection_status()`
+8.  `Call WiFiInterface::set_blocking(true)`
+
+**Expected result:**
+
+ In case of drivers which do not support asynchronous mode `set_blocking(false)` call returns `NSAPI_ERROR_UNSUPPORTED` and skips test case, otherwise:
+`connect()` call returns  `NSAPI_ERROR_OK`. To confirm connection `get_connection_status()` calls return `NSAPI_STATUS_GLOBAL_UP` or `NSAPI_STATUS_LOCAL_UP`.
+`disconnect()` call returns `NSAPI_ERROR_OK`. To confirm disconnection `get_connection_status()` calls return `NSAPI_STATUS_DISCONNECTED`.
 
 ### WIFI_CONNECT_SECURE
 

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -74,6 +74,8 @@ Case cases[] = {
     Case("WIFI-GET-RSSI", wifi_get_rssi),
     Case("WIFI-CONNECT-PARAMS-VALID-UNSECURE", wifi_connect_params_valid_unsecure),
     Case("WIFI-CONNECT", wifi_connect),
+    //Most boards are not passing this test, but they should if they support non-blocking API.
+    //Case("WIFI-CONNECT-NONBLOCKING", wifi_connect_nonblock),
     Case("WIFI-CONNECT-DISCONNECT-REPEAT", wifi_connect_disconnect_repeat),
 #endif
 #if defined(MBED_CONF_APP_WIFI_SECURE_SSID)

--- a/TESTS/network/wifi/wifi_connect_nonblock.cpp
+++ b/TESTS/network/wifi/wifi_connect_nonblock.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+#if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
+
+#define SSID_MAX_LEN 32
+nsapi_connection_status_t status_connection;
+Semaphore sem_conn(0, 1);
+Semaphore sem_disconn(0, 1);
+void status_callback(nsapi_event_t e, intptr_t d)
+{
+    if (d == NSAPI_STATUS_LOCAL_UP || d == NSAPI_STATUS_GLOBAL_UP) {
+        status_connection = (nsapi_connection_status_t)d;
+        sem_conn.release();
+    }
+
+    if (d == NSAPI_STATUS_DISCONNECTED) {
+        status_connection = (nsapi_connection_status_t)d;
+        sem_disconn.release();
+    }
+}
+
+void wifi_connect_nonblock(void)
+{
+    WiFiInterface *wifi = get_interface();
+    char ssid[SSID_MAX_LEN + 1] = MBED_CONF_APP_WIFI_UNSECURE_SSID;
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(ssid, NULL));
+    wifi->attach(status_callback);
+    TEST_SKIP_UNLESS(wifi->set_blocking(false) != NSAPI_ERROR_UNSUPPORTED);
+    nsapi_error_t ret = wifi->connect();
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, ret);
+    bool res = sem_conn.try_acquire_for(30000);
+    TEST_ASSERT_TRUE(res == true);
+    TEST_ASSERT_TRUE(status_connection == NSAPI_STATUS_GLOBAL_UP || status_connection == NSAPI_STATUS_LOCAL_UP);
+    ret = wifi->disconnect();
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, ret);
+    res = sem_disconn.try_acquire_for(30000);
+    TEST_ASSERT_TRUE(res == true);
+    TEST_ASSERT_EQUAL_INT(NSAPI_STATUS_DISCONNECTED, status_connection);
+    wifi->set_blocking(true);
+}
+
+#endif // defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)

--- a/TESTS/network/wifi/wifi_tests.h
+++ b/TESTS/network/wifi/wifi_tests.h
@@ -63,6 +63,9 @@ void wifi_connect_params_channel_fail(void);
 /** Test WiFiInterface::connect() without parameters. Use set_credentials() for setting parameters. */
 void wifi_connect(void);
 
+/** Test WiFiInterface::connect() in nonblocking mode. Use set_credentials() for setting parameters. */
+void wifi_connect_nonblock(void);
+
 /** Test WiFiInterface::connect() without parameters. Don't set parameters with set_credentials() */
 void wifi_connect_nocredentials(void);
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Added test is implemented for testing Wifi in nonblocked mode. However, it is commented in Test cases `TESTS/network/wifi/main.cpp` because most boards do not use this functionality. 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@SeppoTakalo 
@VeijoPesonen 
@michalpasztamobica 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
