### PR TITLE
BLE: make advertising data parser handle early termination

### DIFF
--- a/features/FEATURE_BLE/ble/gap/AdvertisingDataParser.h
+++ b/features/FEATURE_BLE/ble/gap/AdvertisingDataParser.h
@@ -69,6 +69,11 @@ public:
         if (position >= data.size()) {
             return false;
         }
+        
+        /* early termination of packet, no more meaningful octets */
+        if (current_length() == 0) {
+            return false;
+        }
 
         if (position + current_length() >= data.size()) {
             return false;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

The advertising data parser should handle zero length AD types which terminate the packet early. Otherwise a packet with padding will cause errors.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@donatieng 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
