### PR TITLE
Change default optimisation level to O1 when exporting to uVision

### DIFF
--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -355,7 +355,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>0</interw>
-            <Optim>1</Optim>
+            <Optim>2</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>1</OneElfS>


### PR DESCRIPTION
### Description


  When exporting to uVision the default level is O0 which is wasteful as dead code and variables are included. O1 removes this without causing debugging issues.

From
[http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0472k/chr1359124221739.html](url)
> Although the debug view produced by -O0 corresponds most closely to the source code, users might prefer the debug view produced by -O1 because this improves the quality of the code without changing the fundamental structure.

Fixes #11068

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes
Default uVision optimisation level changed to O1. It matches the debug profile.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
