### PR TITLE
minimal-printf should not bypass the retargetting code

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.c
+++ b/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.c
@@ -23,7 +23,7 @@ int mbed_printf(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;
@@ -41,7 +41,7 @@ int mbed_snprintf(char *buffer, size_t length, const char *format, ...)
 
 int mbed_vprintf(const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
 }
 
 int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list arguments)
@@ -49,7 +49,6 @@ int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list argu
     return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
 
-#if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FILE_STREAM
 int mbed_fprintf(FILE *stream, const char *format, ...)
 {
     va_list arguments;
@@ -64,4 +63,3 @@ int mbed_vfprintf(FILE *stream, const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
 }
-#endif

--- a/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.h
+++ b/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.h
@@ -52,7 +52,6 @@ int mbed_vprintf(const char *format, va_list arguments);
  */
 int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list arguments);
 
-#if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FILE_STREAM
 /**
  * Minimal fprintf
  *
@@ -66,7 +65,6 @@ int mbed_fprintf(FILE *stream, const char *format, ...);
  * Prints directly to file stream without using malloc.
  */
 int mbed_vfprintf(FILE *stream, const char *format, va_list arguments);
-#endif
 
 #ifdef __cplusplus
 }

--- a/TESTS/mbed_platform/minimal-printf/compliance/test_app.json
+++ b/TESTS/mbed_platform/minimal-printf/compliance/test_app.json
@@ -1,7 +1,0 @@
-{
-    "target_overrides": {
-        "*": {
-            "platform.minimal-printf-enable-file-stream": 1
-        }
-    }
-}

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -128,16 +128,8 @@
             "help": "Use the MPU if available to fault execution from RAM and writes to ROM. Can be disabled to reduce image size.",
             "value": true
         },
-        "minimal-printf-console-output": {
-            "help": "Console output when using mprintf profile. Options: UART, SWO",
-            "value": "UART"
-        },
         "minimal-printf-enable-64-bit": {
             "help": "Enable printing 64 bit integers when using mprintf profile",
-            "value": true
-        },
-        "minimal-printf-enable-file-stream": {
-            "help": "Enable printing to a FILE stream when using mprintf profile",
             "value": true
         },
         "minimal-printf-enable-floating-point": {

--- a/platform/source/minimal-printf/README.md
+++ b/platform/source/minimal-printf/README.md
@@ -4,6 +4,7 @@
 Library supports both printf and snprintf in 1252 bytes of flash.
 
 Prints directly to stdio/UART without using malloc. All flags and precision modifiers are ignored.
+There is no error handling if a writing error occurs.
 
 Supports:
 * %d: signed integer [h, hh, (none), l, ll, z, j, t].
@@ -30,20 +31,12 @@ Floating point limitations:
 
 Minimal printf is configured by the following parameters defined in `platform/mbed_lib.json`:
 
-```
+```json
 {
     "name": "platform",
     "config": {
-       "minimal-printf-console-output": {
-            "help": "Console output when using minimal-printf profile. Options: UART, SWO",
-            "value": "UART"
-        },
         "minimal-printf-enable-64-bit": {
             "help": "Enable printing 64 bit integers when using minimal-printf profile",
-            "value": true
-        },
-        "minimal-printf-enable-file-stream": {
-            "help": "Enable printing to a FILE stream when using minimal-printf profile",
             "value": true
         },
         "minimal-printf-enable-floating-point": {
@@ -64,10 +57,9 @@ If your target does not require some options then you can override the default c
 
 In mbed_app.json:
 
-```
+```json
     "target_overrides": {
         "*": {
-            "platform.minimal-printf-enable-file-stream": false,
             "platform.minimal-printf-enable-floating-point": false,
             "platform.minimal-printf-set-floating-point-max-decimals": 6,
             "platform.minimal-printf-enable-64-bit": false

--- a/platform/source/minimal-printf/mbed_printf_wrapper.c
+++ b/platform/source/minimal-printf/mbed_printf_wrapper.c
@@ -34,12 +34,10 @@
 #define SUB_VSPRINTF     __wrap_vsprintf
 #define SUPER_VSNPRINTF  __real_vsnprintf
 #define SUB_VSNPRINTF    __wrap_vsnprintf
-#if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FILE_STREAM
 #define SUPER_FPRINTF  __real_fprintf
 #define SUB_FPRINTF    __wrap_fprintf
 #define SUPER_VFPRINTF __real_vfprintf
 #define SUB_VFPRINTF   __wrap_vfprintf
-#endif
 #elif defined(TOOLCHAIN_ARM) /* ARMC5/ARMC6 */\
  || defined(__ICCARM__)      /* IAR        */
 #define SUPER_PRINTF     $Super$$printf
@@ -54,33 +52,19 @@
 #define SUB_VSPRINTF     $Sub$$vsprintf
 #define SUPER_VSNPRINTF  $Super$$vsnprintf
 #define SUB_VSNPRINTF    $Sub$$vsnprintf
-#if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FILE_STREAM
 #define SUPER_FPRINTF    $Super$$fprintf
 #define SUB_FPRINTF      $Sub$$fprintf
 #define SUPER_VFPRINTF   $Super$$vfprintf
 #define SUB_VFPRINTF     $Sub$$vfprintf
-#endif
 #else
 #warning "This compiler is not yet supported."
 #endif
 
-// Prevent optimization of printf() by the ARMCC or IAR compiler.
-// This is done to prevent optimization which can cause printf() to be
-// substituted with a different function (e.g. puts()) and cause
-// the output to be missing some strings.
-// Note: Optimization prevention for other supported compilers is done
-//       via compiler optional command line arguments.
-#if defined(__CC_ARM) /* ARMC5 */
-#pragma push
-#pragma O0
-#elif defined(__ICCARM__) /* IAR */
-#pragma optimize=none
-#endif
 int SUB_PRINTF(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;
@@ -108,7 +92,7 @@ int SUB_SNPRINTF(char *buffer, size_t length, const char *format, ...)
 
 int SUB_VPRINTF(const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
 }
 
 int SUB_VSPRINTF(char *buffer, const char *format, va_list arguments)
@@ -121,7 +105,6 @@ int SUB_VSNPRINTF(char *buffer, size_t length, const char *format, va_list argum
     return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
 
-#if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FILE_STREAM
 int SUB_FPRINTF(FILE *stream, const char *format, ...)
 {
     va_list arguments;
@@ -136,6 +119,5 @@ int SUB_VFPRINTF(FILE *stream, const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
 }
-#endif
 
 #endif // MBED_MINIMAL_PRINTF

--- a/tools/profiles/extensions/minimal-printf.json
+++ b/tools/profiles/extensions/minimal-printf.json
@@ -1,12 +1,12 @@
 {
     "GCC_ARM": {
-       "common": ["-DMBED_MINIMAL_PRINTF", "-fno-builtin-printf"],
+       "common": ["-DMBED_MINIMAL_PRINTF"],
         "ld": ["-Wl,--wrap,printf", "-Wl,--wrap,sprintf", "-Wl,--wrap,snprintf",
                "-Wl,--wrap,vprintf", "-Wl,--wrap,vsprintf", "-Wl,--wrap,vsnprintf",
                "-Wl,--wrap,fprintf", "-Wl,--wrap,vfprintf"]
     },
     "ARMC6": {
-        "common": ["-DMBED_MINIMAL_PRINTF", "-fno-builtin-printf"]
+        "common": ["-DMBED_MINIMAL_PRINTF"]
     },
     "ARM": {
         "common": ["-DMBED_MINIMAL_PRINTF"]


### PR DESCRIPTION


### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

minimal-printf should not be trying to work around the retargetting - it should just use fputc.
Fixes #11234

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@kjbracey-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->