### PR TITLE
Cellular: moved string_to_pdp_type from AT_CellularContext to Cellula…

### DIFF
--- a/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
+++ b/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "CellularUtil.h"
 
+using namespace mbed;
 using namespace mbed_cellular_util;
 
 // AStyle ignored as the definition is not clear due to preprocessor usage
@@ -213,5 +214,23 @@ TEST_F(Testutil, int_to_hex_str)
 
     EXPECT_TRUE(buf[0] == '6');
     EXPECT_TRUE(buf[1] == '4');
+}
+
+TEST_F(Testutil, string_to_pdp_type)
+{
+    pdp_type_t type = string_to_pdp_type("IPV4V6");
+    ASSERT_EQ(type, IPV4V6_PDP_TYPE);
+
+    type = string_to_pdp_type("IPV6");
+    ASSERT_EQ(type, IPV6_PDP_TYPE);
+
+    type = string_to_pdp_type("IP");
+    ASSERT_EQ(type, IPV4_PDP_TYPE);
+
+    type = string_to_pdp_type("Non-IP");
+    ASSERT_EQ(type, NON_IP_PDP_TYPE);
+
+    type = string_to_pdp_type("diipadaapa");
+    ASSERT_EQ(type, DEFAULT_PDP_TYPE);
 }
 

--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -166,11 +166,6 @@ AT_CellularBase::CellularProperty AT_CellularContext::pdp_type_t_to_cellular_pro
     return prop;
 }
 
-pdp_type_t AT_CellularContext::string_to_pdp_type(const char *pdp_type)
-{
-    return IPV4V6_PDP_TYPE;
-}
-
 // PDP Context handling
 nsapi_error_t AT_CellularContext::delete_current_context()
 {

--- a/UNITTESTS/stubs/CellularUtil_stub.cpp
+++ b/UNITTESTS/stubs/CellularUtil_stub.cpp
@@ -28,6 +28,7 @@ int CellularUtil_stub::char_pos = 0;
 char *CellularUtil_stub::char_table[50] = {};
 int CellularUtil_stub::table_idx = 0;
 
+using namespace mbed;
 namespace mbed_cellular_util {
 
 #define MAX_STRING_LEN 200
@@ -122,6 +123,11 @@ int char_str_to_hex_str(const char *str, uint16_t len, char *buf, bool omit_lead
 uint16_t get_dynamic_ip_port()
 {
     return CellularUtil_stub::uint16_value;
+}
+
+pdp_type_t string_to_pdp_type(const char *pdp_type)
+{
+    return IPV4V6_PDP_TYPE;
 }
 
 } // namespace mbed_cellular_util

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -19,6 +19,7 @@
 
 #include "CellularInterface.h"
 #include "CellularDevice.h"
+#include "CellularUtil.h"
 #include "ControlPlane_netif.h"
 #include "PinNames.h"
 
@@ -28,14 +29,6 @@
  */
 
 namespace mbed {
-
-typedef enum pdp_type {
-    DEFAULT_PDP_TYPE = DEFAULT_STACK,
-    IPV4_PDP_TYPE = IPV4_STACK,
-    IPV6_PDP_TYPE = IPV6_STACK,
-    IPV4V6_PDP_TYPE = IPV4V6_STACK,
-    NON_IP_PDP_TYPE
-} pdp_type_t;
 
 /**
  * @addtogroup cellular

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -20,7 +20,6 @@
 #include "AT_CellularStack.h"
 #include "AT_CellularDevice.h"
 #include "CellularLog.h"
-#include "CellularUtil.h"
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
 #include "UARTSerial.h"
 #endif // #if DEVICE_SERIAL
@@ -289,23 +288,6 @@ void AT_CellularContext::set_credentials(const char *apn, const char *uname, con
     _apn = apn;
     _uname = uname;
     _pwd = pwd;
-}
-
-pdp_type_t AT_CellularContext::string_to_pdp_type(const char *pdp_type_str)
-{
-    pdp_type_t pdp_type = DEFAULT_PDP_TYPE;
-    int len = strlen(pdp_type_str);
-
-    if (len == 6 && memcmp(pdp_type_str, "IPV4V6", len) == 0) {
-        pdp_type = IPV4V6_PDP_TYPE;
-    } else if (len == 4 && memcmp(pdp_type_str, "IPV6", len) == 0) {
-        pdp_type = IPV6_PDP_TYPE;
-    } else if (len == 2 && memcmp(pdp_type_str, "IP", len) == 0) {
-        pdp_type = IPV4_PDP_TYPE;
-    } else if (len == 6 && memcmp(pdp_type_str, "Non-IP", len) == 0) {
-        pdp_type = NON_IP_PDP_TYPE;
-    }
-    return pdp_type;
 }
 
 // PDP Context handling

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -101,7 +101,6 @@ protected:
     virtual void set_disconnect();
     virtual void deactivate_context();
     virtual bool get_context();
-    pdp_type_t string_to_pdp_type(const char *pdp_type);
     AT_CellularBase::CellularProperty pdp_type_t_to_cellular_property(pdp_type_t pdp_type);
     bool set_new_context(int cid);
 private:

--- a/features/cellular/framework/common/CellularUtil.cpp
+++ b/features/cellular/framework/common/CellularUtil.cpp
@@ -25,7 +25,7 @@
 #define RANDOM_PORT_NUMBER_COUNT (RANDOM_PORT_NUMBER_END - RANDOM_PORT_NUMBER_START + 1)
 #define RANDOM_PORT_NUMBER_MAX_STEP 100
 
-
+using namespace mbed;
 namespace mbed_cellular_util {
 
 void convert_ipv6(char *ip)
@@ -353,6 +353,23 @@ uint16_t get_dynamic_ip_port()
     port_counter %= RANDOM_PORT_NUMBER_COUNT;
 
     return (RANDOM_PORT_NUMBER_START + port_counter);
+}
+
+pdp_type_t string_to_pdp_type(const char *pdp_type_str)
+{
+    pdp_type_t pdp_type = DEFAULT_PDP_TYPE;
+    int len = strlen(pdp_type_str);
+
+    if (len == 6 && memcmp(pdp_type_str, "IPV4V6", len) == 0) {
+        pdp_type = IPV4V6_PDP_TYPE;
+    } else if (len == 4 && memcmp(pdp_type_str, "IPV6", len) == 0) {
+        pdp_type = IPV6_PDP_TYPE;
+    } else if (len == 2 && memcmp(pdp_type_str, "IP", len) == 0) {
+        pdp_type = IPV4_PDP_TYPE;
+    } else if (len == 6 && memcmp(pdp_type_str, "Non-IP", len) == 0) {
+        pdp_type = NON_IP_PDP_TYPE;
+    }
+    return pdp_type;
 }
 
 } // namespace mbed_cellular_util

--- a/features/cellular/framework/common/CellularUtil.h
+++ b/features/cellular/framework/common/CellularUtil.h
@@ -20,7 +20,18 @@
 
 #include <stddef.h>
 #include <inttypes.h>
+#include "nsapi_types.h"
 
+namespace mbed {
+
+typedef enum pdp_type {
+    DEFAULT_PDP_TYPE = DEFAULT_STACK,
+    IPV4_PDP_TYPE = IPV4_STACK,
+    IPV6_PDP_TYPE = IPV6_STACK,
+    IPV4V6_PDP_TYPE = IPV4V6_STACK,
+    NON_IP_PDP_TYPE
+} pdp_type_t;
+}
 namespace mbed_cellular_util {
 
 // some helper macros
@@ -119,6 +130,13 @@ uint32_t binary_str_to_uint(const char *binary_string, int binary_string_length)
  *  @return next port number above 49152
  */
 uint16_t get_dynamic_ip_port();
+
+/** Converts the given pdp type in char format to enum pdp_type_t
+ *
+ *  @param pdp_type     pdp type in string format
+ *  @return             converted pdp_type_t enum
+ */
+mbed::pdp_type_t string_to_pdp_type(const char *pdp_type);
 
 } // namespace mbed_cellular_util
 

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularContext.cpp
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularContext.cpp
@@ -19,6 +19,8 @@
 
 #include "Semaphore.h"
 
+using namespace mbed_cellular_util;
+
 namespace mbed {
 
 TELIT_ME910_CellularContext::TELIT_ME910_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req, bool nonip_req) :


### PR DESCRIPTION

### Description

string_to_pdp_type is a common method for AT and other layers. Without moving there will be duplicate methods.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kivaisan 

### Release Notes

Moved string_to_pdp_type from AT_CellularContext to CellularUtil. string_to_pdp_type is a common method for AT and other layers. Without moving there will be duplicate methods.
