### PR TITLE
Make AT_CellularSMS::list_messages support index 0 in SMS inbox

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsms/at_cellularsmstest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsms/at_cellularsmstest.cpp
@@ -137,7 +137,7 @@ TEST_F(TestAT_CellularSMS, test_AT_CellularSMS_get_sms)
     EXPECT_TRUE(NSAPI_ERROR_PARAMETER == sms.get_sms(NULL, 16, phone, 21, stamp, 21, &size));
 
     ATHandler_stub::resp_info_true_counter = 1;
-    ATHandler_stub::int_value = 0;
+    ATHandler_stub::int_value = -1;
     EXPECT_TRUE(-1 == sms.get_sms(buf, 16, phone, 21, stamp, 21, &size));
 
     //In below we are expecting the stub ATHandler info_resp() to respond

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -1037,7 +1037,7 @@ nsapi_error_t AT_CellularSMS::list_messages()
             (void)_at.consume_to_stop_tag(); // consume until <CR><LF>
         }
 
-        if (index > 0) {
+        if (index >= 0) {
             add_info(info, index, part_number);
         } else {
             delete info;


### PR DESCRIPTION
### Description

When AT+CGML is used to retrieve list of SMS stored in modem inbox, every message has an associated index. ETSI TS 127 005 v7.0.0 does not specify what is the allowed range of such indices - all it says is "integer type; value in the range of location numbers supported by the
associated memory".

Usually, AT modems use positive indexes (starting at 1). Quectel BG96 modem takes a different approach, indexing messages starting at 0.

Current implementation of `AT_CellularSMS::list_messages()` considers index 0 invalid and ignores such message, effectively making it impossible to access using mbed-os API.

This commit changes the behavior so that value of 0 is handled as any other positive message index.

Tested with Quectel BG96 modem.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change