### PR TITLE
Atomics: GCC fix for M23 (again)

### DIFF
--- a/platform/internal/mbed_atomic_impl.h
+++ b/platform/internal/mbed_atomic_impl.h
@@ -141,6 +141,7 @@ extern "C" {
 #elif defined __clang__ || defined __GNUC__
 #define DO_MBED_LOCKFREE_NEWVAL_2OP_ASM(OP, Constants, M)       \
     __asm volatile (                                            \
+        ".syntax unified\n\t"                                   \
         "LDREX"#M "\t%[newValue], %[value]\n\t"                 \
         #OP       "\t%[newValue], %[arg]\n\t"                   \
         "STREX"#M "\t%[fail], %[newValue], %[value]\n\t"        \


### PR DESCRIPTION
### Description

Add another missing unified syntax directive. Was previously fixed in 03f1ac3ffd, but the same problem was not addressed in the pending PR that added the `NEWVAL_2OP` assembler.

Fixes #11102.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Targets 5.14, as fixing PR #10274.

### Reviewers

@ccli8 
