### PR TITLE
Cellular: Fixed improper AT handler setup through virtual calls in co…

### DIFF
--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -405,3 +405,7 @@ void ATHandler::set_debug_list(bool debug_on)
     ATHandler_stub::debug_on = debug_on;
 }
 
+void ATHandler::set_send_delay(uint16_t send_delay)
+{
+}
+

--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -252,3 +252,7 @@ nsapi_error_t AT_CellularDevice::soft_power_off()
 void AT_CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx)
 {
 }
+
+void AT_CellularDevice::set_at_urcs_impl()
+{
+}

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1544,3 +1544,8 @@ bool ATHandler::sync(int timeout_ms)
     unlock();
     return false;
 }
+
+void ATHandler::set_send_delay(uint16_t send_delay)
+{
+    _at_send_delay = send_delay;
+}

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -210,6 +210,12 @@ public:
      */
     bool sync(int timeout_ms);
 
+    /** Sets the delay to be applied before sending any AT command.
+     *
+     *  @param send_delay the minimum delay in ms between the end of last response and the beginning of a new command
+     */
+    void set_send_delay(uint16_t send_delay);
+
 protected:
     void event();
 #ifdef AT_HANDLER_MUTEX

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -144,6 +144,13 @@ public:
 protected:
     virtual void cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx = NULL);
     void send_disconnect_to_context(int cid);
+    // Sets commonly used URCs
+    void set_at_urcs();
+    // To be used for setting target specific URCs
+    virtual void set_at_urcs_impl();
+    // Sets up parameters for AT handler, for now only the send delay and URCs.
+    // This kind of routine is needed for initialisation routines that are virtual and therefore cannot be called from constructor.
+    void setup_at_handler();
 
 private:
     void urc_nw_deact();

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.cpp
@@ -78,6 +78,8 @@ nsapi_error_t GEMALTO_CINTERION::init()
     }
     tr_info("Cinterion model %s (%d)", model, _module);
 
+    set_at_urcs();
+
     return NSAPI_ERROR_OK;
 }
 

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -85,6 +85,8 @@ AT_CellularInformation *QUECTEL_BC95::open_information_impl(ATHandler &at)
 
 nsapi_error_t QUECTEL_BC95::init()
 {
+    setup_at_handler();
+
     _at->lock();
     _at->flush();
     _at->cmd_start("AT");

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -69,11 +69,13 @@ QUECTEL_BG96::QUECTEL_BG96(FileHandle *fh, PinName pwr, bool active_high, PinNam
       _pwr(pwr, !_active_high),
       _rst(rst, !_active_high)
 {
-    _at->set_urc_handler("+QIURC: \"pdpde",  mbed::Callback<void()>(this, &QUECTEL_BG96::urc_pdpdeact));
-
     AT_CellularBase::set_cellular_properties(cellular_properties);
 }
 
+void QUECTEL_BG96::set_at_urcs_impl()
+{
+    _at->set_urc_handler("+QIURC: \"pdpde",  mbed::Callback<void()>(this, &QUECTEL_BG96::urc_pdpdeact));
+}
 
 AT_CellularNetwork *QUECTEL_BG96::open_network_impl(ATHandler &at)
 {
@@ -157,6 +159,8 @@ nsapi_error_t QUECTEL_BG96::hard_power_off()
 
 nsapi_error_t QUECTEL_BG96::init()
 {
+    setup_at_handler();
+
     int retry = 0;
 
     _at->lock();

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
@@ -45,6 +45,7 @@ protected: // AT_CellularDevice
     virtual nsapi_error_t hard_power_off();
     virtual nsapi_error_t soft_power_on();
     virtual nsapi_error_t init();
+    virtual void set_at_urcs_impl();
 
 public:
     void handle_urc(FileHandle *fh);

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -90,6 +90,8 @@ CellularDevice *CellularDevice::get_default_instance()
 
 nsapi_error_t UBLOX_AT::init()
 {
+    setup_at_handler();
+
     _at->lock();
     _at->flush();
     _at->cmd_start("AT");

--- a/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.cpp
+++ b/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.cpp
@@ -39,8 +39,12 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
 UBLOX_N2XX::UBLOX_N2XX(FileHandle *fh): AT_CellularDevice(fh)
 {
     AT_CellularBase::set_cellular_properties(cellular_properties);
-    _at->set_urc_handler("+NPIN:", mbed::Callback<void()>(this, &UBLOX_N2XX::NPIN_URC));
     memset(simstr, 0, sizeof(simstr));
+}
+
+void UBLOX_N2XX::set_at_urcs_impl()
+{
+    _at->set_urc_handler("+NPIN:", mbed::Callback<void()>(this, &UBLOX_N2XX::NPIN_URC));
 }
 
 UBLOX_N2XX::~UBLOX_N2XX()
@@ -66,6 +70,8 @@ AT_CellularSMS *UBLOX_N2XX::open_sms_impl(ATHandler &at)
 
 nsapi_error_t UBLOX_N2XX::init()
 {
+    setup_at_handler();
+
     _at->lock();
     _at->flush();
     _at->cmd_start("AT");

--- a/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.h
+++ b/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.h
@@ -52,6 +52,7 @@ protected: // AT_CellularDevice
 
     virtual AT_CellularContext *create_context_impl(ATHandler &at, const char *apn, bool cp_req = false, bool nonip_req = false);
     virtual AT_CellularSMS *open_sms_impl(ATHandler &at);
+    virtual void set_at_urcs_impl();
 
 public: // NetworkInterface
 


### PR DESCRIPTION
### Description

Added AT handler setup method to be used for initialisation routines that are virtual and therefore cannot be called from constructor.
For now it only sets AT send delay and URCs.

### Pull request type
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AriParkkila @jarvte 