### PR TITLE
LPC1768: Make use of the other 32K of RAM

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
@@ -43,6 +43,5 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   }
   RW_IRAM4 0x40038000 0x0800  {  ; RW data, CAN RAM
    .ANY (CANRAM)
-   .ANY4 (+RW +ZI)
   }
 }

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
@@ -29,17 +29,20 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   ; 8_byte_aligned(49 vect * 4 bytes) =  8_byte_aligned(0xC4) = 0xC8
   ; 32KB (RAM size) - 0xC8 (NIVT) - 32 (topmost 32 bytes used by IAP functions) = 0x7F18
   RW_IRAM1 0x100000C8 0x7F18-Stack_Size  {
-   .ANY (+RW +ZI)
+   .ANY1 (+RW +ZI)
   }
   ARM_LIB_STACK (0x100000C8+0x7F18) EMPTY -Stack_Size { ; stack
   }
   RW_IRAM2 0x2007C000 0x4000  {  ; RW data, ETH RAM
    .ANY (AHBSRAM0)
+   .ANY2 (+RW +ZI)
   }
   RW_IRAM3 0x20080000 0x4000  {  ; RW data, ETH RAM
    .ANY (AHBSRAM1)
+   .ANY3 (+RW +ZI)
   }
   RW_IRAM4 0x40038000 0x0800  {  ; RW data, CAN RAM
    .ANY (CANRAM)
+   .ANY4 (+RW +ZI)
   }
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Make use of the other 32K of RAM if not used by libraries, least priority is IRAM1 to help maximise heap availability.
Most beneficial when LWIP is not in use.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
