### PR TITLE
Allow ATHandler::read_int to return 0 successfully

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -722,7 +722,22 @@ int32_t ATHandler::read_int()
         return -1;
     }
 
-    return std::strtol(buff, NULL, 10);
+    errno = 0;
+    char *endptr;
+    long result = std::strtol(buff, &endptr, 10);
+    if ((result == LONG_MIN || result == LONG_MAX) && errno == ERANGE) {
+        return -1; // overflow/underflow
+    }
+    if (result < 0) {
+        return -1; // negative values are unsupported
+    }
+    if (*buff == '\0') {
+        return -1; // empty string
+    }
+    if (*endptr != '\0') {
+        return -1; // trailing garbage
+    }
+    return (int32_t) result;
 }
 
 void ATHandler::set_delimiter(char delimiter)

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -734,9 +734,6 @@ int32_t ATHandler::read_int()
     if (*buff == '\0') {
         return -1; // empty string
     }
-    if (*endptr != '\0') {
-        return -1; // trailing garbage
-    }
     return (int32_t) result;
 }
 

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -410,9 +410,9 @@ public:
      */
     ssize_t read_hex_string(char *str, size_t size);
 
-    /** Reads as string and converts result to integer. Supports only positive integers.
+    /** Reads as string and converts result to integer. Supports only non-negative integers.
      *
-     *  @return the positive integer or -1 in case of error.
+     *  @return the non-negative integer or -1 in case of error.
      */
     int32_t read_int();
 


### PR DESCRIPTION
### Description

Currently, `ATHandler::read_int` is documented to return a positive integer on success, -1 on error. In cases where `std::strtol` fails to parse a value, 0 is returned - and it is impossible to determine whether that 0 means "parsing failed" or "parsed 0 successfully".

Most places in `mbed-os` that actually do error checking depend on 0 meaning success, e.g.:

- https://github.com/ARMmbed/mbed-os/blob/818c1d6f0fd6d5c868db97e5c380f396addd3fbc/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp#L114
- https://github.com/ARMmbed/mbed-os/blob/818c1d6f0fd6d5c868db97e5c380f396addd3fbc/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularContext.cpp#L137
- https://github.com/ARMmbed/mbed-os/blob/60d047cae335466edb90d45b4c4a2098dc88dfe0/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX_CellularStack.cpp#L96
- https://github.com/ARMmbed/mbed-os/blob/8767ab4e411a946634cd84b783520733afdda03d/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp#L361

This pull request updates `ATHandler::read_int` so that it only returns 0 on success, and updates the method comment appropriately.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change