### PR TITLE
Fix cellular dns test with IAR compiled binary

### DIFF
--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -160,7 +160,7 @@ static void net_bringup()
     net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: IP address is '%s'\n", net->get_ip_address());
+    printf("MBED: IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void net_bringdown()

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -72,7 +72,7 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
+    printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void _ifdown()

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -94,7 +94,7 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TLSClient IP address is '%s'\n", net->get_ip_address());
+    printf("MBED: TLSClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void _ifdown()

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -59,7 +59,7 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: UDPClient IP address is '%s'\n", net->get_ip_address());
+    printf("MBED: UDPClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void _ifdown()

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -537,7 +537,7 @@ TEST_F(TestAT_CellularContext, connect_disconnect_sync)
     ATHandler_stub::read_string_index = 2;
     ASSERT_EQ(ctx1.connect(),  NSAPI_ERROR_OK);
 
-    ASSERT_EQ(network_cb_count, 5);
+    ASSERT_EQ(network_cb_count, 4);
 
     ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_OK);
     ATHandler_stub::resp_info_true_counter = 1;
@@ -704,7 +704,7 @@ TEST_F(TestAT_CellularContext, connect_disconnect_async)
     data.status_data = CellularNetwork::Attached;
     ctx1.cellular_callback((nsapi_event_t)CellularAttachNetwork, (intptr_t)&data);
 
-    ASSERT_EQ(network_cb_count, 5);
+    ASSERT_EQ(network_cb_count, 4);
     ASSERT_EQ(ctx1.connect(), NSAPI_ERROR_IS_CONNECTED);
     EXPECT_TRUE(ctx1.is_connected() == true);
     ASSERT_EQ(ctx1.disconnect(), NSAPI_ERROR_NO_MEMORY);

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
@@ -175,7 +175,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_get_ip_address)
     ATHandler at(&fh1, que, 0, ",");
 
     MyStack st(at, 0, IPV6_STACK);
-    EXPECT_EQ(strlen(st.get_ip_address()), 0);
+    EXPECT_TRUE(st.get_ip_address() == NULL);
 
     char table[] = "1.2.3.4.5.65.7.8.9.10.11\0";
     ATHandler_stub::ssize_value = -1;

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
@@ -28,4 +28,5 @@ set(unittest-test-sources
   stubs/NetworkStack_stub.cpp
   stubs/SocketAddress_stub.cpp
   stubs/mbed_assert_stub.c
+  stubs/ThisThread_stub.cpp
 )

--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -21,7 +21,7 @@ using namespace mbed;
 
 AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn,  bool cp_req, bool nonip_req) :
     AT_CellularBase(at), _is_connected(false),
-    _current_op(OP_INVALID), _fh(0), _cp_req(cp_req), _nonip_req(nonip_req), _cp_in_use(false)
+    _current_op(OP_INVALID), _fh(0), _cp_req(cp_req)
 {
     _stack = NULL;
     _pdp_type = DEFAULT_PDP_TYPE;
@@ -43,6 +43,8 @@ AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, co
     _is_blocking = true;
     _device = device;
     _nw = NULL;
+    _nonip_req = nonip_req;
+    _cp_in_use = false;
 }
 
 AT_CellularContext::~AT_CellularContext()

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -344,6 +344,11 @@ protected: // Device specific implementations might need these so protected
      */
     virtual void do_connect();
 
+    /** After we have connected successfully we must check that we have a valid IP address.
+     *  Some modems/networks don't give IP address right after connect so we must poll it for a while.
+     */
+    void validate_ip_address();
+
     // member variables needed in target override methods
     NetworkStack *_stack; // must be pointer because of PPP
     pdp_type_t _pdp_type;
@@ -368,6 +373,10 @@ protected: // Device specific implementations might need these so protected
     CellularDevice *_device;
     CellularNetwork *_nw;
     bool _is_blocking;
+    // flag indicating if Non-IP context was requested to be setup
+    bool _nonip_req;
+    // tells if CCIOTOPTI received green from network for CP optimization use
+    bool _cp_in_use;
 };
 
 /**

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -48,10 +48,10 @@ using namespace mbed;
 using namespace rtos;
 
 AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req, bool nonip_req) :
-    AT_CellularBase(at), _is_connected(false), _current_op(OP_INVALID), _fh(0), _cp_req(cp_req),
-    _nonip_req(nonip_req), _cp_in_use(false)
+    AT_CellularBase(at), _is_connected(false), _current_op(OP_INVALID), _fh(0), _cp_req(cp_req)
 {
     tr_info("New CellularContext %s (%p)", apn ? apn : "", this);
+    _nonip_req = nonip_req;
     _apn = apn;
     _device = device;
 }
@@ -587,7 +587,6 @@ void AT_CellularContext::do_connect()
     }
 #else
     _is_connected = true;
-    call_network_cb(NSAPI_STATUS_GLOBAL_UP);
 #endif
 }
 

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -131,10 +131,6 @@ protected:
     char _found_apn[MAX_APN_LENGTH];
     // flag indicating if CP was requested to be setup
     bool _cp_req;
-    // flag indicating if Non-IP context was requested to be setup
-    bool _nonip_req;
-    // tells if CCIOTOPTI received green from network for CP optimization use
-    bool _cp_in_use;
 };
 
 } // namespace mbed


### PR DESCRIPTION
### Description

Binary compiled with IAR crashes when trying to print null string. Fixed to print 'null' when the dns test is trying to print an empty ip address.
Fixed also that there should not be an empty ip address after connect. After fix, still some modems don't give an ip address even they have it. This can't be fixed but network communication works properly.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kivaisan @kimlep01 