### PR TITLE
Review follow-up mstd fixes

### DIFF
--- a/platform/cxxsupport/README.md
+++ b/platform/cxxsupport/README.md
@@ -16,7 +16,7 @@ Omissions are:
 User code should normally be able to include C++14 headers and get
 most expected functionality. (But bear in mind that many C++ library
 features like streams and STL containers are quite heavy and may
-not be appropriate for small embnedded use).
+not be appropriate for small embedded use).
 
 However, ARM C 5 has only C++11 language support (at least a large subset), and
 no C++11/14 library. For the headers that are totally new in C++11,

--- a/platform/cxxsupport/mstd_functional
+++ b/platform/cxxsupport/mstd_functional
@@ -474,7 +474,7 @@ public:
 }
 
 template <typename F>
-impl::not_fn_t<F> not_fn_t(F&& f)
+impl::not_fn_t<F> not_fn(F&& f)
 {
     return impl::not_fn_t<F>(std::forward<F>(f));
 }

--- a/platform/cxxsupport/mstd_functional
+++ b/platform/cxxsupport/mstd_functional
@@ -89,23 +89,14 @@ namespace std {
 // [refwrap]
 template <typename T>
 class reference_wrapper {
-    T &FUN(T &x) noexcept { return x; }
-    void FUN(T &&x) = delete;
     T *ptr;
 public:
     using type = T;
     // [refwrap.const]
-#if 0
-    // decltype doesn't seem to work well enough for this revised version
-    template <typename U,
-                typename = enable_if_t<!is_same<reference_wrapper, decay_t<U>>::value &&
-                                       !is_void<decltype(FUN(declval<U>()))>::value>>
-    reference_wrapper(U&& x) //noexcept(noexcept(FUN(declval<U>())))
-        : ptr(addressof(FUN(forward<U>(x)))) { }
-#else
+    // LWG 2993 version of constructor does not seem to work in ARM C 5, so stick with
+    // this original version.
     reference_wrapper(T &x) noexcept : ptr(addressof(x)) { }
     reference_wrapper(T &&x) = delete;
-#endif
 
     reference_wrapper(const reference_wrapper &) noexcept = default;
     // [refwrap.assign]


### PR DESCRIPTION
### Description

Minor fixes to #11039 - following up review comments from there.

* Fix README.md typo
* Drop dead ARMC5 `std::reference_wrapper` code
* Fix `mstd::not_fn`

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Targeting 5.14.0, as fixing new feature.

### Reviewers

@pan-
