### PR TITLE
AT_CellularSMS: allow configuring SMS encoding (7-bit/8-bit) at initialization

### DIFF
--- a/UNITTESTS/stubs/AT_CellularSMS_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularSMS_stub.cpp
@@ -71,7 +71,8 @@ nsapi_error_t AT_CellularSMS::set_csdh(int show_header)
     return NSAPI_ERROR_OK;
 }
 
-nsapi_error_t AT_CellularSMS::initialize(CellularSMSMmode mode)
+nsapi_error_t AT_CellularSMS::initialize(CellularSMSMmode mode,
+                                         CellularSMSEncoding encoding)
 {
     return NSAPI_ERROR_OK;
 }

--- a/features/cellular/framework/API/CellularSMS.h
+++ b/features/cellular/framework/API/CellularSMS.h
@@ -62,6 +62,11 @@ public:
         CellularSMSMmodeText
     };
 
+    enum CellularSMSEncoding {
+        CellularSMSEncoding7Bit,
+        CellularSMSEncoding8Bit,
+    };
+
     /** Does all the necessary initializations needed for receiving and sending SMS.
      *
      *  @param mode          enumeration for choosing the correct mode: text/pdu
@@ -69,7 +74,8 @@ public:
      *                       NSAPI_ERROR_NO_MEMORY on memory failure
      *                       NSAPI_ERROR_DEVICE_ERROR on other failures
      */
-    virtual nsapi_error_t initialize(CellularSMSMmode mode) = 0;
+    virtual nsapi_error_t initialize(CellularSMSMmode mode,
+                                     CellularSMSEncoding encoding = CellularSMSEncoding::CellularSMSEncoding7Bit) = 0;
 
     /** Send the SMS with the given parameters
      *

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -291,8 +291,11 @@ char *AT_CellularSMS::create_pdu(const char *phone_number, const char *message, 
     // there might be need for padding so some more space
     totalPDULength += 2;
 
-    // message 7-bit padded and it will be converted to hex so it will take twice as much space
-    totalPDULength += (message_length - (message_length / 8)) * 2;
+    // 8-bit message, converted to hex so it will take twice as much space
+    totalPDULength += message_length * 2;
+
+    // terminating nullbyte, because callers use strlen() to find out PDU size
+    totalPDULength += 1;
 
     char *pdu = new char[totalPDULength];
     memset(pdu, 0, totalPDULength);

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -245,8 +245,11 @@ nsapi_error_t AT_CellularSMS::set_csdh(int show_header)
     return _at.at_cmd_discard("+CSDH", "=", "%d", show_header);
 }
 
-nsapi_error_t AT_CellularSMS::initialize(CellularSMSMmode mode)
+nsapi_error_t AT_CellularSMS::initialize(CellularSMSMmode mode,
+                                         CellularSMSEncoding encoding)
 {
+    _use_8bit_encoding = (encoding == CellularSMSEncoding8Bit);
+
     _at.set_urc_handler("+CMTI:", callback(this, &AT_CellularSMS::cmti_urc));
     _at.set_urc_handler("+CMT:", callback(this, &AT_CellularSMS::cmt_urc));
 

--- a/features/cellular/framework/AT/AT_CellularSMS.h
+++ b/features/cellular/framework/AT/AT_CellularSMS.h
@@ -39,7 +39,8 @@ public:
 public:
     // from CellularSMS
 
-    virtual nsapi_error_t initialize(CellularSMSMmode mode);
+    virtual nsapi_error_t initialize(CellularSMSMmode mode,
+                                     CellularSMSEncoding encoding = CellularSMSEncoding7Bit);
 
     virtual nsapi_size_or_error_t send_sms(const char *phone_number, const char *message, int msg_len);
 


### PR DESCRIPTION
### Description

Currently, `AT_CellularSMS` contains a `_use_8bit_encoding` flag that supposedly toggles encoding of sent SMSes. The flag is initialized with `false` and there is no public API to toggle it.

This pull request makes it possible to select desired encoding when initializing `AT_CellularSMS` object, and fixes a bug found on the way (PDU buffer size calculation was enough for 7-bit-encoded SMS, but not for 8-bit-encoded ones, resulting in a out-of-bounds access when a long 8-bit SMS was being sent).

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Release Notes

 `AT_CellularSMS::initialize` takes an additional encoding parameter that defaults to 7-bit (behavior of existing code does not change, one needs to opt-in to send 8-bit SMS)