### PR TITLE
hal fhss timer: removed unnecessary and potentially unsafe memset

### DIFF
--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -77,7 +77,6 @@ static fhss_timeout_s *allocate_timeout(void)
 {
     for (int i = 0; i < NUMBER_OF_SIMULTANEOUS_TIMEOUTS; i++) {
         if (fhss_timeout[i].fhss_timer_callback == NULL) {
-            memset(&fhss_timeout[i], 0, sizeof(fhss_timeout_s));
             return &fhss_timeout[i];
         }
     }

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -32,6 +32,7 @@
 #define NUMBER_OF_SIMULTANEOUS_TIMEOUTS  2
 #endif //NUMBER_OF_SIMULTANEOUS_TIMEOUTS
 
+namespace {
 using namespace mbed;
 using namespace events;
 
@@ -168,6 +169,7 @@ static uint32_t platform_fhss_timestamp_read(const fhss_api_t *api)
     (void)api;
     return read_current_time();
 }
+} // anonymous namespace
 
 fhss_timer_t fhss_functions = {
     .fhss_timer_start = platform_fhss_timer_start,


### PR DESCRIPTION
### Description

<!--
Removed unnecessary and potentially unsafe memset. Tested with Nucleo-F429ZI.
-->

hal fhss timer: removed unnecessary and potentially unsafe memset


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
