### PR TITLE
SPI: Add explicit pinmap mechanism

### DIFF
--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -131,6 +131,32 @@ public:
      */
     SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel, use_gpio_ssel_t);
 
+    /** Create a SPI master connected to the specified pins.
+     *
+     *  @note This constructor passes the SSEL pin selection to the target HAL.
+     *  Not all targets support SSEL, so this cannot be relied on in portable code.
+     *  Portable code should use the alternative constructor that uses GPIO
+     *  for SSEL.
+     *
+     *  @note You can specify mosi or miso as NC if not used.
+     *
+     *  @param explicit_pinmap pointer to strucure which holds static pinmap.
+     */
+    SPI(explicit_pinmap_t *explicit_pinmap);
+
+    /** Create a SPI master connected to the specified pins.
+     *
+     *  @note This constructor manipulates the SSEL pin as a GPIO output
+     *  using a DigitalOut object. This should work on any target, and permits
+     *  the use of select() and deselect() methods to keep the pin asserted
+     *  between transfers.
+     *
+     *  @note You can specify mosi or miso as NC if not used.
+     *
+     *  @param explicit_pinmap pointer to strucure which holds static pinmap.
+     */
+    SPI(use_gpio_ssel_t, explicit_pinmap_t *explicit_pinmap);
+
     virtual ~SPI();
 
     /** Configure the data transmission format.
@@ -408,6 +434,12 @@ protected:
     char _write_fill;
     /* Select count to handle re-entrant selection */
     int8_t _select_count;
+    /* Static pinmap data */
+    explicit_pinmap_t *_explicit_pinmap;
+    /* SPI peripheral name */
+    SPIName _peripheral_name;
+    /* Pointer to spi init function */
+    void *_init_func;
 
 private:
     void _do_construct();

--- a/drivers/SPISlave.h
+++ b/drivers/SPISlave.h
@@ -71,6 +71,14 @@ public:
      */
     SPISlave(PinName mosi, PinName miso, PinName sclk, PinName ssel);
 
+    /** Create a SPI slave connected to the specified pins.
+     *
+     *  @note Either mosi or miso can be specified as NC if not used.
+     *
+     *  @param explicit_pinmap pointer to strucure which holds static pinmap.
+     */
+    SPISlave(explicit_pinmap_t *explicit_pinmap);
+
     /** Configure the data transmission format.
      *
      *  @param bits Number of bits per SPI frame (4 - 16).

--- a/drivers/source/SPI.cpp
+++ b/drivers/source/SPI.cpp
@@ -38,7 +38,7 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
     _hw_ssel(ssel),
     _sw_ssel(NC),
     _explicit_pinmap(NULL),
-    _init_func((void*)spi_init)
+    _init_func((void *)spi_init)
 {
     // Need backwards compatibility with HALs not providing API
 #ifdef DEVICE_SPI_COUNT
@@ -60,7 +60,7 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel, use_gpio_ssel_t
     _hw_ssel(NC),
     _sw_ssel(ssel, 1),
     _explicit_pinmap(NULL),
-    _init_func((void*)spi_init)
+    _init_func((void *)spi_init)
 {
     // Need backwards compatibility with HALs not providing API
 #ifdef DEVICE_SPI_COUNT
@@ -82,7 +82,7 @@ SPI::SPI(explicit_pinmap_t *explicit_pinmap) :
     _sw_ssel(NC),
     _explicit_pinmap(explicit_pinmap),
     _peripheral_name((SPIName)explicit_pinmap->peripheral),
-    _init_func((void*)spi_init_direct)
+    _init_func((void *)spi_init_direct)
 
 {
     MBED_ASSERT(explicit_pinmap != NULL);
@@ -100,7 +100,7 @@ SPI::SPI(use_gpio_ssel_t, explicit_pinmap_t *explicit_pinmap) :
     _sw_ssel(explicit_pinmap->pin[3], 1),
     _explicit_pinmap(explicit_pinmap),
     _peripheral_name((SPIName)explicit_pinmap->peripheral),
-    _init_func((void*)spi_init_direct)
+    _init_func((void *)spi_init_direct)
 {
     MBED_ASSERT(explicit_pinmap != NULL);
     _do_construct();
@@ -204,11 +204,11 @@ void SPI::_acquire()
 {
     if (_peripheral->owner != this) {
         if (_explicit_pinmap) {
-            typedef void (*p_spi_init_t)(spi_t*, explicit_pinmap_t*);
+            typedef void (*p_spi_init_t)(spi_t *, explicit_pinmap_t *);
             p_spi_init_t p_spi_init = (p_spi_init_t)_init_func;
             p_spi_init(&_peripheral->spi, _explicit_pinmap);
         } else {
-            typedef void (*p_spi_init_t)(spi_t*, PinName, PinName, PinName, PinName);
+            typedef void (*p_spi_init_t)(spi_t *, PinName, PinName, PinName, PinName);
             p_spi_init_t p_spi_init = (p_spi_init_t)_init_func;
             p_spi_init(&_peripheral->spi, _mosi, _miso, _sclk, _hw_ssel);
         }

--- a/drivers/source/SPISlave.cpp
+++ b/drivers/source/SPISlave.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "drivers/SPISlave.h"
+#include "mbed_assert.h"
 
 #if DEVICE_SPISLAVE
 
@@ -27,6 +28,18 @@ SPISlave::SPISlave(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
     _hz(1000000)
 {
     spi_init(&_spi, mosi, miso, sclk, ssel);
+    spi_format(&_spi, _bits, _mode, 1);
+    spi_frequency(&_spi, _hz);
+}
+
+SPISlave::SPISlave(explicit_pinmap_t *explicit_pinmap) :
+    _spi(),
+    _bits(8),
+    _mode(0),
+    _hz(1000000)
+{
+    MBED_ASSERT(explicit_pinmap != NULL);
+    spi_init_direct(&_spi, explicit_pinmap);
     spi_format(&_spi, _bits, _mode, 1);
     spi_frequency(&_spi, _hz);
 }

--- a/hal/pinmap.h
+++ b/hal/pinmap.h
@@ -43,6 +43,12 @@ typedef struct {
     const int *peripheral;
 } PeripheralList;
 
+typedef struct {
+    int peripheral;    // Explicitly specified peripheral
+    PinName *pin;;     // Pointer to array which contains pins
+    int *function;     // Pointer to array which contains pins functions
+} explicit_pinmap_t;
+
 void pin_function(PinName pin, int function);
 void pin_mode(PinName pin, PinMode mode);
 

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -84,6 +84,15 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName mclk);
  */
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel);
 
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
+ */
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap);
+
+
 /** Release a SPI object
  *
  * TODO: spi_free is currently unimplemented

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
@@ -177,7 +177,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     struct spi_pl022_ctrl_cfg_t ctrl_cfg;
 
     if (!(bits >= SPI_BITS_MIN_VALUE && bits <= SPI_BITS_MAX_VALUE) ||
-        (mode & ~SPI_MODE_MAX_VALUE_MSK)) {
+            (mode & ~SPI_MODE_MAX_VALUE_MSK)) {
         error("SPI format error");
         return;
     }
@@ -197,7 +197,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     ctrl_cfg.frame_format = (uint8_t) frame_format;
     ctrl_cfg.word_size = (uint8_t) bits;
     ctrl_cfg.spi_mode =
-                  slave ? SPI_PL022_SLAVE_SELECT : SPI_PL022_MASTER_SELECT;
+        slave ? SPI_PL022_SLAVE_SELECT : SPI_PL022_MASTER_SELECT;
 
     if (spi_pl022_set_ctrl_cfg(obj->spi, &ctrl_cfg) != 0) {
         error("SPI configuration failed");
@@ -223,11 +223,11 @@ int spi_master_write(spi_t *obj, int value)
     int32_t rx_data = 0;
     uint32_t size = 1;
 
-    if(obj->spi->data->ctrl_cfg.word_size > 8) {
+    if (obj->spi->data->ctrl_cfg.word_size > 8) {
         size = 2;
     }
 
-    if (spi_pl022_txrx_blocking(obj->spi, &value, &size, &rx_data, &size) ) {
+    if (spi_pl022_txrx_blocking(obj->spi, &value, &size, &rx_data, &size)) {
         return 0;
     }
 
@@ -237,8 +237,8 @@ int spi_master_write(spi_t *obj, int value)
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
                            char *rx_buffer, int rx_length, char write_fill)
 {
-    if (spi_pl022_txrx_blocking(obj->spi, tx_buffer, (uint32_t*)&tx_length,
-                                          rx_buffer, (uint32_t*)&rx_length)) {
+    if (spi_pl022_txrx_blocking(obj->spi, tx_buffer, (uint32_t *)&tx_length,
+                                rx_buffer, (uint32_t *)&rx_length)) {
         return 0;
     }
 
@@ -250,7 +250,7 @@ int spi_slave_receive(spi_t *obj)
     int32_t status = spi_pl022_get_status(obj->spi);
     /* Rx FIFO not empty and device not busy */
     int32_t ret = ((status & SPI_PL022_SSPSR_RNE_MSK) &&
-                        !(status & SPI_PL022_SSPSR_BSY_MSK));
+                   !(status & SPI_PL022_SSPSR_BSY_MSK));
     return ret;
 }
 
@@ -274,7 +274,7 @@ uint8_t spi_get_module(spi_t *obj)
 
 int spi_slave_read(spi_t *obj)
 {
-    while(spi_slave_receive(obj) == 0) {};
+    while (spi_slave_receive(obj) == 0) {};
     return spi_pl022_slave_read(obj->spi);
 }
 

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
@@ -115,9 +115,9 @@ static uint32_t spi_fill_object(spi_t *obj, PinName mosi, PinName miso,
     }
 }
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    if (spi_fill_object(obj, mosi, miso, sclk, ssel) != 0) {
+    if (spi_fill_object(obj, explicit_pinmap->pin[0], explicit_pinmap->pin[1], explicit_pinmap->pin[2], explicit_pinmap->pin[3]) != 0) {
         return;
     }
 
@@ -129,16 +129,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
      * Mosi, miso and ssel pins are allowed to be NC,
      * call pin_function only if they are connected
      */
-    if (mosi != NC) {
-        pin_function(mosi, pinmap_function(mosi, PinMap_SPI_MOSI));
+    if (explicit_pinmap->pin[0] != NC) {
+        pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
     }
-    if (miso != NC) {
-        pin_function(miso, pinmap_function(miso, PinMap_SPI_MISO));
+    if (explicit_pinmap->pin[1] != NC) {
+        pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
     }
-    if (ssel != NC) {
-        pin_function(ssel, pinmap_function(ssel, PinMap_SPI_SSEL));
+    if (explicit_pinmap->pin[2] != NC) {
+        pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
     }
-    pin_function(sclk, pinmap_function(sclk, PinMap_SPI_SCLK));
+    pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
@@ -23,12 +23,12 @@
 #include "mbed_wait_api.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {SCLK_SPI , SPI_0, 0},
-    {CLCD_SCLK , SPI_1, 0},
-    {ADC_SCLK , SPI_2, 0},
-    {SHIELD_0_SPI_SCK , SPI_3, 0},
-    {SHIELD_1_SPI_SCK , SPI_4, 0},
-    {NC   , NC   , 0}
+    {SCLK_SPI, SPI_0, 0},
+    {CLCD_SCLK, SPI_1, 0},
+    {ADC_SCLK, SPI_2, 0},
+    {SHIELD_0_SPI_SCK, SPI_3, 0},
+    {SHIELD_1_SPI_SCK, SPI_4, 0},
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
@@ -37,7 +37,7 @@ static const PinMap PinMap_SPI_MOSI[] = {
     {ADC_MOSI, SPI_2, 0},
     {SHIELD_0_SPI_MOSI, SPI_3, 0},
     {SHIELD_1_SPI_MOSI, SPI_4, 0},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
@@ -46,7 +46,7 @@ static const PinMap PinMap_SPI_MISO[] = {
     {ADC_MISO, SPI_2, 0},
     {SHIELD_0_SPI_MISO, SPI_3, 0},
     {SHIELD_1_SPI_MISO, SPI_4, 0},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
@@ -55,7 +55,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {ADC_SSEL, SPI_2, 0},
     {SHIELD_0_SPI_nCS, SPI_3, 0},
     {SHIELD_1_SPI_nCS, SPI_4, 0},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -63,14 +63,14 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (MPS2_SSP_TypeDef*) explicit_pinmap->peripheral;
+    obj->spi = (MPS2_SSP_TypeDef *) explicit_pinmap->peripheral;
     if ((int)obj->spi == NC) {
         error("SPI pinout mapping failed");
     }
 
     // enable power and clocking
     switch ((int)obj->spi) {
-      case (int)SPI_0:
+        case (int)SPI_0:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -79,23 +79,23 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
             obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_1:
-                      /* Configure SSP used for LCD                                               */
+        case (int)SPI_1:
+            /* Configure SSP used for LCD                                               */
             obj->spi->CR1   =   0;                 /* Synchronous serial port disable  */
             obj->spi->DMACR =   0;                 /* Disable FIFO DMA                 */
             obj->spi->IMSC  =   0;                 /* Mask all FIFO/IRQ interrupts     */
             obj->spi->ICR   = ((1ul <<  0) |       /* Clear SSPRORINTR interrupt       */
-                                (1ul <<  1) );      /* Clear SSPRTINTR interrupt        */
-              obj->spi->CR0   = ((7ul <<  0) |       /* 8 bit data size                  */
-                                (0ul <<  4) |       /* Motorola frame format            */
-                                (0ul <<  6) |       /* CPOL = 0                         */
-                                (0ul <<  7) |       /* CPHA = 0                         */
-                                (1ul <<  8) );      /* Set serial clock rate            */
-            obj->spi->CPSR  =  (2ul <<  0);        /* set SSP clk to 6MHz (6.6MHz max) */
+                               (1ul <<  1));       /* Clear SSPRTINTR interrupt        */
+            obj->spi->CR0   = ((7ul <<  0) |       /* 8 bit data size                  */
+                               (0ul <<  4) |       /* Motorola frame format            */
+                               (0ul <<  6) |       /* CPOL = 0                         */
+                               (0ul <<  7) |       /* CPHA = 0                         */
+                               (1ul <<  8));       /* Set serial clock rate            */
+            obj->spi->CPSR  = (2ul <<  0);         /* set SSP clk to 6MHz (6.6MHz max) */
             obj->spi->CR1   = ((1ul <<  1) |       /* Synchronous serial port enable   */
-                                (0ul <<  2) );      /* Device configured as master      */
+                               (0ul <<  2));       /* Device configured as master      */
             break;
-      case (int)SPI_2:
+        case (int)SPI_2:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -104,7 +104,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
             obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_3:
+        case (int)SPI_3:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -113,7 +113,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
             obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_4:
+        case (int)SPI_4:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -126,16 +126,16 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 
     // enable alt function
     switch ((int)obj->spi) {
-      case (int)SPI_2:
-                CMSDK_GPIO1->ALTFUNCSET |= (explicit_pinmap->function[2]<<5 | explicit_pinmap->function[0]<<4 | explicit_pinmap->function[1]<<3 | explicit_pinmap->function[3]<<2);
+        case (int)SPI_2:
+            CMSDK_GPIO1->ALTFUNCSET |= (explicit_pinmap->function[2] << 5 | explicit_pinmap->function[0] << 4 | explicit_pinmap->function[1] << 3 | explicit_pinmap->function[3] << 2);
             break;
-      case (int)SPI_3:
-                CMSDK_GPIO0->ALTFUNCSET |= (explicit_pinmap->function[2]<<13 | explicit_pinmap->function[1]<<12 | explicit_pinmap->function[0]<<11 | explicit_pinmap->function[3]<<10);
+        case (int)SPI_3:
+            CMSDK_GPIO0->ALTFUNCSET |= (explicit_pinmap->function[2] << 13 | explicit_pinmap->function[1] << 12 | explicit_pinmap->function[0] << 11 | explicit_pinmap->function[3] << 10);
             break;
-      case (int)SPI_4:
-                CMSDK_GPIO4->ALTFUNCSET |= (explicit_pinmap->function[2]<<3 | explicit_pinmap->function[1]<<2 | explicit_pinmap->function[0]<<1 | explicit_pinmap->function[3]);
+        case (int)SPI_4:
+            CMSDK_GPIO4->ALTFUNCSET |= (explicit_pinmap->function[2] << 3 | explicit_pinmap->function[1] << 2 | explicit_pinmap->function[0] << 1 | explicit_pinmap->function[3]);
             break;
-        }
+    }
 
     // set default format and frequency
     if (explicit_pinmap->pin[3] == NC) {
@@ -188,7 +188,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     ssp_disable(obj);
     if (!(bits >= 4 && bits <= 16) || !(mode >= 0 && mode <= 3)) {
         error("SPI format error");
@@ -206,27 +207,28 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0xFFFF);
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
 
-        int prescaler;
+    int prescaler;
 
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
@@ -249,43 +251,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= SSP_CR1_SSE_Msk;
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & SSP_SR_BSY_Msk;
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     obj->spi->DR = value;
     while (ssp_writeable(obj));
 }
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     int read_DR = obj->spi->DR;
     return read_DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     while (obj->spi->SR & SSP_SR_BSY_Msk);  /* Wait for send to finish      */
     return (ssp_read(obj));
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -299,20 +310,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
@@ -61,31 +61,23 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    
-        int altfunction[4];
-        // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (MPS2_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (MPS2_SSP_TypeDef*) explicit_pinmap->peripheral;
     if ((int)obj->spi == NC) {
         error("SPI pinout mapping failed");
     }
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
-      case (int)SPI_0: 
+      case (int)SPI_0:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
       case (int)SPI_1:
                       /* Configure SSP used for LCD                                               */
@@ -103,71 +95,95 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             obj->spi->CR1   = ((1ul <<  1) |       /* Synchronous serial port enable   */
                                 (0ul <<  2) );      /* Device configured as master      */
             break;
-      case (int)SPI_2: 
+      case (int)SPI_2:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_3: 
+      case (int)SPI_3:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_4: 
+      case (int)SPI_4:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
     }
-    
-        if(mosi != NC){ altfunction[0] = 1;}else{ altfunction[0] = 0;}
-        if(miso != NC){ altfunction[1] = 1;}else{ altfunction[1] = 0;}
-        if(sclk != NC){ altfunction[2] = 1;}else{ altfunction[2] = 0;}
-        if(ssel != NC){ altfunction[3] = 1;}else{ altfunction[3] = 0;}
-        
+
     // enable alt function
     switch ((int)obj->spi) {
       case (int)SPI_2:
-                CMSDK_GPIO1->ALTFUNCSET |= (altfunction[2]<<5 | altfunction[0]<<4 | altfunction[1]<<3 | altfunction[3]<<2);
+                CMSDK_GPIO1->ALTFUNCSET |= (explicit_pinmap->function[2]<<5 | explicit_pinmap->function[0]<<4 | explicit_pinmap->function[1]<<3 | explicit_pinmap->function[3]<<2);
             break;
       case (int)SPI_3:
-                CMSDK_GPIO0->ALTFUNCSET |= (altfunction[2]<<13 | altfunction[1]<<12 | altfunction[0]<<11 | altfunction[3]<<10);
+                CMSDK_GPIO0->ALTFUNCSET |= (explicit_pinmap->function[2]<<13 | explicit_pinmap->function[1]<<12 | explicit_pinmap->function[0]<<11 | explicit_pinmap->function[3]<<10);
             break;
       case (int)SPI_4:
-                CMSDK_GPIO4->ALTFUNCSET |= (altfunction[2]<<3 | altfunction[1]<<2 | altfunction[0]<<1 | altfunction[3]);
+                CMSDK_GPIO4->ALTFUNCSET |= (explicit_pinmap->function[2]<<3 | explicit_pinmap->function[1]<<2 | explicit_pinmap->function[0]<<1 | explicit_pinmap->function[3]);
             break;
         }
-        
+
     // set default format and frequency
-    if (ssel == NC) {
+    if (explicit_pinmap->pin[3] == NC) {
         spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
     } else {
         spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
     }
     spi_frequency(obj, 1000000);
-    
+
     // enable the ssp channel
     ssp_enable(obj);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = ((mosi != NC) ? 1 : 0);
+    int miso_function = ((miso != NC) ? 1 : 0);
+    int sclk_function = ((sclk != NC) ? 1 : 0);
+    int ssel_function = ((ssel != NC) ? 1 : 0);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -177,15 +193,15 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     if (!(bits >= 4 && bits <= 16) || !(mode >= 0 && mode <= 3)) {
         error("SPI format error");
     }
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0xFFFF);
@@ -194,35 +210,35 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-   
+
     uint32_t PCLK = SystemCoreClock;
-    
+
         int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFFFF << 8);
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
@@ -23,12 +23,12 @@
 #include "mbed_wait_api.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {SCLK_SPI , SPI_0, 0},
-    {CLCD_SCLK , SPI_1, 0},
-    {ADC_SCLK , SPI_2, 0},
-    {SHIELD_0_SPI_SCK , SPI_3, 0},
-    {SHIELD_1_SPI_SCK , SPI_4, 0},
-    {NC   , NC   , 0}
+    {SCLK_SPI, SPI_0, 0},
+    {CLCD_SCLK, SPI_1, 0},
+    {ADC_SCLK, SPI_2, 0},
+    {SHIELD_0_SPI_SCK, SPI_3, 0},
+    {SHIELD_1_SPI_SCK, SPI_4, 0},
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
@@ -37,7 +37,7 @@ static const PinMap PinMap_SPI_MOSI[] = {
     {ADC_MOSI, SPI_2, 0},
     {SHIELD_0_SPI_MOSI, SPI_3, 0},
     {SHIELD_1_SPI_MOSI, SPI_4, 0},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
@@ -46,7 +46,7 @@ static const PinMap PinMap_SPI_MISO[] = {
     {ADC_MISO, SPI_2, 0},
     {SHIELD_0_SPI_MISO, SPI_3, 0},
     {SHIELD_1_SPI_MISO, SPI_4, 0},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
@@ -55,7 +55,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {ADC_SSEL, SPI_2, 0},
     {SHIELD_0_SPI_nCS, SPI_3, 0},
     {SHIELD_1_SPI_nCS, SPI_4, 0},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -63,14 +63,14 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (MPS2_SSP_TypeDef*) explicit_pinmap->peripheral;
+    obj->spi = (MPS2_SSP_TypeDef *) explicit_pinmap->peripheral;
     if ((int)obj->spi == NC) {
         error("SPI pinout mapping failed");
     }
 
     // enable power and clocking
     switch ((int)obj->spi) {
-      case (int)SPI_0:
+        case (int)SPI_0:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -79,23 +79,23 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
             obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_1:
-                      /* Configure SSP used for LCD                                               */
+        case (int)SPI_1:
+            /* Configure SSP used for LCD                                               */
             obj->spi->CR1   =   0;                 /* Synchronous serial port disable  */
             obj->spi->DMACR =   0;                 /* Disable FIFO DMA                 */
             obj->spi->IMSC  =   0;                 /* Mask all FIFO/IRQ interrupts     */
             obj->spi->ICR   = ((1ul <<  0) |       /* Clear SSPRORINTR interrupt       */
-                                (1ul <<  1) );      /* Clear SSPRTINTR interrupt        */
-              obj->spi->CR0   = ((7ul <<  0) |       /* 8 bit data size                  */
-                                (0ul <<  4) |       /* Motorola frame format            */
-                                (0ul <<  6) |       /* CPOL = 0                         */
-                                (0ul <<  7) |       /* CPHA = 0                         */
-                                (1ul <<  8) );      /* Set serial clock rate            */
-            obj->spi->CPSR  =  (2ul <<  0);        /* set SSP clk to 6MHz (6.6MHz max) */
+                               (1ul <<  1));       /* Clear SSPRTINTR interrupt        */
+            obj->spi->CR0   = ((7ul <<  0) |       /* 8 bit data size                  */
+                               (0ul <<  4) |       /* Motorola frame format            */
+                               (0ul <<  6) |       /* CPOL = 0                         */
+                               (0ul <<  7) |       /* CPHA = 0                         */
+                               (1ul <<  8));       /* Set serial clock rate            */
+            obj->spi->CPSR  = (2ul <<  0);         /* set SSP clk to 6MHz (6.6MHz max) */
             obj->spi->CR1   = ((1ul <<  1) |       /* Synchronous serial port enable   */
-                                (0ul <<  2) );      /* Device configured as master      */
+                               (0ul <<  2));       /* Device configured as master      */
             break;
-      case (int)SPI_2:
+        case (int)SPI_2:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -104,7 +104,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
             obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_3:
+        case (int)SPI_3:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -113,7 +113,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
             obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_4:
+        case (int)SPI_4:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
             obj->spi->CPSR      = SSP_CPSR_DFLT;
@@ -126,16 +126,16 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 
     // enable alt function
     switch ((int)obj->spi) {
-      case (int)SPI_2:
-                CMSDK_GPIO1->ALTFUNCSET |= (explicit_pinmap->function[2]<<3 | explicit_pinmap->function[0]<<2 | explicit_pinmap->function[1]<<1 | explicit_pinmap->function[3]);
+        case (int)SPI_2:
+            CMSDK_GPIO1->ALTFUNCSET |= (explicit_pinmap->function[2] << 3 | explicit_pinmap->function[0] << 2 | explicit_pinmap->function[1] << 1 | explicit_pinmap->function[3]);
             break;
-      case (int)SPI_3:
-                CMSDK_GPIO0->ALTFUNCSET |= (explicit_pinmap->function[1]<<14 | explicit_pinmap->function[0]<<13 | explicit_pinmap->function[3]<<12 | explicit_pinmap->function[2]<<11);
+        case (int)SPI_3:
+            CMSDK_GPIO0->ALTFUNCSET |= (explicit_pinmap->function[1] << 14 | explicit_pinmap->function[0] << 13 | explicit_pinmap->function[3] << 12 | explicit_pinmap->function[2] << 11);
             break;
-      case (int)SPI_4:
-                CMSDK_GPIO2->ALTFUNCSET |= (explicit_pinmap->function[2]<<12 | explicit_pinmap->function[1]<<8 | explicit_pinmap->function[0]<<7 | explicit_pinmap->function[3]<<6);
+        case (int)SPI_4:
+            CMSDK_GPIO2->ALTFUNCSET |= (explicit_pinmap->function[2] << 12 | explicit_pinmap->function[1] << 8 | explicit_pinmap->function[0] << 7 | explicit_pinmap->function[3] << 6);
             break;
-        }
+    }
 
     // set default format and frequency
     if (explicit_pinmap->pin[3] == NC) {
@@ -188,7 +188,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     ssp_disable(obj);
     if (!(bits >= 4 && bits <= 16) || !(mode >= 0 && mode <= 3)) {
         error("SPI format error");
@@ -206,27 +207,28 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0xFFFF);
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
 
-        int prescaler;
+    int prescaler;
 
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
@@ -249,43 +251,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= SSP_CR1_SSE_Msk;
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & SSP_SR_BSY_Msk;
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     obj->spi->DR = value;
     while (ssp_writeable(obj));
 }
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     int read_DR = obj->spi->DR;
     return read_DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     while (obj->spi->SR & SSP_SR_BSY_Msk);  /* Wait for send to finish      */
     return (ssp_read(obj));
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -299,20 +310,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
@@ -61,31 +61,23 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    
-        int altfunction[4];
-        // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (MPS2_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (MPS2_SSP_TypeDef*) explicit_pinmap->peripheral;
     if ((int)obj->spi == NC) {
         error("SPI pinout mapping failed");
     }
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
-      case (int)SPI_0: 
+      case (int)SPI_0:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
       case (int)SPI_1:
                       /* Configure SSP used for LCD                                               */
@@ -103,71 +95,95 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             obj->spi->CR1   = ((1ul <<  1) |       /* Synchronous serial port enable   */
                                 (0ul <<  2) );      /* Device configured as master      */
             break;
-      case (int)SPI_2: 
+      case (int)SPI_2:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_3: 
+      case (int)SPI_3:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
-      case (int)SPI_4: 
+      case (int)SPI_4:
             obj->spi->CR1       = 0;
             obj->spi->CR0       = SSP_CR0_SCR_DFLT | SSP_CR0_FRF_MOT | SSP_CR0_DSS_8;
-            obj->spi->CPSR      = SSP_CPSR_DFLT; 
-            obj->spi->IMSC      = 0x8; 
+            obj->spi->CPSR      = SSP_CPSR_DFLT;
+            obj->spi->IMSC      = 0x8;
             obj->spi->DMACR     = 0;
             obj->spi->CR1       = SSP_CR1_SSE_Msk;
-            obj->spi->ICR       = 0x3;  
+            obj->spi->ICR       = 0x3;
             break;
     }
-    
-        if(mosi != NC){ altfunction[0] = 1;}else{ altfunction[0] = 0;}
-        if(miso != NC){ altfunction[1] = 1;}else{ altfunction[1] = 0;}
-        if(sclk != NC){ altfunction[2] = 1;}else{ altfunction[2] = 0;}
-        if(ssel != NC){ altfunction[3] = 1;}else{ altfunction[3] = 0;}
-        
+
     // enable alt function
     switch ((int)obj->spi) {
       case (int)SPI_2:
-                CMSDK_GPIO1->ALTFUNCSET |= (altfunction[2]<<3 | altfunction[0]<<2 | altfunction[1]<<1 | altfunction[3]);
+                CMSDK_GPIO1->ALTFUNCSET |= (explicit_pinmap->function[2]<<3 | explicit_pinmap->function[0]<<2 | explicit_pinmap->function[1]<<1 | explicit_pinmap->function[3]);
             break;
       case (int)SPI_3:
-                CMSDK_GPIO0->ALTFUNCSET |= (altfunction[1]<<14 | altfunction[0]<<13 | altfunction[3]<<12 | altfunction[2]<<11);
+                CMSDK_GPIO0->ALTFUNCSET |= (explicit_pinmap->function[1]<<14 | explicit_pinmap->function[0]<<13 | explicit_pinmap->function[3]<<12 | explicit_pinmap->function[2]<<11);
             break;
       case (int)SPI_4:
-                CMSDK_GPIO2->ALTFUNCSET |= (altfunction[2]<<12 | altfunction[1]<<8 | altfunction[0]<<7 | altfunction[3]<<6);
+                CMSDK_GPIO2->ALTFUNCSET |= (explicit_pinmap->function[2]<<12 | explicit_pinmap->function[1]<<8 | explicit_pinmap->function[0]<<7 | explicit_pinmap->function[3]<<6);
             break;
         }
-        
+
     // set default format and frequency
-    if (ssel == NC) {
+    if (explicit_pinmap->pin[3] == NC) {
         spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
     } else {
         spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
     }
     spi_frequency(obj, 1000000);
-    
+
     // enable the ssp channel
     ssp_enable(obj);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = ((mosi != NC) ? 1 : 0);
+    int miso_function = ((miso != NC) ? 1 : 0);
+    int sclk_function = ((sclk != NC) ? 1 : 0);
+    int ssel_function = ((ssel != NC) ? 1 : 0);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -177,15 +193,15 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     if (!(bits >= 4 && bits <= 16) || !(mode >= 0 && mode <= 3)) {
         error("SPI format error");
     }
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0xFFFF);
@@ -194,35 +210,35 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-   
+
     uint32_t PCLK = SystemCoreClock;
-    
+
         int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFFFF << 8);
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/spi_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/spi_api.c
@@ -64,11 +64,11 @@ int adi_spi_memtype = 0;
    guarantee 4 byte alignmnet.
  *******************************************************************************/
 ADI_SPI_HANDLE      spi_Handle0;
-uint32_t            spi_Mem0[(ADI_SPI_MEMORY_SIZE + 3)/4];
+uint32_t            spi_Mem0[(ADI_SPI_MEMORY_SIZE + 3) / 4];
 ADI_SPI_HANDLE      spi_Handle1;
-uint32_t            spi_Mem1[(ADI_SPI_MEMORY_SIZE + 3)/4];
+uint32_t            spi_Mem1[(ADI_SPI_MEMORY_SIZE + 3) / 4];
 ADI_SPI_HANDLE      spi_Handle2;
-uint32_t            spi_Mem2[(ADI_SPI_MEMORY_SIZE + 3)/4];
+uint32_t            spi_Mem2[(ADI_SPI_MEMORY_SIZE + 3) / 4];
 #if defined(ADI_DEBUG)
 #warning "BUILD_SPI_MI_DYNAMIC is NOT defined.  Memory allocation for SPI will be static"
 int adi_spi_memtype = 1;
@@ -143,13 +143,13 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     }
 
     if (explicit_pinmap->pin[3] != NC) {
-        if ( (explicit_pinmap->pin[3] == SPI0_CS0) || (explicit_pinmap->pin[3] == SPI1_CS0) || (explicit_pinmap->pin[3] == SPI2_CS0)) {
+        if ((explicit_pinmap->pin[3] == SPI0_CS0) || (explicit_pinmap->pin[3] == SPI1_CS0) || (explicit_pinmap->pin[3] == SPI2_CS0)) {
             spi_cs = ADI_SPI_CS0;
-        } else if ( (explicit_pinmap->pin[3] == SPI0_CS1) || (explicit_pinmap->pin[3] == SPI1_CS1) || (explicit_pinmap->pin[3] == SPI2_CS1)) {
+        } else if ((explicit_pinmap->pin[3] == SPI0_CS1) || (explicit_pinmap->pin[3] == SPI1_CS1) || (explicit_pinmap->pin[3] == SPI2_CS1)) {
             spi_cs = ADI_SPI_CS1;
-        } else if ( (explicit_pinmap->pin[3] == SPI0_CS2) || (explicit_pinmap->pin[3] == SPI1_CS2) || (explicit_pinmap->pin[3] == SPI2_CS2)) {
+        } else if ((explicit_pinmap->pin[3] == SPI0_CS2) || (explicit_pinmap->pin[3] == SPI1_CS2) || (explicit_pinmap->pin[3] == SPI2_CS2)) {
             spi_cs = ADI_SPI_CS2;
-        } else if ( (explicit_pinmap->pin[3] == SPI0_CS3) || (explicit_pinmap->pin[3] == SPI1_CS3) || (explicit_pinmap->pin[3] == SPI2_CS3)) {
+        } else if ((explicit_pinmap->pin[3] == SPI0_CS3) || (explicit_pinmap->pin[3] == SPI1_CS3) || (explicit_pinmap->pin[3] == SPI2_CS3)) {
             spi_cs = ADI_SPI_CS3;
         }
 
@@ -265,8 +265,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
     if ((uint32_t)mode & 0x1) {
         phase = true;
-    }
-    else {
+    } else {
         phase = false;
     }
     SPI_Return = adi_spi_SetClockPhase(SPI_Handle, phase);
@@ -277,8 +276,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
     if ((uint32_t)mode & 0x2) {
         polarity = true;
-    }
-    else {
+    } else {
         polarity = false;
     }
     SPI_Return = adi_spi_SetClockPolarity(SPI_Handle, polarity);
@@ -349,7 +347,7 @@ int spi_master_write(spi_t *obj, int value)
         return 1;
     }
 
-    return((int)RxBuf);
+    return ((int)RxBuf);
 }
 
 
@@ -375,10 +373,10 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     ADI_SPI_HANDLE  SPI_Handle;
     ADI_SPI_RESULT  SPI_Return = ADI_SPI_SUCCESS;
 
-    transceive.pReceiver        = (uint8_t*)rx_buffer;
+    transceive.pReceiver        = (uint8_t *)rx_buffer;
     transceive.ReceiverBytes    = rx_length;            /* link transceive data size to the remaining count */
     transceive.nRxIncrement     = 1;                    /* auto increment buffer */
-    transceive.pTransmitter     = (uint8_t*)tx_buffer;  /* initialize data attributes */
+    transceive.pTransmitter     = (uint8_t *)tx_buffer; /* initialize data attributes */
     transceive.TransmitterBytes = tx_length;            /* link transceive data size to the remaining count */
     transceive.nTxIncrement     = 1;                    /* auto increment buffer */
 
@@ -389,9 +387,8 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     if (SPI_Return) {
         obj->error = SPI_EVENT_ERROR;
         return -1;
-    }
-    else {
-        return((int)tx_length);
+    } else {
+        return ((int)tx_length);
     }
 }
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/spi_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/spi_api.c
@@ -64,11 +64,11 @@ int adi_spi_memtype = 0;
    guarantee 4 byte alignmnet.
  *******************************************************************************/
 ADI_SPI_HANDLE      spi_Handle0;
-uint32_t            spi_Mem0[(ADI_SPI_MEMORY_SIZE + 3)/4];
+uint32_t            spi_Mem0[(ADI_SPI_MEMORY_SIZE + 3) / 4];
 ADI_SPI_HANDLE      spi_Handle1;
-uint32_t            spi_Mem1[(ADI_SPI_MEMORY_SIZE + 3)/4];
+uint32_t            spi_Mem1[(ADI_SPI_MEMORY_SIZE + 3) / 4];
 ADI_SPI_HANDLE      spi_Handle2;
-uint32_t            spi_Mem2[(ADI_SPI_MEMORY_SIZE + 3)/4];
+uint32_t            spi_Mem2[(ADI_SPI_MEMORY_SIZE + 3) / 4];
 #if defined(ADI_DEBUG)
 #warning "BUILD_SPI_MI_DYNAMIC is NOT defined.  Memory allocation for SPI will be static"
 int adi_spi_memtype = 1;
@@ -144,13 +144,13 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     }
 
     if (explicit_pinmap->pin[3] != NC) {
-        if ( (explicit_pinmap->pin[3] == SPI0_CS0) || (explicit_pinmap->pin[3] == SPI1_CS0) || (explicit_pinmap->pin[3] == SPI2_CS0)) {
+        if ((explicit_pinmap->pin[3] == SPI0_CS0) || (explicit_pinmap->pin[3] == SPI1_CS0) || (explicit_pinmap->pin[3] == SPI2_CS0)) {
             spi_cs = ADI_SPI_CS0;
-        } else if ( (explicit_pinmap->pin[3] == SPI0_CS1) || (explicit_pinmap->pin[3] == SPI1_CS1) || (explicit_pinmap->pin[3] == SPI2_CS1)) {
+        } else if ((explicit_pinmap->pin[3] == SPI0_CS1) || (explicit_pinmap->pin[3] == SPI1_CS1) || (explicit_pinmap->pin[3] == SPI2_CS1)) {
             spi_cs = ADI_SPI_CS1;
-        } else if ( (explicit_pinmap->pin[3] == SPI0_CS2) || (explicit_pinmap->pin[3] == SPI1_CS2) || (explicit_pinmap->pin[3] == SPI2_CS2)) {
+        } else if ((explicit_pinmap->pin[3] == SPI0_CS2) || (explicit_pinmap->pin[3] == SPI1_CS2) || (explicit_pinmap->pin[3] == SPI2_CS2)) {
             spi_cs = ADI_SPI_CS2;
-        } else if ( (explicit_pinmap->pin[3] == SPI0_CS3) || (explicit_pinmap->pin[3] == SPI1_CS3) || (explicit_pinmap->pin[3] == SPI2_CS3)) {
+        } else if ((explicit_pinmap->pin[3] == SPI0_CS3) || (explicit_pinmap->pin[3] == SPI1_CS3) || (explicit_pinmap->pin[3] == SPI2_CS3)) {
             spi_cs = ADI_SPI_CS3;
         }
 
@@ -323,7 +323,7 @@ int spi_master_write(spi_t *obj, int value)
         return 1;
     }
 
-    return((int)RxBuf);
+    return ((int)RxBuf);
 }
 
 
@@ -349,10 +349,10 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     ADI_SPI_HANDLE  SPI_Handle;
     ADI_SPI_RESULT  SPI_Return = ADI_SPI_SUCCESS;
 
-    transceive.pReceiver        = (uint8_t*)rx_buffer;
+    transceive.pReceiver        = (uint8_t *)rx_buffer;
     transceive.ReceiverBytes    = rx_length;            /* link transceive data size to the remaining count */
     transceive.nRxIncrement     = 1;                    /* auto increment buffer */
-    transceive.pTransmitter     = (uint8_t*)tx_buffer;  /* initialize data attributes */
+    transceive.pTransmitter     = (uint8_t *)tx_buffer; /* initialize data attributes */
     transceive.TransmitterBytes = tx_length;            /* link transceive data size to the remaining count */
     transceive.nTxIncrement     = 1;                    /* auto increment buffer */
 
@@ -363,9 +363,8 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     if (SPI_Return) {
         obj->error = SPI_EVENT_ERROR;
         return -1;
-    }
-    else {
-        return((int)tx_length);
+    } else {
+        return ((int)tx_length);
     }
 }
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/spi_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/spi_api.c
@@ -53,8 +53,6 @@
 #include "PeripheralPins.h"
 #include "drivers/spi/adi_spi.h"
 
-
-
 #if defined(BUILD_SPI_MI_DYNAMIC)
 #if defined(ADI_DEBUG)
 #warning "BUILD_SPI_MI_DYNAMIC is defined.  Memory allocation for SPI will be dynamic"
@@ -78,6 +76,92 @@ int adi_spi_memtype = 1;
 #endif
 
 
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
+ */
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // determine the SPI to use
+    ADI_SPI_HANDLE      *pSPI_Handle;
+    uint32_t            *SPI_Mem;
+    ADI_SPI_RESULT      SPI_Return = ADI_SPI_SUCCESS;
+    uint32_t            nDeviceNum = 0;
+    ADI_SPI_CHIP_SELECT spi_cs = ADI_SPI_CS_NONE;
+
+
+#if defined(BUILD_SPI_MI_DYNAMIC)
+    if (explicit_pinmap->pin[0] == SPI0_MOSI) {
+        nDeviceNum = SPI_0;
+    } else if (explicit_pinmap->pin[0] == SPI1_MOSI) {
+        nDeviceNum = SPI_1;
+    } else if (explicit_pinmap->pin[0] == SPI2_MOSI) {
+        nDeviceNum = SPI_2;
+    }
+    pSPI_Handle = &obj->SPI_Handle;
+    obj->pSPI_Handle = pSPI_Handle;
+    SPI_Mem = obj->SPI_Mem;
+#else
+    if (explicit_pinmap->pin[0] == SPI0_MOSI) {
+        nDeviceNum = SPI_0;
+        pSPI_Handle = &spi_Handle0;
+        SPI_Mem = &spi_Mem0[0];
+    } else if (explicit_pinmap->pin[0] == SPI1_MOSI) {
+        nDeviceNum = SPI_1;
+        pSPI_Handle = &spi_Handle1;
+        SPI_Mem = &spi_Mem1[0];
+    } else if (explicit_pinmap->pin[0] == SPI2_MOSI) {
+        nDeviceNum = SPI_2;
+        pSPI_Handle = &spi_Handle2;
+        SPI_Mem = &spi_Mem2[0];
+    }
+    obj->pSPI_Handle    = pSPI_Handle;
+#endif
+
+
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+
+    SystemCoreClockUpdate();
+    SPI_Return = adi_spi_Open(nDeviceNum, SPI_Mem, ADI_SPI_MEMORY_SIZE, pSPI_Handle);
+    if (SPI_Return) {
+        obj->error = SPI_EVENT_ERROR;
+        return;
+    }
+
+    if (explicit_pinmap->pin[3] != NC) {
+        if ( (explicit_pinmap->pin[3] == SPI0_CS0) || (explicit_pinmap->pin[3] == SPI1_CS0) || (explicit_pinmap->pin[3] == SPI2_CS0)) {
+            spi_cs = ADI_SPI_CS0;
+        } else if ( (explicit_pinmap->pin[3] == SPI0_CS1) || (explicit_pinmap->pin[3] == SPI1_CS1) || (explicit_pinmap->pin[3] == SPI2_CS1)) {
+            spi_cs = ADI_SPI_CS1;
+        } else if ( (explicit_pinmap->pin[3] == SPI0_CS2) || (explicit_pinmap->pin[3] == SPI1_CS2) || (explicit_pinmap->pin[3] == SPI2_CS2)) {
+            spi_cs = ADI_SPI_CS2;
+        } else if ( (explicit_pinmap->pin[3] == SPI0_CS3) || (explicit_pinmap->pin[3] == SPI1_CS3) || (explicit_pinmap->pin[3] == SPI2_CS3)) {
+            spi_cs = ADI_SPI_CS3;
+        }
+
+        SPI_Return = adi_spi_SetChipSelect(*pSPI_Handle, spi_cs);
+        if (SPI_Return) {
+            obj->error = SPI_EVENT_ERROR;
+            return;
+        }
+    }
+}
+
 
 /** Initialize the SPI peripheral
  *
@@ -97,77 +181,20 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
-    ADI_SPI_HANDLE      *pSPI_Handle;
-    uint32_t            *SPI_Mem;
-    ADI_SPI_RESULT      SPI_Return = ADI_SPI_SUCCESS;
-    uint32_t            nDeviceNum = 0;
-    ADI_SPI_CHIP_SELECT spi_cs = ADI_SPI_CS_NONE;
 
-
-#if defined(BUILD_SPI_MI_DYNAMIC)
-    if (mosi == SPI0_MOSI) {
-        nDeviceNum = SPI_0;
-    } else if (mosi == SPI1_MOSI) {
-        nDeviceNum = SPI_1;
-    } else if (mosi == SPI2_MOSI) {
-        nDeviceNum = SPI_2;
-    }
-    pSPI_Handle = &obj->SPI_Handle;
-    obj->pSPI_Handle = pSPI_Handle;
-    SPI_Mem = obj->SPI_Mem;
-#else
-    if (mosi == SPI0_MOSI) {
-        nDeviceNum = SPI_0;
-        pSPI_Handle = &spi_Handle0;
-        SPI_Mem = &spi_Mem0[0];
-    } else if (mosi == SPI1_MOSI) {
-        nDeviceNum = SPI_1;
-        pSPI_Handle = &spi_Handle1;
-        SPI_Mem = &spi_Mem1[0];
-    } else if (mosi == SPI2_MOSI) {
-        nDeviceNum = SPI_2;
-        pSPI_Handle = &spi_Handle2;
-        SPI_Mem = &spi_Mem2[0];
-    }
-    obj->pSPI_Handle    = pSPI_Handle;
-#endif
-
-
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
 
-    SystemCoreClockUpdate();
-    SPI_Return = adi_spi_Open(nDeviceNum, SPI_Mem, ADI_SPI_MEMORY_SIZE, pSPI_Handle);
-    if (SPI_Return) {
-        obj->error = SPI_EVENT_ERROR;
-        return;
-    }
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
 
-    if (ssel != NC) {
-        if ( (ssel == SPI0_CS0) || (ssel == SPI1_CS0) || (ssel == SPI2_CS0)) {
-            spi_cs = ADI_SPI_CS0;
-        } else if ( (ssel == SPI0_CS1) || (ssel == SPI1_CS1) || (ssel == SPI2_CS1)) {
-            spi_cs = ADI_SPI_CS1;
-        } else if ( (ssel == SPI0_CS2) || (ssel == SPI1_CS2) || (ssel == SPI2_CS2)) {
-            spi_cs = ADI_SPI_CS2;
-        } else if ( (ssel == SPI0_CS3) || (ssel == SPI1_CS3) || (ssel == SPI2_CS3)) {
-            spi_cs = ADI_SPI_CS3;
-        }
-
-        SPI_Return = adi_spi_SetChipSelect(*pSPI_Handle, spi_cs);
-        if (SPI_Return) {
-            obj->error = SPI_EVENT_ERROR;
-            return;
-        }
-    }
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
@@ -375,6 +375,18 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spi_enable(obj);
 }
 
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
+ */
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // Not supported
+    MBED_ASSERT(false);
+}
+
 /** Release a SPI object
  *
  * TODO: spi_free is currently unimplemented

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
@@ -22,13 +22,13 @@
 
 #include "pinmap_function.h"
 
-#define 	SERCOM_SPI_STATUS_SYNCBUSY_Pos   15
-#define 	SERCOM_SPI_STATUS_SYNCBUSY   (0x1u << SERCOM_SPI_STATUS_SYNCBUSY_Pos)
+#define     SERCOM_SPI_STATUS_SYNCBUSY_Pos   15
+#define     SERCOM_SPI_STATUS_SYNCBUSY   (0x1u << SERCOM_SPI_STATUS_SYNCBUSY_Pos)
 
-#define SPI_MOSI_INDEX	0
-#define SPI_MISO_INDEX	1
-#define SPI_SCLK_INDEX	2
-#define SPI_SSEL_INDEX	3
+#define SPI_MOSI_INDEX  0
+#define SPI_MISO_INDEX  1
+#define SPI_SCLK_INDEX  2
+#define SPI_SSEL_INDEX  3
 
 /**
  * \brief SPI modes enum
@@ -43,16 +43,16 @@ enum spi_mode {
 };
 
 #if DEVICE_SPI_ASYNCH
-#define pSPI_S(obj)			(&obj->spi)
-#define pSPI_SERCOM(obj)	obj->spi.spi
+#define pSPI_S(obj)         (&obj->spi)
+#define pSPI_SERCOM(obj)    obj->spi.spi
 #else
-#define pSPI_S(obj)			(obj)
-#define pSPI_SERCOM(obj)	(obj->spi)
+#define pSPI_S(obj)         (obj)
+#define pSPI_SERCOM(obj)    (obj->spi)
 #endif
-#define _SPI(obj)			pSPI_SERCOM(obj)->SPI
+#define _SPI(obj)           pSPI_SERCOM(obj)->SPI
 
 /** SPI default baud rate. */
-#define SPI_DEFAULT_BAUD	100000
+#define SPI_DEFAULT_BAUD    100000
 
 
 /** SPI timeout value. */
@@ -256,7 +256,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     /* Calculate SERCOM instance from pins */
     uint32_t sercom_index = pinmap_find_sercom(mosi, miso, sclk, ssel);
-    pSPI_SERCOM(obj) = (Sercom*)pinmap_peripheral_sercom(NC, sercom_index);
+    pSPI_SERCOM(obj) = (Sercom *)pinmap_peripheral_sercom(NC, sercom_index);
 
     /* Disable SPI */
     spi_disable(obj);
@@ -448,13 +448,13 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     _SPI(obj).CTRLA.reg = ctrla;
 
     /* Set SPI Frame size - only 8-bit and 9-bit supported now */
-    _SPI(obj).CTRLB.bit.CHSIZE = (bits > 8)? 1 : 0;
+    _SPI(obj).CTRLB.bit.CHSIZE = (bits > 8) ? 1 : 0;
 
     /* Set SPI Clock Phase */
-    _SPI(obj).CTRLA.bit.CPHA = (mode & 0x01)? 1 : 0;
+    _SPI(obj).CTRLA.bit.CPHA = (mode & 0x01) ? 1 : 0;
 
     /* Set SPI Clock Polarity */
-    _SPI(obj).CTRLA.bit.CPOL = (mode & 0x02)? 1 : 0;
+    _SPI(obj).CTRLA.bit.CPOL = (mode & 0x02) ? 1 : 0;
 
     /* Enable SPI */
     spi_enable(obj);
@@ -568,7 +568,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -753,8 +754,9 @@ static void _spi_write_async(spi_t *obj)
         obj->tx_buff.pos++;
 
         if (_SPI(obj).CTRLB.bit.CHSIZE == 1) {
-            if (tx_buffer)
+            if (tx_buffer) {
                 data_to_send |= (tx_buffer[obj->tx_buff.pos] << 8);
+            }
             /* Increment 8-bit index */
             obj->tx_buff.pos++;
         }
@@ -937,14 +939,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     uint8_t sercom_index = _sercom_get_sercom_inst_index(obj->spi.spi);
 
     obj->spi.tx_buffer = (void *)tx;
-    obj->tx_buff.buffer =(void *)tx;
+    obj->tx_buff.buffer = (void *)tx;
     obj->tx_buff.pos = 0;
     if (tx) {
         /* Only two bit rates supported now */
-        obj->tx_buff.length = tx_length * ((bit_width > 8)? 2 : 1);
+        obj->tx_buff.length = tx_length * ((bit_width > 8) ? 2 : 1);
     } else {
         if (rx) {
-            obj->tx_buff.length = rx_length * ((bit_width > 8)? 2 : 1);
+            obj->tx_buff.length = rx_length * ((bit_width > 8) ? 2 : 1);
         } else {
             /* Nothing to transfer */
             return;
@@ -956,7 +958,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     obj->rx_buff.pos = 0;
     if (rx) {
         /* Only two bit rates supported now */
-        obj->rx_buff.length = rx_length * ((bit_width > 8)? 2 : 1);
+        obj->rx_buff.length = rx_length * ((bit_width > 8) ? 2 : 1);
     } else {
         /* Disable RXEN */
         spi_disable(obj);

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
@@ -181,6 +181,18 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi.is_slave=0;
 }
 
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
+ */
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // Not supported
+    MBED_ASSERT(false);
+}
+
 /** Release a SPI object
  *
  * TODO: spi_free is currently unimplemented
@@ -499,12 +511,12 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
         if(obj->spi.event | SPI_EVENT_COMPLETE)
             event |=SPI_EVENT_COMPLETE;
     }
-	
+
     if((obj->spi.spi_base->SPI_SR & SPI_IER_RXBUFF)) {
 	    spi_disable_interrupt(obj->spi.spi_base, SPI_IDR_RXBUFF | SPI_IDR_MODF | SPI_IDR_OVRES);
 	    if(obj->spi.event | SPI_EVENT_COMPLETE)
 	    event |=SPI_EVENT_COMPLETE;
-    }	
+    }
 
     if(obj->spi.spi_base->SPI_SR & SPI_SR_MODF) {
         if(obj->spi.event | SPI_EVENT_ERROR)

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
@@ -34,7 +34,7 @@
 #define SPI_CLK_PHASE 0
 
 /* Last data */
-#define SPI_LAST	0
+#define SPI_LAST    0
 
 
 /* Delay before SPCK. */
@@ -43,10 +43,10 @@
 /* Delay between consecutive transfers. */
 #define SPI_DLYBCT 0x10
 
-#define MAX_SPI	8
+#define MAX_SPI 8
 
 /* SPI clock setting (Hz). */
-uint32_t gSPI_clock=500000;
+uint32_t gSPI_clock = 500000;
 
 extern uint8_t g_sys_init;
 
@@ -54,61 +54,62 @@ extern uint8_t g_sys_init;
 
 void pinmap_find_spi_info(Spi *sercombase, spi_t *obj)
 {
-    if(sercombase==SPI0) {
-        obj->spi.flexcom=FLEXCOM0;
-        obj->spi.module_number=0;
-        obj->spi.pdc =PDC_SPI0;
-        obj->spi.irq_type=FLEXCOM0_IRQn;
-    } else if(sercombase==SPI1) {
-        obj->spi.flexcom=FLEXCOM1;
-        obj->spi.module_number=1;
-        obj->spi.pdc =PDC_SPI1;
-        obj->spi.irq_type=FLEXCOM1_IRQn;
-    } else if(sercombase==SPI2) {
-        obj->spi.flexcom=FLEXCOM2;
-        obj->spi.module_number=2;
-        obj->spi.pdc =PDC_SPI2;
-        obj->spi.irq_type=FLEXCOM2_IRQn;
-    } else if(sercombase==SPI3) {
-        obj->spi.flexcom=FLEXCOM3;
-        obj->spi.module_number=3;
-        obj->spi.pdc =PDC_SPI3;
-        obj->spi.irq_type=FLEXCOM3_IRQn;
-    } else if(sercombase==SPI4) {
-        obj->spi.flexcom=FLEXCOM4;
-        obj->spi.module_number=4;
-        obj->spi.pdc =PDC_SPI4;
-        obj->spi.irq_type=FLEXCOM4_IRQn;
-    } else if(sercombase==SPI5) {
-        obj->spi.flexcom=FLEXCOM5;
-        obj->spi.module_number=5;
-        obj->spi.pdc =PDC_SPI5;
-        obj->spi.irq_type=FLEXCOM5_IRQn;
-    } else if(sercombase==SPI6) {
-        obj->spi.flexcom=FLEXCOM6;
-        obj->spi.module_number=6;
-        obj->spi.pdc =PDC_SPI6;
-        obj->spi.irq_type=FLEXCOM6_IRQn;
-    } else if(sercombase==SPI7) {
-        obj->spi.flexcom=FLEXCOM7;
-        obj->spi.module_number=7;
-        obj->spi.pdc =PDC_SPI7;
-        obj->spi.irq_type=FLEXCOM7_IRQn;
+    if (sercombase == SPI0) {
+        obj->spi.flexcom = FLEXCOM0;
+        obj->spi.module_number = 0;
+        obj->spi.pdc = PDC_SPI0;
+        obj->spi.irq_type = FLEXCOM0_IRQn;
+    } else if (sercombase == SPI1) {
+        obj->spi.flexcom = FLEXCOM1;
+        obj->spi.module_number = 1;
+        obj->spi.pdc = PDC_SPI1;
+        obj->spi.irq_type = FLEXCOM1_IRQn;
+    } else if (sercombase == SPI2) {
+        obj->spi.flexcom = FLEXCOM2;
+        obj->spi.module_number = 2;
+        obj->spi.pdc = PDC_SPI2;
+        obj->spi.irq_type = FLEXCOM2_IRQn;
+    } else if (sercombase == SPI3) {
+        obj->spi.flexcom = FLEXCOM3;
+        obj->spi.module_number = 3;
+        obj->spi.pdc = PDC_SPI3;
+        obj->spi.irq_type = FLEXCOM3_IRQn;
+    } else if (sercombase == SPI4) {
+        obj->spi.flexcom = FLEXCOM4;
+        obj->spi.module_number = 4;
+        obj->spi.pdc = PDC_SPI4;
+        obj->spi.irq_type = FLEXCOM4_IRQn;
+    } else if (sercombase == SPI5) {
+        obj->spi.flexcom = FLEXCOM5;
+        obj->spi.module_number = 5;
+        obj->spi.pdc = PDC_SPI5;
+        obj->spi.irq_type = FLEXCOM5_IRQn;
+    } else if (sercombase == SPI6) {
+        obj->spi.flexcom = FLEXCOM6;
+        obj->spi.module_number = 6;
+        obj->spi.pdc = PDC_SPI6;
+        obj->spi.irq_type = FLEXCOM6_IRQn;
+    } else if (sercombase == SPI7) {
+        obj->spi.flexcom = FLEXCOM7;
+        obj->spi.module_number = 7;
+        obj->spi.pdc = PDC_SPI7;
+        obj->spi.irq_type = FLEXCOM7_IRQn;
     } else {
-        obj->spi.flexcom=(Flexcom *)NC;
-        obj->spi.module_number=0;
-        obj->spi.pdc =(Pdc *) NC;
+        obj->spi.flexcom = (Flexcom *)NC;
+        obj->spi.module_number = 0;
+        obj->spi.pdc = (Pdc *) NC;
     }
 }
 
-Spi* pinmap_find_sercom(PinName mosi, PinName miso, PinName sclk)
+Spi *pinmap_find_sercom(PinName mosi, PinName miso, PinName sclk)
 {
-    Spi* sercomIndex=(Spi*)pinmap_peripheral (mosi,PinMap_SPI_MOSI);
-    if(sercomIndex== (Spi*)pinmap_peripheral (miso, PinMap_SPI_MISO) &&
-            sercomIndex == (Spi*)pinmap_peripheral (sclk, PinMap_SPI_SCLK))
+    Spi *sercomIndex = (Spi *)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    if (sercomIndex == (Spi *)pinmap_peripheral(miso, PinMap_SPI_MISO) &&
+            sercomIndex == (Spi *)pinmap_peripheral(sclk, PinMap_SPI_SCLK)) {
         return sercomIndex;
+    }
 
-    return (Spi*)NC;
+    return (Spi *)NC;
 }
 
 
@@ -124,7 +125,7 @@ Spi* pinmap_find_sercom(PinName mosi, PinName miso, PinName sclk)
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel /*Not Used*/)
 {
     MBED_ASSERT(obj);
-    MBED_ASSERT(mosi !=NC && miso!=NC && sclk !=NC );
+    MBED_ASSERT(mosi != NC && miso != NC && sclk != NC);
 
     if (g_sys_init == 0) {
         sysclk_init();
@@ -132,12 +133,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         g_sys_init = 1;
     }
 
-    Spi *sercombase = pinmap_find_sercom(mosi,miso,sclk);
-    MBED_ASSERT(sercombase!=NC);
+    Spi *sercombase = pinmap_find_sercom(mosi, miso, sclk);
+    MBED_ASSERT(sercombase != NC);
 
     pinmap_find_spi_info(sercombase, obj);
-    MBED_ASSERT(obj->spi.flexcom!=NC);
-    MBED_ASSERT(obj->spi.pdc!=NC);
+    MBED_ASSERT(obj->spi.flexcom != NC);
+    MBED_ASSERT(obj->spi.pdc != NC);
 
     /* Configure SPI pins */
     pin_function(mosi, pinmap_find_function(mosi, PinMap_SPI_MOSI));
@@ -166,19 +167,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spi_set_clock_polarity(sercombase, SPI_CHIP_SEL, SPI_CLK_POLARITY);
     spi_set_clock_phase(sercombase, SPI_CHIP_SEL, SPI_CLK_PHASE);
     spi_set_bits_per_transfer(sercombase, SPI_CHIP_SEL, SPI_CSR_BITS_8_BIT);
-    spi_set_baudrate_div(sercombase, SPI_CHIP_SEL,(sysclk_get_cpu_hz() / gSPI_clock));
-    spi_set_transfer_delay(sercombase, SPI_CHIP_SEL, SPI_DLYBS,SPI_DLYBCT);
+    spi_set_baudrate_div(sercombase, SPI_CHIP_SEL, (sysclk_get_cpu_hz() / gSPI_clock));
+    spi_set_transfer_delay(sercombase, SPI_CHIP_SEL, SPI_DLYBS, SPI_DLYBCT);
 
     spi_enable(sercombase);
 
-    pdc_disable_transfer(obj->spi.pdc, PERIPH_PTCR_RXTDIS |	PERIPH_PTCR_TXTDIS);
+    pdc_disable_transfer(obj->spi.pdc, PERIPH_PTCR_RXTDIS | PERIPH_PTCR_TXTDIS);
 
-    obj->spi.spi_base=sercombase;
-    obj->spi.cs= SPI_CHIP_SEL;
-    obj->spi.polarity=SPI_CLK_POLARITY;
-    obj->spi.phase=SPI_CLK_PHASE;
-    obj->spi.transferrate=SPI_CSR_BITS_8_BIT;
-    obj->spi.is_slave=0;
+    obj->spi.spi_base = sercombase;
+    obj->spi.cs = SPI_CHIP_SEL;
+    obj->spi.polarity = SPI_CLK_POLARITY;
+    obj->spi.phase = SPI_CLK_PHASE;
+    obj->spi.transferrate = SPI_CSR_BITS_8_BIT;
+    obj->spi.is_slave = 0;
 }
 
 /** Initialize the SPI peripheral
@@ -213,7 +214,7 @@ void spi_free(spi_t *obj)
 
 uint32_t get_transfer_rate(int bits)
 {
-    switch(bits) {
+    switch (bits) {
         case 8:
             return SPI_CSR_BITS_8_BIT;
         case 9:
@@ -247,24 +248,24 @@ uint32_t get_transfer_rate(int bits)
  */
 void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
-    uint32_t transferrate= get_transfer_rate(bits);
-    MBED_ASSERT(transferrate!=NC);
+    uint32_t transferrate = get_transfer_rate(bits);
+    MBED_ASSERT(transferrate != NC);
 
     spi_disable(obj->spi.spi_base);
-    obj->spi.transferrate=transferrate;
-    if(slave) {
+    obj->spi.transferrate = transferrate;
+    if (slave) {
         spi_set_slave_mode(obj->spi.spi_base);
-        obj->spi.is_slave=1;
+        obj->spi.is_slave = 1;
     } else {
         spi_set_master_mode(obj->spi.spi_base);
-        obj->spi.is_slave=0;
+        obj->spi.is_slave = 0;
     }
     spi_set_bits_per_transfer(obj->spi.spi_base, obj->spi.cs, obj->spi.transferrate);
     spi_set_clock_phase(obj->spi.spi_base, SPI_CHIP_SEL, (mode & 0x01));
     spi_set_clock_polarity(obj->spi.spi_base, SPI_CHIP_SEL, (mode & 0x02));
 
-    obj->spi.phase=(mode & 0x01);
-    obj->spi.polarity=(mode & 0x02);
+    obj->spi.phase = (mode & 0x01);
+    obj->spi.polarity = (mode & 0x02);
     spi_enable(obj->spi.spi_base);
 }
 
@@ -279,8 +280,8 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 void spi_frequency(spi_t *obj, int hz)
 {
     spi_disable(obj->spi.spi_base);
-    int16_t baudrate_div=spi_calc_baudrate_div(hz, sysclk_get_cpu_hz());
-    spi_set_baudrate_div(obj->spi.spi_base,obj->spi.cs,(uint8_t)baudrate_div);
+    int16_t baudrate_div = spi_calc_baudrate_div(hz, sysclk_get_cpu_hz());
+    spi_set_baudrate_div(obj->spi.spi_base, obj->spi.cs, (uint8_t)baudrate_div);
     spi_enable(obj->spi.spi_base);
 }
 
@@ -298,18 +299,20 @@ void spi_frequency(spi_t *obj, int hz)
  */
 int  spi_master_write(spi_t *obj, int value)
 {
-    spi_status_t status=spi_write(obj->spi.spi_base,(uint16_t)value,obj->spi.cs,SPI_LAST);
-    if(status ==SPI_OK) {
+    spi_status_t status = spi_write(obj->spi.spi_base, (uint16_t)value, obj->spi.cs, SPI_LAST);
+    if (status == SPI_OK) {
         uint16_t data;
-        status =spi_read(obj->spi.spi_base,&data,&obj->spi.cs);
-        if(status == SPI_OK)
+        status = spi_read(obj->spi.spi_base, &data, &obj->spi.cs);
+        if (status == SPI_OK) {
             return data;
+        }
     }
     return 0;
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char _write_fill) {
+                           char *rx_buffer, int rx_length, char _write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -330,8 +333,9 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
  */
 int  spi_slave_receive(spi_t *obj)
 {
-    if(obj->spi.spi_base->SPI_SR & SPI_SR_RDRF)
+    if (obj->spi.spi_base->SPI_SR & SPI_SR_RDRF) {
         return 1;
+    }
     return 0;
 }
 
@@ -344,9 +348,10 @@ int  spi_slave_receive(spi_t *obj)
 int  spi_slave_read(spi_t *obj)
 {
     uint16_t data;
-    spi_status_t status =spi_read(obj->spi.spi_base, &data, &obj->spi.cs);
-    if(status == SPI_OK)
+    spi_status_t status = spi_read(obj->spi.spi_base, &data, &obj->spi.cs);
+    if (status == SPI_OK) {
         return data;
+    }
     return 0;
 }
 
@@ -358,7 +363,7 @@ int  spi_slave_read(spi_t *obj)
  */
 void spi_slave_write(spi_t *obj, int value)
 {
-    spi_write(obj->spi.spi_base,(uint16_t)value,obj->spi.cs,SPI_LAST);
+    spi_write(obj->spi.spi_base, (uint16_t)value, obj->spi.cs, SPI_LAST);
 }
 
 /** Checks if the specified SPI peripheral is in use
@@ -368,8 +373,9 @@ void spi_slave_write(spi_t *obj, int value)
  */
 int  spi_busy(spi_t *obj)
 {
-    if(obj->spi.spi_base->SPI_SR & SPI_SR_TDRE) //Transmit Data Register Empty
+    if (obj->spi.spi_base->SPI_SR & SPI_SR_TDRE) { //Transmit Data Register Empty
         return 0;
+    }
     return 1;
 }
 
@@ -447,50 +453,51 @@ const PinMap *spi_slave_cs_pinmap()
 
 void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
-    uint32_t pdcenable=0;
+    uint32_t pdcenable = 0;
 
-    if(bit_width) {
-        uint32_t transferrate= get_transfer_rate(bit_width);
+    if (bit_width) {
+        uint32_t transferrate = get_transfer_rate(bit_width);
         spi_set_bits_per_transfer(obj->spi.spi_base, obj->spi.cs, transferrate);
     }
 
-    if(tx) {
+    if (tx) {
         pdc_packet_t pdc_packet_tx;
-        pdc_packet_tx.ul_addr=(uint32_t)tx;
-        pdc_packet_tx.ul_size=tx_length;
+        pdc_packet_tx.ul_addr = (uint32_t)tx;
+        pdc_packet_tx.ul_size = tx_length;
 
-        pdcenable|=PERIPH_PTCR_TXTEN;
+        pdcenable |= PERIPH_PTCR_TXTEN;
         /* Configure PDC for data send */
         pdc_tx_init(obj->spi.pdc, &pdc_packet_tx, NULL);
     }
 
-    if(rx) {
+    if (rx) {
         pdc_rx_clear_cnt(obj->spi.pdc);
         pdc_packet_t pdc_packet_rx;
-        pdc_packet_rx.ul_addr=(uint32_t)rx;
-        pdc_packet_rx.ul_size=rx_length;
-        pdcenable|=PERIPH_PTCR_RXTEN;
-        char *rxbuffer=(char *)rx;
-        for(uint8_t index=0; index<rx_length; index++, rxbuffer++)
-            *rxbuffer=SPI_FILL_WORD;
+        pdc_packet_rx.ul_addr = (uint32_t)rx;
+        pdc_packet_rx.ul_size = rx_length;
+        pdcenable |= PERIPH_PTCR_RXTEN;
+        char *rxbuffer = (char *)rx;
+        for (uint8_t index = 0; index < rx_length; index++, rxbuffer++) {
+            *rxbuffer = SPI_FILL_WORD;
+        }
 
         /* Configure PDC for data receive */
         pdc_rx_init(obj->spi.pdc, &pdc_packet_rx, NULL);
     }
 
-    obj->spi.dma_usage=hint;
-    obj->spi.event=event;
+    obj->spi.dma_usage = hint;
+    obj->spi.event = event;
 
     NVIC_ClearPendingIRQ(obj->spi.irq_type);
     NVIC_DisableIRQ(obj->spi.irq_type);
-	NVIC_SetVector(obj->spi.irq_type,handler);
+    NVIC_SetVector(obj->spi.irq_type, handler);
     NVIC_EnableIRQ(obj->spi.irq_type);
 
     /* Enable SPI IRQ */
-    spi_enable_interrupt(obj->spi.spi_base, SPI_IER_RXBUFF| SPI_IER_TXBUFE | SPI_IER_MODF | SPI_IER_OVRES);
+    spi_enable_interrupt(obj->spi.spi_base, SPI_IER_RXBUFF | SPI_IER_TXBUFE | SPI_IER_MODF | SPI_IER_OVRES);
 
     /* Enable PDC transfers */
-    pdc_enable_transfer(obj->spi.pdc, pdcenable );
+    pdc_enable_transfer(obj->spi.pdc, pdcenable);
 
 }
 
@@ -503,29 +510,33 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
  */
 uint32_t spi_irq_handler_asynch(spi_t *obj)
 {
-    uint32_t event=0;
+    uint32_t event = 0;
 
     // Data transferred via DMA
-    if((obj->spi.spi_base->SPI_SR & SPI_IER_TXBUFE)) {
-	    spi_disable_interrupt(obj->spi.spi_base, SPI_IDR_TXBUFE | SPI_IDR_MODF | SPI_IDR_OVRES);
-        if(obj->spi.event | SPI_EVENT_COMPLETE)
-            event |=SPI_EVENT_COMPLETE;
+    if ((obj->spi.spi_base->SPI_SR & SPI_IER_TXBUFE)) {
+        spi_disable_interrupt(obj->spi.spi_base, SPI_IDR_TXBUFE | SPI_IDR_MODF | SPI_IDR_OVRES);
+        if (obj->spi.event | SPI_EVENT_COMPLETE) {
+            event |= SPI_EVENT_COMPLETE;
+        }
     }
 
-    if((obj->spi.spi_base->SPI_SR & SPI_IER_RXBUFF)) {
-	    spi_disable_interrupt(obj->spi.spi_base, SPI_IDR_RXBUFF | SPI_IDR_MODF | SPI_IDR_OVRES);
-	    if(obj->spi.event | SPI_EVENT_COMPLETE)
-	    event |=SPI_EVENT_COMPLETE;
+    if ((obj->spi.spi_base->SPI_SR & SPI_IER_RXBUFF)) {
+        spi_disable_interrupt(obj->spi.spi_base, SPI_IDR_RXBUFF | SPI_IDR_MODF | SPI_IDR_OVRES);
+        if (obj->spi.event | SPI_EVENT_COMPLETE) {
+            event |= SPI_EVENT_COMPLETE;
+        }
     }
 
-    if(obj->spi.spi_base->SPI_SR & SPI_SR_MODF) {
-        if(obj->spi.event | SPI_EVENT_ERROR)
-            event |=SPI_EVENT_ERROR;
+    if (obj->spi.spi_base->SPI_SR & SPI_SR_MODF) {
+        if (obj->spi.event | SPI_EVENT_ERROR) {
+            event |= SPI_EVENT_ERROR;
+        }
     }
 
-    if(obj->spi.spi_base->SPI_SR & SPI_SR_OVRES) {
-        if(obj->spi.event | SPI_EVENT_RX_OVERFLOW)
-            event |=SPI_EVENT_RX_OVERFLOW;
+    if (obj->spi.spi_base->SPI_SR & SPI_SR_OVRES) {
+        if (obj->spi.event | SPI_EVENT_RX_OVERFLOW) {
+            event |= SPI_EVENT_RX_OVERFLOW;
+        }
     }
 
     return event;
@@ -545,8 +556,9 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
 
 uint8_t spi_active(spi_t *obj)
 {
-    if(obj->spi.spi_base->SPI_SR & SPI_SR_ENDTX && obj->spi.spi_base->SPI_SR & SPI_SR_ENDRX)
+    if (obj->spi.spi_base->SPI_SR & SPI_SR_ENDTX && obj->spi.spi_base->SPI_SR & SPI_SR_ENDRX) {
         return 0;
+    }
     return 1;
 }
 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
@@ -81,6 +81,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     cyhal_spi_register_irq(&(spi->hal_spi), &cy_spi_irq_handler_internal, obj);
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // Not supported
+    MBED_ASSERT(false);
+}
+
 void spi_free(spi_t *obj)
 {
     struct spi_s *spi = cy_get_spi(obj);

--- a/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/spi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6_FUTURE/spi_api.c
@@ -110,7 +110,7 @@ static int spi_irq_setup_channel(spi_obj_t *obj)
         irq_config.cm0pSrc = obj->cm0p_irq_src;
 #endif
         if (Cy_SysInt_Init(&irq_config, (cy_israddress)(obj->handler)) != CY_SYSINT_SUCCESS) {
-            return(-1);
+            return (-1);
         }
 
         obj->irqn = irqn;
@@ -127,7 +127,7 @@ static int allocate_divider(spi_obj_t *obj)
         obj->div_type = CY_SYSCLK_DIV_16_BIT;
         obj->div_num = cy_clk_allocate_divider(CY_SYSCLK_DIV_16_BIT);
     }
-    return (obj->div_num == CY_INVALID_DIVIDER)? -1 : 0;
+    return (obj->div_num == CY_INVALID_DIVIDER) ? -1 : 0;
 }
 
 static void free_divider(spi_obj_t *obj)
@@ -155,7 +155,7 @@ static cy_en_sysclk_status_t spi_init_clock(spi_obj_t *obj, uint32_t frequency)
     }
 
     // Set up proper frequency; round up the divider so the frequency is not higher than specified.
-    div_value = (CY_CLK_PERICLK_FREQ_HZ + frequency *(SPI_OVERSAMPLE - 1)) / frequency / SPI_OVERSAMPLE;
+    div_value = (CY_CLK_PERICLK_FREQ_HZ + frequency * (SPI_OVERSAMPLE - 1)) / frequency / SPI_OVERSAMPLE;
     obj->clk_frequency = CY_CLK_PERICLK_FREQ_HZ / div_value / SPI_OVERSAMPLE;
     // Delay (in us) required for serialized read operation == 1.5 clocks, min 1us.
     obj->clk_delay = (1500000UL - 1 + obj->clk_frequency) / obj->clk_frequency;
@@ -298,7 +298,7 @@ void spi_init_direct(spi_t *obj_in, explicit_pinmap_t *explicit_pinmap)
     }
 
     if (spi != (uint32_t)NC) {
-        obj->base = (CySCB_Type*) explicit_pinmap->peripheral;
+        obj->base = (CySCB_Type *) explicit_pinmap->peripheral;
         obj->spi_id = ((SPIName)spi - SPI_0) / (SPI_1 - SPI_0);
         obj->pin_mosi = explicit_pinmap->pin[0];
         obj->pin_miso = explicit_pinmap->pin[1];
@@ -366,7 +366,7 @@ void spi_free(spi_t *obj_in)
 
     spi_default_pins(obj);
     Cy_SCB_SPI_Disable(obj->base, &obj->context);
-    Cy_SCB_SPI_DeInit (obj->base);
+    Cy_SCB_SPI_DeInit(obj->base);
 
 #if DEVICE_SLEEP && DEVICE_LOWPOWERTIMER
     Cy_SysPm_UnregisterCallback(&obj->pm_callback_handler);
@@ -405,8 +405,10 @@ void spi_free(spi_t *obj_in)
 void spi_format(spi_t *obj_in, int bits, int mode, int slave)
 {
     spi_obj_t *obj = OBJ_P(obj_in);
-    cy_en_scb_spi_mode_t new_mode = slave? CY_SCB_SPI_SLAVE : CY_SCB_SPI_MASTER;
-    if ((bits < 4) || (bits > 16)) return;
+    cy_en_scb_spi_mode_t new_mode = slave ? CY_SCB_SPI_SLAVE : CY_SCB_SPI_MASTER;
+    if ((bits < 4) || (bits > 16)) {
+        return;
+    }
     spi_default_pins(obj);
     Cy_SCB_SPI_Disable(obj->base, &obj->context);
     obj->data_bits = bits;
@@ -465,7 +467,7 @@ int spi_master_block_write(spi_t *obj_in, const char *tx_buffer, int tx_length, 
     // Make sure no leftovers from previous transactions.
     Cy_SCB_SPI_ClearRxFifo(obj->base);
     // Calculate transaction length,
-    trans_length = (tx_length > rx_length)? tx_length : rx_length;
+    trans_length = (tx_length > rx_length) ? tx_length : rx_length;
     // get first byte to transmit.
     if (tx_count < tx_length) {
         tx_byte = *tx_buffer++;
@@ -632,28 +634,28 @@ void spi_master_transfer(spi_t *obj_in,
             // I) write + read, II) write only
             obj->pending = PENDING_TX_RX;
             obj->rx_buffer = NULL;
-            obj->tx_buffer = (bit_width == 8)?
-                             (void*)(((uint8_t*)tx) + rx_length) :
-                             (void*)(((uint16_t*)tx) + rx_length);
+            obj->tx_buffer = (bit_width == 8) ?
+                             (void *)(((uint8_t *)tx) + rx_length) :
+                             (void *)(((uint16_t *)tx) + rx_length);
             obj->tx_buffer_size = tx_length - rx_length;
-            Cy_SCB_SPI_Transfer(obj->base, (void*)tx, rx, rx_length, &obj->context);
+            Cy_SCB_SPI_Transfer(obj->base, (void *)tx, rx, rx_length, &obj->context);
         } else {
             // I) write only.
             obj->pending = PENDING_TX;
             obj->rx_buffer = NULL;
             obj->tx_buffer = NULL;
-            Cy_SCB_SPI_Transfer(obj->base, (void*)tx, NULL, tx_length, &obj->context);
+            Cy_SCB_SPI_Transfer(obj->base, (void *)tx, NULL, tx_length, &obj->context);
         }
     } else if (rx_length > tx_length) {
         if (tx_length > 0) {
             // I) write + read, II) read only
             obj->pending = PENDING_TX_RX;
-            obj->rx_buffer = (bit_width == 8)?
-                             (void*)(((uint8_t*)rx) + tx_length) :
-                             (void*)(((uint16_t*)rx) + tx_length);
+            obj->rx_buffer = (bit_width == 8) ?
+                             (void *)(((uint8_t *)rx) + tx_length) :
+                             (void *)(((uint16_t *)rx) + tx_length);
             obj->rx_buffer_size = rx_length - tx_length;
             obj->tx_buffer = NULL;
-            Cy_SCB_SPI_Transfer(obj->base, (void*)tx, rx, tx_length, &obj->context);
+            Cy_SCB_SPI_Transfer(obj->base, (void *)tx, rx, tx_length, &obj->context);
         } else {
             // I) read only.
             obj->pending = PENDING_RX;
@@ -667,7 +669,7 @@ void spi_master_transfer(spi_t *obj_in,
         obj->pending = PENDING_TX_RX;
         obj->rx_buffer = NULL;
         obj->tx_buffer = NULL;
-        Cy_SCB_SPI_Transfer(obj->base, (void*)tx, rx, tx_length, &obj->context);
+        Cy_SCB_SPI_Transfer(obj->base, (void *)tx, rx, tx_length, &obj->context);
     }
 }
 

--- a/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
@@ -23,16 +23,9 @@
 #include "clk_freqs.h"
 #include "PeripheralPins.h"
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    
-    obj->spi = (SPI_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (SPI_Type*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     SIM->SCGC5 |= SIM_SCGC5_PORTC_MASK | SIM_SCGC5_PORTD_MASK;
@@ -45,13 +38,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->SR |= SPI_SR_EOQF_MASK;
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
 }
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
+}
+
 
 void spi_free(spi_t *obj) {
     // [TODO]
@@ -74,7 +97,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // CTAR0 is used
     obj->spi->CTAR[0] &= ~(SPI_CTAR_CPHA_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_FMSZ_MASK);
     obj->spi->CTAR[0] |= (polarity << SPI_CTAR_CPOL_SHIFT) | (phase << SPI_CTAR_CPHA_SHIFT) | ((bits - 1) << SPI_CTAR_FMSZ_SHIFT);
-    
+
     //If clk idle state was changed, start a dummy transmission
     //This is a 'feature' in DSPI: https://community.freescale.com/thread/105526
     if ((old_polarity != polarity) && (slave == 0)) {

--- a/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
@@ -25,7 +25,7 @@
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (SPI_Type*)explicit_pinmap->peripheral;
+    obj->spi = (SPI_Type *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     SIM->SCGC5 |= SIM_SCGC5_PORTC_MASK | SIM_SCGC5_PORTD_MASK;
@@ -76,10 +76,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 }
 
 
-void spi_free(spi_t *obj) {
+void spi_free(spi_t *obj)
+{
     // [TODO]
 }
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT((bits > 4) || (bits < 16));
     MBED_ASSERT((mode >= 0) && (mode <= 3));
 
@@ -106,10 +108,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     }
 }
 
-static const uint8_t baudrate_prescaler[] = {2,3,5,7};
-static const uint16_t baudrate_scaler[] = {2,4,6,8,16,32,64,128,256,512,1024,2048,4096,8192,16384,32768};
+static const uint8_t baudrate_prescaler[] = {2, 3, 5, 7};
+static const uint16_t baudrate_scaler[] = {2, 4, 6, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     uint32_t f_error = 0;
     uint32_t p_error = 0xffffffff;
     uint32_t ref = 0;
@@ -125,8 +128,9 @@ void spi_frequency(spi_t *obj, int hz) {
         for (br = 0; br <= 15; br++) {
             for (uint32_t dr = 0; dr < 2; dr++) {
                 ref = (PCLK * (1U + dr) / baudrate_prescaler[i]) / baudrate_scaler[br];
-                if (ref > (uint32_t)hz)
+                if (ref > (uint32_t)hz) {
                     continue;
+                }
                 f_error = hz - ref;
                 if (f_error < p_error) {
                     ref_spr = br;
@@ -143,19 +147,22 @@ void spi_frequency(spi_t *obj, int hz) {
     obj->spi->CTAR[0] |= (ref_prescaler << SPI_CTAR_PBR_SHIFT) | (ref_spr << SPI_CTAR_BR_SHIFT) | (ref_dr << SPI_CTAR_DBR_SHIFT);
 }
 
-static inline int spi_writeable(spi_t *obj) {
+static inline int spi_writeable(spi_t *obj)
+{
     return (obj->spi->SR & SPI_SR_TFFF_MASK) ? 1 : 0;
 }
 
-static inline int spi_readable(spi_t *obj) {
+static inline int spi_readable(spi_t *obj)
+{
     return (obj->spi->SR & SPI_SR_RFDF_MASK) ? 1 : 0;
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     //clear RX buffer flag
     obj->spi->SR |= SPI_SR_RFDF_MASK;
     // wait tx buffer empty
-    while(!spi_writeable(obj));
+    while (!spi_writeable(obj));
     obj->spi->PUSHR = SPI_PUSHR_TXDATA(value & 0xffff) /*| SPI_PUSHR_EOQ_MASK*/;
 
     // wait rx buffer full
@@ -164,7 +171,8 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -178,16 +186,19 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return spi_readable(obj);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     obj->spi->SR |= SPI_SR_RFDF_MASK;
     return obj->spi->POPR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (!spi_writeable(obj));
 }
 

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
@@ -22,35 +22,35 @@
 
 static const PinMap PinMap_SPI_SCLK[] = {
     {PTB0, SPI_0, 3},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
     {PTA7, SPI_0, 3},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
     {PTA6, SPI_0, 3},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
     {PTA5, SPI_0, 3},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (SPI_Type*) explicit_pinmap->peripheral;
+    obj->spi = (SPI_Type *) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0:
-          SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK | SIM_SCGC5_PORTB_MASK);
-          SIM->SCGC4 |= SIM_SCGC4_SPI0_MASK;
-          break;
+            SIM->SCGC5 |= (SIM_SCGC5_PORTA_MASK | SIM_SCGC5_PORTB_MASK);
+            SIM->SCGC4 |= SIM_SCGC4_SPI0_MASK;
+            break;
     }
 
     // enable SPI
@@ -94,10 +94,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
-void spi_free(spi_t *obj) {
+void spi_free(spi_t *obj)
+{
     // [TODO]
 }
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT(bits == 8);
     MBED_ASSERT((mode >= 0) && (mode <= 3));
 
@@ -112,7 +114,8 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     obj->spi->C1 |= c1_data;
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     uint32_t error = 0;
     uint32_t p_error = 0xffffffff;
     uint32_t ref = 0;
@@ -128,9 +131,10 @@ void spi_frequency(spi_t *obj, int hz) {
     for (prescaler = 1; prescaler <= 8; prescaler++) {
         divisor = 2;
         for (spr = 0; spr <= 8; spr++) {
-            ref = PCLK / (prescaler*divisor);
-            if (ref > (uint32_t)hz)
+            ref = PCLK / (prescaler * divisor);
+            if (ref > (uint32_t)hz) {
                 continue;
+            }
             error = hz - ref;
             if (error < p_error) {
                 ref_spr = spr;
@@ -145,17 +149,20 @@ void spi_frequency(spi_t *obj, int hz) {
     obj->spi->BR = ((ref_prescaler & 0x7) << 4) | (ref_spr & 0xf);
 }
 
-static inline int spi_writeable(spi_t * obj) {
+static inline int spi_writeable(spi_t *obj)
+{
     return (obj->spi->S & SPI_S_SPTEF_MASK) ? 1 : 0;
 }
 
-static inline int spi_readable(spi_t * obj) {
+static inline int spi_readable(spi_t *obj)
+{
     return (obj->spi->S & SPI_S_SPRF_MASK) ? 1 : 0;
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     // wait tx buffer empty
-    while(!spi_writeable(obj));
+    while (!spi_writeable(obj));
     obj->spi->D = (value & 0xff);
 
     // wait rx buffer full
@@ -164,7 +171,8 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -178,15 +186,18 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return spi_readable(obj);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->D;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (!spi_writeable(obj));
     obj->spi->D = value;
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
@@ -40,16 +40,9 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {NC  , NC   , 0}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    obj->spi = (SPI_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (SPI_Type*) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -64,12 +57,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->C1 |= SPI_C1_SPE_MASK;
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
@@ -22,16 +22,9 @@
 #include "clk_freqs.h"
 #include "PeripheralPins.h"
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    obj->spi = (SPI_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (SPI_Type*) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -44,12 +37,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->C1 |= SPI_C1_SPE_MASK;
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
@@ -24,13 +24,19 @@
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (SPI_Type*) explicit_pinmap->peripheral;
+    obj->spi = (SPI_Type *) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {
-        case SPI_0: SIM->SCGC5 |= 1 << 11; SIM->SCGC4 |= 1 << 22; break;
-        case SPI_1: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 23; break;
+        case SPI_0:
+            SIM->SCGC5 |= 1 << 11;
+            SIM->SCGC4 |= 1 << 22;
+            break;
+        case SPI_1:
+            SIM->SCGC5 |= 1 << 13;
+            SIM->SCGC4 |= 1 << 23;
+            break;
     }
 
     // enable SPI
@@ -74,10 +80,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
-void spi_free(spi_t *obj) {
+void spi_free(spi_t *obj)
+{
     // [TODO]
 }
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT(bits == 8);
     MBED_ASSERT((mode >= 0) && (mode <= 3));
 
@@ -92,7 +100,8 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     obj->spi->C1 |= c1_data;
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     uint32_t error = 0;
     uint32_t p_error = 0xffffffff;
     uint32_t ref = 0;
@@ -108,9 +117,10 @@ void spi_frequency(spi_t *obj, int hz) {
     for (prescaler = 1; prescaler <= 8; prescaler++) {
         divisor = 2;
         for (spr = 0; spr <= 8; spr++, divisor *= 2) {
-            ref = PCLK / (prescaler*divisor);
-            if (ref > (uint32_t)hz)
+            ref = PCLK / (prescaler * divisor);
+            if (ref > (uint32_t)hz) {
                 continue;
+            }
             error = hz - ref;
             if (error < p_error) {
                 ref_spr = spr;
@@ -124,17 +134,20 @@ void spi_frequency(spi_t *obj, int hz) {
     obj->spi->BR = ((ref_prescaler & 0x7) << 4) | (ref_spr & 0xf);
 }
 
-static inline int spi_writeable(spi_t * obj) {
+static inline int spi_writeable(spi_t *obj)
+{
     return (obj->spi->S & SPI_S_SPTEF_MASK) ? 1 : 0;
 }
 
-static inline int spi_readable(spi_t * obj) {
+static inline int spi_readable(spi_t *obj)
+{
     return (obj->spi->S & SPI_S_SPRF_MASK) ? 1 : 0;
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     // wait tx buffer empty
-    while(!spi_writeable(obj));
+    while (!spi_writeable(obj));
     obj->spi->D = (value & 0xff);
 
     // wait rx buffer full
@@ -143,7 +156,8 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -157,15 +171,18 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return spi_readable(obj);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->D;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (!spi_writeable(obj));
     obj->spi->D = value;
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
@@ -80,16 +80,9 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {NC  ,  NC   , 0}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    obj->spi = (SPI_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (SPI_Type*) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -103,12 +96,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->C2 &= ~SPI_C2_SPIMODE_MASK; //8bit
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
@@ -80,16 +80,9 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {NC  ,  NC   , 0}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    obj->spi = (SPI_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (SPI_Type*) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -103,12 +96,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->C2 &= ~SPI_C2_SPIMODE_MASK; //8bit
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
@@ -51,6 +51,24 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
     return spi_per;
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -61,16 +79,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
@@ -116,7 +116,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -140,7 +140,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -42,16 +60,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
@@ -116,7 +116,7 @@ void spi_frequency(spi_t *obj, int hz)
     SPI_MasterSetBaudRate(spi_address[obj->instance], (uint32_t)hz, CLOCK_GetFreq(spi_clocks[obj->instance]));
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (SPI_GetStatusFlags(spi_address[obj->instance]) & kSPI_RxBufferFullFlag);
 }
@@ -137,7 +137,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi.instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->spi.instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -42,16 +60,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
@@ -116,7 +116,7 @@ void spi_frequency(spi_t *obj, int hz)
     SPI_MasterSetBaudRate(spi_address[obj->instance], (uint32_t)hz, CLOCK_GetFreq(spi_clocks[obj->instance]));
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (SPI_GetStatusFlags(spi_address[obj->instance]) & kSPI_RxBufferFullFlag);
 }
@@ -137,7 +137,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi.instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->spi.instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -42,16 +60,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
@@ -115,7 +115,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -139,7 +139,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi.instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->spi.instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -42,16 +60,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
@@ -51,6 +51,24 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
     return spi_per;
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -61,16 +79,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
@@ -51,6 +51,24 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
     return spi_per;
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -61,16 +79,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
@@ -115,7 +115,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -139,7 +139,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
@@ -32,6 +32,24 @@ static SPI_Type *const spi_address[] = SPI_BASE_PTRS;
 /* Array of SPI bus clock frequencies */
 static clock_name_t const spi_clocks[] = SPI_CLOCK_FREQS;
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -42,16 +60,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
@@ -125,7 +125,7 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->spi.instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->spi.instance]) & kDSPI_RxFifoDrainRequestFlag);
 }
@@ -149,7 +149,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -198,7 +199,7 @@ static int32_t spi_master_transfer_asynch(spi_t *obj)
     obj->spi.status = kDSPI_Busy;
 
     if (obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_ALLOCATED ||
-        obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
+            obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
         status = DSPI_MasterTransferEDMA(spi_address[obj->spi.instance], &obj->spi.spi_dma_master_handle, &masterXfer);
         if (status ==  kStatus_DSPI_OutOfRange) {
             if (obj->spi.bits > 8) {
@@ -330,14 +331,14 @@ static void spi_buffer_set(spi_t *obj, const void *tx, uint32_t tx_length, void 
 
 void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
-    if(spi_active(obj)) {
+    if (spi_active(obj)) {
         return;
     }
 
     /* check corner case */
-    if(tx_length == 0) {
+    if (tx_length == 0) {
         tx_length = rx_length;
-        tx = (void*) 0;
+        tx = (void *) 0;
     }
 
     /* First, set the buffer */
@@ -438,13 +439,13 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
 void spi_abort_asynch(spi_t *obj)
 {
     // If we're not currently transferring, then there's nothing to do here
-    if(spi_active(obj) == 0) {
+    if (spi_active(obj) == 0) {
         return;
     }
 
     // Determine whether we're running DMA or interrupt
     if (obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_ALLOCATED ||
-        obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
+            obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
         DSPI_MasterTransferAbortEDMA(spi_address[obj->spi.instance], &obj->spi.spi_dma_master_handle);
         /* Release the dma channels if they were opportunistically allocated */
         if (obj->spi.spiDmaMasterRx.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -52,6 +52,29 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
     return spi_per;
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi.instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->spi.instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+
+    /* Set the transfer status to idle */
+    obj->spi.status = kDSPI_Idle;
+
+    obj->spi.spiDmaMasterRx.dmaUsageState = DMA_USAGE_OPPORTUNISTIC;
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -62,21 +85,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->spi.instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->spi.instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
 
-    /* Set the transfer status to idle */
-    obj->spi.status = kDSPI_Idle;
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
 
-    obj->spi.spiDmaMasterRx.dmaUsageState = DMA_USAGE_OPPORTUNISTIC;
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_GigaDevice/TARGET_GD32E10X/spi_api.c
+++ b/targets/TARGET_GigaDevice/TARGET_GD32E10X/spi_api.c
@@ -75,25 +75,13 @@ static void dev_spi_struct_init(spi_t *obj)
  *
  * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
  * @param[out] obj  The SPI object to initialize
- * @param[in]  mosi The pin to use for MOSI
- * @param[in]  miso The pin to use for MISO
- * @param[in]  sclk The pin to use for SCLK
- * @param[in]  ssel The pin to use for SSEL
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
  */
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     struct spi_s *spiobj = SPI_S(obj);
 
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-
-    /* return SPIName according to PinName */
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    spiobj->spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    spiobj->spi = (SPIName) explicit_pinmap->peripheral;
     MBED_ASSERT(spiobj->spi != (SPIName)NC);
 
     /* Set iqr type */
@@ -111,15 +99,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     /* config GPIO mode of SPI pins */
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    spiobj->pin_miso = miso;
-    spiobj->pin_mosi = mosi;
-    spiobj->pin_sclk = sclk;
-    spiobj->pin_ssel = ssel;
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    spiobj->pin_miso = explicit_pinmap->pin[0];
+    spiobj->pin_mosi = explicit_pinmap->pin[1];
+    spiobj->pin_sclk = explicit_pinmap->pin[2];
+    spiobj->pin_ssel = explicit_pinmap->pin[3];
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
         spiobj->spi_struct.nss = SPI_NSS_HARD;
         spi_nss_output_enable(spiobj->spi);
     } else {
@@ -134,6 +126,40 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spiobj->spi_struct.endian               = SPI_ENDIAN_MSB;
 
     dev_spi_struct_init(obj);
+}
+
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  mosi The pin to use for MOSI
+ * @param[in]  miso The pin to use for MISO
+ * @param[in]  sclk The pin to use for SCLK
+ * @param[in]  ssel The pin to use for SSEL
+ */
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 /** Release a SPI object

--- a/targets/TARGET_GigaDevice/TARGET_GD32F4XX/spi_api.c
+++ b/targets/TARGET_GigaDevice/TARGET_GD32F4XX/spi_api.c
@@ -87,25 +87,13 @@ static void dev_spi_struct_init(spi_t *obj)
  *
  * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
  * @param[out] obj  The SPI object to initialize
- * @param[in]  mosi The pin to use for MOSI
- * @param[in]  miso The pin to use for MISO
- * @param[in]  sclk The pin to use for SCLK
- * @param[in]  ssel The pin to use for SSEL
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
  */
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     struct spi_s *spiobj = SPI_S(obj);
 
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-
-    /* return SPIName according to PinName */
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    spiobj->spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    spiobj->spi = (SPIName) explicit_pinmap->peripheral;
     MBED_ASSERT(spiobj->spi != (SPIName)NC);
 
     /* set iqr type */
@@ -135,15 +123,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     /* configure GPIO mode of SPI pins */
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    spiobj->pin_miso = miso;
-    spiobj->pin_mosi = mosi;
-    spiobj->pin_sclk = sclk;
-    spiobj->pin_ssel = ssel;
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    spiobj->pin_miso = explicit_pinmap->pin[0];
+    spiobj->pin_mosi = explicit_pinmap->pin[1];
+    spiobj->pin_sclk = explicit_pinmap->pin[2];
+    spiobj->pin_ssel = explicit_pinmap->pin[3];
     if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
         spiobj->spi_struct.nss = SPI_NSS_HARD;
         spi_nss_output_enable(spiobj->spi);
     } else {
@@ -159,6 +151,40 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spiobj->spi_struct.endian               = SPI_ENDIAN_MSB;
 
     dev_spi_struct_init(obj);
+}
+
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  mosi The pin to use for MOSI
+ * @param[in]  miso The pin to use for MISO
+ * @param[in]  sclk The pin to use for SCLK
+ * @param[in]  ssel The pin to use for SSEL
+ */
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 /** Release a SPI object

--- a/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
@@ -40,9 +40,9 @@
 #include "clkman_regs.h"
 #include "PeripheralPins.h"
 
-#define DEFAULT_CHAR	8
-#define DEFAULT_MODE	0
-#define DEFAULT_FREQ 	1000000
+#define DEFAULT_CHAR    8
+#define DEFAULT_MODE    0
+#define DEFAULT_FREQ    1000000
 
 // Formatting settings
 static int spi_bits;
@@ -55,7 +55,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     MBED_ASSERT((SPIName)spi != (SPIName)NC);
 
     // Set the obj pointer to the proper SPI Instance
-    obj->spi = (mxc_spi_regs_t*)spi;
+    obj->spi = (mxc_spi_regs_t *)spi;
 
     // Set the SPI index and FIFOs
     obj->index = MXC_SPI_BASE_TO_INSTANCE(obj->spi);
@@ -77,7 +77,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     // Enable SPI and FIFOs
     obj->spi->gen_ctrl = (MXC_F_SPI_GEN_CTRL_SPI_MSTR_EN |
                           MXC_F_SPI_GEN_CTRL_TX_FIFO_EN |
-                          MXC_F_SPI_GEN_CTRL_RX_FIFO_EN );
+                          MXC_F_SPI_GEN_CTRL_RX_FIFO_EN);
 }
 
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
@@ -127,12 +127,12 @@ void spi_frequency(spi_t *obj, int hz)
 {
     // Maximum frequency is half the system frequency
     MBED_ASSERT((unsigned int)hz <= (SystemCoreClock / 2));
-    unsigned clocks = ((SystemCoreClock/2)/(hz));
+    unsigned clocks = ((SystemCoreClock / 2) / (hz));
 
     // Figure out the divider ratio
     int clk_div = 1;
-    while(clk_div < 10) {
-        if(clocks < 0x10) {
+    while (clk_div < 10) {
+        if (clocks < 0x10) {
             break;
         }
         clk_div++;
@@ -140,11 +140,11 @@ void spi_frequency(spi_t *obj, int hz)
     }
 
     // Turn on the SPI clock
-    if(obj->index == 0) {
+    if (obj->index == 0) {
         MXC_CLKMAN->clk_ctrl_3_spi0 = clk_div;
-    } else if(obj->index == 1) {
+    } else if (obj->index == 1) {
         MXC_CLKMAN->clk_ctrl_4_spi1 = clk_div;
-    } else if(obj->index == 2) {
+    } else if (obj->index == 2) {
         MXC_CLKMAN->clk_ctrl_5_spi2 = clk_div;
     } else {
         MBED_ASSERT(0);
@@ -152,18 +152,18 @@ void spi_frequency(spi_t *obj, int hz)
 
     // Set the number of clocks to hold sclk high and low
     MXC_SET_FIELD(&obj->spi->mstr_cfg, (MXC_F_SPI_MSTR_CFG_SCK_HI_CLK | MXC_F_SPI_MSTR_CFG_SCK_LO_CLK),
-        ((clocks << MXC_F_SPI_MSTR_CFG_SCK_HI_CLK_POS) | (clocks << MXC_F_SPI_MSTR_CFG_SCK_LO_CLK_POS)));
+                  ((clocks << MXC_F_SPI_MSTR_CFG_SCK_HI_CLK_POS) | (clocks << MXC_F_SPI_MSTR_CFG_SCK_LO_CLK_POS)));
 }
 
 //******************************************************************************
 int spi_master_write(spi_t *obj, int value)
 {
     int bits = spi_bits;
-    if(spi_bits == 32) {
+    if (spi_bits == 32) {
         bits = 0;
     }
     // Create the header
-    uint16_t header = ((0x3 << MXC_F_SPI_FIFO_DIR_POS ) |  // TX and RX
+    uint16_t header = ((0x3 << MXC_F_SPI_FIFO_DIR_POS) |   // TX and RX
                        (0x0 << MXC_F_SPI_FIFO_UNIT_POS) | // Send bits
                        (bits << MXC_F_SPI_FIFO_SIZE_POS) | // Number of units
                        (0x1 << MXC_F_SPI_FIFO_DASS_POS));      // Deassert SS
@@ -172,7 +172,7 @@ int spi_master_write(spi_t *obj, int value)
     obj->txfifo->txfifo_16 = header;
 
     // Send the data
-    if(spi_bits < 17) {
+    if (spi_bits < 17) {
         obj->txfifo->txfifo_16 = (uint16_t)value;
     } else {
         obj->txfifo->txfifo_32 = (uint32_t)value;
@@ -182,20 +182,21 @@ int spi_master_write(spi_t *obj, int value)
     bits = spi_bits;
     int result = 0;
     int i = 0;
-    while(bits > 0) {
+    while (bits > 0) {
         // Wait for data
-        while(((obj->spi->fifo_ctrl & MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED)
+        while (((obj->spi->fifo_ctrl & MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED)
                 >> MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED_POS) < 1) {}
 
-        result |= (obj->rxfifo->rxfifo_8 << (i++*8));
-        bits-=8;
+        result |= (obj->rxfifo->rxfifo_8 << (i++ * 8));
+        bits -= 8;
     }
 
     return result;
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
@@ -48,25 +48,9 @@
 static int spi_bits;
 
 //******************************************************************************
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    // Make sure pins are pointing to the same SPI instance
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl;
-
-    // Give the application the option to manually control Slave Select
-    if((SPIName)spi_ssel != (SPIName)NC) {
-        spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    } else {
-        spi_cntl = spi_sclk;
-    }
-
-    SPIName spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    SPIName spi = (SPIName)explicit_pinmap->peripheral;
 
     MBED_ASSERT((SPIName)spi != (SPIName)NC);
 
@@ -79,15 +63,46 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->txfifo = MXC_SPI_GET_TXFIFO(obj->index);
 
     // Configure the pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
 
     // Enable SPI and FIFOs
     obj->spi->gen_ctrl = (MXC_F_SPI_GEN_CTRL_SPI_MSTR_EN |
                           MXC_F_SPI_GEN_CTRL_TX_FIFO_EN |
                           MXC_F_SPI_GEN_CTRL_RX_FIFO_EN );
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
@@ -40,9 +40,9 @@
 #include "clkman_regs.h"
 #include "PeripheralPins.h"
 
-#define DEFAULT_CHAR	8
-#define DEFAULT_MODE	0
-#define DEFAULT_FREQ 	1000000
+#define DEFAULT_CHAR    8
+#define DEFAULT_MODE    0
+#define DEFAULT_FREQ    1000000
 
 // Formatting settings
 static int spi_bits;
@@ -55,7 +55,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     MBED_ASSERT((SPIName)spi != (SPIName)NC);
 
     // Set the obj pointer to the proper SPI Instance
-    obj->spi = (mxc_spi_regs_t*)spi;
+    obj->spi = (mxc_spi_regs_t *)spi;
 
     // Set the SPI index and FIFOs
     obj->index = MXC_SPI_BASE_TO_INSTANCE(obj->spi);
@@ -77,7 +77,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     // Enable SPI and FIFOs
     obj->spi->gen_ctrl = (MXC_F_SPI_GEN_CTRL_SPI_MSTR_EN |
                           MXC_F_SPI_GEN_CTRL_TX_FIFO_EN |
-                          MXC_F_SPI_GEN_CTRL_RX_FIFO_EN );
+                          MXC_F_SPI_GEN_CTRL_RX_FIFO_EN);
 }
 
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
@@ -127,12 +127,12 @@ void spi_frequency(spi_t *obj, int hz)
 {
     // Maximum frequency is half the system frequency
     MBED_ASSERT((unsigned int)hz <= (SystemCoreClock / 2));
-    unsigned clocks = ((SystemCoreClock/2)/(hz));
+    unsigned clocks = ((SystemCoreClock / 2) / (hz));
 
     // Figure out the divider ratio
     int clk_div = 1;
-    while(clk_div < 10) {
-        if(clocks < 0x10) {
+    while (clk_div < 10) {
+        if (clocks < 0x10) {
             break;
         }
         clk_div++;
@@ -140,11 +140,11 @@ void spi_frequency(spi_t *obj, int hz)
     }
 
     // Turn on the SPI clock
-    if(obj->index == 0) {
+    if (obj->index == 0) {
         MXC_CLKMAN->clk_ctrl_3_spi0 = clk_div;
-    } else if(obj->index == 1) {
+    } else if (obj->index == 1) {
         MXC_CLKMAN->clk_ctrl_4_spi1 = clk_div;
-    } else if(obj->index == 2) {
+    } else if (obj->index == 2) {
         MXC_CLKMAN->clk_ctrl_5_spi2 = clk_div;
     } else {
         MBED_ASSERT(0);
@@ -152,18 +152,18 @@ void spi_frequency(spi_t *obj, int hz)
 
     // Set the number of clocks to hold sclk high and low
     MXC_SET_FIELD(&obj->spi->mstr_cfg, (MXC_F_SPI_MSTR_CFG_SCK_HI_CLK | MXC_F_SPI_MSTR_CFG_SCK_LO_CLK),
-        ((clocks << MXC_F_SPI_MSTR_CFG_SCK_HI_CLK_POS) | (clocks << MXC_F_SPI_MSTR_CFG_SCK_LO_CLK_POS)));
+                  ((clocks << MXC_F_SPI_MSTR_CFG_SCK_HI_CLK_POS) | (clocks << MXC_F_SPI_MSTR_CFG_SCK_LO_CLK_POS)));
 }
 
 //******************************************************************************
 int spi_master_write(spi_t *obj, int value)
 {
     int bits = spi_bits;
-    if(spi_bits == 32) {
+    if (spi_bits == 32) {
         bits = 0;
     }
     // Create the header
-    uint16_t header = ((0x3 << MXC_F_SPI_FIFO_DIR_POS ) |  // TX and RX
+    uint16_t header = ((0x3 << MXC_F_SPI_FIFO_DIR_POS) |   // TX and RX
                        (0x0 << MXC_F_SPI_FIFO_UNIT_POS) | // Send bits
                        (bits << MXC_F_SPI_FIFO_SIZE_POS) | // Number of units
                        (0x1 << MXC_F_SPI_FIFO_DASS_POS));      // Deassert SS
@@ -172,7 +172,7 @@ int spi_master_write(spi_t *obj, int value)
     obj->txfifo->txfifo_16 = header;
 
     // Send the data
-    if(spi_bits < 17) {
+    if (spi_bits < 17) {
         obj->txfifo->txfifo_16 = (uint16_t)value;
     } else {
         obj->txfifo->txfifo_32 = (uint32_t)value;
@@ -182,20 +182,21 @@ int spi_master_write(spi_t *obj, int value)
     bits = spi_bits;
     int result = 0;
     int i = 0;
-    while(bits > 0) {
+    while (bits > 0) {
         // Wait for data
-        while(((obj->spi->fifo_ctrl & MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED)
+        while (((obj->spi->fifo_ctrl & MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED)
                 >> MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED_POS) < 1) {}
 
-        result |= (obj->rxfifo->rxfifo_8 << (i++*8));
-        bits-=8;
+        result |= (obj->rxfifo->rxfifo_8 << (i++ * 8));
+        bits -= 8;
     }
 
     return result;
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
@@ -48,25 +48,9 @@
 static int spi_bits;
 
 //******************************************************************************
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    // Make sure pins are pointing to the same SPI instance
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl;
-
-    // Give the application the option to manually control Slave Select
-    if((SPIName)spi_ssel != (SPIName)NC) {
-        spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    } else {
-        spi_cntl = spi_sclk;
-    }
-
-    SPIName spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    SPIName spi = (SPIName)explicit_pinmap->peripheral;
 
     MBED_ASSERT((SPIName)spi != (SPIName)NC);
 
@@ -79,15 +63,46 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->txfifo = MXC_SPI_GET_TXFIFO(obj->index);
 
     // Configure the pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
 
     // Enable SPI and FIFOs
     obj->spi->gen_ctrl = (MXC_F_SPI_GEN_CTRL_SPI_MSTR_EN |
                           MXC_F_SPI_GEN_CTRL_TX_FIFO_EN |
                           MXC_F_SPI_GEN_CTRL_RX_FIFO_EN );
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32620/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/spi_api.c
@@ -62,7 +62,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     MBED_ASSERT((SPIName)spi != (SPIName)NC);
 
     // Set the obj pointer to the proper SPI Instance
-    obj->spi.spi = (mxc_spi_regs_t*)spi;
+    obj->spi.spi = (mxc_spi_regs_t *)spi;
 
     // Set the SPI index and FIFOs
     obj->spi.index = MXC_SPI_GET_IDX(obj->spi.spi);
@@ -88,7 +88,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     // Enable SPI and FIFOs
     obj->spi.spi->gen_ctrl = (MXC_F_SPI_GEN_CTRL_SPI_MSTR_EN |
                               MXC_F_SPI_GEN_CTRL_TX_FIFO_EN |
-                              MXC_F_SPI_GEN_CTRL_RX_FIFO_EN );
+                              MXC_F_SPI_GEN_CTRL_RX_FIFO_EN);
 
     obj->spi.sclk = explicit_pinmap->pin[2];       // save the sclk PinName in the object as a key for Quad SPI pin mapping lookup
     spi_master_width(obj, 0);   // default this for Single SPI communications
@@ -165,7 +165,7 @@ void spi_frequency(spi_t *obj, int hz)
 
     // Set the number of clocks to hold sclk high and low
     MXC_SET_FIELD(&obj->spi.spi->mstr_cfg, (MXC_F_SPI_MSTR_CFG_SCK_HI_CLK | MXC_F_SPI_MSTR_CFG_SCK_LO_CLK),
-        ((clocks << MXC_F_SPI_MSTR_CFG_SCK_HI_CLK_POS) | (clocks << MXC_F_SPI_MSTR_CFG_SCK_LO_CLK_POS)));
+                  ((clocks << MXC_F_SPI_MSTR_CFG_SCK_HI_CLK_POS) | (clocks << MXC_F_SPI_MSTR_CFG_SCK_LO_CLK_POS)));
 }
 
 //******************************************************************************
@@ -202,11 +202,11 @@ static int spi_master_transaction(spi_t *obj, int value, uint32_t direction)
     int bits;
 
     // Create the header
-    uint16_t header =  (direction |                 // direction based on SPI object
-                        MXC_S_SPI_FIFO_UNIT_BITS |  // unit size
-                        ((obj->spi.bits == 32) ? 0 : obj->spi.bits << MXC_F_SPI_FIFO_SIZE_POS) |    // Number of units
-                        obj->spi.width |            // I/O width
-                        ((obj->spi.ssel == -1) ? 0 : 1 << MXC_F_SPI_FIFO_DASS_POS));
+    uint16_t header = (direction |                  // direction based on SPI object
+                       MXC_S_SPI_FIFO_UNIT_BITS |  // unit size
+                       ((obj->spi.bits == 32) ? 0 : obj->spi.bits << MXC_F_SPI_FIFO_SIZE_POS) |    // Number of units
+                       obj->spi.width |            // I/O width
+                       ((obj->spi.ssel == -1) ? 0 : 1 << MXC_F_SPI_FIFO_DASS_POS));
 
     // Send the message header
     *obj->spi.fifo->trans_16 = header;
@@ -227,8 +227,8 @@ static int spi_master_transaction(spi_t *obj, int value, uint32_t direction)
         while (((obj->spi.spi->fifo_ctrl & MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED)
                 >> MXC_F_SPI_FIFO_CTRL_RX_FIFO_USED_POS) < 1);
 
-        result |= (*obj->spi.fifo->rslts_8 << (i++*8));
-        bits-=8;
+        result |= (*obj->spi.fifo->rslts_8 << (i++ * 8));
+        bits -= 8;
     }
 
     return result;
@@ -242,7 +242,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -441,7 +442,7 @@ static uint32_t spi_master_transfer_handler(spi_t *obj)
             // Only memcpy even numbers
             length = ((length / 2) * 2);
 
-            memcpy((void*)fifo->trans_32, &(req->tx_data[req->write_num]), length);
+            memcpy((void *)fifo->trans_32, &(req->tx_data[req->write_num]), length);
 
             head_rem_temp -= length;
             req->write_num += length;
@@ -578,9 +579,18 @@ static void SPI_IRQHandler(int spim_num)
 }
 
 //******************************************************************************
-void SPI0_IRQHandler(void) { SPI_IRQHandler(0); }
-void SPI1_IRQHandler(void) { SPI_IRQHandler(1); }
-void SPI2_IRQHandler(void) { SPI_IRQHandler(2); }
+void SPI0_IRQHandler(void)
+{
+    SPI_IRQHandler(0);
+}
+void SPI1_IRQHandler(void)
+{
+    SPI_IRQHandler(1);
+}
+void SPI2_IRQHandler(void)
+{
+    SPI_IRQHandler(2);
+}
 
 const PinMap *spi_master_mosi_pinmap()
 {

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/spi_api.c
@@ -128,8 +128,8 @@ void spi_frequency(spi_t *obj, int hz)
 
     // Figure out the divider ratio
     int clk_div = 1;
-    while(clk_div < 10) {
-        if(clocks < 0x10) {
+    while (clk_div < 10) {
+        if (clocks < 0x10) {
             break;
         }
         clk_div++;
@@ -137,11 +137,11 @@ void spi_frequency(spi_t *obj, int hz)
     }
 
     // Turn on the SPI clock
-    if(obj->index == 0) {
+    if (obj->index == 0) {
         MXC_CLKMAN->sys_clk_ctrl_11_spi0 = clk_div;
-    } else if(obj->index == 1) {
+    } else if (obj->index == 1) {
         MXC_CLKMAN->sys_clk_ctrl_12_spi1 = clk_div;
-    } else if(obj->index == 2) {
+    } else if (obj->index == 2) {
         MXC_CLKMAN->sys_clk_ctrl_13_spi2 = clk_div;
     } else {
         MBED_ASSERT(0);
@@ -183,8 +183,8 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     spim_req_t req;
 
     if (!(tx_length | rx_length) ||
-        (tx_length < 0) ||
-        (rx_length < 0)) {
+            (tx_length < 0) ||
+            (rx_length < 0)) {
         return 0;
     }
 

--- a/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
@@ -128,8 +128,8 @@ void spi_frequency(spi_t *obj, int hz)
 
     // Figure out the divider ratio
     int clk_div = 1;
-    while(clk_div < 10) {
-        if(clocks < 0x10) {
+    while (clk_div < 10) {
+        if (clocks < 0x10) {
             break;
         }
         clk_div++;
@@ -137,11 +137,11 @@ void spi_frequency(spi_t *obj, int hz)
     }
 
     // Turn on the SPI clock
-    if(obj->index == 0) {
+    if (obj->index == 0) {
         MXC_CLKMAN->sys_clk_ctrl_11_spi0 = clk_div;
-    } else if(obj->index == 1) {
+    } else if (obj->index == 1) {
         MXC_CLKMAN->sys_clk_ctrl_12_spi1 = clk_div;
-    } else if(obj->index == 2) {
+    } else if (obj->index == 2) {
         MXC_CLKMAN->sys_clk_ctrl_13_spi2 = clk_div;
     } else {
         MBED_ASSERT(0);
@@ -183,8 +183,8 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     spim_req_t req;
 
     if (!(tx_length | rx_length) ||
-        (tx_length < 0) ||
-        (rx_length < 0)) {
+            (tx_length < 0) ||
+            (rx_length < 0)) {
         return 0;
     }
 

--- a/targets/TARGET_Maxim/TARGET_MAX32630/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/spi_api.c
@@ -128,8 +128,8 @@ void spi_frequency(spi_t *obj, int hz)
 
     // Figure out the divider ratio
     int clk_div = 1;
-    while(clk_div < 10) {
-        if(clocks < 0x10) {
+    while (clk_div < 10) {
+        if (clocks < 0x10) {
             break;
         }
         clk_div++;
@@ -137,11 +137,11 @@ void spi_frequency(spi_t *obj, int hz)
     }
 
     // Turn on the SPI clock
-    if(obj->index == 0) {
+    if (obj->index == 0) {
         MXC_CLKMAN->sys_clk_ctrl_11_spi0 = clk_div;
-    } else if(obj->index == 1) {
+    } else if (obj->index == 1) {
         MXC_CLKMAN->sys_clk_ctrl_12_spi1 = clk_div;
-    } else if(obj->index == 2) {
+    } else if (obj->index == 2) {
         MXC_CLKMAN->sys_clk_ctrl_13_spi2 = clk_div;
     } else {
         MBED_ASSERT(0);
@@ -183,10 +183,10 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     spim_req_t req;
 
     if (!(tx_length | rx_length) ||
-        (tx_length < 0) ||
-        (rx_length < 0)) {
+            (tx_length < 0) ||
+            (rx_length < 0)) {
         return 0;
-        }
+    }
 
     req.width = SPIM_WIDTH_1;
     req.ssel = 0;

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
@@ -76,9 +76,9 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         spi = SPI_0;
         obj->peripheral = 0x1;
     } else if (ssel == NC && i2c1_spi1_peripheral.usage == I2C_SPI_PERIPHERAL_FOR_SPI &&
-            i2c1_spi1_peripheral.sda_mosi == (uint8_t)mosi &&
-            i2c1_spi1_peripheral.scl_miso == (uint8_t)miso &&
-            i2c1_spi1_peripheral.sclk     == (uint8_t)sclk) {
+               i2c1_spi1_peripheral.sda_mosi == (uint8_t)mosi &&
+               i2c1_spi1_peripheral.scl_miso == (uint8_t)miso &&
+               i2c1_spi1_peripheral.sclk     == (uint8_t)sclk) {
         // The SPI with the same pins is already initialized
         spi = SPI_1;
         obj->peripheral = 0x2;
@@ -103,7 +103,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         error("No available SPI");
     }
 
-    if (ssel==NC) {
+    if (ssel == NC) {
         obj->spi  = (NRF_SPI_Type *)spi;
         obj->spis = (NRF_SPIS_Type *)NC;
     } else {
@@ -117,25 +117,25 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         obj->spis->POWER = 1;
 
         NRF_GPIO->PIN_CNF[mosi] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
         NRF_GPIO->PIN_CNF[miso] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
         NRF_GPIO->PIN_CNF[sclk] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
         NRF_GPIO->PIN_CNF[ssel] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
 
         obj->spis->PSELMOSI = mosi;
         obj->spis->PSELMISO = miso;
@@ -157,25 +157,25 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
         //NRF_GPIO->DIR |= (1<<mosi);
         NRF_GPIO->PIN_CNF[mosi] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
         obj->spi->PSELMOSI = mosi;
 
         NRF_GPIO->PIN_CNF[sclk] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos);
         obj->spi->PSELSCK = sclk;
 
         //NRF_GPIO->DIR &= ~(1<<miso);
         NRF_GPIO->PIN_CNF[miso] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
-                                    | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
-                                    | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
-                                    | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
-                                    | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
+                                  | (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
+                                  | (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos)
+                                  | (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+                                  | (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos);
 
         obj->spi->PSELMISO = miso;
 
@@ -252,22 +252,22 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
 void spi_frequency(spi_t *obj, int hz)
 {
-    if ((int)obj->spi==NC) {
+    if ((int)obj->spi == NC) {
         return;
     }
     spi_disable(obj, 0);
 
-    if (hz<250000) { //125Kbps
+    if (hz < 250000) { //125Kbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_K125;
-    } else if (hz<500000) { //250Kbps
+    } else if (hz < 500000) { //250Kbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_K250;
-    } else if (hz<1000000) { //500Kbps
+    } else if (hz < 1000000) { //500Kbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_K500;
-    } else if (hz<2000000) { //1Mbps
+    } else if (hz < 2000000) { //1Mbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_M1;
-    } else if (hz<4000000) { //2Mbps
+    } else if (hz < 4000000) { //2Mbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_M2;
-    } else if (hz<8000000) { //4Mbps
+    } else if (hz < 8000000) { //4Mbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_M4;
     } else { //8Mbps
         obj->spi->FREQUENCY = (uint32_t) SPI_FREQUENCY_FREQUENCY_M8;
@@ -304,7 +304,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
@@ -67,7 +67,7 @@ static const PinMap PinMap_SPI_testing[] = {
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     SPIName spi = SPI_0;
-    
+
     if (ssel == NC && i2c0_spi0_peripheral.usage == I2C_SPI_PERIPHERAL_FOR_SPI &&
             i2c0_spi0_peripheral.sda_mosi == (uint8_t)mosi &&
             i2c0_spi0_peripheral.scl_miso == (uint8_t)miso &&
@@ -87,7 +87,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         i2c1_spi1_peripheral.sda_mosi = (uint8_t)mosi;
         i2c1_spi1_peripheral.scl_miso = (uint8_t)miso;
         i2c1_spi1_peripheral.sclk     = (uint8_t)sclk;
-        
+
         spi = SPI_1;
         obj->peripheral = 0x2;
     } else if (i2c0_spi0_peripheral.usage == 0) {
@@ -95,7 +95,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         i2c0_spi0_peripheral.sda_mosi = (uint8_t)mosi;
         i2c0_spi0_peripheral.scl_miso = (uint8_t)miso;
         i2c0_spi0_peripheral.sclk     = (uint8_t)sclk;
-        
+
         spi = SPI_0;
         obj->peripheral = 0x1;
     } else {
@@ -184,6 +184,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
         spi_frequency(obj, 1000000);
     }
+}
+
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // NRF targets do not use pinmaps
+    MBED_ASSERT(false);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/spi_api.c
@@ -1,28 +1,28 @@
-/* 
+/*
  * Copyright (c) 2013 Nordic Semiconductor ASA
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list 
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list
  *      of conditions and the following disclaimer.
  *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA 
- *      integrated circuit in a product or a software update for such product, must reproduce 
- *      the above copyright notice, this list of conditions and the following disclaimer in 
+ *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
+ *      integrated circuit in a product or a software update for such product, must reproduce
+ *      the above copyright notice, this list of conditions and the following disclaimer in
  *      the documentation and/or other materials provided with the distribution.
  *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be 
- *      used to endorse or promote products derived from this software without specific prior 
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without specific prior
  *      written permission.
  *
- *   4. This software, with or without modification, must only be used with a 
+ *   4. This software, with or without modification, must only be used with a
  *      Nordic Semiconductor ASA integrated circuit.
  *
- *   5. Any software provided in binary or object form under this license must not be reverse 
- *      engineered, decompiled, modified and/or disassembled. 
- * 
+ *   5. Any software provided in binary or object form under this license must not be reverse
+ *      engineered, decompiled, modified and/or disassembled.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,7 +33,7 @@
  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 
 
@@ -145,7 +145,7 @@ static const peripheral_handler_desc_t spi_handler_desc[SPI_COUNT] = {
         SPI2_IRQ,
         (uint32_t) SPIM2_SPIS2_SPI2_IRQHandler
     },
-#endif    
+#endif
 };
 
 
@@ -353,6 +353,12 @@ void spi_init(spi_t *obj,
 
     // No available peripheral
     error("No available SPI peripheral\r\n");
+}
+
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // NRF targets do not use pinmaps
+    MBED_ASSERT(false);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/spi_api.c
@@ -51,9 +51,9 @@
 #include "sdk_config.h"
 
 #if DEVICE_SPI_ASYNCH
-    #define SPI_IDX(obj)    ((obj)->spi.spi_idx)
+#define SPI_IDX(obj)    ((obj)->spi.spi_idx)
 #else
-    #define SPI_IDX(obj)    ((obj)->spi_idx)
+#define SPI_IDX(obj)    ((obj)->spi_idx)
 #endif
 #define SPI_INFO(obj)       (&m_spi_info[SPI_IDX(obj)])
 #define MASTER_INST(obj)    (&m_instances[SPI_IDX(obj)].master)
@@ -191,13 +191,13 @@ static void master_event_handler(uint8_t spi_idx,
         master_event_handler(SPI##idx##_INSTANCE_INDEX, p_event); \
     }
 #if SPI0_ENABLED
-    MASTER_EVENT_HANDLER(0)
+MASTER_EVENT_HANDLER(0)
 #endif
 #if SPI1_ENABLED
-    MASTER_EVENT_HANDLER(1)
+MASTER_EVENT_HANDLER(1)
 #endif
 #if SPI2_ENABLED
-    MASTER_EVENT_HANDLER(2)
+MASTER_EVENT_HANDLER(2)
 #endif
 
 static nrf_drv_spi_handler_t const m_master_event_handlers[SPI_COUNT] = {
@@ -227,8 +227,8 @@ static void slave_event_handler(uint8_t spi_idx,
         // now use the default one, until some new is set by 'spi_slave_write'.
         p_spi_info->tx_buf = SPIS_DEFAULT_ORC;
         nrf_drv_spis_buffers_set(&m_instances[spi_idx].slave,
-            (uint8_t const *)&p_spi_info->tx_buf, 1,
-            (uint8_t *)&p_spi_info->rx_buf, 1);
+                                 (uint8_t const *)&p_spi_info->tx_buf, 1,
+                                 (uint8_t *)&p_spi_info->rx_buf, 1);
     }
 }
 #define SLAVE_EVENT_HANDLER(idx) \
@@ -236,13 +236,13 @@ static void slave_event_handler(uint8_t spi_idx,
         slave_event_handler(SPIS##idx##_INSTANCE_INDEX, event); \
     }
 #if SPIS0_ENABLED
-    SLAVE_EVENT_HANDLER(0)
+SLAVE_EVENT_HANDLER(0)
 #endif
 #if SPIS1_ENABLED
-    SLAVE_EVENT_HANDLER(1)
+SLAVE_EVENT_HANDLER(1)
 #endif
 #if SPIS2_ENABLED
-    SLAVE_EVENT_HANDLER(2)
+SLAVE_EVENT_HANDLER(2)
 #endif
 
 static nrf_drv_spis_event_handler_t const m_slave_event_handlers[SPIS_COUNT] = {
@@ -301,10 +301,10 @@ void spi_init(spi_t *obj,
     for (i = 0; i < SPI_COUNT; ++i) {
         spi_info_t *p_spi_info = &m_spi_info[i];
         if (p_spi_info->initialized &&
-            p_spi_info->mosi_pin == (uint8_t)mosi &&
-            p_spi_info->miso_pin == (uint8_t)miso &&
-            p_spi_info->sck_pin  == (uint8_t)sclk &&
-            p_spi_info->ss_pin   == (uint8_t)ssel) {
+                p_spi_info->mosi_pin == (uint8_t)mosi &&
+                p_spi_info->miso_pin == (uint8_t)miso &&
+                p_spi_info->sck_pin  == (uint8_t)sclk &&
+                p_spi_info->ss_pin   == (uint8_t)ssel) {
             // Reuse the already allocated SPI instance (instead of allocating
             // a new one), if it appears to be initialized with exactly the same
             // pin assignments.
@@ -320,11 +320,11 @@ void spi_init(spi_t *obj,
 
             p_spi_info->sck_pin   = (uint8_t)sclk;
             p_spi_info->mosi_pin  = (mosi != NC) ?
-                (uint8_t)mosi : NRF_DRV_SPI_PIN_NOT_USED;
+                                    (uint8_t)mosi : NRF_DRV_SPI_PIN_NOT_USED;
             p_spi_info->miso_pin  = (miso != NC) ?
-                (uint8_t)miso : NRF_DRV_SPI_PIN_NOT_USED;
+                                    (uint8_t)miso : NRF_DRV_SPI_PIN_NOT_USED;
             p_spi_info->ss_pin    = (ssel != NC) ?
-                (uint8_t)ssel : NRF_DRV_SPI_PIN_NOT_USED;
+                                    (uint8_t)ssel : NRF_DRV_SPI_PIN_NOT_USED;
             p_spi_info->spi_mode  = (uint8_t)NRF_DRV_SPI_MODE_0;
             p_spi_info->frequency = NRF_DRV_SPI_FREQ_1M;
 
@@ -336,7 +336,7 @@ void spi_init(spi_t *obj,
 
             nrf_drv_spi_t const *p_spi = &m_instances[i].master;
             ret_code_t ret_code = nrf_drv_spi_init(p_spi,
-                &config, m_master_event_handlers[i]);
+                                                   &config, m_master_event_handlers[i]);
             if (ret_code == NRF_SUCCESS) {
                 p_spi_info->initialized = true;
                 p_spi_info->master      = true;
@@ -366,8 +366,7 @@ void spi_free(spi_t *obj)
     spi_info_t *p_spi_info = SPI_INFO(obj);
     if (p_spi_info->master) {
         nrf_drv_spi_uninit(MASTER_INST(obj));
-    }
-    else {
+    } else {
         nrf_drv_spis_uninit(SLAVE_INST(obj));
     }
     p_spi_info->initialized = false;
@@ -389,8 +388,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
     spi_info_t *p_spi_info = SPI_INFO(obj);
 
-    if (slave)
-    {
+    if (slave) {
         nrf_drv_spis_mode_t spi_modes[4] = {
             NRF_DRV_SPIS_MODE_0,
             NRF_DRV_SPIS_MODE_1,
@@ -408,8 +406,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
         // re-initialized (there is no other way to change its configuration).
         else if (p_spi_info->spi_mode != (uint8_t)new_mode) {
             nrf_drv_spis_uninit(SLAVE_INST(obj));
-        }
-        else {
+        } else {
             return;
         }
 
@@ -421,16 +418,14 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
         nrf_drv_spis_config_t config;
         prepare_slave_config(&config, p_spi_info);
         (void)nrf_drv_spis_init(SLAVE_INST(obj), &config,
-            m_slave_event_handlers[SPI_IDX(obj)]);
+                                m_slave_event_handlers[SPI_IDX(obj)]);
 
         // Prepare the slave for transfer.
         p_spi_info->tx_buf = SPIS_DEFAULT_ORC;
         nrf_drv_spis_buffers_set(SLAVE_INST(obj),
-            (uint8_t const *)&p_spi_info->tx_buf, 1,
-            (uint8_t *)&p_spi_info->rx_buf, 1);
-    }
-    else // master
-    {
+                                 (uint8_t const *)&p_spi_info->tx_buf, 1,
+                                 (uint8_t *)&p_spi_info->rx_buf, 1);
+    } else { // master
         nrf_drv_spi_mode_t spi_modes[4] = {
             NRF_DRV_SPI_MODE_0,
             NRF_DRV_SPI_MODE_1,
@@ -448,8 +443,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
         // re-initialized (there is no other way to change its configuration).
         else if (p_spi_info->spi_mode != (uint8_t)new_mode) {
             nrf_drv_spi_uninit(MASTER_INST(obj));
-        }
-        else {
+        } else {
             return;
         }
 
@@ -461,24 +455,24 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
         nrf_drv_spi_config_t config;
         prepare_master_config(&config, p_spi_info);
         (void)nrf_drv_spi_init(MASTER_INST(obj), &config,
-            m_master_event_handlers[SPI_IDX(obj)]);
+                               m_master_event_handlers[SPI_IDX(obj)]);
     }
 }
 
 static nrf_drv_spi_frequency_t freq_translate(int hz)
 {
     nrf_drv_spi_frequency_t frequency;
-    if (hz<250000) { //125Kbps
+    if (hz < 250000) { //125Kbps
         frequency = NRF_DRV_SPI_FREQ_125K;
-    } else if (hz<500000) { //250Kbps
+    } else if (hz < 500000) { //250Kbps
         frequency = NRF_DRV_SPI_FREQ_250K;
-    } else if (hz<1000000) { //500Kbps
+    } else if (hz < 1000000) { //500Kbps
         frequency = NRF_DRV_SPI_FREQ_500K;
-    } else if (hz<2000000) { //1Mbps
+    } else if (hz < 2000000) { //1Mbps
         frequency = NRF_DRV_SPI_FREQ_1M;
-    } else if (hz<4000000) { //2Mbps
+    } else if (hz < 4000000) { //2Mbps
         frequency = NRF_DRV_SPI_FREQ_2M;
-    } else if (hz<8000000) { //4Mbps
+    } else if (hz < 8000000) { //4Mbps
         frequency = NRF_DRV_SPI_FREQ_4M;
     } else { //8Mbps
         frequency = NRF_DRV_SPI_FREQ_8M;
@@ -491,8 +485,7 @@ void spi_frequency(spi_t *obj, int hz)
     spi_info_t *p_spi_info = SPI_INFO(obj);
     nrf_drv_spi_frequency_t new_frequency = freq_translate(hz);
 
-    if (p_spi_info->master)
-    {
+    if (p_spi_info->master) {
         if (p_spi_info->frequency != new_frequency) {
             p_spi_info->frequency = new_frequency;
 
@@ -502,7 +495,7 @@ void spi_frequency(spi_t *obj, int hz)
             nrf_drv_spi_t const *p_spi = MASTER_INST(obj);
             nrf_drv_spi_uninit(p_spi);
             (void)nrf_drv_spi_init(p_spi, &config,
-                m_master_event_handlers[SPI_IDX(obj)]);
+                                   m_master_event_handlers[SPI_IDX(obj)]);
         }
     }
     // There is no need to set anything in slaves when it comes to frequency,
@@ -521,8 +514,8 @@ int spi_master_write(spi_t *obj, int value)
     p_spi_info->tx_buf = value;
     p_spi_info->flag.busy = true;
     (void)nrf_drv_spi_transfer(MASTER_INST(obj),
-        (uint8_t const *)&p_spi_info->tx_buf, 1,
-        (uint8_t *)&p_spi_info->rx_buf, 1);
+                               (uint8_t const *)&p_spi_info->tx_buf, 1,
+                               (uint8_t *)&p_spi_info->rx_buf, 1);
     while (p_spi_info->flag.busy) {
     }
 
@@ -530,7 +523,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -549,7 +543,7 @@ int spi_slave_receive(spi_t *obj)
     spi_info_t *p_spi_info = SPI_INFO(obj);
     MBED_ASSERT(!p_spi_info->master);
     return p_spi_info->flag.readable;
-;
+    ;
 }
 
 int spi_slave_read(spi_t *obj)
@@ -627,8 +621,8 @@ void spi_master_transfer(spi_t *obj,
 
     p_spi_info->flag.busy = true;
     (void)nrf_drv_spi_transfer(MASTER_INST(obj),
-        (uint8_t const *)tx, tx_length,
-        (uint8_t *)rx, rx_length);
+                               (uint8_t const *)tx, tx_length,
+                               (uint8_t *)rx, rx_length);
 }
 
 uint32_t spi_irq_handler_asynch(spi_t *obj)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
@@ -128,6 +128,12 @@ static void spi_configure_driver_instance(spi_t *obj)
     }
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // NRF targets do not use pinmaps
+    MBED_ASSERT(false);
+}
+
 /** Initialize the SPI peripheral
  *
  * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/spi_api.c
@@ -105,7 +105,7 @@ static void spi_configure_driver_instance(spi_t *obj)
 
         /* Clean up and uninitialize peripheral if already initialized. */
         if (nordic_nrf5_spi_initialized[instance]) {
-             nrfx_spi_uninit(&nordic_nrf5_spi_instance[instance]);
+            nrfx_spi_uninit(&nordic_nrf5_spi_instance[instance]);
         }
 
 #if DEVICE_SPI_ASYNCH
@@ -197,7 +197,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         /* Register interrupt handlers in driver with the NVIC. */
         NVIC_SetVector(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn, (uint32_t) SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler);
         NVIC_SetVector(SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn, (uint32_t) SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler);
-        NVIC_SetVector(SPIM2_SPIS2_SPI2_IRQn,                  (uint32_t) SPIM2_SPIS2_SPI2_IRQHandler);
+        NVIC_SetVector(SPIM2_SPIS2_SPI2_IRQn, (uint32_t) SPIM2_SPIS2_SPI2_IRQHandler);
     }
 }
 
@@ -253,13 +253,13 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     nrf_spi_mode_t new_mode = NRF_SPI_MODE_0;
 
     /* Convert Mbed HAL mode to Nordic mode. */
-    if(mode == 0) {
+    if (mode == 0) {
         new_mode = NRF_SPI_MODE_0;
-    } else if(mode == 1) {
+    } else if (mode == 1) {
         new_mode = NRF_SPI_MODE_1;
-    } else if(mode == 2) {
+    } else if (mode == 2) {
         new_mode = NRF_SPI_MODE_2;
-    } else if(mode == 3) {
+    } else if (mode == 3) {
         new_mode = NRF_SPI_MODE_3;
     }
 
@@ -357,8 +357,9 @@ int spi_master_write(spi_t *obj, int value)
     desc.rx_length = 1;
     ret = nrfx_spi_xfer(&nordic_nrf5_spi_instance[instance], &desc, 0);
 
-    if (ret != NRFX_SUCCESS)
+    if (ret != NRFX_SUCCESS) {
         DEBUG_PRINTF("%d error returned from nrf_spi_xfer\n\r");
+    }
 
     /* Manually set chip select pin if defined. */
     if (spi_inst->cs != NC) {
@@ -427,17 +428,17 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
         int tx_actual_length = (tx_length > 255) ? 255 : tx_length;
 
         /* Set tx buffer pointer. Set to NULL if no data is going to be transmitted. */
-        const uint8_t * tx_actual_buffer = (tx_actual_length > 0) ?
-                                           (const uint8_t *)(tx_buffer + tx_offset) :
-                                           NULL;
+        const uint8_t *tx_actual_buffer = (tx_actual_length > 0) ?
+                                          (const uint8_t *)(tx_buffer + tx_offset) :
+                                          NULL;
 
         /* Check if rx_length is larger than 255 and if so, limit to 255. */
         int rx_actual_length = (rx_length > 255) ? 255 : rx_length;
 
         /* Set rx buffer pointer. Set to NULL if no data is going to be received. */
-        uint8_t * rx_actual_buffer = (rx_actual_length > 0) ?
-                                     (uint8_t *)(rx_buffer + rx_offset) :
-                                     NULL;
+        uint8_t *rx_actual_buffer = (rx_actual_length > 0) ?
+                                    (uint8_t *)(rx_buffer + rx_offset) :
+                                    NULL;
 
         /* Blocking transfer. */
         desc.p_tx_buffer = tx_actual_buffer;
@@ -445,7 +446,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
         desc.tx_length = tx_actual_length;
         desc.rx_length = rx_actual_length;
         result = nrfx_spi_xfer(&nordic_nrf5_spi_instance[instance],
-                            &desc, 0);
+                               &desc, 0);
 
         /* Update loop variables. */
         tx_length -= tx_actual_length;
@@ -602,7 +603,7 @@ static ret_code_t spi_master_transfer_async_continue(spi_t *obj)
     desc.rx_length = rx_length;
 
     ret_code_t result = nrfx_spi_xfer(&nordic_nrf5_spi_instance[obj->spi.instance],
-                                            &desc, 0);
+                                      &desc, 0);
     return result;
 }
 
@@ -668,7 +669,7 @@ static void nordic_nrf5_spi_event_handler(nrfx_spi_evt_t const *p_event, void *p
             callback();
         }
 
-    /* Transfer failed, signal error if mask is set. */
+        /* Transfer failed, signal error if mask is set. */
     } else if (signal_error) {
 
         /* Signal error if event mask matches and event handler is set. */
@@ -727,7 +728,7 @@ void spi_master_transfer(spi_t *obj,
     struct buffer_s *buffer_pointer;
 
     buffer_pointer = &obj->tx_buff;
-    buffer_pointer->buffer = (void*) tx;
+    buffer_pointer->buffer = (void *) tx;
     buffer_pointer->length = tx_length;
     buffer_pointer->pos    = 0;
     buffer_pointer->width  = 8;

--- a/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
@@ -94,7 +94,7 @@ __STATIC_INLINE void SPI_DISABLE_SYNC(SPI_T *spi_base)
     if (spi_base->CTL & SPI_CTL_SPIEN_Msk) {
         // NOTE: SPI H/W may get out of state without the busy check.
         while (SPI_IS_BUSY(spi_base));
-    
+
         SPI_DISABLE(spi_base);
     }
     while (spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk);
@@ -131,16 +131,9 @@ static const struct nu_modinit_s spi_modinit_tab[] = {
     {NC, 0, 0, 0, 0, (IRQn_Type) 0, NULL}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    // Determine which SPI_x the pins are used for
-    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
-    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
-    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi.spi = (SPIName) pinmap_merge(spi_data, spi_cntl);
+    obj->spi.spi = (SPIName) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi.spi != NC);
 
     const struct nu_modinit_s *modinit = get_modinit(obj->spi.spi, spi_modinit_tab);
@@ -165,15 +158,21 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
      */
     CLK_EnableModuleClock_S(modinit->clkidx);
 
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
 
-    obj->spi.pin_mosi = mosi;
-    obj->spi.pin_miso = miso;
-    obj->spi.pin_sclk = sclk;
-    obj->spi.pin_ssel = ssel;
+    obj->spi.pin_mosi = explicit_pinmap->pin[0];
+    obj->spi.pin_miso = explicit_pinmap->pin[1];
+    obj->spi.pin_sclk = explicit_pinmap->pin[2];
+    obj->spi.pin_ssel = explicit_pinmap->pin[3];
 
 
 #if DEVICE_SPI_ASYNCH
@@ -181,7 +180,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi.event = 0;
     obj->spi.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
     obj->spi.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
-    
+
     /* NOTE: We use vector to judge if asynchronous transfer is on-going (spi_active).
      *       At initial time, asynchronous transfer is not on-going and so vector must
      *       be cleared to zero for correct judgement. */
@@ -191,6 +190,31 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     // Mark this module to be inited.
     int i = modinit - spi_modinit_tab;
     spi_modinit_mask |= 1 << i;
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)
@@ -497,7 +521,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
          * H/W spec: In SPI Master mode with full duplex transfer, if both TX and RX PDMA functions are
          *           enabled, RX PDMA function cannot be enabled prior to TX PDMA function. User can enable
          *           TX PDMA function firstly or enable both functions simultaneously.
-         * Per real test, it is safer to start RX PDMA first and then TX PDMA. Otherwise, receive FIFO is 
+         * Per real test, it is safer to start RX PDMA first and then TX PDMA. Otherwise, receive FIFO is
          * subject to overflow by TX DMA.
          *
          * With the above conflicts, we enable PDMA TX/RX functions simultaneously.

--- a/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/spi_api.c
@@ -84,10 +84,10 @@ static struct nu_spi_var spi5_var = {
  */
 __STATIC_INLINE void SPI_ENABLE_SYNC(SPI_T *spi_base)
 {
-    if (! (spi_base->CTL & SPI_CTL_SPIEN_Msk)) {
+    if (!(spi_base->CTL & SPI_CTL_SPIEN_Msk)) {
         SPI_ENABLE(spi_base);
     }
-    while (! (spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk));
+    while (!(spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk));
 }
 __STATIC_INLINE void SPI_DISABLE_SYNC(SPI_T *spi_base)
 {
@@ -112,8 +112,8 @@ static void spi_check_dma_usage(DMAUsage *dma_usage, int *dma_ch_tx, int *dma_ch
 static uint8_t spi_get_data_width(spi_t *obj);
 static int spi_is_tx_complete(spi_t *obj);
 static int spi_is_rx_complete(spi_t *obj);
-static int spi_writeable(spi_t * obj);
-static int spi_readable(spi_t * obj);
+static int spi_writeable(spi_t *obj);
+static int spi_readable(spi_t *obj);
 static void spi_dma_handler_tx(uint32_t id, uint32_t event_dma);
 static void spi_dma_handler_rx(uint32_t id, uint32_t event_dma);
 static uint32_t spi_fifo_depth(spi_t *obj);
@@ -303,7 +303,7 @@ int spi_master_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
     // Wait for rx buffer full
@@ -316,7 +316,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -399,7 +400,7 @@ void spi_slave_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 }
 #endif
@@ -458,8 +459,8 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         PDMA_SetTransferAddr(pdma_base,
                              obj->spi.dma_chn_id_tx,
                              (uint32_t) tx, // NOTE:
-                                            // NUC472: End of source address
-                                            // M451/M480/M2351: Start of source address
+                             // NUC472: End of source address
+                             // M451/M480/M2351: Start of source address
                              PDMA_SAR_INC,  // Source address incremental
                              (uint32_t) &spi_base->TX,  // Destination address
                              PDMA_DAR_FIX); // Destination address fixed
@@ -605,13 +606,13 @@ uint8_t spi_active(spi_t *obj)
     return vec ? 1 : 0;
 }
 
-static int spi_writeable(spi_t * obj)
+static int spi_writeable(spi_t *obj)
 {
     // Receive FIFO must not be full to avoid receive FIFO overflow on next transmit/receive
     return (! SPI_GET_TX_FIFO_FULL_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi))));
 }
 
-static int spi_readable(spi_t * obj)
+static int spi_readable(spi_t *obj)
 {
     return ! SPI_GET_RX_FIFO_EMPTY_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi)));
 }
@@ -716,18 +717,18 @@ static uint32_t spi_master_write_asynch(spi_t *obj, uint32_t tx_limit)
             SPI_WRITE_TX(spi_base, 0);
         } else {
             switch (bytes_per_word) {
-            case 4:
-                SPI_WRITE_TX(spi_base, nu_get32_le(tx));
-                tx += 4;
-                break;
-            case 2:
-                SPI_WRITE_TX(spi_base, nu_get16_le(tx));
-                tx += 2;
-                break;
-            case 1:
-                SPI_WRITE_TX(spi_base, *((uint8_t *) tx));
-                tx += 1;
-                break;
+                case 4:
+                    SPI_WRITE_TX(spi_base, nu_get32_le(tx));
+                    tx += 4;
+                    break;
+                case 2:
+                    SPI_WRITE_TX(spi_base, nu_get16_le(tx));
+                    tx += 2;
+                    break;
+                case 1:
+                    SPI_WRITE_TX(spi_base, *((uint8_t *) tx));
+                    tx += 1;
+                    break;
             }
 
             obj->tx_buff.pos ++;
@@ -767,21 +768,21 @@ static uint32_t spi_master_read_asynch(spi_t *obj)
             SPI_READ_RX(spi_base);
         } else {
             switch (bytes_per_word) {
-            case 4: {
-                uint32_t val = SPI_READ_RX(spi_base);
-                nu_set32_le(rx, val);
-                rx += 4;
-                break;
-            }
-            case 2: {
-                uint16_t val = SPI_READ_RX(spi_base);
-                nu_set16_le(rx, val);
-                rx += 2;
-                break;
-            }
-            case 1:
-                *rx ++ = SPI_READ_RX(spi_base);
-                break;
+                case 4: {
+                    uint32_t val = SPI_READ_RX(spi_base);
+                    nu_set32_le(rx, val);
+                    rx += 4;
+                    break;
+                }
+                case 2: {
+                    uint16_t val = SPI_READ_RX(spi_base);
+                    nu_set16_le(rx, val);
+                    rx += 2;
+                    break;
+                }
+                case 1:
+                    *rx ++ = SPI_READ_RX(spi_base);
+                    break;
             }
 
             obj->rx_buff.pos ++;

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -72,10 +72,10 @@ static struct nu_spi_var spi2_var = {
  */
 __STATIC_INLINE void SPI_ENABLE_SYNC(SPI_T *spi_base)
 {
-    if (! (spi_base->CTL & SPI_CTL_SPIEN_Msk)) {
+    if (!(spi_base->CTL & SPI_CTL_SPIEN_Msk)) {
         SPI_ENABLE(spi_base);
     }
-    while (! (spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk));
+    while (!(spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk));
 }
 __STATIC_INLINE void SPI_DISABLE_SYNC(SPI_T *spi_base)
 {
@@ -100,8 +100,8 @@ static void spi_check_dma_usage(DMAUsage *dma_usage, int *dma_ch_tx, int *dma_ch
 static uint8_t spi_get_data_width(spi_t *obj);
 static int spi_is_tx_complete(spi_t *obj);
 static int spi_is_rx_complete(spi_t *obj);
-static int spi_writeable(spi_t * obj);
-static int spi_readable(spi_t * obj);
+static int spi_writeable(spi_t *obj);
+static int spi_readable(spi_t *obj);
 static void spi_dma_handler_tx(uint32_t id, uint32_t event_dma);
 static void spi_dma_handler_rx(uint32_t id, uint32_t event_dma);
 #endif
@@ -231,10 +231,10 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     SPI_DISABLE_SYNC(spi_base);
 
     SPI_Open(spi_base,
-        slave ? SPI_SLAVE : SPI_MASTER,
-        (mode == 0) ? SPI_MODE_0 : (mode == 1) ? SPI_MODE_1 : (mode == 2) ? SPI_MODE_2 : SPI_MODE_3,
-        bits,
-        SPI_GetBusClock(spi_base));
+             slave ? SPI_SLAVE : SPI_MASTER,
+             (mode == 0) ? SPI_MODE_0 : (mode == 1) ? SPI_MODE_1 : (mode == 2) ? SPI_MODE_2 : SPI_MODE_3,
+             bits,
+             SPI_GetBusClock(spi_base));
     // NOTE: Hardcode to be MSB first.
     SPI_SET_MSB_FIRST(spi_base);
 
@@ -243,12 +243,10 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
         if (obj->spi.pin_ssel != NC) {
             // Configure SS as low active.
             SPI_EnableAutoSS(spi_base, SPI_SS, SPI_SS_ACTIVE_LOW);
-        }
-        else {
+        } else {
             SPI_DisableAutoSS(spi_base);
         }
-    }
-    else {
+    } else {
         // Slave
         // Configure SS as low active.
         spi_base->SSCTL &= ~SPI_SSCTL_SSACTPOL_Msk;
@@ -277,7 +275,7 @@ int spi_master_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
     // Wait for rx buffer full
@@ -290,7 +288,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -373,7 +372,7 @@ void spi_slave_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 }
 #endif
@@ -391,7 +390,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     // (1) No DMA support for non-8 multiple data width.
     // (2) tx length >= rx length. Otherwise, as tx DMA is done, no bus activity for remaining rx.
     if ((data_width % 8) ||
-        (tx_length < rx_length)) {
+            (tx_length < rx_length)) {
         obj->spi.dma_usage = DMA_USAGE_NEVER;
         dma_channel_free(obj->spi.dma_chn_id_tx);
         obj->spi.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
@@ -421,48 +420,48 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         // Configure tx DMA
         pdma_base->CHCTL |= 1 << obj->spi.dma_chn_id_tx;  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_tx,
-            ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
-            0,  // Scatter-gather disabled
-            0); // Scatter-gather descriptor address
+                             ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
+                             0,  // Scatter-gather disabled
+                             0); // Scatter-gather descriptor address
         PDMA_SetTransferCnt(obj->spi.dma_chn_id_tx,
-            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
-            tx_length);
+                            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
+                            tx_length);
         PDMA_SetTransferAddr(obj->spi.dma_chn_id_tx,
-            (uint32_t) tx,  // NOTE:
-                            // NUC472: End of source address
-                            // M451: Start of source address
-            PDMA_SAR_INC,   // Source address incremental
-            (uint32_t) &spi_base->TX,   // Destination address
-            PDMA_DAR_FIX);  // Destination address fixed
+                             (uint32_t) tx,  // NOTE:
+                             // NUC472: End of source address
+                             // M451: Start of source address
+                             PDMA_SAR_INC,   // Source address incremental
+                             (uint32_t) &spi_base->TX,   // Destination address
+                             PDMA_DAR_FIX);  // Destination address fixed
         PDMA_SetBurstType(obj->spi.dma_chn_id_tx,
-            PDMA_REQ_SINGLE,    // Single mode
-            0); // Burst size
+                          PDMA_REQ_SINGLE,    // Single mode
+                          0); // Burst size
         PDMA_EnableInt(obj->spi.dma_chn_id_tx,
-            PDMA_INT_TRANS_DONE);   // Interrupt type
+                       PDMA_INT_TRANS_DONE);   // Interrupt type
         // Register DMA event handler
         dma_set_handler(obj->spi.dma_chn_id_tx, (uint32_t) spi_dma_handler_tx, (uint32_t) obj, DMA_EVENT_ALL);
 
         // Configure rx DMA
         pdma_base->CHCTL |= 1 << obj->spi.dma_chn_id_rx;  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_rx,
-            ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
-            0,  // Scatter-gather disabled
-            0); // Scatter-gather descriptor address
+                             ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
+                             0,  // Scatter-gather disabled
+                             0); // Scatter-gather descriptor address
         PDMA_SetTransferCnt(obj->spi.dma_chn_id_rx,
-            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
-            rx_length);
+                            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
+                            rx_length);
         PDMA_SetTransferAddr(obj->spi.dma_chn_id_rx,
-            (uint32_t) &spi_base->RX,   // Source address
-            PDMA_SAR_FIX,   // Source address fixed
-            (uint32_t) rx,  // NOTE:
-                            // NUC472: End of destination address
-                            // M451: Start of destination address
-            PDMA_DAR_INC);  // Destination address incremental
+                             (uint32_t) &spi_base->RX,   // Source address
+                             PDMA_SAR_FIX,   // Source address fixed
+                             (uint32_t) rx,  // NOTE:
+                             // NUC472: End of destination address
+                             // M451: Start of destination address
+                             PDMA_DAR_INC);  // Destination address incremental
         PDMA_SetBurstType(obj->spi.dma_chn_id_rx,
-            PDMA_REQ_SINGLE,    // Single mode
-            0); // Burst size
+                          PDMA_REQ_SINGLE,    // Single mode
+                          0); // Burst size
         PDMA_EnableInt(obj->spi.dma_chn_id_rx,
-            PDMA_INT_TRANS_DONE);   // Interrupt type
+                       PDMA_INT_TRANS_DONE);   // Interrupt type
         // Register DMA event handler
         dma_set_handler(obj->spi.dma_chn_id_rx, (uint32_t) spi_dma_handler_rx, (uint32_t) obj, DMA_EVENT_ALL);
 
@@ -569,13 +568,13 @@ uint8_t spi_active(spi_t *obj)
     return vec ? 1 : 0;
 }
 
-static int spi_writeable(spi_t * obj)
+static int spi_writeable(spi_t *obj)
 {
     // Receive FIFO must not be full to avoid receive FIFO overflow on next transmit/receive
     return (! SPI_GET_TX_FIFO_FULL_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi))));
 }
 
-static int spi_readable(spi_t * obj)
+static int spi_readable(spi_t *obj)
 {
     return ! SPI_GET_RX_FIFO_EMPTY_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi)));
 }
@@ -598,8 +597,7 @@ static void spi_enable_vector_interrupt(spi_t *obj, uint32_t handler, uint8_t en
     if (enable) {
         NVIC_SetVector(modinit->irq_n, handler);
         NVIC_EnableIRQ(modinit->irq_n);
-    }
-    else {
+    } else {
         NVIC_DisableIRQ(modinit->irq_n);
         NVIC_SetVector(modinit->irq_n, 0);
     }
@@ -613,15 +611,13 @@ static void spi_master_enable_interrupt(spi_t *obj, uint8_t enable)
         // For SPI0, it could be 0 ~ 7. For SPI1 and SPI2, it could be 0 ~ 3.
         if (spi_base == (SPI_T *) SPI0_BASE) {
             SPI_SetFIFO(spi_base, 4, 4);
-        }
-        else {
+        } else {
             SPI_SetFIFO(spi_base, 2, 2);
         }
 
         // Enable tx/rx FIFO threshold interrupt
         SPI_EnableInt(spi_base, SPI_FIFO_RXTH_INT_MASK | SPI_FIFO_TXTH_INT_MASK);
-    }
-    else {
+    } else {
         SPI_DisableInt(spi_base, SPI_FIFO_RXTH_INT_MASK | SPI_FIFO_TXTH_INT_MASK);
     }
 }
@@ -686,8 +682,7 @@ static uint32_t spi_master_write_asynch(spi_t *obj, uint32_t tx_limit)
         if (spi_is_tx_complete(obj)) {
             // Transmit dummy as transmit buffer is empty
             SPI_WRITE_TX(spi_base, 0);
-        }
-        else {
+        } else {
             switch (bytes_per_word) {
                 case 4:
                     SPI_WRITE_TX(spi_base, nu_get32_le(tx));
@@ -738,8 +733,7 @@ static uint32_t spi_master_read_asynch(spi_t *obj)
         if (spi_is_rx_complete(obj)) {
             // Disregard as receive buffer is full
             SPI_READ_RX(spi_base);
-        }
-        else {
+        } else {
             switch (bytes_per_word) {
                 case 4: {
                     uint32_t val = SPI_READ_RX(spi_base);

--- a/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
@@ -83,10 +83,10 @@ static struct nu_spi_var spi4_var = {
  */
 __STATIC_INLINE void SPI_ENABLE_SYNC(SPI_T *spi_base)
 {
-    if (! (spi_base->CTL & SPI_CTL_SPIEN_Msk)) {
+    if (!(spi_base->CTL & SPI_CTL_SPIEN_Msk)) {
         SPI_ENABLE(spi_base);
     }
-    while (! (spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk));
+    while (!(spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk));
 }
 __STATIC_INLINE void SPI_DISABLE_SYNC(SPI_T *spi_base)
 {
@@ -111,8 +111,8 @@ static void spi_check_dma_usage(DMAUsage *dma_usage, int *dma_ch_tx, int *dma_ch
 static uint8_t spi_get_data_width(spi_t *obj);
 static int spi_is_tx_complete(spi_t *obj);
 static int spi_is_rx_complete(spi_t *obj);
-static int spi_writeable(spi_t * obj);
-static int spi_readable(spi_t * obj);
+static int spi_writeable(spi_t *obj);
+static int spi_readable(spi_t *obj);
 static void spi_dma_handler_tx(uint32_t id, uint32_t event_dma);
 static void spi_dma_handler_rx(uint32_t id, uint32_t event_dma);
 static uint32_t spi_fifo_depth(spi_t *obj);
@@ -289,7 +289,7 @@ int spi_master_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 
     // Wait for rx buffer full
@@ -302,7 +302,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -385,7 +386,7 @@ void spi_slave_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     SPI_WRITE_TX(spi_base, value);
 }
 #endif
@@ -581,13 +582,13 @@ uint8_t spi_active(spi_t *obj)
     return vec ? 1 : 0;
 }
 
-static int spi_writeable(spi_t * obj)
+static int spi_writeable(spi_t *obj)
 {
     // Receive FIFO must not be full to avoid receive FIFO overflow on next transmit/receive
     return (! SPI_GET_TX_FIFO_FULL_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi))));
 }
 
-static int spi_readable(spi_t * obj)
+static int spi_readable(spi_t *obj)
 {
     return ! SPI_GET_RX_FIFO_EMPTY_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi)));
 }
@@ -692,18 +693,18 @@ static uint32_t spi_master_write_asynch(spi_t *obj, uint32_t tx_limit)
             SPI_WRITE_TX(spi_base, 0);
         } else {
             switch (bytes_per_word) {
-            case 4:
-                SPI_WRITE_TX(spi_base, nu_get32_le(tx));
-                tx += 4;
-                break;
-            case 2:
-                SPI_WRITE_TX(spi_base, nu_get16_le(tx));
-                tx += 2;
-                break;
-            case 1:
-                SPI_WRITE_TX(spi_base, *((uint8_t *) tx));
-                tx += 1;
-                break;
+                case 4:
+                    SPI_WRITE_TX(spi_base, nu_get32_le(tx));
+                    tx += 4;
+                    break;
+                case 2:
+                    SPI_WRITE_TX(spi_base, nu_get16_le(tx));
+                    tx += 2;
+                    break;
+                case 1:
+                    SPI_WRITE_TX(spi_base, *((uint8_t *) tx));
+                    tx += 1;
+                    break;
             }
 
             obj->tx_buff.pos ++;
@@ -743,21 +744,21 @@ static uint32_t spi_master_read_asynch(spi_t *obj)
             SPI_READ_RX(spi_base);
         } else {
             switch (bytes_per_word) {
-            case 4: {
-                uint32_t val = SPI_READ_RX(spi_base);
-                nu_set32_le(rx, val);
-                rx += 4;
-                break;
-            }
-            case 2: {
-                uint16_t val = SPI_READ_RX(spi_base);
-                nu_set16_le(rx, val);
-                rx += 2;
-                break;
-            }
-            case 1:
-                *rx ++ = SPI_READ_RX(spi_base);
-                break;
+                case 4: {
+                    uint32_t val = SPI_READ_RX(spi_base);
+                    nu_set32_le(rx, val);
+                    rx += 4;
+                    break;
+                }
+                case 2: {
+                    uint16_t val = SPI_READ_RX(spi_base);
+                    nu_set16_le(rx, val);
+                    rx += 2;
+                    break;
+                }
+                case 1:
+                    *rx ++ = SPI_READ_RX(spi_base);
+                    break;
             }
 
             obj->rx_buff.pos ++;

--- a/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/spi_api.c
@@ -93,7 +93,7 @@ __STATIC_INLINE void SPI_DISABLE_SYNC(SPI_T *spi_base)
     if (spi_base->CTL & SPI_CTL_SPIEN_Msk) {
         // NOTE: SPI H/W may get out of state without the busy check.
         while (SPI_IS_BUSY(spi_base));
-    
+
         SPI_DISABLE(spi_base);
     }
     while (spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk);
@@ -130,16 +130,9 @@ static const struct nu_modinit_s spi_modinit_tab[] = {
     {NC, 0, 0, 0, 0, (IRQn_Type) 0, NULL}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    // Determine which SPI_x the pins are used for
-    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
-    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
-    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi.spi = (SPIName) pinmap_merge(spi_data, spi_cntl);
+    obj->spi.spi = (SPIName) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi.spi != NC);
 
     const struct nu_modinit_s *modinit = get_modinit(obj->spi.spi, spi_modinit_tab);
@@ -154,15 +147,21 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     // Enable IP clock
     CLK_EnableModuleClock(modinit->clkidx);
 
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
 
-    obj->spi.pin_mosi = mosi;
-    obj->spi.pin_miso = miso;
-    obj->spi.pin_sclk = sclk;
-    obj->spi.pin_ssel = ssel;
+    obj->spi.pin_mosi = explicit_pinmap->pin[0];
+    obj->spi.pin_miso = explicit_pinmap->pin[1];
+    obj->spi.pin_sclk = explicit_pinmap->pin[2];
+    obj->spi.pin_ssel = explicit_pinmap->pin[3];
 
 
 #if DEVICE_SPI_ASYNCH
@@ -170,7 +169,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi.event = 0;
     obj->spi.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
     obj->spi.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
-    
+
     /* NOTE: We use vector to judge if asynchronous transfer is on-going (spi_active).
      *       At initial time, asynchronous transfer is not on-going and so vector must
      *       be cleared to zero for correct judgement. */
@@ -180,6 +179,31 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     // Mark this module to be inited.
     int i = modinit - spi_modinit_tab;
     spi_modinit_mask |= 1 << i;
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)
@@ -473,7 +497,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
          * H/W spec: In SPI Master mode with full duplex transfer, if both TX and RX PDMA functions are
          *           enabled, RX PDMA function cannot be enabled prior to TX PDMA function. User can enable
          *           TX PDMA function firstly or enable both functions simultaneously.
-         * Per real test, it is safer to start RX PDMA first and then TX PDMA. Otherwise, receive FIFO is 
+         * Per real test, it is safer to start RX PDMA first and then TX PDMA. Otherwise, receive FIFO is
          * subject to overflow by TX DMA.
          *
          * With the above conflicts, we enable PDMA TX/RX functions simultaneously.

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/spi_api.c
@@ -35,8 +35,8 @@
 #define NU_SPI_FIFO_DEPTH   8
 
 struct nu_spi_var {
-    spi_t *     obj;
-    void        (*vec)(void);
+    spi_t      *obj;
+    void (*vec)(void);
 #if DEVICE_SPI_ASYNCH
     uint8_t     pdma_perp_tx;
     uint8_t     pdma_perp_rx;
@@ -92,7 +92,7 @@ static struct nu_spi_var spi2_var = {
 __STATIC_INLINE void SPI_ENABLE_SYNC(SPI_T *spi_base)
 {
     /* NOTE: On NANO130, FIFO mode defaults to disabled. */
-    if (! (spi_base->CTL & SPI_CTL_FIFOM_Msk)) {
+    if (!(spi_base->CTL & SPI_CTL_FIFOM_Msk)) {
         SPI_EnableFIFO(spi_base, NU_SPI_FIFO_DEPTH / 2, NU_SPI_FIFO_DEPTH / 2);
     }
 }
@@ -119,8 +119,8 @@ static void spi_check_dma_usage(DMAUsage *dma_usage, int *dma_ch_tx, int *dma_ch
 static uint8_t spi_get_data_width(spi_t *obj);
 static int spi_is_tx_complete(spi_t *obj);
 static int spi_is_rx_complete(spi_t *obj);
-static int spi_writeable(spi_t * obj);
-static int spi_readable(spi_t * obj);
+static int spi_writeable(spi_t *obj);
+static int spi_readable(spi_t *obj);
 static void spi_dma_handler_tx(uint32_t id, uint32_t event_dma);
 static void spi_dma_handler_rx(uint32_t id, uint32_t event_dma);
 #endif
@@ -202,8 +202,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     if (NU_MODBASE(spi_data) == NU_MODBASE(spi_cntl)) {
         // NOTE: spi_data has subindex(port) encoded but spi_cntl hasn't.
         peripheral = (int) spi_data;
-    }
-    else {
+    } else {
         peripheral = (int) NC;
     }
 
@@ -259,10 +258,10 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     SPI_DISABLE_SYNC(spi_base);
 
     SPI_Open(spi_base,
-        slave ? SPI_SLAVE : SPI_MASTER,
-        (mode == 0) ? SPI_MODE_0 : (mode == 1) ? SPI_MODE_1 : (mode == 2) ? SPI_MODE_2 : SPI_MODE_3,
-        bits,
-        SPI_GetBusClock(spi_base));
+             slave ? SPI_SLAVE : SPI_MASTER,
+             (mode == 0) ? SPI_MODE_0 : (mode == 1) ? SPI_MODE_1 : (mode == 2) ? SPI_MODE_2 : SPI_MODE_3,
+             bits,
+             SPI_GetBusClock(spi_base));
     // NOTE: Hardcode to be MSB first.
     SPI_SET_MSB_FIRST(spi_base);
 
@@ -279,12 +278,10 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
                     SPI_EnableAutoSS(spi_base, SPI_SS1, SPI_SS1_ACTIVE_LOW);
                     break;
             }
-        }
-        else {
+        } else {
             SPI_DisableAutoSS(spi_base);
         }
-    }
-    else {
+    } else {
         // Slave
         // Configure SS as low active.
         switch (NU_MODSUBINDEX(obj->spi.spi)) {
@@ -326,7 +323,7 @@ int spi_master_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     uint32_t TX = (NU_MODSUBINDEX(obj->spi.spi) == 0) ? ((uint32_t) &spi_base->TX0) : ((uint32_t) &spi_base->TX1);
     M32(TX) = value;
 
@@ -426,7 +423,7 @@ void spi_slave_write(spi_t *obj, int value)
     SPI_ENABLE_SYNC(spi_base);
 
     // Wait for tx buffer empty
-    while(! spi_writeable(obj));
+    while (! spi_writeable(obj));
     uint32_t TX = (NU_MODSUBINDEX(obj->spi.spi) == 0) ? ((uint32_t) &spi_base->TX0) : ((uint32_t) &spi_base->TX1);
     M32(TX) = value;
 }
@@ -445,7 +442,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     // (1) No DMA support for non-8 multiple data width.
     // (2) tx length >= rx length. Otherwise, as tx DMA is done, no bus activity for remaining rx.
     if ((data_width % 8) ||
-        (tx_length < rx_length)) {
+            (tx_length < rx_length)) {
         obj->spi.dma_usage = DMA_USAGE_NEVER;
         dma_channel_free(obj->spi.dma_chn_id_tx);
         obj->spi.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
@@ -473,44 +470,44 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         // Configure tx DMA
         dma_enable(obj->spi.dma_chn_id_tx, 1);                  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_tx,
-            ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
-            0,  // Scatter-gather disabled
-            0); // Scatter-gather descriptor address
+                             ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
+                             0,  // Scatter-gather disabled
+                             0); // Scatter-gather descriptor address
         PDMA_SetTransferCnt(obj->spi.dma_chn_id_tx,
-            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
-            tx_length);
+                            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
+                            tx_length);
         PDMA_SetTransferAddr(obj->spi.dma_chn_id_tx,
-            (uint32_t) tx,  // NOTE:
-                            // NUC472: End of source address
-                            // M451: Start of source address
-                            // NANO130: Start of destination address
-            PDMA_SAR_INC,   // Source address incremental
-            NU_MODSUBINDEX(obj->spi.spi) == 0 ? (uint32_t) &spi_base->TX0 : (uint32_t) &spi_base->TX1,  // Destination address
-            PDMA_DAR_FIX);  // Destination address fixed
+                             (uint32_t) tx,  // NOTE:
+                             // NUC472: End of source address
+                             // M451: Start of source address
+                             // NANO130: Start of destination address
+                             PDMA_SAR_INC,   // Source address incremental
+                             NU_MODSUBINDEX(obj->spi.spi) == 0 ? (uint32_t) &spi_base->TX0 : (uint32_t) &spi_base->TX1,  // Destination address
+                             PDMA_DAR_FIX);  // Destination address fixed
         PDMA_EnableInt(obj->spi.dma_chn_id_tx,
-            PDMA_IER_TD_IE_Msk);    // Interrupt type
+                       PDMA_IER_TD_IE_Msk);    // Interrupt type
         // Register DMA event handler
         dma_set_handler(obj->spi.dma_chn_id_tx, (uint32_t) spi_dma_handler_tx, (uint32_t) obj, DMA_EVENT_ALL);
 
         // Configure rx DMA
         dma_enable(obj->spi.dma_chn_id_rx, 1);              // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_rx,
-            ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
-            0,  // Scatter-gather disabled
-            0); // Scatter-gather descriptor address
+                             ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
+                             0,  // Scatter-gather disabled
+                             0); // Scatter-gather descriptor address
         PDMA_SetTransferCnt(obj->spi.dma_chn_id_rx,
-            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
-            rx_length);
+                            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
+                            rx_length);
         PDMA_SetTransferAddr(obj->spi.dma_chn_id_rx,
-            NU_MODSUBINDEX(obj->spi.spi) == 0 ? (uint32_t) &spi_base->RX0 : (uint32_t) &spi_base->RX1,  // Source address
-            PDMA_SAR_FIX,   // Source address fixed
-            (uint32_t) rx,  // NOTE:
-                            // NUC472: End of destination address
-                            // M451: Start of destination address
-                            // NANO130: Start of destination address
-            PDMA_DAR_INC);  // Destination address incremental
+                             NU_MODSUBINDEX(obj->spi.spi) == 0 ? (uint32_t) &spi_base->RX0 : (uint32_t) &spi_base->RX1,  // Source address
+                             PDMA_SAR_FIX,   // Source address fixed
+                             (uint32_t) rx,  // NOTE:
+                             // NUC472: End of destination address
+                             // M451: Start of destination address
+                             // NANO130: Start of destination address
+                             PDMA_DAR_INC);  // Destination address incremental
         PDMA_EnableInt(obj->spi.dma_chn_id_rx,
-            PDMA_IER_TD_IE_Msk);    // Interrupt type
+                       PDMA_IER_TD_IE_Msk);    // Interrupt type
         // Register DMA event handler
         dma_set_handler(obj->spi.dma_chn_id_rx, (uint32_t) spi_dma_handler_rx, (uint32_t) obj, DMA_EVENT_ALL);
 
@@ -639,13 +636,13 @@ static void spi_irq(spi_t *obj)
     }
 }
 
-static int spi_writeable(spi_t * obj)
+static int spi_writeable(spi_t *obj)
 {
     // Receive FIFO must not be full to avoid receive FIFO overflow on next transmit/receive
     return (! SPI_GET_TX_FIFO_FULL_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi))));
 }
 
-static int spi_readable(spi_t * obj)
+static int spi_readable(spi_t *obj)
 {
     return ! SPI_GET_RX_FIFO_EMPTY_FLAG(((SPI_T *) NU_MODBASE(obj->spi.spi)));
 }
@@ -672,8 +669,7 @@ static void spi_enable_vector_interrupt(spi_t *obj, uint32_t handler, uint8_t en
         obj->spi.hdlr_async = handler;
         /* NOTE: On NANO130, vector table is fixed in ROM and cannot be modified. */
         NVIC_EnableIRQ(modinit->irq_n);
-    }
-    else {
+    } else {
         NVIC_DisableIRQ(modinit->irq_n);
         /* NOTE: On NANO130, vector table is fixed in ROM and cannot be modified. */
         var->obj = NULL;
@@ -690,8 +686,7 @@ static void spi_master_enable_interrupt(spi_t *obj, uint8_t enable, uint32_t mas
     if (enable) {
         // Enable tx/rx FIFO threshold interrupt
         SPI_EnableInt(spi_base, mask);
-    }
-    else {
+    } else {
         SPI_DisableInt(spi_base, mask);
     }
 }
@@ -752,8 +747,7 @@ static uint32_t spi_master_write_asynch(spi_t *obj, uint32_t tx_limit)
         if (spi_is_tx_complete(obj)) {
             // Transmit dummy as transmit buffer is empty
             M32(TX) = 0;
-        }
-        else {
+        } else {
             switch (bytes_per_word) {
                 case 4:
                     M32(TX) = nu_get32_le(tx);
@@ -805,8 +799,7 @@ static uint32_t spi_master_read_asynch(spi_t *obj)
         if (spi_is_rx_complete(obj)) {
             // Disregard as receive buffer is full
             M32(RX);
-        }
-        else {
+        } else {
             switch (bytes_per_word) {
                 case 4: {
                     uint32_t val = M32(RX);

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -88,7 +88,7 @@ __STATIC_INLINE void SPI_DISABLE_SYNC(SPI_T *spi_base)
     if (spi_base->CTL & SPI_CTL_SPIEN_Msk) {
         // NOTE: SPI H/W may get out of state without the busy check.
         while (SPI_IS_BUSY(spi_base));
-    
+
         SPI_DISABLE(spi_base);
     }
     while (spi_base->STATUS & SPI_STATUS_SPIENSTS_Msk);
@@ -119,19 +119,13 @@ static const struct nu_modinit_s spi_modinit_tab[] = {
     {SPI_1, SPI1_MODULE, 0, 0, SPI1_RST, SPI1_IRQn, &spi1_var},
     {SPI_2, SPI2_MODULE, 0, 0, SPI2_RST, SPI2_IRQn, &spi2_var},
     {SPI_3, SPI3_MODULE, 0, 0, SPI3_RST, SPI3_IRQn, &spi3_var},
-    
+
     {NC, 0, 0, 0, 0, (IRQn_Type) 0, NULL}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // Determine which SPI_x the pins are used for
-    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
-    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
-    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi.spi = (SPIName) pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi.spi = (SPIName) explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi.spi != NC);
 
     const struct nu_modinit_s *modinit = get_modinit(obj->spi.spi, spi_modinit_tab);
@@ -144,15 +138,21 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     // Enable IP clock
     CLK_EnableModuleClock(modinit->clkidx);
 
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
 
-    obj->spi.pin_mosi = mosi;
-    obj->spi.pin_miso = miso;
-    obj->spi.pin_sclk = sclk;
-    obj->spi.pin_ssel = ssel;
+    obj->spi.pin_mosi = explicit_pinmap->pin[0];
+    obj->spi.pin_miso = explicit_pinmap->pin[1];
+    obj->spi.pin_sclk = explicit_pinmap->pin[2];
+    obj->spi.pin_ssel = explicit_pinmap->pin[3];
 
 
 #if DEVICE_SPI_ASYNCH
@@ -160,7 +160,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi.event = 0;
     obj->spi.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
     obj->spi.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
-    
+
     /* NOTE: We use vector to judge if asynchronous transfer is on-going (spi_active).
      *       At initial time, asynchronous transfer is not on-going and so vector must
      *       be cleared to zero for correct judgement. */
@@ -200,6 +200,31 @@ void spi_free(spi_t *obj)
     // Mark this module to be deinited.
     int i = modinit - spi_modinit_tab;
     spi_modinit_mask &= ~(1 << i);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_format(spi_t *obj, int bits, int mode, int slave)
@@ -406,15 +431,15 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
             ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
             0,  // Scatter-gather disabled
             0); // Scatter-gather descriptor address
-        PDMA_SetTransferCnt(obj->spi.dma_chn_id_tx, 
-            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32, 
+        PDMA_SetTransferCnt(obj->spi.dma_chn_id_tx,
+            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
             tx_length);
-        PDMA_SetTransferAddr(obj->spi.dma_chn_id_tx, 
+        PDMA_SetTransferAddr(obj->spi.dma_chn_id_tx,
             ((uint32_t) tx) + (data_width / 8) * tx_length,   // NOTE: End of source address
             PDMA_SAR_INC,   // Source address incremental
             (uint32_t) &spi_base->TX,   // Destination address
             PDMA_DAR_FIX);  // Destination address fixed
-        PDMA_SetBurstType(obj->spi.dma_chn_id_tx, 
+        PDMA_SetBurstType(obj->spi.dma_chn_id_tx,
             PDMA_REQ_SINGLE,    // Single mode
             0); // Burst size
         PDMA_EnableInt(obj->spi.dma_chn_id_tx,
@@ -428,15 +453,15 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
             ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
             0,  // Scatter-gather disabled
             0); // Scatter-gather descriptor address
-        PDMA_SetTransferCnt(obj->spi.dma_chn_id_rx, 
-            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32, 
+        PDMA_SetTransferCnt(obj->spi.dma_chn_id_rx,
+            (data_width == 8) ? PDMA_WIDTH_8 : (data_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32,
             rx_length);
         PDMA_SetTransferAddr(obj->spi.dma_chn_id_rx,
             (uint32_t) &spi_base->RX,   // Source address
             PDMA_SAR_FIX,   // Source address fixed
             ((uint32_t) rx) + (data_width / 8) * rx_length,   // NOTE: End of destination address
             PDMA_DAR_INC);  // Destination address incremental
-        PDMA_SetBurstType(obj->spi.dma_chn_id_rx, 
+        PDMA_SetBurstType(obj->spi.dma_chn_id_rx,
             PDMA_REQ_SINGLE,    // Single mode
             0); // Burst size
         PDMA_EnableInt(obj->spi.dma_chn_id_rx,
@@ -463,7 +488,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
          * H/W spec: In SPI Master mode with full duplex transfer, if both TX and RX PDMA functions are
          *           enabled, RX PDMA function cannot be enabled prior to TX PDMA function. User can enable
          *           TX PDMA function firstly or enable both functions simultaneously.
-         * Per real test, it is safer to start RX PDMA first and then TX PDMA. Otherwise, receive FIFO is 
+         * Per real test, it is safer to start RX PDMA first and then TX PDMA. Otherwise, receive FIFO is
          * subject to overflow by TX DMA.
          *
          * With the above conflicts, we enable PDMA TX/RX functions simultaneously.

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -59,18 +59,11 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    
-    obj->spi = (LPC_SSP0_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSP0_Type*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0:
@@ -84,14 +77,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             LPC_SYSCON->PRESETCTRL |= 1 << 2;
             break;
     }
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -99,15 +121,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     ssp_disable(obj);
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) || ((mode >= 0) && (mode <= 3)));
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -116,35 +138,35 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     uint32_t PCLK = SystemCoreClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -24,36 +24,36 @@
 #if DEVICE_SPI
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_6 , SPI_0, 0x02},
+    {P0_6, SPI_0, 0x02},
     {P1_29, SPI_0, 0x01},
-    {P2_7 , SPI_0, 0x01},
+    {P2_7, SPI_0, 0x01},
     {P1_20, SPI_1, 0x02},
     {P1_27, SPI_1, 0x04},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_0, 0x01},
+    {P0_9, SPI_0, 0x01},
     {P1_12, SPI_0, 0x01},
     {P0_21, SPI_1, 0x02},
     {P1_22, SPI_1, 0x01},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_0, 0x01},
+    {P0_8, SPI_0, 0x01},
     {P1_16, SPI_0, 0x01},
     {P0_22, SPI_1, 0x03},
     {P1_21, SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_2 , SPI_0, 0x01},
+    {P0_2, SPI_0, 0x01},
     {P1_15, SPI_0, 0x01},
     {P0_23, SPI_1, 0x04},
     {P1_23, SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -61,7 +61,7 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSP0_Type*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSP0_Type *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -118,7 +118,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     ssp_disable(obj);
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) || ((mode >= 0) && (mode <= 3)));
 
@@ -134,22 +135,23 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
@@ -177,43 +179,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -227,20 +238,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -24,18 +24,11 @@
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    
-    obj->spi = (LPC_SSPx_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSPx_Type*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0:
@@ -49,14 +42,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             LPC_SYSCON->PRESETCTRL |= 1 << 2;
             break;
     }
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -65,15 +87,15 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     MBED_ASSERT((bits >= 4 && bits <= 16) || (mode >= 0 && mode <= 3));
 
     ssp_disable(obj);
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -82,35 +104,35 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     uint32_t PCLK = SystemCoreClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -26,7 +26,7 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSPx_Type*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSPx_Type *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -83,7 +83,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT((bits >= 4 && bits <= 16) || (mode >= 0 && mode <= 3));
 
     ssp_disable(obj);
@@ -100,22 +101,23 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
@@ -143,43 +145,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -193,20 +204,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -49,18 +49,11 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    
-    obj->spi = (LPC_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0:
@@ -86,14 +79,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             }
             break;
     }
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -101,15 +123,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     MBED_ASSERT((bits >= 4 && bits <= 16) || (mode >= 0 && mode <= 3));
     ssp_disable(obj);
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -118,35 +140,35 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     uint32_t PCLK = SystemCoreClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -21,29 +21,29 @@
 #include "mbed_error.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_6 , SPI_0, 0x02},
+    {P0_6, SPI_0, 0x02},
     // {P0_10, SPI_0, 0x02}, -- should be mapped to SWCLK only
     {P2_11, SPI_0, 0x01},
-    {P2_1 , SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {P2_1, SPI_1, 0x02},
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_0, 0x01},
-    {P2_3 , SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {P0_9, SPI_0, 0x01},
+    {P2_3, SPI_1, 0x02},
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_0, 0x01},
-    {P2_2 , SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {P0_8, SPI_0, 0x01},
+    {P2_2, SPI_1, 0x02},
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_2 , SPI_0, 0x01},
-    {P2_0 , SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {P0_2, SPI_0, 0x01},
+    {P2_0, SPI_1, 0x02},
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -51,7 +51,7 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSP_TypeDef *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -62,8 +62,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             LPC_SYSCON->PRESETCTRL |= 1 << 0;
             if (sclk == P0_6) {
                 LPC_IOCON->SCK_LOC = 0x02;
-            }
-            else {
+            } else {
                 LPC_IOCON->SCK_LOC = 0x01;
             }
             break;
@@ -120,7 +119,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT((bits >= 4 && bits <= 16) || (mode >= 0 && mode <= 3));
     ssp_disable(obj);
 
@@ -136,22 +136,23 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
@@ -179,43 +180,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -229,20 +239,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return ssp_readable(obj) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR & 0xFFFF;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -21,33 +21,33 @@
 #include "mbed_error.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_6 , SPI_0, 0x02},
+    {P0_6, SPI_0, 0x02},
     {P0_10, SPI_0, 0x02},
     {P1_29, SPI_0, 0x01},
     {P1_15, SPI_1, 0x03},
     {P1_20, SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_0, 0x01},
+    {P0_9, SPI_0, 0x01},
     {P0_21, SPI_1, 0x02},
     {P1_22, SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_0, 0x01},
+    {P0_8, SPI_0, 0x01},
     {P0_22, SPI_1, 0x03},
     {P1_21, SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_2 , SPI_0, 0x01},
+    {P0_2, SPI_0, 0x01},
     {P1_19, SPI_1, 0x02},
     {P1_23, SPI_1, 0x02},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -55,7 +55,7 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSPx_Type*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSPx_Type *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -112,7 +112,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     ssp_disable(obj);
     MBED_ASSERT((bits >= 4 && bits <= 16) || (mode >= 0 && mode <= 3));
 
@@ -128,22 +129,23 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
@@ -171,43 +173,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -221,20 +232,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -53,18 +53,11 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    
-    obj->spi = (LPC_SSPx_Type*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSPx_Type*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0:
@@ -78,14 +71,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             LPC_SYSCON->PRESETCTRL |= 1 << 2;
             break;
     }
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -93,15 +115,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     ssp_disable(obj);
     MBED_ASSERT((bits >= 4 && bits <= 16) || (mode >= 0 && mode <= 3));
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -110,35 +132,35 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     uint32_t PCLK = SystemCoreClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
@@ -243,6 +243,18 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     LPC_SYSCON->PRESETCTRL1    &= ~(0x1 << (obj->spi_n + 9));
 }
 
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * @param[out] obj  The SPI object to initialize
+ * @param[in]  explicit_pinmap pointer to strucure which holds static pinmap
+ */
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // Not supported
+    MBED_ASSERT(false);
+}
+
 void spi_free(spi_t *obj)
 {
 }

--- a/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
@@ -137,7 +137,7 @@ static int get_available_spi(PinName mosi, PinName miso, PinName sclk, PinName s
 
     // Investigate if same pins as the used SPI0/1 - to be able to reuse it
     for (int spi_n = 0; spi_n < 2; spi_n++) {
-        if (spi_used & (1<<spi_n)) {
+        if (spi_used & (1 << spi_n)) {
             if (sclk != NC) {
                 swm = &SWM_SPI_SCLK[spi_n];
                 regVal = LPC_SWM->PINASSIGN[swm->n] & (0xFF << swm->offset);
@@ -213,33 +213,33 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     if (sclk != NC) {
         swm = &SWM_SPI_SCLK[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  (sclk   << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | (sclk   << swm->offset);
     }
 
     if (mosi != NC) {
         swm = &SWM_SPI_MOSI[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  (mosi   << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | (mosi   << swm->offset);
     }
 
     if (miso != NC) {
         swm = &SWM_SPI_MISO[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  (miso   << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | (miso   << swm->offset);
     }
 
     if (ssel != NC) {
         swm = &SWM_SPI_SSEL[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  (ssel   << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | (ssel   << swm->offset);
     }
 
     // clear interrupts
     obj->spi->INTENCLR = 0x3f;
 
     // enable power and clocking
-    LPC_SYSCON->SYSAHBCLKCTRL1 |=  (0x1 << (obj->spi_n + 9));
-    LPC_SYSCON->PRESETCTRL1    |=  (0x1 << (obj->spi_n + 9));
+    LPC_SYSCON->SYSAHBCLKCTRL1 |= (0x1 << (obj->spi_n + 9));
+    LPC_SYSCON->PRESETCTRL1    |= (0x1 << (obj->spi_n + 9));
     LPC_SYSCON->PRESETCTRL1    &= ~(0x1 << (obj->spi_n + 9));
 }
 
@@ -291,7 +291,7 @@ void spi_frequency(spi_t *obj, int hz)
     spi_disable(obj);
 
     // rise DIV value if it cannot be divided
-    obj->spi->DIV = (SystemCoreClock + (hz - 1))/hz - 1;
+    obj->spi->DIV = (SystemCoreClock + (hz - 1)) / hz - 1;
     obj->spi->DLY = 0;
 
     spi_enable(obj);
@@ -344,7 +344,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer,
-                           int tx_length, char *rx_buffer, int rx_length, char write_fill) {
+                           int tx_length, char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -22,35 +22,35 @@
 #include "mbed_error.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_7 , SPI_1, 2},
+    {P0_7, SPI_1, 2},
     {P0_15, SPI_0, 2},
     {P1_20, SPI_0, 3},
     {P1_31, SPI_1, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_1, 2},
+    {P0_9, SPI_1, 2},
     {P0_13, SPI_1, 2},
     {P0_18, SPI_0, 2},
     {P1_24, SPI_0, 3},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_1, 2},
+    {P0_8, SPI_1, 2},
     {P0_12, SPI_1, 2},
     {P0_17, SPI_0, 2},
     {P1_23, SPI_0, 3},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_6 , SPI_1, 2},
+    {P0_6, SPI_1, 2},
     {P0_11, SPI_1, 2},
     {P0_16, SPI_0, 2},
     {P1_21, SPI_0, 3},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -58,13 +58,17 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSP_TypeDef *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {
-        case SPI_0: LPC_SC->PCONP |= 1 << 21; break;
-        case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
+        case SPI_0:
+            LPC_SC->PCONP |= 1 << 21;
+            break;
+        case SPI_1:
+            LPC_SC->PCONP |= 1 << 10;
+            break;
     }
 
     // pin out the spi pins
@@ -107,7 +111,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     ssp_disable(obj);
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && (mode >= 0 && mode <= 3));
 
@@ -123,33 +128,34 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     // setup the spi clock diveder to /1
     switch ((int)obj->spi) {
         case SPI_0:
             LPC_SC->PCLKSEL1 &= ~(3 << 10);
-            LPC_SC->PCLKSEL1 |=  (1 << 10);
+            LPC_SC->PCLKSEL1 |= (1 << 10);
             break;
         case SPI_1:
             LPC_SC->PCLKSEL0 &= ~(3 << 20);
-            LPC_SC->PCLKSEL0 |=  (1 << 20);
+            LPC_SC->PCLKSEL0 |= (1 << 20);
             break;
     }
 
@@ -178,43 +184,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -228,20 +243,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -56,17 +56,11 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (LPC_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0: LPC_SC->PCONP |= 1 << 21; break;
@@ -74,12 +68,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -87,15 +110,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     ssp_disable(obj);
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && (mode >= 0 && mode <= 3));
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -104,20 +127,20 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     // setup the spi clock diveder to /1
     switch ((int)obj->spi) {
         case SPI_0:
@@ -129,22 +152,22 @@ void spi_frequency(spi_t *obj, int hz) {
             LPC_SC->PCLKSEL0 |=  (1 << 20);
             break;
     }
-    
+
     uint32_t PCLK = SystemCoreClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -76,31 +76,54 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (LPC_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0: LPC_SC->PCONP |= 1 << 21; break;
         case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
         case SPI_2: LPC_SC->PCONP |= 1 << 20; break;
     }
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -108,15 +131,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && ((mode >= 0) && (mode <= 3)));
     ssp_disable(obj);
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -125,7 +148,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
@@ -137,22 +160,22 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     uint32_t PCLK = PeripheralClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -21,7 +21,7 @@
 #include "mbed_error.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_7 , SPI_1, 2},
+    {P0_7, SPI_1, 2},
     {P0_15, SPI_0, 2},
     {P1_0,  SPI_2, 4},
     {P1_19, SPI_1, 5},
@@ -30,11 +30,11 @@ static const PinMap PinMap_SPI_SCLK[] = {
     {P2_22, SPI_0, 2},
     {P4_20, SPI_1, 3},
     {P5_2,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_1, 2},
+    {P0_9, SPI_1, 2},
     {P0_13, SPI_1, 2},
     {P0_18, SPI_0, 2},
     {P1_1,  SPI_2, 4},
@@ -43,11 +43,11 @@ static const PinMap PinMap_SPI_MOSI[] = {
     {P2_27, SPI_0, 2},
     {P4_23, SPI_1, 3},
     {P5_0,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_1, 2},
+    {P0_8, SPI_1, 2},
     {P0_12, SPI_1, 2},
     {P0_17, SPI_0, 2},
     {P1_4,  SPI_2, 4},
@@ -56,11 +56,11 @@ static const PinMap PinMap_SPI_MISO[] = {
     {P2_26, SPI_0, 2},
     {P4_22, SPI_1, 3},
     {P5_1,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_6 , SPI_1, 2},
+    {P0_6, SPI_1, 2},
     {P0_14, SPI_1, 2},
     {P0_16, SPI_0, 2},
     {P1_8,  SPI_2, 4},
@@ -70,7 +70,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {P2_23, SPI_0, 2},
     {P4_21, SPI_1, 3},
     {P5_3,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -78,14 +78,20 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSP_TypeDef *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {
-        case SPI_0: LPC_SC->PCONP |= 1 << 21; break;
-        case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
-        case SPI_2: LPC_SC->PCONP |= 1 << 20; break;
+        case SPI_0:
+            LPC_SC->PCONP |= 1 << 21;
+            break;
+        case SPI_1:
+            LPC_SC->PCONP |= 1 << 10;
+            break;
+        case SPI_2:
+            LPC_SC->PCONP |= 1 << 20;
+            break;
     }
 
     // pin out the spi pins
@@ -128,7 +134,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && ((mode >= 0) && (mode <= 3)));
     ssp_disable(obj);
 
@@ -144,21 +151,22 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = PeripheralClock;
@@ -186,43 +194,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -236,20 +253,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
@@ -21,35 +21,35 @@
 #include "mbed_error.h"
 
 static const PinMap PinMap_SPI_SCLK[] = {
-    {P0_7 , SPI_1, 2},
+    {P0_7, SPI_1, 2},
     {P1_19, SPI_1, 5},
     {P1_20, SPI_0, 5},
     {P2_22, SPI_0, 2},
     {P5_2,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
-    {P0_9 , SPI_1, 2},
+    {P0_9, SPI_1, 2},
     {P1_24, SPI_0, 5},
     {P2_27, SPI_0, 2},
     {P5_0,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
-    {P0_8 , SPI_1, 2},
+    {P0_8, SPI_1, 2},
     {P1_23, SPI_0, 5},
     {P2_26, SPI_0, 2},
     {P5_1,  SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {P0_6 , SPI_1, 2},
+    {P0_6, SPI_1, 2},
     {P2_23, SPI_0, 2},
     {P5_3, SPI_2, 2},
-    {NC   , NC   , 0}
+    {NC, NC, 0}
 };
 
 static inline int ssp_disable(spi_t *obj);
@@ -57,14 +57,20 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSP_TypeDef *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {
-        case SPI_0: LPC_SC->PCONP |= 1 << 21; break;
-        case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
-        case SPI_2: LPC_SC->PCONP |= 1 << 20; break;
+        case SPI_0:
+            LPC_SC->PCONP |= 1 << 21;
+            break;
+        case SPI_1:
+            LPC_SC->PCONP |= 1 << 10;
+            break;
+        case SPI_2:
+            LPC_SC->PCONP |= 1 << 20;
+            break;
     }
 
     // pin out the spi pins
@@ -107,7 +113,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && ((mode >= 0) && (mode <= 3)));
     ssp_disable(obj);
 
@@ -123,21 +130,22 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = PeripheralClock;
@@ -165,43 +173,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -215,20 +232,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
@@ -55,15 +55,9 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (LPC_SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSP_TypeDef*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
@@ -74,12 +68,41 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}

--- a/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -76,13 +76,17 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (LPC_SSP_T*)explicit_pinmap->peripheral;
+    obj->spi = (LPC_SSP_T *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable clocking
     switch ((int)obj->spi) {
-        case SPI_0: LPC_CGU->BASE_CLK[CLK_BASE_SSP0] = (1 << 11) | (CLKIN_MAINPLL << 24); break;
-        case SPI_1: LPC_CGU->BASE_CLK[CLK_BASE_SSP1] = (1 << 11) | (CLKIN_MAINPLL << 24); break;
+        case SPI_0:
+            LPC_CGU->BASE_CLK[CLK_BASE_SSP0] = (1 << 11) | (CLKIN_MAINPLL << 24);
+            break;
+        case SPI_1:
+            LPC_CGU->BASE_CLK[CLK_BASE_SSP1] = (1 << 11) | (CLKIN_MAINPLL << 24);
+            break;
     }
 
     // pin out the spi pins
@@ -125,7 +129,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) || ((mode >= 0) && (mode <= 3)));
     ssp_disable(obj);
 
@@ -141,21 +146,22 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
@@ -183,43 +189,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -233,20 +248,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -74,31 +74,53 @@ static const PinMap PinMap_SPI_SSEL[] = {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    obj->spi = (LPC_SSP_T*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (LPC_SSP_T*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable clocking
     switch ((int)obj->spi) {
         case SPI_0: LPC_CGU->BASE_CLK[CLK_BASE_SSP0] = (1 << 11) | (CLKIN_MAINPLL << 24); break;
         case SPI_1: LPC_CGU->BASE_CLK[CLK_BASE_SSP1] = (1 << 11) | (CLKIN_MAINPLL << 24); break;
     }
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -106,15 +128,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) || ((mode >= 0) && (mode <= 3)));
     ssp_disable(obj);
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
@@ -123,7 +145,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
@@ -135,22 +157,22 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     uint32_t PCLK = SystemCoreClock;
-    
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = PCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;

--- a/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
@@ -67,11 +67,13 @@ static const PinMap PinMap_SPI_testing[] = {
 
 // bit flags for used SPIs
 static unsigned char spi_used = 0;
-static int get_available_spi(void) {
+static int get_available_spi(void)
+{
     int i;
-    for (i=0; i<2; i++) {
-        if ((spi_used & (1 << i)) == 0)
+    for (i = 0; i < 2; i++) {
+        if ((spi_used & (1 << i)) == 0) {
             return i;
+        }
     }
     return -1;
 }
@@ -79,7 +81,8 @@ static int get_available_spi(void) {
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
     int spi_n = get_available_spi();
     if (spi_n == -1) {
         error("No available SPI");
@@ -94,19 +97,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     swm = &SWM_SPI_SCLK[obj->spi_n];
     regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-    LPC_SWM->PINASSIGN[swm->n] = regVal |  (sclk   << swm->offset);
+    LPC_SWM->PINASSIGN[swm->n] = regVal | (sclk   << swm->offset);
 
     swm = &SWM_SPI_MOSI[obj->spi_n];
     regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-    LPC_SWM->PINASSIGN[swm->n] = regVal |  (mosi   << swm->offset);
+    LPC_SWM->PINASSIGN[swm->n] = regVal | (mosi   << swm->offset);
 
     swm = &SWM_SPI_MISO[obj->spi_n];
     regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-    LPC_SWM->PINASSIGN[swm->n] = regVal |  (miso   << swm->offset);
+    LPC_SWM->PINASSIGN[swm->n] = regVal | (miso   << swm->offset);
 
     swm = &SWM_SPI_SSEL[obj->spi_n];
     regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-    LPC_SWM->PINASSIGN[swm->n] = regVal |  (ssel   << swm->offset);
+    LPC_SWM->PINASSIGN[swm->n] = regVal | (ssel   << swm->offset);
 
     // clear interrupts
     obj->spi->INTENCLR = 0x3f;
@@ -114,14 +117,14 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     // enable power and clocking
     switch (obj->spi_n) {
         case 0:
-            LPC_SYSCON->SYSAHBCLKCTRL |= (1<<11);
-            LPC_SYSCON->PRESETCTRL &= ~(0x1<<0);
-            LPC_SYSCON->PRESETCTRL |= (0x1<<0);
+            LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 11);
+            LPC_SYSCON->PRESETCTRL &= ~(0x1 << 0);
+            LPC_SYSCON->PRESETCTRL |= (0x1 << 0);
             break;
         case 1:
-            LPC_SYSCON->SYSAHBCLKCTRL |= (1<<12);
-            LPC_SYSCON->PRESETCTRL &= ~(0x1<<1);
-            LPC_SYSCON->PRESETCTRL |= (0x1<<1);
+            LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 12);
+            LPC_SYSCON->PRESETCTRL &= ~(0x1 << 1);
+            LPC_SYSCON->PRESETCTRL |= (0x1 << 1);
             break;
     }
 }
@@ -140,7 +143,8 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     MBED_ASSERT(((bits >= 1) && (bits <= 16)) && ((mode >= 0) && (mode <= 3)));
     ssp_disable(obj);
 
@@ -166,56 +170,66 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     uint32_t PCLK = SystemCoreClock;
 
-    obj->spi->DIV = PCLK/hz - 1;
+    obj->spi->DIV = PCLK / hz - 1;
     obj->spi->DLY = 0;
     ssp_enable(obj);
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CFG &= ~(1 << 0);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CFG |= (1 << 0);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->STAT & (1 << 0);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->STAT & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     // end of transfer
     obj->spi->TXDATCTL |= (1 << 20);
     obj->spi->TXDAT = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->RXDAT;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     // checking RXOV(Receiver Overrun interrupt flag)
     return obj->spi->STAT & (1 << 2);
-    }
+}
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -229,20 +243,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->RXDAT;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->TXDAT = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
@@ -141,6 +141,12 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->DLY = 2;             // 2 SPI clock times pre-delay
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // Not supported
+    MBED_ASSERT(false);
+}
+
 void spi_free(spi_t *obj)
 {
 }

--- a/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
@@ -83,9 +83,10 @@ static unsigned char spi_used = 0;
 static int get_available_spi(void)
 {
     int i;
-    for (i=0; i<2; i++) {
-        if ((spi_used & (1 << i)) == 0)
+    for (i = 0; i < 2; i++) {
+        if ((spi_used & (1 << i)) == 0) {
             return i;
+        }
     }
     return -1;
 }
@@ -110,33 +111,33 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     if (sclk != (PinName)NC) {
         swm = &SWM_SPI_SCLK[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  ((sclk >> PIN_SHIFT) << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | ((sclk >> PIN_SHIFT) << swm->offset);
     }
 
     if (mosi != (PinName)NC) {
         swm = &SWM_SPI_MOSI[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  ((mosi >> PIN_SHIFT) << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | ((mosi >> PIN_SHIFT) << swm->offset);
     }
 
     if (miso != (PinName)NC) {
         swm = &SWM_SPI_MISO[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  ((miso >> PIN_SHIFT) << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | ((miso >> PIN_SHIFT) << swm->offset);
     }
 
     if (ssel != (PinName)NC) {
         swm = &SWM_SPI_SSEL[obj->spi_n];
         regVal = LPC_SWM->PINASSIGN[swm->n] & ~(0xFF << swm->offset);
-        LPC_SWM->PINASSIGN[swm->n] = regVal |  ((ssel >> PIN_SHIFT) << swm->offset);
+        LPC_SWM->PINASSIGN[swm->n] = regVal | ((ssel >> PIN_SHIFT) << swm->offset);
     }
 
     // clear interrupts
     obj->spi->INTENCLR = 0x3f;
 
-    LPC_SYSCON->SYSAHBCLKCTRL |=  (1 << (11 + obj->spi_n));
+    LPC_SYSCON->SYSAHBCLKCTRL |= (1 << (11 + obj->spi_n));
     LPC_SYSCON->PRESETCTRL    &= ~(1 << obj->spi_n);
-    LPC_SYSCON->PRESETCTRL    |=  (1 << obj->spi_n);
+    LPC_SYSCON->PRESETCTRL    |= (1 << obj->spi_n);
 
     obj->spi->DLY = 2;             // 2 SPI clock times pre-delay
 }
@@ -157,10 +158,10 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     spi_disable(obj);
 
     obj->spi->CFG &= ~((0x3 << 4) | (1 << 2));
-    obj->spi->CFG |=  ((mode & 0x3) << 4) | ((slave ? 0 : 1) << 2);
+    obj->spi->CFG |= ((mode & 0x3) << 4) | ((slave ? 0 : 1) << 2);
 
-    obj->spi->TXCTL &= ~( 0xF << 24);
-    obj->spi->TXCTL |=  ((bits - 1) << 24);
+    obj->spi->TXCTL &= ~(0xF << 24);
+    obj->spi->TXCTL |= ((bits - 1) << 24);
 
     spi_enable(obj);
 }
@@ -170,7 +171,7 @@ void spi_frequency(spi_t *obj, int hz)
     spi_disable(obj);
 
     // rise DIV value if it cannot be divided
-    obj->spi->DIV = (SystemCoreClock + (hz - 1))/hz - 1;
+    obj->spi->DIV = (SystemCoreClock + (hz - 1)) / hz - 1;
 
     spi_enable(obj);
 }
@@ -216,7 +217,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/spi_api.c
@@ -122,7 +122,7 @@ void spi_frequency(spi_t *obj, int hz)
     LPSPI_Enable(spibase, true);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (LPSPI_GetStatusFlags(spi_address[obj->instance]) & kLPSPI_RxDataReadyFlag);
 }
@@ -143,17 +143,18 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     // Default write is done in each and every call, in future can create HAL API instead
     LPSPI_SetDummyData(spi_address[obj->instance], write_fill);
 
-    LPSPI_MasterTransferBlocking(spi_address[obj->instance], &(lpspi_transfer_t){
-          .txData = (uint8_t *)tx_buffer,
-          .rxData = (uint8_t *)rx_buffer,
-          .dataSize = total,
-          .configFlags = kLPSPI_MasterPcs0 | kLPSPI_MasterPcsContinuous | kLPSPI_SlaveByteSwap,
+    LPSPI_MasterTransferBlocking(spi_address[obj->instance], &(lpspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kLPSPI_MasterPcs0 | kLPSPI_MasterPcsContinuous | kLPSPI_SlaveByteSwap,
     });
 
     return total;
@@ -180,8 +181,7 @@ void spi_slave_write(spi_t *obj, int value)
     LPSPI_WriteData(spi_address[obj->instance], (uint32_t)value);
 
     /* Transfer is not complete until transfer complete flag sets */
-    while (!(LPSPI_GetStatusFlags(spi_address[obj->instance]) & kLPSPI_FrameCompleteFlag))
-    {
+    while (!(LPSPI_GetStatusFlags(spi_address[obj->instance]) & kLPSPI_FrameCompleteFlag)) {
     }
 
     LPSPI_ClearStatusFlags(spi_address[obj->instance], kLPSPI_FrameCompleteFlag);

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/spi_api.c
@@ -31,6 +31,27 @@ static LPSPI_Type *const spi_address[] = LPSPI_BASE_PTRS;
 extern uint32_t spi_get_clock(void);
 extern void spi_setup_clock();
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+
+    obj->instance = explicit_pinmap->peripheral;
+    MBED_ASSERT((int)obj->instance != NC);
+
+    // pin out the spi pins
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
+    }
+
+    spi_setup_clock();
+}
+
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     // determine the SPI to use
@@ -41,18 +62,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->instance = pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->instance != NC);
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
 
-    spi_setup_clock();
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/spi_api.c
@@ -164,7 +164,7 @@ void spi_frequency(spi_t *obj, int hz)
     SPI_MasterSetBaud(spi_address[obj->instance], (uint32_t)hz, 12000000);
 }
 
-static inline int spi_readable(spi_t * obj)
+static inline int spi_readable(spi_t *obj)
 {
     return (SPI_GetStatusFlags(spi_address[obj->instance]) & kSPI_RxNotEmptyFlag);
 }
@@ -181,7 +181,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/spi_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/spi_api.c
@@ -54,7 +54,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     MBED_ASSERT((int)obj->membase != NC);
 
     /* Check device to be activated */
-    if(obj->membase == SPI1REG) {
+    if (obj->membase == SPI1REG) {
         /* SPI 1 selected */
         CLOCK_ENABLE(CLOCK_SPI);         /* Enable clock */
     } else {
@@ -80,16 +80,16 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     pin_mode(explicit_pinmap->pin[0], PushPullPullDown);
 
     /* PAD drive strength */
-    PadReg_t *padRegOffset = (PadReg_t*)(PADREG_BASE + (explicit_pinmap->pin[2] * PAD_REG_ADRS_BYTE_SIZE));
+    PadReg_t *padRegOffset = (PadReg_t *)(PADREG_BASE + (explicit_pinmap->pin[2] * PAD_REG_ADRS_BYTE_SIZE));
     padRegOffset->PADIO0.BITS.POWER = True; /* sclk: Drive strength */
     padRegOffset->PADIO1.BITS.POWER = True; /* mosi: Drive strength */
-    if(explicit_pinmap->pin[1] != NC) {
+    if (explicit_pinmap->pin[1] != NC) {
         pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
         pin_mode(explicit_pinmap->pin[1], PullNone);
         pin_mode(explicit_pinmap->pin[1], OpenDrainNoPull);      /* Pad setting */
         padRegOffset->PADIO2.BITS.POWER = True;  /* miso: Drive strength */
     }
-    if(explicit_pinmap->pin[3] != NC) {
+    if (explicit_pinmap->pin[3] != NC) {
         pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
         pin_mode(explicit_pinmap->pin[3], PullNone);
         pin_mode(explicit_pinmap->pin[3], PushPullPullUp);               /* Pad setting */
@@ -157,21 +157,21 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
     /* Clear word width | Slave/Master | CPOL | CPHA | MSB first bits in control register */
     obj->membase->CONTROL.WORD &= ~(uint32_t)((True << SPI_WORD_WIDTH_BIT_POS) |
-                                    (True << SPI_SLAVE_MASTER_BIT_POS) |
-                                    (True << SPI_CPOL_BIT_POS) |
-                                    (True << SPI_CPHA_BIT_POS));
+                                              (True << SPI_SLAVE_MASTER_BIT_POS) |
+                                              (True << SPI_CPOL_BIT_POS) |
+                                              (True << SPI_CPHA_BIT_POS));
 
     /* Configure word width | Slave/Master | CPOL | CPHA | MSB first bits in control register */
     obj->membase->CONTROL.WORD |= (uint32_t)(((bits >> 0x4) << SPI_WORD_WIDTH_BIT_POS) |
-                                              (!slave << SPI_SLAVE_MASTER_BIT_POS) |
-                                              ((mode >> 0x1) << SPI_CPOL_BIT_POS) |
-                                              ((mode & 0x1) << SPI_CPHA_BIT_POS));
+                                             (!slave << SPI_SLAVE_MASTER_BIT_POS) |
+                                             ((mode >> 0x1) << SPI_CPOL_BIT_POS) |
+                                             ((mode & 0x1) << SPI_CPHA_BIT_POS));
 }
 
 void spi_frequency(spi_t *obj, int hz)
 {
     /* If the frequency is outside the allowable range, set it to the max */
-    if(hz > SPI_FREQ_MAX) {
+    if (hz > SPI_FREQ_MAX) {
         hz = SPI_FREQ_MAX;
     }
     obj->membase->FDIV = ((fClockGetPeriphClockfrequency() / hz) >> 1) - 1;
@@ -179,11 +179,12 @@ void spi_frequency(spi_t *obj, int hz)
 
 int  spi_master_write(spi_t *obj, int value)
 {
-    return(fSpiWriteB(obj, value));
+    return (fSpiWriteB(obj, value));
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -199,14 +200,14 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 
 int  spi_busy(spi_t *obj)
 {
-    return(obj->membase->STATUS.BITS.XFER_IP);
+    return (obj->membase->STATUS.BITS.XFER_IP);
 }
 
 uint8_t spi_get_module(spi_t *obj)
 {
-    if(obj->membase == SPI1REG) {
+    if (obj->membase == SPI1REG) {
         return 0; /* UART #1 */
-    } else if(obj->membase == SPI2REG) {
+    } else if (obj->membase == SPI2REG) {
         return 1; /* UART #2 */
     } else {
         return 2; /* Invalid address */
@@ -215,7 +216,7 @@ uint8_t spi_get_module(spi_t *obj)
 
 int  spi_slave_receive(spi_t *obj)
 {
-    if(obj->membase->STATUS.BITS.RX_EMPTY != True){ /* if receive status is not empty */
+    if (obj->membase->STATUS.BITS.RX_EMPTY != True) { /* if receive status is not empty */
         return True;    /* Byte available to read */
     }
     return False; /* Byte not available to read */
@@ -232,7 +233,7 @@ int  spi_slave_read(spi_t *obj)
 
 void spi_slave_write(spi_t *obj, int value)
 {
-    while((obj->membase->STATUS.BITS.TX_FULL == True) && (obj->membase->STATUS.BITS.RX_FULL == True)); /* Wait till Tx/Rx status is full */
+    while ((obj->membase->STATUS.BITS.TX_FULL == True) && (obj->membase->STATUS.BITS.RX_FULL == True)); /* Wait till Tx/Rx status is full */
     obj->membase->TX_DATA = value;
 }
 
@@ -285,10 +286,10 @@ void spi_master_transfer(spi_t *obj, void *tx, size_t tx_length, void *rx, size_
     int ndata = 0;
     uint16_t *tx_ptr = (uint16_t *) tx;
 
-    if(obj->spi->CONTROL.BITS.WORD_WIDTH == 0) {
+    if (obj->spi->CONTROL.BITS.WORD_WIDTH == 0) {
         /* Word size 8 bits */
         WORD_WIDTH_MASK = 0xFF;
-    } else if(obj->spi->CONTROL.BITS.WORD_WIDTH == 1) {
+    } else if (obj->spi->CONTROL.BITS.WORD_WIDTH == 1) {
         /* Word size 16 bits */
         WORD_WIDTH_MASK = 0xFFFF;
     } else {
@@ -297,9 +298,9 @@ void spi_master_transfer(spi_t *obj, void *tx, size_t tx_length, void *rx, size_
     }
 
     //frame size
-    if(tx_length == 0) {
+    if (tx_length == 0) {
         tx_length = rx_length;
-        tx = (void*) 0;
+        tx = (void *) 0;
     }
     //set tx rx buffer
     obj->tx_buff.buffer = (void *)tx;
@@ -312,9 +313,9 @@ void spi_master_transfer(spi_t *obj, void *tx, size_t tx_length, void *rx, size_
     obj->rx_buff.width = bit_width;
 
 
-    if((obj->spi.bits == 9) && (tx != 0)) {
+    if ((obj->spi.bits == 9) && (tx != 0)) {
         // Make sure we don't have inadvertent non-zero bits outside 9-bit frames which could trigger unwanted operation
-        for(i = 0; i < (tx_length / 2); i++) {
+        for (i = 0; i < (tx_length / 2); i++) {
             tx_ptr[i] &= 0x1FF;
         }
     }
@@ -330,7 +331,7 @@ void spi_master_transfer(spi_t *obj, void *tx, size_t tx_length, void *rx, size_
 
     //write async
 
-    if ( && ) {
+    if (&&) {
 
     }
     while ((obj->tx_buff.pos < obj->tx_buff.length) &&

--- a/targets/TARGET_RDA/TARGET_UNO_91H/spi_api.c
+++ b/targets/TARGET_RDA/TARGET_UNO_91H/spi_api.c
@@ -23,9 +23,8 @@
 #include "pinmap.h"
 
 /*------------- Wlan Monitor (WLANMON) ---------------------------------------*/
-typedef struct
-{
-  __IO uint32_t PHYSEL_3_0;             /* 0x00 : PHY select register 0 - 3   */
+typedef struct {
+    __IO uint32_t PHYSEL_3_0;             /* 0x00 : PHY select register 0 - 3   */
 } RDA_WLANMON_TypeDef;
 
 /*
@@ -46,7 +45,7 @@ typedef struct
 static const PinMap PinMap_SPI_SCLK[] = {
     {PB_4, SPI_0, 4},
     {PD_0, SPI_0, 1},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MOSI[] = {
@@ -54,7 +53,7 @@ static const PinMap PinMap_SPI_MOSI[] = {
     {PC_0, SPI_0, 6},
     {PD_2, SPI_0, 1},
     {PB_3, SPI_0, 2},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_MISO[] = {
@@ -62,7 +61,7 @@ static const PinMap PinMap_SPI_MISO[] = {
     {PC_1, SPI_0, 6},
     {PD_3, SPI_0, 1},
     {PB_8, SPI_0, 3},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
@@ -70,7 +69,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {PB_5, SPI_0, 4},
     {PA_0, SPI_0, 3},
     {PA_1, SPI_0, 3},
-    {NC  , NC   , 0}
+    {NC, NC, 0}
 };
 
 /*
@@ -87,11 +86,11 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     uint32_t reg_val;
 
-    obj->spi = (RDA_SPI_TypeDef*)explicit_pinmap->peripheral;
+    obj->spi = (RDA_SPI_TypeDef *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     /* Enable power and clocking */
-    SPI_CLKGATE_REG |=  (0x01UL << 18);
+    SPI_CLKGATE_REG |= (0x01UL << 18);
 
     /* Select 4-wire SPI mode */
     SPI_MODESEL_REG &= ~(0x01UL << 14);
@@ -101,12 +100,12 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 
 #if ENABLE_RDA_SPI_MODE
     /* RDA SPI mode */
-    reg_val |=  (0x01UL << 2);
+    reg_val |= (0x01UL << 2);
 #else  /* ENABLE_RDA_SPI_MODE */
     /* Normal SPI mode */
     reg_val &= ~(0x01UL << 2);
     /* Set read flag */
-    reg_val |=  (0x01UL << 3);
+    reg_val |= (0x01UL << 3);
 #endif /* ENABLE_RDA_SPI_MODE */
 
     /* Set core cfg for mosi, miso */
@@ -122,9 +121,9 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
         SPI_MODESEL_REG &= ~(0x0FUL);
         SPI_PINSEL_REG1 &= ~(0x3FUL << 24);
         SPI_PINSEL_REG2 &= ~(0x0FUL << 12);
-        SPI_MODESEL_REG |=  (0x0BUL);
-        SPI_PINSEL_REG1 |=  (0x02UL << 24);
-        SPI_PINSEL_REG2 |=  (0x01UL << 12);
+        SPI_MODESEL_REG |= (0x0BUL);
+        SPI_PINSEL_REG1 |= (0x02UL << 24);
+        SPI_PINSEL_REG2 |= (0x01UL << 12);
     }
     if (PB_8 == explicit_pinmap->pin[1]) {
         SPI_PINSEL_REG0 &= ~(0x01UL << 11);
@@ -248,8 +247,9 @@ static inline int spi_pin_cs_num(PinName ssel)
 {
     int idx = 0;
     while (PinMap_SPI_SSEL[idx].pin != NC) {
-        if (PinMap_SPI_SSEL[idx].pin == ssel)
+        if (PinMap_SPI_SSEL[idx].pin == ssel) {
             return idx;
+        }
         idx++;
     }
     return (int)NC;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
@@ -97,7 +97,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     int      DSS;      // DSS (data select size)
     int      polarity  = (mode & 0x2) ? 1 : 0;
     int      phase     = (mode & 0x1) ? 1 : 0;
@@ -147,14 +148,15 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     obj->spi.spi->SPCMD0 = wk_spcmd0;
     obj->spi.spi->SPDCR   = splw;
     if (slave) {
-        obj->spi.spi->SPCR &=~(1 << 3);  // MSTR to 0
+        obj->spi.spi->SPCR &= ~(1 << 3); // MSTR to 0
     } else {
         obj->spi.spi->SPCR |= (1 << 3);  // MSTR to 1
     }
     spi_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     uint32_t  pclk_base;
     uint32_t  div;
     uint32_t  brdv = 0;
@@ -196,23 +198,28 @@ void spi_frequency(spi_t *obj, int hz) {
     spi_enable(obj);
 }
 
-static inline void spi_disable(spi_t *obj) {
+static inline void spi_disable(spi_t *obj)
+{
     obj->spi.spi->SPCR &= ~(1 << 6);       // SPE to 0
 }
 
-static inline void spi_enable(spi_t *obj) {
-    obj->spi.spi->SPCR |=  (1 << 6);       // SPE to 1
+static inline void spi_enable(spi_t *obj)
+{
+    obj->spi.spi->SPCR |= (1 << 6);        // SPE to 1
 }
 
-static inline int spi_readable(spi_t *obj) {
+static inline int spi_readable(spi_t *obj)
+{
     return obj->spi.spi->SPSR & (1 << 7);  // SPRF
 }
 
-static inline int spi_tend(spi_t *obj) {
+static inline int spi_tend(spi_t *obj)
+{
     return obj->spi.spi->SPSR & (1 << 6);  // TEND
 }
 
-static inline void spi_write(spi_t *obj, int value) {
+static inline void spi_write(spi_t *obj, int value)
+{
     if (obj->spi.bits == 8) {
         obj->spi.spi->SPDR.UINT8[0]  = (uint8_t)value;
     } else if (obj->spi.bits == 16) {
@@ -222,7 +229,8 @@ static inline void spi_write(spi_t *obj, int value) {
     }
 }
 
-static inline int spi_read(spi_t *obj) {
+static inline int spi_read(spi_t *obj)
+{
     int read_data;
 
     if (obj->spi.bits == 8) {
@@ -236,14 +244,16 @@ static inline int spi_read(spi_t *obj) {
     return read_data;
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     spi_write(obj, value);
-    while(!spi_tend(obj));
+    while (!spi_tend(obj));
     return spi_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -257,19 +267,23 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return spi_read(obj);
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     spi_write(obj, value);
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return 0;
 }
 
@@ -411,34 +425,44 @@ static void spi_err_irq(IRQn_Type irq_num, uint32_t index)
     }
 }
 
-static void spi0_rx_irq(void) {
+static void spi0_rx_irq(void)
+{
     spi_rx_irq(RSPISPRI0_IRQn, 0);
 }
-static void spi0_er_irq(void) {
+static void spi0_er_irq(void)
+{
     spi_err_irq(RSPISPEI0_IRQn, 0);
 }
-static void spi1_rx_irq(void) {
+static void spi1_rx_irq(void)
+{
     spi_rx_irq(RSPISPRI1_IRQn, 1);
 }
-static void spi1_er_irq(void) {
+static void spi1_er_irq(void)
+{
     spi_err_irq(RSPISPEI1_IRQn, 1);
 }
-static void spi2_rx_irq(void) {
+static void spi2_rx_irq(void)
+{
     spi_rx_irq(RSPISPRI2_IRQn, 2);
 }
-static void spi2_er_irq(void) {
+static void spi2_er_irq(void)
+{
     spi_err_irq(RSPISPEI2_IRQn, 2);
 }
-static void spi3_rx_irq(void) {
+static void spi3_rx_irq(void)
+{
     spi_rx_irq(RSPISPRI3_IRQn, 3);
 }
-static void spi3_er_irq(void) {
+static void spi3_er_irq(void)
+{
     spi_err_irq(RSPISPEI3_IRQn, 3);
 }
-static void spi4_rx_irq(void) {
+static void spi4_rx_irq(void)
+{
     spi_rx_irq(RSPISPRI4_IRQn, 4);
 }
-static void spi4_er_irq(void) {
+static void spi4_er_irq(void)
+{
     spi_err_irq(RSPISPEI4_IRQn, 4);
 }
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
@@ -31,27 +31,21 @@ static inline int spi_readable(spi_t *obj);
 static inline void spi_write(spi_t *obj, int value);
 static inline int spi_read(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
     volatile uint8_t dummy;
-    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
-    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
-    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
-    uint32_t spi      = pinmap_merge(spi_data, spi_cntl);
-    
+    uint32_t spi      = (uint32_t)explicit_pinmap->peripheral;
+
     MBED_ASSERT((int)spi != NC);
-    
+
     obj->spi.spi = (struct st_rspi *)RSPI[spi];
     obj->spi.index = spi;
-    
+
     // enable power and clocking
     CPGSTBCR10 &= ~(0x80 >> spi);
     dummy = CPGSTBCR10;
     (void)dummy;
-    
+
     obj->spi.spi->SPCR   = 0x00;  // CTRL to 0
     obj->spi.spi->SPSCR  = 0x00;  // no sequential operation
     obj->spi.spi->SSLP   = 0x00;  // SSL 'L' active
@@ -62,14 +56,43 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi.spi->SPPCR  = 0x20;  // MOSI Idle fixed value equals 0
     obj->spi.spi->SPBFCR = 0xf0;  // and set trigger count: read 1, write 1
     obj->spi.spi->SPBFCR = 0x30;  // and reset buffer
-    
+
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if ((int)ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -82,7 +105,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint16_t mask      = 0xf03;
     uint16_t wk_spcmd0;
     uint8_t  splw;
-    
+
     switch (mode) {
         case 0:
         case 1:
@@ -94,7 +117,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
             error("SPI format error");
             return;
     }
-    
+
     switch (bits) {
         case 8:
             DSS  = 0x7;
@@ -116,7 +139,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     tmp |= (polarity << 1);
     tmp |= (DSS << 8);
     obj->spi.bits = bits;
-    
+
     spi_disable(obj);
     wk_spcmd0 = obj->spi.spi->SPCMD0;
     wk_spcmd0 &= ~mask;
@@ -139,14 +162,14 @@ void spi_frequency(spi_t *obj, int hz) {
     uint32_t  hz_min;
     uint16_t  mask = 0x000c;
     uint16_t  wk_spcmd0;
-    
+
     /* set PCLK */
     if (RZ_A1_IsClockMode0() == false) {
         pclk_base = CM1_RENESAS_RZ_A1_P1_CLK;
     } else {
         pclk_base = CM0_RENESAS_RZ_A1_P1_CLK;
     }
-    
+
     hz_min = pclk_base / 2 / 256 / 8;
     hz_max = pclk_base / 2;
     if ((uint32_t)hz < hz_min) {
@@ -155,7 +178,7 @@ void spi_frequency(spi_t *obj, int hz) {
     if ((uint32_t)hz > hz_max) {
         hz = hz_max;
     }
-    
+
     div = (pclk_base / hz / 2);
     while (div > 256) {
         div >>= 1;
@@ -163,7 +186,7 @@ void spi_frequency(spi_t *obj, int hz) {
     }
     div  -= 1;
     brdv  = (brdv << 2);
-    
+
     spi_disable(obj);
     obj->spi.spi->SPBR = div;
     wk_spcmd0 = obj->spi.spi->SPCMD0;
@@ -201,7 +224,7 @@ static inline void spi_write(spi_t *obj, int value) {
 
 static inline int spi_read(spi_t *obj) {
     int read_data;
-    
+
     if (obj->spi.bits == 8) {
         read_data = obj->spi.spi->SPDR.UINT8[0];
     } else if (obj->spi.bits == 16) {
@@ -209,7 +232,7 @@ static inline int spi_read(spi_t *obj) {
     } else {
         read_data = obj->spi.spi->SPDR.UINT32;
     }
-    
+
     return read_data;
 }
 
@@ -446,7 +469,7 @@ static void spi_async_write(spi_t *obj)
     uint8_t **width8;
     uint16_t **width16;
     uint32_t **width32;
-    
+
     if (obj->tx_buff.buffer) {
         switch (obj->tx_buff.width) {
             case 8:
@@ -455,21 +478,21 @@ static void spi_async_write(spi_t *obj)
                 ++*width8;
                 obj->tx_buff.pos += sizeof(uint8_t);
                 break;
-                
+
             case 16:
                 width16 = (uint16_t **)&obj->tx_buff.buffer;
                 spi_write(obj, **width16);
                 ++*width16;
                 obj->tx_buff.pos += sizeof(uint16_t);
                 break;
-                
+
             case 32:
                 width32 = (uint32_t **)&obj->tx_buff.buffer;
                 spi_write(obj, **width32);
                 ++*width32;
                 obj->tx_buff.pos += sizeof(uint32_t);
                 break;
-                
+
             default:
                 MBED_ASSERT(0);
                 break;
@@ -484,7 +507,7 @@ static void spi_async_read(spi_t *obj)
     uint8_t **width8;
     uint16_t **width16;
     uint32_t **width32;
-    
+
     switch (obj->rx_buff.width) {
         case 8:
             width8 = (uint8_t **)&obj->rx_buff.buffer;
@@ -492,21 +515,21 @@ static void spi_async_read(spi_t *obj)
             ++*width8;
             obj->rx_buff.pos += sizeof(uint8_t);
             break;
-            
+
         case 16:
             width16 = (uint16_t **)&obj->rx_buff.buffer;
             **width16 = spi_read(obj);
             ++*width16;
             obj->rx_buff.pos += sizeof(uint16_t);
             break;
-            
+
         case 32:
             width32 = (uint32_t **)&obj->rx_buff.buffer;
             **width32 = spi_read(obj);
             ++*width32;
             obj->rx_buff.pos += sizeof(uint32_t);
             break;
-            
+
         default:
             MBED_ASSERT(0);
             break;
@@ -526,7 +549,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     MBED_ASSERT(rx && ! tx ? rx_length : 1);
     MBED_ASSERT(obj->spi.spi->SPCR & (1 << 3)); /* Slave mode */
     MBED_ASSERT(bit_width == 8 || bit_width == 16 || bit_width == 32);
-    
+
     if (tx_length) {
         obj->tx_buff.buffer = (void *)tx;
     } else {
@@ -546,14 +569,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     for (i = 0; i < (int)obj->rx_buff.length; i++) {
         ((uint8_t *)obj->rx_buff.buffer)[i] = SPI_FILL_WORD;
     }
-    
+
     spi_data[obj->spi.index].async_callback = handler;
     spi_data[obj->spi.index].async_obj = obj;
     spi_data[obj->spi.index].event = 0;
     spi_data[obj->spi.index].wanted_events = event;
-    
+
     spi_irqs_set(obj, 1);
-    
+
     spi_async_write(obj);
 }
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/spi_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/spi_api.c
@@ -94,7 +94,7 @@ static const PinMap PinMap_SSI_SSEL[] = {
 };
 #endif
 
-void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
     SSI_DBG_ENTRANCE("spi_init()\n");
 
@@ -103,7 +103,7 @@ void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName sse
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     PHAL_SSI_OP pHalSsiOp;
 
-    _memset((void*)obj, 0, sizeof(spi_t));
+    _memset((void *)obj, 0, sizeof(spi_t));
     obj->state = 0;
 
     uint32_t SystemClock = SystemGetCpuClk();
@@ -133,7 +133,7 @@ void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName sse
     pHalSsiAdaptor->PinmuxSelect = ssi_pinmux;
     pHalSsiAdaptor->Role = SSI_MASTER;
 
-    HalSsiOpInit((VOID*)pHalSsiOp);
+    HalSsiOpInit((VOID *)pHalSsiOp);
 
     pHalSsiOp->HalSsiSetDeviceRole(pHalSsiAdaptor, pHalSsiAdaptor->Role);
 
@@ -143,27 +143,27 @@ void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName sse
     }
 
     if ((ssi_idx == 0) && (ssi_pinmux == SSI0_MUX_TO_GPIOE)) {
-            DBG_SSI_WARN(ANSI_COLOR_MAGENTA"SPI0 Pin may conflict with JTAG\r\n"ANSI_COLOR_RESET);
+        DBG_SSI_WARN(ANSI_COLOR_MAGENTA"SPI0 Pin may conflict with JTAG\r\n"ANSI_COLOR_RESET);
     }
 
     //TODO: Implement default setting structure.
-    pHalSsiOp->HalSsiLoadSetting(pHalSsiAdaptor, (void*)&SpiDefaultSetting);
+    pHalSsiOp->HalSsiLoadSetting(pHalSsiAdaptor, (void *)&SpiDefaultSetting);
     pHalSsiAdaptor->DefaultRxThresholdLevel = SpiDefaultSetting.RxThresholdLevel;
 
-    if(HalSsiInit(pHalSsiAdaptor) != HAL_OK){
-        DBG_SSI_ERR(ANSI_COLOR_RED"spi_init(): SPI %x init fails.\n"ANSI_COLOR_RESET,pHalSsiAdaptor->Index);
+    if (HalSsiInit(pHalSsiAdaptor) != HAL_OK) {
+        DBG_SSI_ERR(ANSI_COLOR_RED"spi_init(): SPI %x init fails.\n"ANSI_COLOR_RESET, pHalSsiAdaptor->Index);
         return;
     }
 
     pHalSsiAdaptor->TxCompCallback = spi_tx_done_callback;
-    pHalSsiAdaptor->TxCompCbPara = (void*)obj;
+    pHalSsiAdaptor->TxCompCbPara = (void *)obj;
     pHalSsiAdaptor->RxCompCallback = spi_rx_done_callback;
-    pHalSsiAdaptor->RxCompCbPara = (void*)obj;
+    pHalSsiAdaptor->RxCompCbPara = (void *)obj;
     pHalSsiAdaptor->TxIdleCallback = spi_bus_tx_done_callback;
-    pHalSsiAdaptor->TxIdleCbPara = (void*)obj;
+    pHalSsiAdaptor->TxIdleCbPara = (void *)obj;
 
 #ifdef CONFIG_GDMA_EN
-    HalGdmaOpInit((VOID*)&SpiGdmaOp);
+    HalGdmaOpInit((VOID *)&SpiGdmaOp);
     pHalSsiAdaptor->DmaConfig.pHalGdmaOp = &SpiGdmaOp;
     pHalSsiAdaptor->DmaConfig.pRxHalGdmaAdapter = &obj->spi_gdma_adp_rx;
     pHalSsiAdaptor->DmaConfig.pTxHalGdmaAdapter = &obj->spi_gdma_adp_tx;
@@ -179,7 +179,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     MBED_ASSERT(false);
 }
 
-void spi_free (spi_t *obj)
+void spi_free(spi_t *obj)
 {
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     pHalSsiAdaptor = &obj->spi_adp;
@@ -199,7 +199,7 @@ void spi_free (spi_t *obj)
 #endif
 }
 
-void spi_format (spi_t *obj, int bits, int mode, int slave)
+void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     PHAL_SSI_OP pHalSsiOp;
@@ -223,8 +223,7 @@ void spi_format (spi_t *obj, int bits, int mode, int slave)
      * SCPH_TOGGLES_IN_MIDDLE = 0,
      * SCPH_TOGGLES_AT_START  = 1
      */
-    switch (mode)
-    {
+    switch (mode) {
         case 0:
             pHalSsiAdaptor->SclkPolarity = SCPOL_INACTIVE_IS_LOW;
             pHalSsiAdaptor->SclkPhase    = SCPH_TOGGLES_IN_MIDDLE;
@@ -274,7 +273,7 @@ void spi_format (spi_t *obj, int bits, int mode, int slave)
     HalSsiSetFormat(pHalSsiAdaptor);
 }
 
-void spi_frequency (spi_t *obj, int hz)
+void spi_frequency(spi_t *obj, int hz)
 {
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
 
@@ -282,7 +281,7 @@ void spi_frequency (spi_t *obj, int hz)
     HalSsiSetSclk(pHalSsiAdaptor, (u32)hz);
 }
 
-static inline void ssi_write (spi_t *obj, int value)
+static inline void ssi_write(spi_t *obj, int value)
 {
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     PHAL_SSI_OP pHalSsiOp;
@@ -291,7 +290,7 @@ static inline void ssi_write (spi_t *obj, int value)
     pHalSsiOp = &obj->spi_op;
 
     while (!pHalSsiOp->HalSsiWriteable(pHalSsiAdaptor));
-    pHalSsiOp->HalSsiWrite((VOID*)pHalSsiAdaptor, value);
+    pHalSsiOp->HalSsiWrite((VOID *)pHalSsiAdaptor, value);
 }
 
 static inline int ssi_read(spi_t *obj)
@@ -306,7 +305,7 @@ static inline int ssi_read(spi_t *obj)
     return (int)pHalSsiOp->HalSsiRead(pHalSsiAdaptor);
 }
 
-int spi_master_write (spi_t *obj, int value)
+int spi_master_write(spi_t *obj, int value)
 {
     ssi_write(obj, value);
     return ssi_read(obj);
@@ -330,7 +329,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive (spi_t *obj)
+int spi_slave_receive(spi_t *obj)
 {
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     PHAL_SSI_OP pHalSsiOp;
@@ -345,17 +344,17 @@ int spi_slave_receive (spi_t *obj)
     return ((Readable && !Busy) ? 1 : 0);
 }
 
-int spi_slave_read (spi_t *obj)
+int spi_slave_read(spi_t *obj)
 {
     return ssi_read(obj);
 }
 
-void spi_slave_write (spi_t *obj, int value)
+void spi_slave_write(spi_t *obj, int value)
 {
     ssi_write(obj, value);
 }
 
-int spi_busy (spi_t *obj)
+int spi_busy(spi_t *obj)
 {
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     PHAL_SSI_OP pHalSsiOp;

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/spi_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/spi_api.c
@@ -143,7 +143,7 @@ void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName sse
     }
 
     if ((ssi_idx == 0) && (ssi_pinmux == SSI0_MUX_TO_GPIOE)) {
-            DBG_SSI_WARN(ANSI_COLOR_MAGENTA"SPI0 Pin may conflict with JTAG\r\n"ANSI_COLOR_RESET);        
+            DBG_SSI_WARN(ANSI_COLOR_MAGENTA"SPI0 Pin may conflict with JTAG\r\n"ANSI_COLOR_RESET);
     }
 
     //TODO: Implement default setting structure.
@@ -152,7 +152,7 @@ void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName sse
 
     if(HalSsiInit(pHalSsiAdaptor) != HAL_OK){
         DBG_SSI_ERR(ANSI_COLOR_RED"spi_init(): SPI %x init fails.\n"ANSI_COLOR_RESET,pHalSsiAdaptor->Index);
-        return;        
+        return;
     }
 
     pHalSsiAdaptor->TxCompCallback = spi_tx_done_callback;
@@ -173,9 +173,15 @@ void spi_init (spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName sse
 #endif
 }
 
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    // Explicit pin config not supported
+    MBED_ASSERT(false);
+}
+
 void spi_free (spi_t *obj)
 {
-    PHAL_SSI_ADAPTOR pHalSsiAdaptor;    
+    PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     pHalSsiAdaptor = &obj->spi_adp;
     HalSsiDeInit(pHalSsiAdaptor);
 
@@ -188,7 +194,7 @@ void spi_free (spi_t *obj)
 
     if (obj->dma_en & SPI_DMA_TX_EN) {
         HalSsiTxGdmaDeInit(pHalSsiAdaptor);
-    }    
+    }
     obj->dma_en = 0;
 #endif
 }
@@ -369,7 +375,7 @@ void spi_bus_tx_done_callback(VOID *obj)
     if (spi_obj->bus_tx_done_handler) {
         handler = (spi_irq_handler)spi_obj->bus_tx_done_handler;
         handler(spi_obj->bus_tx_done_irq_id, (SpiIrq)0);
-    }    
+    }
 }
 
 void spi_tx_done_callback(VOID *obj)
@@ -437,4 +443,3 @@ const PinMap *spi_slave_cs_pinmap()
 {
     return PinMap_SSI_SSEL;
 }
-

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -215,7 +215,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     * According the STM32 Datasheet for SPI peripheral we need to PULLDOWN
     * or PULLUP the SCK pin according the polarity used.
     */
-    pin_mode(spiobj->pin_sclk, (handle->Init.CLKPolarity == SPI_POLARITY_LOW) ? PullDown: PullUp);
+    pin_mode(spiobj->pin_sclk, (handle->Init.CLKPolarity == SPI_POLARITY_LOW) ? PullDown : PullUp);
 
     init_spi(obj);
 }
@@ -363,7 +363,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     * According the STM32 Datasheet for SPI peripheral we need to PULLDOWN
     * or PULLUP the SCK pin according the polarity used.
     */
-    pull = (handle->Init.CLKPolarity == SPI_POLARITY_LOW) ? PullDown: PullUp;
+    pull = (handle->Init.CLKPolarity == SPI_POLARITY_LOW) ? PullDown : PullUp;
     pin_mode(spiobj->pin_sclk, pull);
 
     init_spi(obj);

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -111,21 +111,12 @@ SPIName spi_get_peripheral_name(PinName mosi, PinName miso, PinName sclk)
     return spi_per;
 }
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
 
-    // Determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    spiobj->spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    spiobj->spi = (SPIName)explicit_pinmap->peripheral;
     MBED_ASSERT(spiobj->spi != (SPIName)NC);
 
 #if defined SPI1_BASE
@@ -172,15 +163,19 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 #endif
 
     // Configure the SPI pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    spiobj->pin_miso = miso;
-    spiobj->pin_mosi = mosi;
-    spiobj->pin_sclk = sclk;
-    spiobj->pin_ssel = ssel;
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    spiobj->pin_miso = explicit_pinmap->function[0];
+    spiobj->pin_mosi = explicit_pinmap->function[1];
+    spiobj->pin_sclk = explicit_pinmap->function[2];
+    spiobj->pin_ssel = explicit_pinmap->function[3];
+    if (explicit_pinmap->function[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
         handle->Init.NSS = SPI_NSS_HARD_OUTPUT;
 #if defined(SPI_NSS_PULSE_ENABLE)
         handle->Init.NSSPMode = SPI_NSS_PULSE_ENABLE;
@@ -197,7 +192,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     handle->Init.Mode              = SPI_MODE_MASTER;
     handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
 
-    if (miso != NC) {
+    if (explicit_pinmap->pin[1] != NC) {
         handle->Init.Direction     = SPI_DIRECTION_2LINES;
     } else {
         handle->Init.Direction      = SPI_DIRECTION_1LINE;
@@ -291,6 +286,32 @@ void spi_free(spi_t *obj)
         pin_function(spiobj->pin_ssel, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
     }
 }
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
+}
+
 
 void spi_format(spi_t *obj, int bits, int mode, int slave)
 {

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -120,7 +120,7 @@ uint8_t spi_get_module(spi_t *obj)
     return spi_get_index(obj);
 }
 
-static void usart_init(spi_t *obj, uint32_t baudrate, USART_Databits_TypeDef databits, bool master, USART_ClockMode_TypeDef clockMode )
+static void usart_init(spi_t *obj, uint32_t baudrate, USART_Databits_TypeDef databits, bool master, USART_ClockMode_TypeDef clockMode)
 {
     USART_InitSync_TypeDef init = USART_INITSYNC_DEFAULT;
     init.enable = usartDisable;
@@ -197,21 +197,21 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     uint32_t route = USART_ROUTEPEN_CLKPEN;
 
     obj->spi.spi->ROUTELOC0 &= ~_USART_ROUTELOC0_CLKLOC_MASK;
-    obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[2], PinMap_SPI_CLK)<<_USART_ROUTELOC0_CLKLOC_SHIFT;
+    obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[2], PinMap_SPI_CLK) << _USART_ROUTELOC0_CLKLOC_SHIFT;
     if (explicit_pinmap->pin[0] != NC) {
         route |= USART_ROUTEPEN_TXPEN;
         obj->spi.spi->ROUTELOC0 &= ~_USART_ROUTELOC0_TXLOC_MASK;
-        obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[0], PinMap_SPI_MOSI)<<_USART_ROUTELOC0_TXLOC_SHIFT;
+        obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[0], PinMap_SPI_MOSI) << _USART_ROUTELOC0_TXLOC_SHIFT;
     }
     if (explicit_pinmap->pin[1] != NC) {
         route |= USART_ROUTEPEN_RXPEN;
         obj->spi.spi->ROUTELOC0 &= ~_USART_ROUTELOC0_RXLOC_MASK;
-        obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[1], PinMap_SPI_MISO)<<_USART_ROUTELOC0_RXLOC_SHIFT;
+        obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[1], PinMap_SPI_MISO) << _USART_ROUTELOC0_RXLOC_SHIFT;
     }
     if (!obj->spi.master) {
         route |= USART_ROUTEPEN_CSPEN;
         obj->spi.spi->ROUTELOC0 &= ~_USART_ROUTELOC0_CSLOC_MASK;
-        obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[3], PinMap_SPI_CS)<<_USART_ROUTELOC0_CSLOC_SHIFT;
+        obj->spi.spi->ROUTELOC0 |= pin_location(explicit_pinmap->pin[3], PinMap_SPI_CS) << _USART_ROUTELOC0_CSLOC_SHIFT;
     }
     obj->spi.location = obj->spi.spi->ROUTELOC0;
     obj->spi.route = route;
@@ -271,8 +271,11 @@ void spi_free(spi_t *obj)
 
 void spi_enable_event(spi_t *obj, uint32_t event, uint8_t enable)
 {
-    if(enable) obj->spi.event |= event;
-    else obj->spi.event &= ~event;
+    if (enable) {
+        obj->spi.event |= event;
+    } else {
+        obj->spi.event &= ~event;
+    }
 }
 
 /****************************************************************************
@@ -342,7 +345,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     MBED_ASSERT(bits >= 4 && bits <= 16);
     obj->spi.bits = bits;
     /* 0x01 = usartDatabits4, etc, up to 0x0D = usartDatabits16 */
-    USART_Databits_TypeDef databits = (USART_Databits_TypeDef) (bits - 3);
+    USART_Databits_TypeDef databits = (USART_Databits_TypeDef)(bits - 3);
 
     USART_ClockMode_TypeDef clockMode;
     MBED_ASSERT(mode >= 0 && mode <= 3);
@@ -376,7 +379,9 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 #endif
     obj->spi.spi->IEN = iflags;
 
-    if(enabled) spi_enable(obj, enabled);
+    if (enabled) {
+        spi_enable(obj, enabled);
+    }
 }
 
 void spi_frequency(spi_t *obj, int hz)
@@ -425,7 +430,8 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -476,15 +482,15 @@ void spi_irq_handler(spi_t *obj)
 
 uint8_t spi_active(spi_t *obj)
 {
-    switch(obj->spi.dmaOptionsTX.dmaUsageState) {
+    switch (obj->spi.dmaOptionsTX.dmaUsageState) {
         case DMA_USAGE_TEMPORARY_ALLOCATED:
             return true;
         case DMA_USAGE_ALLOCATED:
             /* Check whether the allocated DMA channel is active */
 #ifdef LDMA_PRESENT
-            return(LDMAx_ChannelEnabled(obj->spi.dmaOptionsTX.dmaChannel) || LDMAx_ChannelEnabled(obj->spi.dmaOptionsRX.dmaChannel));
+            return (LDMAx_ChannelEnabled(obj->spi.dmaOptionsTX.dmaChannel) || LDMAx_ChannelEnabled(obj->spi.dmaOptionsRX.dmaChannel));
 #else
-            return(DMA_ChannelEnabled(obj->spi.dmaOptionsTX.dmaChannel) || DMA_ChannelEnabled(obj->spi.dmaOptionsRX.dmaChannel));
+            return (DMA_ChannelEnabled(obj->spi.dmaOptionsTX.dmaChannel) || DMA_ChannelEnabled(obj->spi.dmaOptionsRX.dmaChannel));
 #endif
         default:
             /* Check whether interrupt for spi is enabled */
@@ -506,9 +512,9 @@ void spi_buffer_set(spi_t *obj, const void *tx, uint32_t tx_length, void *rx, ui
     obj->tx_buff.width = bit_width;
     obj->rx_buff.width = bit_width;
 
-    if((obj->spi.bits == 9) && (tx != 0)) {
+    if ((obj->spi.bits == 9) && (tx != 0)) {
         // Make sure we don't have inadvertent non-zero bits outside 9-bit frames which could trigger unwanted operation
-        for(i = 0; i < (tx_length / 2); i++) {
+        for (i = 0; i < (tx_length / 2); i++) {
             tx_ptr[i] &= 0x1FF;
         }
     }
@@ -522,13 +528,13 @@ static void spi_buffer_tx_write(spi_t *obj)
     if (!obj->tx_buff.buffer) {
         data = SPI_FILL_WORD;
     } else if (obj->tx_buff.width == 32) {
-        uint32_t * tx = (uint32_t *)obj->tx_buff.buffer;
+        uint32_t *tx = (uint32_t *)obj->tx_buff.buffer;
         data = tx[obj->tx_buff.pos];
     } else if (obj->tx_buff.width == 16) {
-        uint16_t * tx = (uint16_t *)obj->tx_buff.buffer;
+        uint16_t *tx = (uint16_t *)obj->tx_buff.buffer;
         data = tx[obj->tx_buff.pos];
     } else {
-        uint8_t * tx = (uint8_t *)obj->tx_buff.buffer;
+        uint8_t *tx = (uint8_t *)obj->tx_buff.buffer;
         data = tx[obj->tx_buff.pos];
     }
     obj->tx_buff.pos++;
@@ -560,13 +566,13 @@ static void spi_buffer_rx_read(spi_t *obj)
         // If there is room in the buffer, store the data
         if (obj->rx_buff.buffer && obj->rx_buff.pos < obj->rx_buff.length) {
             if (obj->rx_buff.width == 32) {
-                uint32_t * rx = (uint32_t *)(obj->rx_buff.buffer);
+                uint32_t *rx = (uint32_t *)(obj->rx_buff.buffer);
                 rx[obj->rx_buff.pos] = data;
             } else if (obj->rx_buff.width == 16) {
-                uint16_t * rx = (uint16_t *)(obj->rx_buff.buffer);
+                uint16_t *rx = (uint16_t *)(obj->rx_buff.buffer);
                 rx[obj->rx_buff.pos] = data;
             } else {
-                uint8_t * rx = (uint8_t *)(obj->rx_buff.buffer);
+                uint8_t *rx = (uint8_t *)(obj->rx_buff.buffer);
                 rx[obj->rx_buff.pos] = data;
             }
             obj->rx_buff.pos++;
@@ -602,12 +608,12 @@ int spi_master_read_asynch(spi_t *obj)
 
 uint8_t spi_buffer_rx_empty(spi_t *obj)
 {
-    return (obj->rx_buff.pos >= obj->rx_buff.length ? true : false );
+    return (obj->rx_buff.pos >= obj->rx_buff.length ? true : false);
 }
 
 uint8_t spi_buffer_tx_empty(spi_t *obj)
 {
-    return (obj->tx_buff.pos >= obj->tx_buff.length ? true : false );
+    return (obj->tx_buff.pos >= obj->tx_buff.length ? true : false);
 }
 
 //TODO_LP implement slave
@@ -640,7 +646,7 @@ uint32_t spi_event_check(spi_t *obj)
         event |= SPI_EVENT_COMPLETE;
     }
 
-    if(quit == true) {
+    if (quit == true) {
         event |= SPI_EVENT_INTERNAL_TRANSFER_COMPLETE;
     }
 
@@ -751,7 +757,7 @@ static void serial_dmaTransferComplete(unsigned int channel, bool primary, void 
         ((DMACallback)user)();
     }
 }
-static void spi_master_dma_channel_setup(spi_t *obj, void* callback)
+static void spi_master_dma_channel_setup(spi_t *obj, void *callback)
 {
     obj->spi.dmaOptionsRX.dmaCallback.userPtr = callback;
 }
@@ -764,7 +770,7 @@ static void spi_master_dma_channel_setup(spi_t *obj, void* callback)
 * The channel numbers are fetched from the SPI instance, so this function
 * should only be called when those channels have actually been allocated.
 ******************************************/
-static void spi_master_dma_channel_setup(spi_t *obj, void* callback)
+static void spi_master_dma_channel_setup(spi_t *obj, void *callback)
 {
     DMA_CfgChannel_TypeDef  rxChnlCfg;
     DMA_CfgChannel_TypeDef  txChnlCfg;
@@ -841,15 +847,15 @@ static void spi_master_dma_channel_setup(spi_t *obj, void* callback)
 *   * rx_length: how many bytes will get received. If > tx_length, TX will get padded with n lower bits of SPI_FILL_WORD.
 ******************************************/
 #ifdef LDMA_PRESENT
-static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int tx_length, int rx_length)
+static void spi_activate_dma(spi_t *obj, void *rxdata, const void *txdata, int tx_length, int rx_length)
 {
     LDMA_PeripheralSignal_t dma_periph;
 
-    if(rxdata) {
+    if (rxdata) {
         volatile const void *source_addr;
         /* Select RX source address. 9 bit frame length requires to use extended register.
            10 bit and larger frame requires to use RXDOUBLE register. */
-        switch((int)obj->spi.spi) {
+        switch ((int)obj->spi.spi) {
 #ifdef USART0
             case USART_0:
                 dma_periph = ldmaPeripheralSignal_USART0_RXDATAV;
@@ -882,7 +888,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
 #endif
             default:
                 EFM_ASSERT(0);
-                while(1);
+                while (1);
                 break;
         }
 
@@ -897,7 +903,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
         LDMA_TransferCfg_t xferConf = LDMA_TRANSFER_CFG_PERIPHERAL(dma_periph);
         LDMA_Descriptor_t desc = LDMA_DESCRIPTOR_SINGLE_P2M_BYTE(source_addr, rxdata, rx_length);
 
-        if(obj->spi.bits >= 9){
+        if (obj->spi.bits >= 9) {
             desc.xfer.size = ldmaCtrlSizeHalf;
         }
 
@@ -917,7 +923,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
             desc.xfer.dstInc = ldmaCtrlDstIncOne;
         }
 
-        LDMAx_StartTransfer(obj->spi.dmaOptionsRX.dmaChannel, &xferConf, &desc, serial_dmaTransferComplete,obj->spi.dmaOptionsRX.dmaCallback.userPtr);
+        LDMAx_StartTransfer(obj->spi.dmaOptionsRX.dmaChannel, &xferConf, &desc, serial_dmaTransferComplete, obj->spi.dmaOptionsRX.dmaCallback.userPtr);
     }
 
     volatile void *target_addr;
@@ -933,7 +939,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
             break;
         default:
             EFM_ASSERT(0);
-            while(1);
+            while (1);
             break;
     }
 
@@ -948,7 +954,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
     /*  Check the transmit length, and split long transfers to smaller ones */
     int max_length = 1024;
 #ifdef _LDMA_CH_CTRL_XFERCNT_MASK
-    max_length = (_LDMA_CH_CTRL_XFERCNT_MASK>>_LDMA_CH_CTRL_XFERCNT_SHIFT)+1;
+    max_length = (_LDMA_CH_CTRL_XFERCNT_MASK >> _LDMA_CH_CTRL_XFERCNT_SHIFT) + 1;
 #endif
     if (tx_length > max_length) {
         tx_length = max_length;
@@ -983,7 +989,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
     }
 
     // Kick off DMA TX
-    LDMAx_StartTransfer(obj->spi.dmaOptionsTX.dmaChannel, &xferConf, &desc, serial_dmaTransferComplete,obj->spi.dmaOptionsTX.dmaCallback.userPtr);
+    LDMAx_StartTransfer(obj->spi.dmaOptionsTX.dmaChannel, &xferConf, &desc, serial_dmaTransferComplete, obj->spi.dmaOptionsTX.dmaCallback.userPtr);
 }
 
 #else
@@ -997,7 +1003,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
 *   * tx_length: how many bytes will get sent.
 *   * rx_length: how many bytes will get received. If > tx_length, TX will get padded with n lower bits of SPI_FILL_WORD.
 ******************************************/
-static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int tx_length, int rx_length)
+static void spi_activate_dma(spi_t *obj, void *rxdata, const void *txdata, int tx_length, int rx_length)
 {
     /* DMA descriptors */
     DMA_CfgDescr_TypeDef rxDescrCfg;
@@ -1033,7 +1039,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
         rxDescrCfg.hprot = 0;
         DMA_CfgDescr(obj->spi.dmaOptionsRX.dmaChannel, true, &rxDescrCfg);
 
-        void * rx_reg;
+        void *rx_reg;
         if (obj->spi.bits > 9) {
             rx_reg = (void *)&obj->spi.spi->RXDOUBLE;
         } else if (obj->spi.bits == 9) {
@@ -1071,7 +1077,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
     txDescrCfg.hprot = 0;
     DMA_CfgDescr(obj->spi.dmaOptionsTX.dmaChannel, true, &txDescrCfg);
 
-    void * tx_reg;
+    void *tx_reg;
     if (obj->spi.bits > 9) {
         tx_reg = (void *)&obj->spi.spi->TXDOUBLE;
     } else if (obj->spi.bits == 9) {
@@ -1106,7 +1112,7 @@ static void spi_activate_dma(spi_t *obj, void* rxdata, const void* txdata, int t
 *                 If the previous transfer has kept the channel, that channel will continue to get used.
 *
 ********************************************************************/
-void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int tx_length, int rx_length, void* cb, DMAUsage hint)
+void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int tx_length, int rx_length, void *cb, DMAUsage hint)
 {
     /* Init DMA here to include it in the power figure */
     dma_init();
@@ -1159,16 +1165,21 @@ void spi_master_transfer_dma(spi_t *obj, const void *txdata, void *rxdata, int t
  */
 void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint)
 {
-    if( spi_active(obj) ) return;
+    if (spi_active(obj)) {
+        return;
+    }
 
     /* update fill word if on 9-bit frame size */
-    if(obj->spi.bits == 9) fill_word = SPI_FILL_WORD & 0x1FF;
-    else fill_word = SPI_FILL_WORD;
+    if (obj->spi.bits == 9) {
+        fill_word = SPI_FILL_WORD & 0x1FF;
+    } else {
+        fill_word = SPI_FILL_WORD;
+    }
 
     /* check corner case */
-    if(tx_length == 0) {
+    if (tx_length == 0) {
         tx_length = rx_length;
-        tx = (void*) 0;
+        tx = (void *) 0;
     }
 
     /* First, set the buffer */
@@ -1179,7 +1190,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spi_enable_event(obj, event, true);
 
     /* And kick off the transfer */
-    spi_master_transfer_dma(obj, tx, rx, tx_length, rx_length, (void*)handler, hint);
+    spi_master_transfer_dma(obj, tx, rx, tx_length, rx_length, (void *)handler, hint);
 }
 
 
@@ -1194,14 +1205,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 *
 ********************************************************************/
 #ifdef LDMA_PRESENT
-uint32_t spi_irq_handler_asynch(spi_t* obj)
+uint32_t spi_irq_handler_asynch(spi_t *obj)
 {
     if (obj->spi.dmaOptionsTX.dmaUsageState == DMA_USAGE_ALLOCATED || obj->spi.dmaOptionsTX.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
         /* DMA implementation */
         /* If there is still data in the TX buffer, setup a new transfer. */
         if (obj->tx_buff.pos < obj->tx_buff.length) {
             /* Find position and remaining length without modifying tx_buff. */
-            void* tx_pointer = (char*)obj->tx_buff.buffer + obj->tx_buff.pos;
+            void *tx_pointer = (char *)obj->tx_buff.buffer + obj->tx_buff.pos;
             uint32_t tx_length = obj->tx_buff.length - obj->tx_buff.pos;
 
             /* Begin transfer. Rely on spi_activate_dma to split up the transfer further. */
@@ -1213,11 +1224,13 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
         if (LDMAx_ChannelEnabled(obj->spi.dmaOptionsRX.dmaChannel)) {
             /* Check if we need to kick off TX transfer again to force more incoming data. */
             if (LDMA_TransferDone(obj->spi.dmaOptionsTX.dmaChannel) && (obj->tx_buff.pos < obj->rx_buff.length)) {
-                void* tx_pointer = (char*)obj->tx_buff.buffer + obj->tx_buff.pos;
+                void *tx_pointer = (char *)obj->tx_buff.buffer + obj->tx_buff.pos;
                 uint32_t tx_length = obj->tx_buff.length - obj->tx_buff.pos;
                 /* Begin transfer. Rely on spi_activate_dma to split up the transfer further. */
                 spi_activate_dma(obj, obj->rx_buff.buffer, tx_pointer, tx_length, obj->rx_buff.length);
-            } else return 0;
+            } else {
+                return 0;
+            }
         }
         /* If there is still a TX transfer ongoing (tx_length > rx_length), wait for it to finish */
         if (!LDMA_TransferDone(obj->spi.dmaOptionsTX.dmaChannel)) {
@@ -1231,7 +1244,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
         }
 
         /* Wait transmit to complete, before user code is indicated*/
-        while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
+        while (!(obj->spi.spi->STATUS & USART_STATUS_TXC));
         /* return to CPP land to say we're finished */
         return SPI_EVENT_COMPLETE;
     } else {
@@ -1257,7 +1270,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
     }
 }
 #else
-uint32_t spi_irq_handler_asynch(spi_t* obj)
+uint32_t spi_irq_handler_asynch(spi_t *obj)
 {
 
     /* Determine whether the current scenario is DMA or IRQ, and act accordingly */
@@ -1273,7 +1286,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
                 return 0;
             }
             /* Find position and remaining length without modifying tx_buff. */
-            void * tx_pointer;
+            void *tx_pointer;
             if (obj->tx_buff.width == 32) {
                 tx_pointer = ((uint32_t *)obj->tx_buff.buffer) + obj->tx_buff.pos;
             } else if (obj->tx_buff.width == 16) {
@@ -1284,7 +1297,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
             uint32_t tx_length = obj->tx_buff.length - obj->tx_buff.pos;
 
             /* Refresh RX transfer too if it exists */
-            void * rx_pointer = NULL;
+            void *rx_pointer = NULL;
             if (obj->rx_buff.pos < obj->rx_buff.length) {
                 if (obj->rx_buff.width == 32) {
                     rx_pointer = ((uint32_t *)obj->rx_buff.buffer) + obj->rx_buff.pos;
@@ -1297,7 +1310,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
             uint32_t rx_length = obj->rx_buff.length - obj->rx_buff.pos;
 
             /* Wait for the previous transfer to complete. */
-            while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
+            while (!(obj->spi.spi->STATUS & USART_STATUS_TXC));
 
             /* Begin transfer. Rely on spi_activate_dma to split up the transfer further. */
             spi_activate_dma(obj, rx_pointer, tx_pointer, tx_length, rx_length);
@@ -1325,7 +1338,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
                 txDescrCfg.hprot = 0;
                 DMA_CfgDescr(obj->spi.dmaOptionsTX.dmaChannel, true, &txDescrCfg);
 
-                void * tx_reg;
+                void *tx_reg;
                 if (obj->spi.bits > 9) {
                     tx_reg = (void *)&obj->spi.spi->TXDOUBLE;
                 } else if (obj->spi.bits == 9) {
@@ -1355,7 +1368,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
         }
 
         /* Wait for transmit to complete, before user code is indicated */
-        while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
+        while (!(obj->spi.spi->STATUS & USART_STATUS_TXC));
 
         /* return to CPP land to say we're finished */
         return SPI_EVENT_COMPLETE;
@@ -1375,7 +1388,7 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
             spi_enable_interrupt(obj, (uint32_t)NULL, false);
 
             /* Wait for transmit to complete, before user code is indicated */
-            while(!(obj->spi.spi->STATUS & USART_STATUS_TXC));
+            while (!(obj->spi.spi->STATUS & USART_STATUS_TXC));
 
             /* Return the event back to userland */
             return event;
@@ -1392,7 +1405,9 @@ uint32_t spi_irq_handler_asynch(spi_t* obj)
 void spi_abort_asynch(spi_t *obj)
 {
     // If we're not currently transferring, then there's nothing to do here
-    if(spi_active(obj) != 0) return;
+    if (spi_active(obj) != 0) {
+        return;
+    }
 
     // Determine whether we're running DMA or interrupt
     if (obj->spi.dmaOptionsTX.dmaUsageState == DMA_USAGE_ALLOCATED || obj->spi.dmaOptionsTX.dmaUsageState == DMA_USAGE_TEMPORARY_ALLOCATED) {
@@ -1430,7 +1445,7 @@ const PinMap *spi_master_miso_pinmap()
 const PinMap *spi_master_clk_pinmap()
 {
     // We don't currently support hardware CS in master mode.
-    static const PinMap PinMap_SPI_CLK_mod[] = {NC ,  NC   , NC};
+    static const PinMap PinMap_SPI_CLK_mod[] = {NC,  NC, NC};
     return PinMap_SPI_CLK_mod;
 }
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/spi_api.c
@@ -89,7 +89,7 @@ void spi_init_direct(spi_t *t_obj, explicit_pinmap_t *explicit_pinmap)
     struct spi_s *obj = SPI_S(t_obj);
 
     obj->module = (SPIName)explicit_pinmap->peripheral;
-    MBED_ASSERT((int)obj->module!= NC);
+    MBED_ASSERT((int)obj->module != NC);
 
     // Identify SPI module to use
     switch ((int)obj->module) {
@@ -239,7 +239,7 @@ void spi_format(spi_t *t_obj, int bits, int mode, int slave)
         obj->p_obj.init.fmr0.ckpha = TSPI_SERIAL_CK_1ST_EDGE;
     }
 
-    if(slave) {
+    if (slave) {
         pinmap_pinout(obj->Slave_SCK, PinMap_SPISLAVE_SCLK);
         obj->p_obj.init.cnt1.mstr = TSPI_SLAVE_OPERATION;      // Slave mode operation
     }
@@ -264,7 +264,7 @@ void spi_frequency(spi_t *t_obj, int hz)
     for (prsck = 1; prsck <= 512; prsck *= 2) {
         fx = ((uint64_t)tmpvar / prsck);
         for (brs = 1; brs <= 16; brs++) {
-            fscl = fx /brs;
+            fscl = fx / brs;
             if ((fscl <= (uint64_t)hz) && (fscl > tmp_fscl)) {
                 tmp_fscl = fscl;
                 obj->p_obj.init.brd.brck = (brck << 4);
@@ -324,7 +324,7 @@ int spi_slave_receive(spi_t *t_obj)
     uint32_t status;
 
     tspi_get_status(&obj->p_obj, &status);
-    if((status & (TSPI_RX_REACH_FILL_LEVEL_MASK)) == 0) {
+    if ((status & (TSPI_RX_REACH_FILL_LEVEL_MASK)) == 0) {
         ret = 0;
     }
 
@@ -455,14 +455,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spiobj->p_obj.p_instance->CR2 |= (TSPI_TX_INT_ENABLE | TSPI_RX_INT_ENABLE | TSPI_ERR_INT_ENABLE);
 
     if (use_tx && use_rx) {
-        spiobj->max_size = tx_length < rx_length ? rx_length:tx_length;
+        spiobj->max_size = tx_length < rx_length ? rx_length : tx_length;
         spiobj->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
         spiobj->p_obj.p_instance->DR = ((uint8_t *)obj->tx_buff.buffer)[obj->tx_buff.pos] & 0xFF;
-    } else if(use_tx) {
+    } else if (use_tx) {
         spiobj->max_size = tx_length;
         spiobj->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
         spiobj->p_obj.p_instance->DR = ((uint8_t *)obj->tx_buff.buffer)[obj->tx_buff.pos] & 0xFF;
-    } else if(use_rx) {
+    } else if (use_rx) {
         spiobj->max_size = rx_length;
         spiobj->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
         spiobj->p_obj.p_instance->DR = 0xFF;
@@ -478,7 +478,7 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
 {
     struct spi_s *spiobj = SPI_S(obj);
     spi_irq_handler(obj);
-    return ((spiobj->event & SPI_EVENT_ALL)| SPI_EVENT_INTERNAL_TRANSFER_COMPLETE) ;
+    return ((spiobj->event & SPI_EVENT_ALL) | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE) ;
 }
 
 uint8_t spi_active(spi_t *obj)
@@ -507,17 +507,17 @@ static void spi_irq_handler(spi_t *obj)
     struct spi_s *spiobj = SPI_S(obj);
 
     // Check for revceive complete flag.
-    if((spiobj->p_obj.p_instance->SR & TSPI_RX_DONE) &&
+    if ((spiobj->p_obj.p_instance->SR & TSPI_RX_DONE) &&
             (spiobj->p_obj.p_instance->SR & TSPI_RX_REACH_FILL_LEVEL_MASK)) {
         // Check receiver FIFO level
         uint8_t rlvl = spiobj->p_obj.p_instance->SR & 0xF;
 
-        while((rlvl != 0) && (obj->rx_buff.pos < obj->rx_buff.length)) {
+        while ((rlvl != 0) && (obj->rx_buff.pos < obj->rx_buff.length)) {
             ((uint8_t *)obj->rx_buff.buffer)[obj->rx_buff.pos++] = spiobj->p_obj.p_instance->DR & 0xFF;
             rlvl--;
         }
 
-        if(obj->rx_buff.pos == spiobj->max_size) {
+        if (obj->rx_buff.pos == spiobj->max_size) {
             spiobj->state = SPI_TRANSFER_STATE_IDLE;
         }
         // Clear rx buffer
@@ -525,15 +525,15 @@ static void spi_irq_handler(spi_t *obj)
     }
 
     // Check for transmit completion flag
-    if(spiobj->p_obj.p_instance->SR & TSPI_TX_DONE) {
+    if (spiobj->p_obj.p_instance->SR & TSPI_TX_DONE) {
         obj->tx_buff.pos++;
         spiobj->p_obj.p_instance->SR |=  TSPI_RX_DONE_CLR;
 
-        if(obj->tx_buff.pos == (spiobj->max_size)) {
+        if (obj->tx_buff.pos == (spiobj->max_size)) {
             spiobj->state = SPI_TRANSFER_STATE_IDLE;
         }
 
-        if((obj->tx_buff.pos < obj->tx_buff.length) && (obj->tx_buff.pos < spiobj->max_size)) {
+        if ((obj->tx_buff.pos < obj->tx_buff.length) && (obj->tx_buff.pos < spiobj->max_size)) {
             spiobj->p_obj.p_instance->DR = (((uint8_t *)obj->tx_buff.buffer)[obj->tx_buff.pos] & 0xFF);
         } else if (obj->tx_buff.pos < spiobj->max_size) {
             spiobj->p_obj.p_instance->DR = 0xFF;
@@ -541,7 +541,7 @@ static void spi_irq_handler(spi_t *obj)
     }
 
     // Check for error flag
-    if(spiobj->p_obj.p_instance->ERR) {
+    if (spiobj->p_obj.p_instance->ERR) {
         spiobj->event = SPI_EVENT_ERROR;
         spiobj->state = SPI_TRANSFER_STATE_IDLE;
         disable_irq(spiobj->irqn);
@@ -551,7 +551,7 @@ static void spi_irq_handler(spi_t *obj)
         return;
     }
 
-    if(spiobj->state == SPI_TRANSFER_STATE_IDLE) {
+    if (spiobj->state == SPI_TRANSFER_STATE_IDLE) {
         spiobj->event = SPI_EVENT_COMPLETE;
         disable_irq(spiobj->irqn);
         spiobj->p_obj.p_instance->SR  |= (TSPI_TX_DONE_CLR | TSPI_RX_DONE_CLR);

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/spi_api.c
@@ -84,19 +84,11 @@ static const PinMap PinMap_SPISLAVE_SCLK[] = {
     {NC,  NC,    0}
 };
 
-void spi_init(spi_t *t_obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *t_obj, explicit_pinmap_t *explicit_pinmap)
 {
     struct spi_s *obj = SPI_S(t_obj);
-    // Check pin parameters
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_sclk);
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    obj->module = (SPIName)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->module!= NC);
 
     // Identify SPI module to use
@@ -124,13 +116,17 @@ void spi_init(spi_t *t_obj, PinName mosi, PinName miso, PinName sclk, PinName ss
     }
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    obj->Slave_SCK = sclk;
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    obj->Slave_SCK = explicit_pinmap->pin[2];
 
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
 
     //Control 1 configurations
@@ -188,6 +184,31 @@ void spi_init(spi_t *t_obj, PinName mosi, PinName miso, PinName sclk, PinName ss
     obj->bits = (uint8_t)TSPI_DATA_LENGTH_8;
     //initialize SPI
     tspi_init(&obj->p_obj);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *t_obj)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3HQ/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3HQ/spi_api.c
@@ -114,7 +114,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     struct spi_s *obj = SPI_S(t_obj);
 
     obj->module = (SPIName)explicit_pinmap->peripheral;
-    MBED_ASSERT((int)obj->module!= NC);
+    MBED_ASSERT((int)obj->module != NC);
 
     // Identify SPI module to use
     switch ((int)obj->module) {
@@ -287,7 +287,7 @@ void spi_format(spi_t *t_obj, int bits, int mode, int slave)
         obj->p_obj.init.fmr0.ckpha = TSPI_SERIAL_CK_1ST_EDGE;
     }
 
-    if(slave) {
+    if (slave) {
         pinmap_pinout(obj->Slave_SCK, PinMap_SPISLAVE_SCLK);
         obj->p_obj.init.cnt1.mstr = TSPI_SLAVE_OPERATION;      // Slave mode operation
     }
@@ -312,7 +312,7 @@ void spi_frequency(spi_t *t_obj, int hz)
     for (prsck = 1; prsck <= 512; prsck *= 2) {
         fx = ((uint64_t)tmpvar / prsck);
         for (brs = 1; brs <= 16; brs++) {
-            fscl = fx /brs;
+            fscl = fx / brs;
             if ((fscl <= (uint64_t)hz) && (fscl > tmp_fscl)) {
                 tmp_fscl = fscl;
                 obj->p_obj.init.brd.brck = (brck << 4);
@@ -387,7 +387,7 @@ int spi_slave_receive(spi_t *t_obj)
     uint32_t status;
 
     tspi_get_status(&obj->p_obj, &status);
-    if((status & (TSPI_RX_REACH_FILL_LEVEL_MASK)) == 0) {
+    if ((status & (TSPI_RX_REACH_FILL_LEVEL_MASK)) == 0) {
         ret = 0;
     }
     return ret;
@@ -503,14 +503,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spiobj->p_obj.p_instance->CR2 |= (TSPI_TX_INT_ENABLE | TSPI_RX_INT_ENABLE | TSPI_ERR_INT_ENABLE);
 
     if (use_tx && use_rx) {
-        spiobj->max_size = tx_length < rx_length ? rx_length:tx_length;
+        spiobj->max_size = tx_length < rx_length ? rx_length : tx_length;
         spiobj->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
         spiobj->p_obj.p_instance->DR   = ((uint8_t *)obj->tx_buff.buffer)[obj->tx_buff.pos] & 0xFF;
-    } else if(use_tx) {
+    } else if (use_tx) {
         spiobj->max_size = tx_length;
         spiobj->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
         spiobj->p_obj.p_instance->DR   = ((uint8_t *)obj->tx_buff.buffer)[obj->tx_buff.pos] & 0xFF;
-    } else if(use_rx) {
+    } else if (use_rx) {
         spiobj->max_size = rx_length;
         spiobj->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
         spiobj->p_obj.p_instance->DR   = 0xFF;
@@ -526,7 +526,7 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
 {
     struct spi_s *spiobj = SPI_S(obj);
     spi_irq_handler(obj);
-    return ((spiobj->event & SPI_EVENT_ALL)| SPI_EVENT_INTERNAL_TRANSFER_COMPLETE) ;
+    return ((spiobj->event & SPI_EVENT_ALL) | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE) ;
 }
 
 uint8_t spi_active(spi_t *obj)
@@ -555,17 +555,17 @@ static void spi_irq_handler(spi_t *obj)
     struct spi_s *spiobj = SPI_S(obj);
 
     // Check for revceive complete flag.
-    if((spiobj->p_obj.p_instance->SR & TSPI_RX_DONE) &&
+    if ((spiobj->p_obj.p_instance->SR & TSPI_RX_DONE) &&
             (spiobj->p_obj.p_instance->SR & TSPI_RX_REACH_FILL_LEVEL_MASK)) {
         // Check receiver FIFO level
         uint8_t rlvl = spiobj->p_obj.p_instance->SR & 0xF;
 
-        while((rlvl != 0) && (obj->rx_buff.pos < obj->rx_buff.length)) {
+        while ((rlvl != 0) && (obj->rx_buff.pos < obj->rx_buff.length)) {
             ((uint8_t *)obj->rx_buff.buffer)[obj->rx_buff.pos++] = spiobj->p_obj.p_instance->DR & 0xFF;
             rlvl--;
         }
 
-        if(obj->rx_buff.pos == spiobj->max_size) {
+        if (obj->rx_buff.pos == spiobj->max_size) {
             spiobj->state = SPI_TRANSFER_STATE_IDLE;
         }
         // Clear rx buffer
@@ -573,15 +573,15 @@ static void spi_irq_handler(spi_t *obj)
     }
 
     // Check for transmit completion flag
-    if(spiobj->p_obj.p_instance->SR & TSPI_TX_DONE) {
+    if (spiobj->p_obj.p_instance->SR & TSPI_TX_DONE) {
         obj->tx_buff.pos++;
         spiobj->p_obj.p_instance->SR |=  TSPI_RX_DONE_CLR;
 
-        if(obj->tx_buff.pos == (spiobj->max_size)) {
+        if (obj->tx_buff.pos == (spiobj->max_size)) {
             spiobj->state = SPI_TRANSFER_STATE_IDLE;
         }
 
-        if((obj->tx_buff.pos < obj->tx_buff.length) && (obj->tx_buff.pos < spiobj->max_size)) {
+        if ((obj->tx_buff.pos < obj->tx_buff.length) && (obj->tx_buff.pos < spiobj->max_size)) {
             spiobj->p_obj.p_instance->DR = (((uint8_t *)obj->tx_buff.buffer)[obj->tx_buff.pos] & 0xFF);
         } else if (obj->tx_buff.pos < spiobj->max_size) {
             spiobj->p_obj.p_instance->DR = 0xFF;
@@ -589,7 +589,7 @@ static void spi_irq_handler(spi_t *obj)
     }
 
     // Check for error flag
-    if(spiobj->p_obj.p_instance->ERR) {
+    if (spiobj->p_obj.p_instance->ERR) {
         spiobj->event = SPI_EVENT_ERROR;
         spiobj->state = SPI_TRANSFER_STATE_IDLE;
         disable_irq(spiobj->irqn);
@@ -599,7 +599,7 @@ static void spi_irq_handler(spi_t *obj)
         return;
     }
 
-    if(spiobj->state == SPI_TRANSFER_STATE_IDLE) {
+    if (spiobj->state == SPI_TRANSFER_STATE_IDLE) {
         spiobj->event = SPI_EVENT_COMPLETE;
         disable_irq(spiobj->irqn);
         spiobj->p_obj.p_instance->SR  |= (TSPI_TX_DONE_CLR | TSPI_RX_DONE_CLR);

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
@@ -63,20 +63,11 @@ static const PinMap PinMap_SPI_SSEL[] = {
 #define TMPM46B_SPI_2_FMAX    20000000
 #define TMPM46B_SPI_FMAX      10000000
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     SSP_InitTypeDef config;
 
-    // Check pin parameters
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_sclk);
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    obj->module = explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->module!= NC);
 
     // Identify SPI module to use
@@ -98,12 +89,15 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
 
     // Declare Config
@@ -125,6 +119,31 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     SSP_SetINTConfig(obj->spi, SSP_INTCFG_NONE);
     SSP_Enable(obj->spi);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/spi_api.c
@@ -68,7 +68,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     SSP_InitTypeDef config;
 
     obj->module = explicit_pinmap->peripheral;
-    MBED_ASSERT((int)obj->module!= NC);
+    MBED_ASSERT((int)obj->module != NC);
 
     // Identify SPI module to use
     switch ((int)obj->module) {
@@ -82,7 +82,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
             obj->spi = TSB_SSP2;
             break;
         default:
-            obj->spi= NULL;
+            obj->spi = NULL;
             obj->module = (SPIName)NC;
             error("Cannot found SPI module corresponding with input pins.");
             break;
@@ -155,7 +155,7 @@ void spi_free(spi_t *obj)
 
 void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
-    TSB_SSP_TypeDef* spi;
+    TSB_SSP_TypeDef *spi;
     MBED_ASSERT(slave == SSP_MASTER);   // Master mode only
 
     spi = obj->spi;
@@ -173,7 +173,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
 void spi_frequency(spi_t *obj, int hz)
 {
-    TSB_SSP_TypeDef* spi;
+    TSB_SSP_TypeDef *spi;
 
     // Search Freq data
     int fr_gear = 1;
@@ -258,7 +258,7 @@ static void spi_clear_FIFOs(TSB_SSP_TypeDef *spi)
 
 int spi_master_write(spi_t *obj, int value)
 {
-    TSB_SSP_TypeDef* spi;
+    TSB_SSP_TypeDef *spi;
 
     spi = obj->spi;
     // Clear all data in transmit FIFO and receive FIFO

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
@@ -99,22 +99,14 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {NC,  NC,    0}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     struct spi_s *obj_s = SPI_S(obj);
-    // Check pin parameters
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
 
-    obj_s->module = (SPIName)pinmap_merge(spi_data, spi_sclk);
-    obj_s->module = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    obj_s->module = (SPIName)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj_s->module!= NC);
 
-    obj_s->clk_pin = sclk;
+    obj_s->clk_pin = explicit_pinmap->pin[2];
 #if DEVICE_SPI_ASYNCH
     obj_s->state = SPI_TRANSFER_STATE_IDLE;
 #endif
@@ -209,12 +201,15 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     // Pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
 
     // Default configurations 8 bit, 1Mhz frequency
@@ -275,6 +270,31 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     //initialize SPI
     tspi_init(&obj_s->p_obj);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/spi_api.c
@@ -104,7 +104,7 @@ void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
     struct spi_s *obj_s = SPI_S(obj);
 
     obj_s->module = (SPIName)explicit_pinmap->peripheral;
-    MBED_ASSERT((int)obj_s->module!= NC);
+    MBED_ASSERT((int)obj_s->module != NC);
 
     obj_s->clk_pin = explicit_pinmap->pin[2];
 #if DEVICE_SPI_ASYNCH
@@ -315,18 +315,18 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     obj_s->bits = bits;
     obj_s->p_obj.init.fmr0.fl = (bits << 24);
 
-    if(slave) {
+    if (slave) {
         pinmap_pinout(obj_s->clk_pin, PinMap_SPI_SLAVE_SCLK);
         obj_s->p_obj.init.cnt1.mstr =  TSPI_SLAVE_OPERATION;   // slave mode operation
     }
 
-    if((mode >> 1) & 0x1) {
+    if ((mode >> 1) & 0x1) {
         obj_s->p_obj.init.fmr0.ckpol = TSPI_SERIAL_CK_IDLE_HI;
     } else {
         obj_s->p_obj.init.fmr0.ckpol = TSPI_SERIAL_CK_IDLE_LOW;
     }
 
-    if(mode & 0x1) {
+    if (mode & 0x1) {
         obj_s->p_obj.init.fmr0.ckpha = TSPI_SERIAL_CK_2ND_EDGE;
     } else {
         obj_s->p_obj.init.fmr0.ckpha = TSPI_SERIAL_CK_1ST_EDGE;
@@ -352,11 +352,11 @@ void spi_frequency(spi_t *obj, int hz)
     for (prsck = 1; prsck <= 512; prsck *= 2) {
         fx = ((uint64_t)tmpvar / prsck);
         for (brs = 1; brs <= 16; brs++) {
-            fscl = fx /brs;
+            fscl = fx / brs;
             if ((fscl <= (uint64_t)hz) && (fscl > tmp_fscl)) {
                 tmp_fscl = fscl;
                 obj_s->p_obj.init.brd.brck = (brck << 4);
-                if(brs == 16) {
+                if (brs == 16) {
                     obj_s->p_obj.init.brd.brs = 0;
                 } else {
                     obj_s->p_obj.init.brd.brs = brs;
@@ -409,7 +409,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 int spi_slave_receive(spi_t *obj)
 {
     struct spi_s *obj_s = SPI_S(obj);
-    if((obj_s->p_obj.p_instance->SR & 0x0F) != 0) {
+    if ((obj_s->p_obj.p_instance->SR & 0x0F) != 0) {
         return 1;
     }
 
@@ -430,7 +430,7 @@ int spi_slave_read(spi_t *obj)
 void spi_slave_write(spi_t *obj, int value)
 {
     struct spi_s *obj_s = SPI_S(obj);
-    if((obj_s->p_obj.p_instance->CR1 & TSPI_TX_ONLY) != TSPI_TX_ONLY) { //Enable TX if not Enabled
+    if ((obj_s->p_obj.p_instance->CR1 & TSPI_TX_ONLY) != TSPI_TX_ONLY) { //Enable TX if not Enabled
         obj_s->p_obj.p_instance->CR1 |= TSPI_TX_ONLY;
     }
 
@@ -538,14 +538,14 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     obj_s->p_obj.p_instance->CR1 |= TSPI_TRXE_ENABLE;
 
     // Enable Interrupt bit in SPI peripheral -  Enabled in init()
-    if(use_tx) {
+    if (use_tx) {
         // Transmit first byte to enter into handler
         p_obj->p_instance->DR = *(uint8_t *)(tx);
         obj->tx_buff.pos++;
         NVIC_EnableIRQ(obj_s->txirqn);
     }
     if (use_rx) {
-        if(!use_tx) {
+        if (!use_tx) {
             //if RX only then transmit one dummy byte to enter into handler
             p_obj->p_instance->DR = 0xFF;
         }
@@ -567,13 +567,13 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
         return (event & obj_s->event_mask);
     }
 
-    if((p_obj->p_instance->SR & TSPI_RX_DONE_FLAG) == TSPI_RX_DONE) {
+    if ((p_obj->p_instance->SR & TSPI_RX_DONE_FLAG) == TSPI_RX_DONE) {
 
-        if(obj->rx_buff.pos < obj->rx_buff.length) {
+        if (obj->rx_buff.pos < obj->rx_buff.length) {
             *((uint8_t *)obj->rx_buff.buffer + obj->rx_buff.pos) = (p_obj->p_instance->DR & 0xFF);
             obj->rx_buff.pos++;
 
-            if((obj->tx_buff.pos == obj->tx_buff.length) && (obj->rx_buff.pos < obj->rx_buff.length)) {
+            if ((obj->tx_buff.pos == obj->tx_buff.length) && (obj->rx_buff.pos < obj->rx_buff.length)) {
                 // transmit complete but receive pending - dummy write
                 p_obj->p_instance->DR = 0xFF;
             }
@@ -583,11 +583,11 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
             uint8_t dummy = p_obj->p_instance->DR;
         }
     }
-    if((p_obj->p_instance->SR & TSPI_TX_DONE_FLAG) == TSPI_TX_DONE) {
+    if ((p_obj->p_instance->SR & TSPI_TX_DONE_FLAG) == TSPI_TX_DONE) {
 
         p_obj->p_instance->SR |= TSPI_TX_DONE_CLR;
 
-        if(obj->tx_buff.pos < obj->tx_buff.length) {
+        if (obj->tx_buff.pos < obj->tx_buff.length) {
             p_obj->p_instance->DR = *((uint8_t *)obj->tx_buff.buffer + obj->tx_buff.pos) & 0xFF;
             obj->tx_buff.pos++;
 
@@ -599,8 +599,8 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
     }
 
     err = p_obj->p_instance->ERR;
-    if(err != 0) {
-        p_obj->p_instance->ERR = (TSPI_TRGERR_ERR | TSPI_UNDERRUN_ERR |TSPI_OVERRUN_ERR | TSPI_PARITY_ERR );
+    if (err != 0) {
+        p_obj->p_instance->ERR = (TSPI_TRGERR_ERR | TSPI_UNDERRUN_ERR | TSPI_OVERRUN_ERR | TSPI_PARITY_ERR);
         event = SPI_EVENT_ERROR | SPI_EVENT_INTERNAL_TRANSFER_COMPLETE;
         state_idle(obj_s);
     }
@@ -637,7 +637,7 @@ static inline void state_idle(struct spi_s *obj_s)
     obj_s->p_obj.p_instance->CR1 &= TSPI_TRXE_DISABLE_MASK;
     obj_s->p_obj.p_instance->SR   = (TSPI_TX_DONE_CLR | TSPI_RX_DONE_CLR);
     obj_s->p_obj.p_instance->CR3  = (TSPI_TX_BUFF_CLR_DONE | TSPI_RX_BUFF_CLR_DONE);
-    obj_s->p_obj.p_instance->ERR  = (TSPI_TRGERR_ERR | TSPI_UNDERRUN_ERR |TSPI_OVERRUN_ERR | TSPI_PARITY_ERR );
+    obj_s->p_obj.p_instance->ERR  = (TSPI_TRGERR_ERR | TSPI_UNDERRUN_ERR | TSPI_OVERRUN_ERR | TSPI_PARITY_ERR);
 }
 
 #endif //DEVICE_SPI_ASYNCH

--- a/targets/TARGET_TT/TARGET_TT_M3HQ/spi_api.c
+++ b/targets/TARGET_TT/TARGET_TT_M3HQ/spi_api.c
@@ -67,18 +67,11 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {NC,  NC,    0}
 };
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     TSB_TSPI_TypeDef* spi;
-    // Check pin parameters
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    obj->module = (SPIName)explicit_pinmap->peripheral;
     spi = obj->spi;
     switch ((int)obj->module) {
         case SPI_0:
@@ -112,12 +105,15 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
     obj->spi = spi;
     // pin out the SPI pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
 
     // TTSPI Software Reset
@@ -142,6 +138,31 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     // Enable the selected TSPI peripheral
     spi->CR0 |= TSPI_ENABLE;
     spi_frequency(obj, 1000000);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_TT/TARGET_TT_M3HQ/spi_api.c
+++ b/targets/TARGET_TT/TARGET_TT_M3HQ/spi_api.c
@@ -69,7 +69,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    TSB_TSPI_TypeDef* spi;
+    TSB_TSPI_TypeDef *spi;
 
     obj->module = (SPIName)explicit_pinmap->peripheral;
     spi = obj->spi;
@@ -167,7 +167,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj)
 {
-    TSB_TSPI_TypeDef* spi;
+    TSB_TSPI_TypeDef *spi;
 
     spi = obj->spi;
     spi->CR0 |= TSPI_DISABLE;
@@ -176,7 +176,7 @@ void spi_free(spi_t *obj)
 
 void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
-    TSB_TSPI_TypeDef* spi;
+    TSB_TSPI_TypeDef *spi;
 
     obj->bits = bits;
     spi = obj->spi;
@@ -195,7 +195,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
 void spi_frequency(spi_t *obj, int hz)
 {
-    TSB_TSPI_TypeDef* spi;
+    TSB_TSPI_TypeDef *spi;
     int clk_div = 1;
     uint32_t clocks = ((SystemCoreClock / 2) / hz);
     obj->spi->CR0 |= TSPI_DISABLE;
@@ -219,18 +219,18 @@ void spi_frequency(spi_t *obj, int hz)
 
 int spi_master_write(spi_t *obj, int value)
 {
-    TSB_TSPI_TypeDef* spi;
+    TSB_TSPI_TypeDef *spi;
     MBED_ASSERT(obj != NULL);
     spi = obj->spi;
     spi->CR3 |= TSPI_TX_BUFF_CLR_DONE; // FIFO Cear
     // Check if the TSPI is already enabled
-    if((spi->CR0 & TSPI_ENABLE) != TSPI_ENABLE) {
+    if ((spi->CR0 & TSPI_ENABLE) != TSPI_ENABLE) {
         spi->CR0 |=  TSPI_ENABLE;
     }
     // Enable TSPI Transmission Control
     spi->CR1 |= TSPI_TRXE_ENABLE;
     // Check the current fill level
-    if(((spi->SR & TSPI_TX_REACH_FILL_LEVEL_MASK) >> 16) <= 7) {
+    if (((spi->SR & TSPI_TX_REACH_FILL_LEVEL_MASK) >> 16) <= 7) {
         do {
             spi->DR = (value & TSPI_DR_8BIT_MASK);
             // check complete transmit
@@ -238,20 +238,20 @@ int spi_master_write(spi_t *obj, int value)
         spi->CR3 |= TSPI_TX_BUFF_CLR_DONE;
         spi->CR1 &= TSPI_TRXE_DISABLE_MASK;
     }
-    if((spi->CR1 & TSPI_Transfer_Mode_MASK) == TSPI_RX_ONLY) {
+    if ((spi->CR1 & TSPI_Transfer_Mode_MASK) == TSPI_RX_ONLY) {
         // Enable TSPI Transmission Control
         spi->CR1 |= TSPI_TRXE_ENABLE;
     }
     // Check if the TSPI is already enabled
-    if((spi->CR0 & TSPI_ENABLE) != TSPI_ENABLE) {
+    if ((spi->CR0 & TSPI_ENABLE) != TSPI_ENABLE) {
         // Enable TSPI Transmission Control
         spi->CR0 |=  TSPI_ENABLE;
     }
     value = 0;
     // Wait until Receive Complete Flag is set to receive data
-    if((spi->SR & TSPI_RX_DONE_FLAG) ==  TSPI_RX_DONE) {
+    if ((spi->SR & TSPI_RX_DONE_FLAG) ==  TSPI_RX_DONE) {
         // Check the remain data exist
-        if((spi->SR & TSPI_RX_REACH_FILL_LEVEL_MASK) != 0) {
+        if ((spi->SR & TSPI_RX_REACH_FILL_LEVEL_MASK) != 0) {
             value = (spi->DR & TSPI_DR_8BIT_MASK);
         }
         spi->SR |=  TSPI_RX_DONE_CLR; // Receive Complete Flag is clear
@@ -279,11 +279,11 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 
 int spi_busy(spi_t *obj)
 {
-    TSB_TSPI_TypeDef* spi;
+    TSB_TSPI_TypeDef *spi;
     uint8_t result = 0;
 
     spi = obj->spi;
-    if( (spi->SR & (1<<7)) || (spi->SR & (1<<23))) {
+    if ((spi->SR & (1 << 7)) || (spi->SR & (1 << 23))) {
         result = 1;
     } else {
         result = 0;

--- a/targets/TARGET_TT/TARGET_TT_M4G9/spi_api.c
+++ b/targets/TARGET_TT/TARGET_TT_M4G9/spi_api.c
@@ -65,7 +65,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
     obj->module = (SPIName)explicit_pinmap->peripheral;
-    MBED_ASSERT((int)obj->module!= NC);
+    MBED_ASSERT((int)obj->module != NC);
 
     // Identify SPI module to use
     switch ((int)obj->module) {
@@ -223,13 +223,13 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     obj->bits = bits;
     obj->p_obj.init.fmr0.fl = (bits << 24);
 
-    if((mode >> 1) & 0x1) {
+    if ((mode >> 1) & 0x1) {
         obj->p_obj.init.fmr0.ckpol = TSPI_SERIAL_CK_IDLE_HI;
     } else {
         obj->p_obj.init.fmr0.ckpol = TSPI_SERIAL_CK_IDLE_LOW;
     }
 
-    if(mode & 0x1) {
+    if (mode & 0x1) {
         obj->p_obj.init.fmr0.ckpha = TSPI_SERIAL_CK_2ND_EDGE;
     } else {
         obj->p_obj.init.fmr0.ckpha = TSPI_SERIAL_CK_1ST_EDGE;
@@ -250,11 +250,11 @@ void spi_frequency(spi_t *obj, int hz)
     for (prsck = 1; prsck <= 512; prsck *= 2) {
         fx = ((uint64_t)tmpvar / prsck);
         for (brs = 1; brs <= 16; brs++) {
-            fscl = fx /brs;
+            fscl = fx / brs;
             if ((fscl <= (uint64_t)hz) && (fscl > tmp_fscl)) {
                 tmp_fscl = fscl;
                 obj->p_obj.init.brd.brck = (brck << 4);
-                if(brs == 16) {
+                if (brs == 16) {
                     obj->p_obj.init.brd.brs = 0;
                 } else {
                     obj->p_obj.init.brd.brs = brs;
@@ -308,7 +308,7 @@ int spi_busy(spi_t *obj)
     int ret = 1;
     uint32_t status;
     tspi_get_status(&obj->p_obj, &status);
-    if((status & (TSPI_TX_FLAG_ACTIVE | TSPI_RX_FLAG_ACTIVE)) == 0) {
+    if ((status & (TSPI_TX_FLAG_ACTIVE | TSPI_RX_FLAG_ACTIVE)) == 0) {
         ret = 0;
     }
 

--- a/targets/TARGET_TT/TARGET_TT_M4G9/spi_api.c
+++ b/targets/TARGET_TT/TARGET_TT_M4G9/spi_api.c
@@ -61,18 +61,10 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {PM3, SPI_5, PIN_DATA(6, 1)},
     {NC,  NC,    0}
 };
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
-{
-    // Check pin parameters
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
 
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_sclk);
-    obj->module = (SPIName)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->module = (SPIName)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->module!= NC);
 
     // Identify SPI module to use
@@ -121,12 +113,15 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     }
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
 
     // Default configurations 8 bit, 1Mhz frequency
@@ -187,6 +182,31 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     //initialize SPI
     tspi_init(&obj->p_obj);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj)

--- a/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
@@ -42,13 +42,17 @@ static inline int ssp_enable(spi_t *obj);
 
 void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
 {
-    obj->spi = (SSP_TypeDef*)explicit_pinmap->peripheral;
+    obj->spi = (SSP_TypeDef *)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {
-        case SPI_0: CRG->SSPCLK_SSR   = CRG_SSPCLK_SSR_MCLK; break; //PLL output clock
-        case SPI_1: CRG->SSPCLK_SSR   = CRG_SSPCLK_SSR_MCLK; break;
+        case SPI_0:
+            CRG->SSPCLK_SSR   = CRG_SSPCLK_SSR_MCLK;
+            break; //PLL output clock
+        case SPI_1:
+            CRG->SSPCLK_SSR   = CRG_SSPCLK_SSR_MCLK;
+            break;
     }
 
     // set default format and frequency
@@ -102,7 +106,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
 void spi_free(spi_t *obj) {}
 
-void spi_format(spi_t *obj, int bits, int mode, int slave) {
+void spi_format(spi_t *obj, int bits, int mode, int slave)
+{
     ssp_disable(obj);
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && (mode >= 0 && mode <= 3));
 
@@ -118,22 +123,23 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0xFFFF);
     tmp |= DSS << 0
-        | FRF << 4
-        | SPO << 6
-        | SPH << 7;
+           | FRF << 4
+           | SPO << 6
+           | SPH << 7;
     obj->spi->CR0 = tmp;
 
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
-        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
-        | 0 << 3;                  // SOD - slave output disable - na
+           | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+           | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
 
     ssp_enable(obj);
 }
 
-void spi_frequency(spi_t *obj, int hz) {
+void spi_frequency(spi_t *obj, int hz)
+{
     ssp_disable(obj);
 
     // setup the spi clock diveder to /1
@@ -171,43 +177,52 @@ void spi_frequency(spi_t *obj, int hz) {
     error("Couldn't setup requested SPI frequency");
 }
 
-static inline int ssp_disable(spi_t *obj) {
+static inline int ssp_disable(spi_t *obj)
+{
     return obj->spi->CR1 &= ~(1 << 1);
 }
 
-static inline int ssp_enable(spi_t *obj) {
+static inline int ssp_enable(spi_t *obj)
+{
     return obj->spi->CR1 |= (1 << 1);
 }
 
-static inline int ssp_readable(spi_t *obj) {
+static inline int ssp_readable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 2);
 }
 
-static inline int ssp_writeable(spi_t *obj) {
+static inline int ssp_writeable(spi_t *obj)
+{
     return obj->spi->SR & (1 << 1);
 }
 
-static inline void ssp_write(spi_t *obj, int value) {
+static inline void ssp_write(spi_t *obj, int value)
+{
     while (!ssp_writeable(obj));
     obj->spi->DR = value;
 }
 
-static inline int ssp_read(spi_t *obj) {
+static inline int ssp_read(spi_t *obj)
+{
     while (!ssp_readable(obj));
     return obj->spi->DR;
 }
 
-static inline int ssp_busy(spi_t *obj) {
+static inline int ssp_busy(spi_t *obj)
+{
     return (obj->spi->SR & (1 << 4)) ? (1) : (0);
 }
 
-int spi_master_write(spi_t *obj, int value) {
+int spi_master_write(spi_t *obj, int value)
+{
     ssp_write(obj, value);
     return ssp_read(obj);
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
@@ -221,20 +236,24 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     return total;
 }
 
-int spi_slave_receive(spi_t *obj) {
+int spi_slave_receive(spi_t *obj)
+{
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }
 
-int spi_slave_read(spi_t *obj) {
+int spi_slave_read(spi_t *obj)
+{
     return obj->spi->DR;
 }
 
-void spi_slave_write(spi_t *obj, int value) {
+void spi_slave_write(spi_t *obj, int value)
+{
     while (ssp_writeable(obj) == 0) ;
     obj->spi->DR = value;
 }
 
-int spi_busy(spi_t *obj) {
+int spi_busy(spi_t *obj)
+{
     return ssp_busy(obj);
 }
 

--- a/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
@@ -1,4 +1,4 @@
-/* mbed Microcontroller Library 
+/* mbed Microcontroller Library
  *******************************************************************************
  * Copyright (c) 2015 WIZnet Co.,Ltd. All rights reserved.
  * All rights reserved.
@@ -27,7 +27,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
- 
+
 #include "mbed_assert.h"
 #include <math.h>
 
@@ -40,41 +40,64 @@
 static inline int ssp_disable(spi_t *obj);
 static inline int ssp_enable(spi_t *obj);
 
-void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
-    // determine the SPI to use
-    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
-    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
-    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
-    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
-    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
-    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
-    obj->spi = (SSP_TypeDef*)pinmap_merge(spi_data, spi_cntl);
+void spi_init_direct(spi_t *obj, explicit_pinmap_t *explicit_pinmap)
+{
+    obj->spi = (SSP_TypeDef*)explicit_pinmap->peripheral;
     MBED_ASSERT((int)obj->spi != NC);
-    
+
     // enable power and clocking
     switch ((int)obj->spi) {
         case SPI_0: CRG->SSPCLK_SSR   = CRG_SSPCLK_SSR_MCLK; break; //PLL output clock
         case SPI_1: CRG->SSPCLK_SSR   = CRG_SSPCLK_SSR_MCLK; break;
     }
-    
+
     // set default format and frequency
-    if (ssel == NC) {
+    if (explicit_pinmap->pin[3] == NC) {
         spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
     } else {
         spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
     }
     spi_frequency(obj, 1000000);
-    
+
     // enable the ssp channel
     ssp_enable(obj);
 
     // pin out the spi pins
-    pinmap_pinout(mosi, PinMap_SPI_MOSI);
-    pinmap_pinout(miso, PinMap_SPI_MISO);
-    pinmap_pinout(sclk, PinMap_SPI_SCLK);
-    if (ssel != NC) {
-        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    pin_function(explicit_pinmap->pin[0], explicit_pinmap->function[0]);
+    pin_mode(explicit_pinmap->pin[0], PullNone);
+    pin_function(explicit_pinmap->pin[1], explicit_pinmap->function[1]);
+    pin_mode(explicit_pinmap->pin[1], PullNone);
+    pin_function(explicit_pinmap->pin[2], explicit_pinmap->function[2]);
+    pin_mode(explicit_pinmap->pin[2], PullNone);
+    if (explicit_pinmap->pin[3] != NC) {
+        pin_function(explicit_pinmap->pin[3], explicit_pinmap->function[3]);
+        pin_mode(explicit_pinmap->pin[3], PullNone);
     }
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+    // determine the SPI to use
+    uint32_t spi_mosi = pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    uint32_t spi_miso = pinmap_peripheral(miso, PinMap_SPI_MISO);
+    uint32_t spi_sclk = pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    uint32_t spi_ssel = pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
+    uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
+
+    int peripheral = (int)pinmap_merge(spi_data, spi_cntl);
+
+    // pin out the spi pins
+    int mosi_function = (int)pinmap_find_function(mosi, PinMap_SPI_MOSI);
+    int miso_function = (int)pinmap_find_function(miso, PinMap_SPI_MISO);
+    int sclk_function = (int)pinmap_find_function(sclk, PinMap_SPI_SCLK);
+    int ssel_function = (int)pinmap_find_function(ssel, PinMap_SPI_SSEL);
+
+    int pins_function[] = {mosi_function, miso_function, sclk_function, ssel_function};
+    PinName pins[] = {mosi, miso, sclk, ssel};
+    explicit_pinmap_t explicit_spi_pinmap = {peripheral, pins, pins_function};
+
+    spi_init_direct(obj, &explicit_spi_pinmap);
 }
 
 void spi_free(spi_t *obj) {}
@@ -82,15 +105,15 @@ void spi_free(spi_t *obj) {}
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     ssp_disable(obj);
     MBED_ASSERT(((bits >= 4) && (bits <= 16)) && (mode >= 0 && mode <= 3));
-    
+
     int polarity = (mode & 0x2) ? 1 : 0;
     int phase = (mode & 0x1) ? 1 : 0;
-    
+
     // set it up
     int DSS = bits - 1;            // DSS (data select size)
     int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
     int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
-    
+
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
     tmp &= ~(0xFFFF);
@@ -99,45 +122,45 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
         | SPO << 6
         | SPH << 7;
     obj->spi->CR0 = tmp;
-    
+
     tmp = obj->spi->CR1;
     tmp &= ~(0xD);
     tmp |= 0 << 0                   // LBM - loop back mode - off
         | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
         | 0 << 3;                  // SOD - slave output disable - na
     obj->spi->CR1 = tmp;
-    
+
     ssp_enable(obj);
 }
 
 void spi_frequency(spi_t *obj, int hz) {
     ssp_disable(obj);
-    
+
     // setup the spi clock diveder to /1
     switch ((int)obj->spi) {
         case SPI_0:
-            CRG->SSPCLK_PVSR  = CRG_SSPCLK_PVSR_DIV1; //1/1 (bypass) 
+            CRG->SSPCLK_PVSR  = CRG_SSPCLK_PVSR_DIV1; //1/1 (bypass)
             break;
         case SPI_1:
             CRG->SSPCLK_PVSR  = CRG_SSPCLK_PVSR_DIV1; //1/1 (bypass)
             break;
     }
-    
-    uint32_t HCLK = SystemCoreClock; 
-    
+
+    uint32_t HCLK = SystemCoreClock;
+
     int prescaler;
-    
+
     for (prescaler = 2; prescaler <= 254; prescaler += 2) {
         int prescale_hz = HCLK / prescaler;
-        
+
         // calculate the divider
         int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
-        
+
         // check we can support the divider
         if (divider < 256) {
             // prescaler
             obj->spi->CPSR = prescaler;
-            
+
             // divider
             obj->spi->CR0 &= ~(0xFFFF << 8);
             obj->spi->CR0 |= (divider - 1) << 8;
@@ -254,4 +277,3 @@ const PinMap *spi_slave_cs_pinmap()
 {
     return PinMap_SPI_SSEL;
 }
-


### PR DESCRIPTION
### Description

The goal of this PR is to give Mbed-os user an option to choose traditional pinmap mechanism while dealing with some peripherals or to statically define pins/peripheral/functions. It is done to save flash memory (when pins configuration is provided directly). 

Summary of the flash memory savings on K64F in bytes below:

| ﻿GCC_ARM             | main.o | drivers\source | targets\TARGET_Freescale | Total |
|---------------------|--------|----------------|--------------------------|-------|
| master              | 48     | 982            | 12496                    | 57272 |
| explicit_pinmap_v3  | 104    | 1046           | 11972                    | 56872 |
| diff: branch-master | 56     | 64             | -524                     | -400  |

| ﻿ARM                 | main.o | drivers\source | targets\TARGET_Freescale | Total |
|---------------------|--------|----------------|--------------------------|-------|
| master              | 54     | 1002           | 18588                    | 47601 |
| explicit_pinmap_v3  | 98     | 1082           | 18028                    | 47165 |
| diff: branch-master | 44     | 80             | -560                     | -436  |

| ﻿IAR                   | main.o | drivers\source | targets\TARGET_Freescale | Total |
|-----------------------|--------|----------------|--------------------------|-------|
| master                | 44     | 722            | 12514                    | 41813 |
| explicit_pinmap_v3    | 124    | 790            | 11982                    | 41429 |
| diff: branch - master | 80     | 68             | -532                     | -384  |

I choose SPI as first since it should be the most complicated case: requires 4 pins (4 pinmaps), so this should give the most memory savings (but maybe I'm wrong). The results on K64F look promising. The explicit pinmap mechanism takes some extra bytes in drivers (modified SPI class) and app but totally gives around ~400 bytes of flash saved (depending on compiler). 

Unfortunately for the other boards, the results are not so good. Few examples below (`GCC_ARM`):

 | ﻿Board/Flash usage [bytes] | master | explicit pinmap | diff |
|---------------------------|--------|-----------------|------|
| NUCLEO_L073RZ             | 63436  | 63428           | -8   |
| NUCLEO_F429ZI             | 63360  | 63296           | -64  |
| K64F                      | 57272  | 56872           | -400 |
| K66F                      | 58286  | 57838           | -448 |
| NUMAKER_PFM_M487          | 42776  | 42840           | 64   |
| MAX32600MBED              | 38588  | 38140           | -448 |
| TMPM3H6                   | 39604  | 39652           | 48   |
| GD32_E103VB               | 38040  | 38104           | 64   |
| UNO_91H                   | 38972  | 39036           | 64   |
| DISCO_L476VG              | 59528  | 59528           | 0    |
| KW24D                     | 54415  | 54119           | -296 |

@ARMmbed/mbed-os-hal @c1728p9 @jamesbeyond @0xc0170 @bulislaw What is your opinion? 
As you can see in some cases flash memory usage increased and in some cases, the savings are very poor. 

I will check how this looks in case of PWM/GPIO now where is only one pinmap table, but should be long and there should be no extra code in the drivers section.

@ARMmbed/mbed-os-test Can we perform mbed-os build for all targets on CI?


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond @fkjagodzinski @maciejbocianski @c1728p9 @0xc0170 @bulislaw 
