### PR TITLE
Loramac UT fixed

### DIFF
--- a/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
+++ b/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
@@ -588,6 +588,9 @@ TEST_F(Test_LoRaMac, clear_tx_pipe)
     conn.connection_u.otaa.nwk_key = key;
     object->prepare_join(&conn, true);
 
+    channel_params_t params[] = {868300000, 0, { ((DR_5 << 4) | DR_0) }, 1};
+    LoRaPHY_stub::channel_params_ptr = params;
+
     EXPECT_TRUE(LORAWAN_STATUS_OK == object->initialize(NULL, my_cb));
     EventQueue_stub::int_value = 0;
     EXPECT_EQ(LORAWAN_STATUS_BUSY, object->clear_tx_pipe());


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
LoRaMAC UT had one uninitialised variable. This is now fixed

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
