### PR TITLE
LoRaWAN: Terminate RX when receiving uplink messages

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -738,6 +738,15 @@ void LoRaMac::on_radio_rx_done(const uint8_t *const payload, uint16_t size,
             break;
 
         default:
+            //  This can happen e.g. if we happen to receive uplink of another device
+            //  during the receive window. Block RX2 window since it can overlap with
+            //  QOS TX and cause a mess.
+            tr_debug("RX unexpected mtype %u", mac_hdr.bits.mtype);
+            if (get_current_slot() == RX_SLOT_WIN_1) {
+                _lora_time.stop(_params.timers.rx_window2_timer);
+            }
+            _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
+            _mcps_indication.pending = false;
             break;
     }
 }


### PR DESCRIPTION
This prevents RX2 window to be enabled at the same time when repeating transmission, when QoS repeated TX is in effect. Failure to do so seems to place the LoRaWAN stack in a state where send() always fails with WOULD_BLOCK error.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
During testing of a LoRa device, the LoRaWAN stack rarely ended up in state where all transmissions would fail (LoRaWANInterface::send() would always return LORAWAN_STATUS_WOULD_BLOCK). After further investigation, this can happen with the following circumstances:
- NbTrans > 1, i.e. TX retransmission occurs
- During the RX1 window of the first transmission, an uplink message from another device coincidentally transmitting on the same channel is captured

The log looks similar to this (note that I've added some extra logging for window timing):
```
[INFO][LMAC]: RTS = 26 bytes, PEND = 0, Port: 2
[DBG ][LMAC]: Frame prepared to send at port 2
[DBG ][LMAC]: TX: Channel=1, TX DR=5, RX1 DR=5
[DBG ][LSTK]: Transmission completed
[DBG ][LMAC]: TX done @ 2291490 time_diff 27 timeout 891 rx2 to 1986
[DBG ][LMAC]: RX1 slot open @ 2292412, Freq = 868300000
*** Uplink received here
[DBG ][LMAC]: RX done @ 2292499
[INFO][LSTK]: QOS: repeated transmission #2 queued
[DBG ][LMAC]: Frame prepared to send at port 2
[DBG ][LMAC]: TX: Channel=7, TX DR=5, RX1 DR=5
[DBG ][LSTK]: Transmission completed
[DBG ][LMAC]: TX done @ 2292723 time_diff 28 timeout 890 rx2 to 1985
*** Both RX2 window of the 1st transmission and RX1 window of the 2nd tranmission overlap
[DBG ][LMAC]: RX2 slot open @ 2293507, Freq = 869525000
[DBG ][LMAC]: RX1 slot open @ 2293644, Freq = 867900000
[DBG ][LMAC]: RX timeout @ 2293812
*** As things are now messed up, TX_DONE indication never occurs, further attempts to transmit will fail.
```
A more appropriate fix would be to delay QOS retransmission until RX2 window closes, but it seems to me that more extensive code changes would be needed for that. At least this should prevent the stack from ending up in an unusable state.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
