### PR TITLE
Netsocket: Change DNS retry and total attempt counts

### DIFF
--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -48,11 +48,11 @@
         },
         "dns-total-attempts": {
             "help": "Number of total DNS query attempts that the DNS translator makes",
-            "value": 3
+            "value": 10
         },
         "dns-retries": {
             "help": "Number of DNS query retries that the DNS translator makes per server, before moving on to the next server. Total retries/attempts is always limited by dns-total-attempts.",
-            "value": 2
+            "value": 1
         },
         "dns-cache-size": {
             "help": "Number of cached host name resolutions",


### PR DESCRIPTION
### Description

With the current DNS defaults, DNS query is sent `dns-retries+1` times to the first server if no response is received. DNS should continue sending queries to another DNS server, but because `dns-total-attempts` limits query count to 3, DNS stops and returns failure.

This change updates DNS counters so that each of five predefined servers are tried twice.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kivaisan 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

DNS lookup is done for each of five predefined servers twice. This change affects the previous DNS lookup functionality only when it's expected that DNS is made three times on the very first DNS server. 
Although that's unlikely needed, the previous functionality can be restored reverting the changes to DNS configuration.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
