### PR TITLE
BLE: add nonscannable connectable type

### DIFF
--- a/features/FEATURE_BLE/ble/gap/Types.h
+++ b/features/FEATURE_BLE/ble/gap/Types.h
@@ -152,6 +152,8 @@ struct advertising_type_t : SafeEnum<advertising_type_t, uint8_t> {
         /**
          * Device is connectable, scannable and doesn't expect connection from a
          * specific peer.
+         * @note Cannot carry extended advertising payload, only legacy PDUs.
+         * Use CONNECTABLE_NON_SCANNABLE_UNDIRECTED for non-legacy payload.
          *
          * @see Vol 3, Part C, Section 9.3.4 and Vol 6, Part B, Section 2.3.1.1.
          */
@@ -185,6 +187,8 @@ struct advertising_type_t : SafeEnum<advertising_type_t, uint8_t> {
 
         /**
          * Device is connectable, but not scannable and doesn't expect connection from a specific peer.
+         * @note Only for use with extended advertising payload, will not allow legacy PDUs
+         * (use CONNECTABLE_UNDIRECTED for legacy PDU).
          */
         CONNECTABLE_NON_SCANNABLE_UNDIRECTED = 0x05,
 

--- a/features/FEATURE_BLE/ble/gap/Types.h
+++ b/features/FEATURE_BLE/ble/gap/Types.h
@@ -183,13 +183,19 @@ struct advertising_type_t : SafeEnum<advertising_type_t, uint8_t> {
          */
         CONNECTABLE_DIRECTED_LOW_DUTY = 0x04,
 
+        /**
+         * Device is connectable, but not scannable and doesn't expect connection from a specific peer.
+         */
+        CONNECTABLE_NON_SCANNABLE_UNDIRECTED = 0x05,
+
 #if !defined(DOXYGEN_ONLY)
         // used by the PAL; naming in line with the the spec.
         ADV_IND = 0x00,
         ADV_DIRECT_IND = 0x01,
         ADV_SCAN_IND = 0x02,
         ADV_NONCONN_IND = 0x03,
-        ADV_DIRECT_IND_LOW_DUTY_CYCLE = 0x04
+        ADV_DIRECT_IND_LOW_DUTY_CYCLE = 0x04,
+        ADV_NONSCAN_IND = 0x05
 #endif
     };
 

--- a/features/FEATURE_BLE/ble/pal/GapTypes.h
+++ b/features/FEATURE_BLE/ble/pal/GapTypes.h
@@ -446,6 +446,9 @@ struct advertising_event_properties_t {
                 break;
             case advertising_type_t::ADV_NONCONN_IND:
                 break;
+            case advertising_type_t::ADV_NONSCAN_IND:
+                connectable = true;
+                break;
         }
     }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
GAP was missing an advertising type that would allow to attach an extended advertising payload (non-legacy PDU) and also be connectable. This adds this type. This is caused by the limitation where extended pdu cannot be added to advertising that is both scannable and connectable.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@donatieng 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

Adds new type, existing functionality unchanged.
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
