### PR TITLE
Fix netsocket DNS test for IAR

### DIFF
--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -160,7 +160,7 @@ static void net_bringup()
     net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: IP address is '%s'\n", net->get_ip_address());
+    printf("MBED: IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void net_bringdown()

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -160,7 +160,9 @@ static void net_bringup()
     net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
+    TEST_ASSERT(net->get_ip_address() != NULL);
+
+    printf("MBED: IP address is '%s'\n", net->get_ip_address());
 }
 
 static void net_bringdown()

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
@@ -175,7 +175,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_get_ip_address)
     ATHandler at(&fh1, que, 0, ",");
 
     MyStack st(at, 0, IPV6_STACK);
-    EXPECT_EQ(strlen(st.get_ip_address()), 0);
+    EXPECT_TRUE(st.get_ip_address() == NULL);
 
     char table[] = "1.2.3.4.5.65.7.8.9.10.11\0";
     ATHandler_stub::ssize_value = -1;

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
@@ -28,4 +28,5 @@ set(unittest-test-sources
   stubs/NetworkStack_stub.cpp
   stubs/SocketAddress_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/ThisThread_stub.cpp
 )

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -18,6 +18,7 @@
 #include "AT_CellularStack.h"
 #include "CellularUtil.h"
 #include "CellularLog.h"
+#include "ThisThread.h"
 
 using namespace mbed_cellular_util;
 using namespace mbed;
@@ -54,41 +55,37 @@ int AT_CellularStack::find_socket_index(nsapi_socket_t handle)
 
 /** NetworkStack
  */
-
 const char *AT_CellularStack::get_ip_address()
 {
     _at.lock();
 
-    _at.cmd_start_stop("+CGPADDR", "=", "%d", _cid);
+    const int IP_MAX_TRIES = 5;
+    int len = -1;
+    for (int i = 0; i < IP_MAX_TRIES && len == -1; i++) {
+        _at.cmd_start_stop("+CGPADDR", "=", "%d", _cid);
+        _at.resp_start("+CGPADDR:");
 
-    _at.resp_start("+CGPADDR:");
+        if (_at.info_resp()) {
+            _at.skip_param();
 
-    if (_at.info_resp()) {
+            len = _at.read_string(_ip, NSAPI_IPv4_SIZE);
 
-        _at.skip_param();
-
-        int len = _at.read_string(_ip, NSAPI_IPv4_SIZE);
-        if (len == -1) {
-            _ip[0] = '\0';
-            _at.resp_stop();
-            _at.unlock();
-            // no IPV4 address, return
-            return NULL;
+            if (len == -1 && i < IP_MAX_TRIES - 1) {
+                rtos::ThisThread::sleep_for(300);
+            } else if (_stack_type != IPV4_STACK) {
+                // in case stack type is not IPV4 only, try to look also for IPV6 address
+                (void)_at.read_string(_ip, PDP_IPV6_SIZE);
+            }
         }
-
-        // in case stack type is not IPV4 only, try to look also for IPV6 address
-        if (_stack_type != IPV4_STACK) {
-            (void)_at.read_string(_ip, PDP_IPV6_SIZE);
-        }
+        _at.resp_stop();
     }
 
-    _at.resp_stop();
     _at.unlock();
 
     // we have at least IPV4 address
     convert_ipv6(_ip);
 
-    return _ip;
+    return len != -1 ? _ip : NULL;
 }
 
 nsapi_error_t AT_CellularStack::socket_stack_init()


### PR DESCRIPTION
### Description

Test case printed IP address. If ip address is null, IAR compiled binary fails.
Added check for printing null. If IP address is null, then it prints string 'null'.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

@kimlep01 @kivaisan 