### PR TITLE
Cellular: Fix BG96 AT driver for IPv6

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
@@ -89,6 +89,14 @@ private:
     hostbyname_cb_t _dns_callback;
     nsapi_version_t _dns_version;
 #endif
+    /** Convert IP address to dotted string representation
+     *
+     *  BG96 requires consecutive zeros so can't use get_ip_address or ip6tos directly.
+     *
+     *  @param ip address
+     *  @param dot buffer with size NSAPI_IPv6, where address is written zero terminated
+     */
+    void ip2dot(const SocketAddress &ip, char *dot);
 };
 } // namespace mbed
 #endif /* QUECTEL_BG96_CELLULARSTACK_H_ */


### PR DESCRIPTION
### Description

Fix BG96 AT driver to support IPv6 addressing.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
