### PR TITLE
FATFS / IAR compilation issue Pe029

### DIFF
--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2012 ARM Limited
+ * Copyright (c) 2006-2019 ARM Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -280,9 +280,8 @@ extern "C" DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 
 // Filesystem implementation (See FATFilySystem.h)
 FATFileSystem::FATFileSystem(const char *name, BlockDevice *bd)
-    : FileSystem(name), _id(-1)
+    : FileSystem(name), _fs(), _id(-1)
 {
-    _fs = { 0 };
     if (bd) {
         mount(bd);
     }


### PR DESCRIPTION
IAR / FATFS - Pe029 error
   
IAR compilation fails at `_fs = { 0 };` due to
    
```
[Error] FATFileSystem.cpp@285,0: [Pe029]: expected an expression
```
    
Changing that initializer fixes the issue. IAR is more sensitive
in C/C++ being mixed together than other compilers.

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@0xc0170 @kjbracey-arm @michalpasztamobica 

