### PR TITLE
Update MCUXpresso SDK SPI drivers

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_dspi.c
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_dspi.h"
@@ -33,6 +11,12 @@
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -138,10 +115,15 @@ static dspi_master_isr_t s_dspiMasterIsr;
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
-volatile uint8_t s_dummyData[ARRAY_SIZE(s_dspiBases)] = {0};
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
@@ -160,15 +142,64 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
     return instance;
 }
 
-void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
 {
-    uint32_t instance = DSPI_GetInstance(base);
-    s_dummyData[instance] = dummyData;
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
 }
 
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
     uint32_t temp;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -179,6 +210,7 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -187,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -199,48 +229,85 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
     DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
     masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
     uint32_t temp = 0;
 
@@ -260,14 +327,14 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
 
@@ -276,21 +343,41 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
-    slaveConfig->whichCtar = kDSPI_Ctar0;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
     slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
@@ -320,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -339,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -405,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -429,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -451,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -482,87 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    assert(command);
+    assert(NULL != command);
 
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    assert(command);
+    assert(NULL != command);
 
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -571,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -587,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = s_dummyData[DSPI_GetInstance(base)];
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -605,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -652,15 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -672,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -713,24 +1013,25 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -738,13 +1039,13 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -752,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -765,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -818,26 +1120,27 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
                         if (rxData != NULL)
                         {
-                            *rxData = wordReceived;
+                            *rxData = (uint8_t)wordReceived;
                             ++rxData;
-                            *rxData = wordReceived >> 8;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
                             ++rxData;
                         }
-                        remainingReceiveByteCount -= 2;
+                        remainingReceiveByteCount -= 2U;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -849,31 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
-    dspi_command_data_config_t commandStruct;
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -881,62 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
 
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
     DSPI_StartTransfer(base);
 
     /* Fill up the Tx FIFO to trigger the transfer. */
     DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -948,13 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -963,41 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    handle->state = kDSPI_Idle;
-
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = s_dummyData[DSPI_GetInstance(base)];
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -1005,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1013,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1029,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1064,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1074,86 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1162,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1190,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1222,65 +1736,76 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
 
     /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
         /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
     }
-    if (handle->txData)
+    if (NULL != handle->txData)
     {
         /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
     }
 
     DSPI_StartTransfer(base);
@@ -1291,17 +1816,27 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1313,24 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = s_dummyData[DSPI_GetInstance(base)];
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1348,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1395,26 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1423,69 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 
-    if (handle->callback)
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint8_t dummyPattern = s_dummyData[DSPI_GetInstance(base)];
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1503,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1519,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1592,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1625,12 +2188,17 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 #if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
@@ -1638,7 +2206,7 @@ void SPI0_DriverIRQHandler(void)
 #if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
@@ -1646,7 +2214,7 @@ void SPI1_DriverIRQHandler(void)
 #if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
@@ -1654,7 +2222,7 @@ void SPI2_DriverIRQHandler(void)
 #if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
@@ -1662,7 +2230,7 @@ void SPI3_DriverIRQHandler(void)
 #if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
@@ -1670,7 +2238,7 @@ void SPI4_DriverIRQHandler(void)
 #if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -43,8 +21,8 @@
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.2.0. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 0))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
 #ifndef DSPI_DUMMY_DATA
@@ -55,37 +33,37 @@
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All statuses above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -102,7 +80,7 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
@@ -132,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -216,7 +194,7 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
     kDSPI_MasterActiveAfterTransfer =
         1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
@@ -241,7 +219,7 @@ enum _dspi_transfer_state
 /*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of the chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
@@ -258,10 +236,10 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
-                                               delay. It also sets the boundary value if out of range.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
-                                               minimum delay. It also sets the boundary value if out of range.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
 
     uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
                                              delay. It also sets the boundary value if out of range.*/
@@ -315,13 +293,13 @@ typedef struct _dspi_slave_config
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -356,11 +334,23 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
@@ -373,7 +363,7 @@ struct _dspi_master_handle
 
     volatile bool
         isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Indicates whether there are extra bytes.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
@@ -527,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -565,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -605,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -685,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -711,7 +707,14 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
@@ -749,8 +752,8 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -762,8 +765,8 @@ static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool en
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -954,11 +957,11 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  *        buffer master mode and waits till complete to return.
  *
  * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
-* 32-bit word
+ * 32-bit word
  * as the data to send.
  * The command portion provides characteristics of the data, such as the optional continuous chip select operation
  * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
-* desired PCS
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
@@ -973,20 +976,20 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
  * @param data The data word (command and data combined) to be sent.
  */
@@ -1037,7 +1040,7 @@ void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1085,6 +1088,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1180,14 +1212,24 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -41,14 +19,20 @@
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
@@ -185,6 +169,21 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief DSPI master aborts a transfer which is using eDMA.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi.c
@@ -1,38 +1,22 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi.h"
 
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -65,27 +42,27 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
 
 /*!
  * @brief Master fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Master finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Slave fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
  * @brief Slave finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -100,7 +77,7 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param);
 /*!
  * @brief Master prepare the transfer.
  * Basically it set up dspi_master_handle .
- * This is not a public API as it is called from other driver functions. fsl_dspi_edma.c also call this function.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
 
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -129,7 +106,7 @@ static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to dspi handles for each instance. */
-static void *g_dspiHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
@@ -137,15 +114,22 @@ static dspi_master_isr_t s_dspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_DSPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_dspiBases); instance++)
     {
         if (s_dspiBases[instance] == base)
         {
@@ -153,14 +137,69 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_DSPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_dspiBases));
 
     return instance;
 }
 
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+{
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
+}
+
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
     uint32_t temp;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -171,6 +210,7 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -179,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -191,47 +229,85 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
     masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
     uint32_t temp = 0;
 
@@ -251,35 +327,57 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
 
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
-    slaveConfig->whichCtar = kDSPI_Ctar0;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
     slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
@@ -309,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -328,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -394,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -418,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -440,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -471,87 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    assert(command);
+    assert(NULL != command);
 
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    assert(command);
+    assert(NULL != command);
 
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -560,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -576,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -594,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -641,15 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -661,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -702,24 +1013,25 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -727,13 +1039,13 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -741,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -754,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -807,26 +1120,27 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
                         if (rxData != NULL)
                         {
-                            *rxData = wordReceived;
+                            *rxData = (uint8_t)wordReceived;
                             ++rxData;
-                            *rxData = wordReceived >> 8;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
                             ++rxData;
                         }
-                        remainingReceiveByteCount -= 2;
+                        remainingReceiveByteCount -= 2U;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -838,31 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
-    dspi_command_data_config_t commandStruct;
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -870,62 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
-    DSPI_StartTransfer(base);
-
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
-    DSPI_MasterTransferFillUpTxFifo(base, handle);
 
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_StartTransfer(base);
+
+    /* Fill up the Tx FIFO to trigger the transfer. */
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -937,13 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -952,42 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
-
-    /* The transfer is complete.*/
-    handle->state = kDSPI_Idle;
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -995,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1003,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1019,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1054,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1064,86 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1152,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1180,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1212,86 +1736,107 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (NULL != handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (NULL != handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
+    }
 
     DSPI_StartTransfer(base);
 
     /* Prepare data to transmit */
     DSPI_SlaveTransferFillUpTxFifo(base, handle);
 
-    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
-
-    /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
-
-    if (handle->rxData)
-    {
-        /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
-    }
-    if (handle->txData)
-    {
-        /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
-    }
-
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1303,24 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1338,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1385,26 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1413,69 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
-
-    handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1493,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1509,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1582,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1615,52 +2188,57 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 0)
+#if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 1)
+#if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 2)
+#if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 3)
+#if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 4)
+#if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 5)
+#if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -37,15 +15,14 @@
  * @{
  */
 
-
 /**********************************************************************************************************************
  * Definitions
  *********************************************************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.1.3. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 3))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
 #ifndef DSPI_DUMMY_DATA
@@ -56,37 +33,37 @@
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All statuses above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -103,11 +80,12 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
- * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is valid
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is
+ * valid
  * only when the CPHA bit in the CTAR register is 0.
  */
 typedef enum _dspi_master_sample_point
@@ -132,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -216,8 +194,9 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Indicates whether the PCS signal is continuous. */
-    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterActiveAfterTransfer =
+        1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
 #define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro; used internally. */
@@ -240,7 +219,7 @@ enum _dspi_transfer_state
 /*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of the chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
@@ -257,10 +236,10 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
-                                               delay. It also sets the boundary value if out of range.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
-                                               minimum delay. It also sets the boundary value if out of range.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
 
     uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
                                              delay. It also sets the boundary value if out of range.*/
@@ -314,13 +293,13 @@ typedef struct _dspi_slave_config
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -355,11 +334,23 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
@@ -370,8 +361,9 @@ struct _dspi_master_handle
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Indicates whether there are extra bytes.*/
+    volatile bool
+        isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
@@ -525,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -563,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -575,6 +567,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
  *
  * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
  * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
  *
  * @code
  *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
@@ -602,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -682,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -708,7 +707,14 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
@@ -746,8 +752,8 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -759,8 +765,8 @@ static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool en
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -950,10 +956,12 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
  *        buffer master mode and waits till complete to return.
  *
- * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total 32-bit word
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
  * as the data to send.
  * The command portion provides characteristics of the data, such as the optional continuous chip select operation
- * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
@@ -968,20 +976,20 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
  * @param data The data word (command and data combined) to be sent.
  */
@@ -1023,8 +1031,16 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 }
 
 /*!
+ * @brief Set up the dummy data.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1072,6 +1088,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1167,14 +1212,24 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi_edma.c
@@ -1,42 +1,25 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi_edma.h"
 
 /***********************************************************************************************************************
-* Definitons
-***********************************************************************************************************************/
+ * Definitions
+ ***********************************************************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi_edma"
+#endif
 
 /*!
-* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_master_edma_private_handle
 {
     SPI_Type *base;                    /*!< DSPI peripheral base address. */
@@ -44,8 +27,8 @@ typedef struct _dspi_master_edma_private_handle
 } dspi_master_edma_private_handle_t;
 
 /*!
-* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_slave_edma_private_handle
 {
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
@@ -53,46 +36,58 @@ typedef struct _dspi_slave_edma_private_handle
 } dspi_slave_edma_private_handle_t;
 
 /***********************************************************************************************************************
-* Prototypes
-***********************************************************************************************************************/
+ * Prototypes
+ ***********************************************************************************************************************/
 /*!
-* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
 /*!
-* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
-/*!
-* @brief Get instance number for DSPI module.
-*
-* This is not a public API and it's extern from fsl_dspi.c.
-*
-* @param base DSPI peripheral base address
-*/
-extern uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /***********************************************************************************************************************
-* Variables
-***********************************************************************************************************************/
+ * Variables
+ ***********************************************************************************************************************/
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 
 /***********************************************************************************************************************
-* Code
-***********************************************************************************************************************/
+ * Code
+ ***********************************************************************************************************************/
 
+/*!
+ * brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          dspi_master_edma_handle_t *handle,
                                          dspi_master_edma_transfer_callback_t callback,
@@ -101,55 +96,72 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          edma_handle_t *edmaTxDataToIntermediaryHandle,
                                          edma_handle_t *edmaIntermediaryToTxRegHandle)
 {
-    assert(handle);
-    assert(edmaRxRegToRxDataHandle);
-    assert(edmaTxDataToIntermediaryHandle);
-    assert(edmaIntermediaryToTxRegHandle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+#if (!(defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET))
+    assert(NULL != edmaTxDataToIntermediaryHandle);
+#endif
+    assert(NULL != edmaIntermediaryToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].base   = base;
     s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
     handle->userData = userData;
 
-    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaRxRegToRxDataHandle        = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
-    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+    handle->edmaIntermediaryToTxRegHandle  = edmaIntermediaryToTxRegHandle;
 }
 
+/*!
+ * brief DSPI master transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    uint32_t instance = DSPI_GetInstance(base);
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
-    uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    uint32_t instance                = DSPI_GetInstance(base);
+    uint16_t wordToSend              = 0;
+    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint8_t dataAlreadyFed           = 0;
+    uint8_t dataFedMax               = 2;
+    uint32_t tmpMCR                  = 0;
+    size_t tmpRemainingSendByteCount = 0;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
@@ -158,33 +170,33 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
 
     edma_transfer_config_t transferConfigA;
     edma_transfer_config_t transferConfigB;
-    edma_transfer_config_t transferConfigC;
 
-    handle->txBuffIfNull = ((uint32_t)DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-
-    handle->state = kDSPI_Busy;
+    handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
 
     dspi_command_data_config_t commandStruct;
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -192,86 +204,123 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    /* This limits the amount of data we can transfer due to the linked channel.
-    * The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (handle->bitsPerFrame > 8)
+    /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (transfer->dataSize > 1022)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
     else
     {
-        if (transfer->dataSize > 511)
+        if (transfer->dataSize > limited_size)
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
     /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize & 0x1))
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
                      &s_dspiMasterEdmaPrivateHandle[instance]);
+
+    /*
+    (1)For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
+    channel_A minor link to channel_B , channel_B minor link to channel_C.
+
+    Already pushed 1 or 2 data in SPI_PUSHR , then start the DMA tansfer.
+    channel_A:SPI_POPR to rxData,
+    channel_B:next txData to handle->command (low 16 bits),
+    channel_C:handle->command (32 bits) to SPI_PUSHR, and use the scatter/gather to transfer the last data
+    (handle->lastCommand to SPI_PUSHR).
+
+    (2)For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C -> channel_B .
+    channel_C major link to channel_B.
+    So need prepare the first data in "intermediary"  before the DMA
+    transfer and then channel_B is used to prepare the next data to "intermediary"
+
+    channel_A:SPI_POPR to rxData,
+    channel_C: handle->command (32 bits) to SPI_PUSHR,
+    channel_B: next txData to handle->command (low 16 bits), and use the scatter/gather to prepare the last data
+    (handle->lastCommand to handle->Command).
+    */
 
     /*If dspi has separate dma request , prepare the first data in "intermediary" .
     else (dspi has shared dma request) , send first 2 data if there is fifo or send first 1 data if there is no fifo*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
-        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
-        */
+         * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+         */
 
         /*Prepare the firt data*/
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
             /* If it's the last word */
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
             }
             else /* For all words except the last word , frame > 8bits */
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     ++handle->txData; /* increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData; /* increment to next data word*/
@@ -281,9 +330,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
             }
             else
             {
@@ -293,57 +343,57 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     }
 
     else /*dspi has shared dma request*/
-
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->remainingSendByteCount <= 2)
+                if (handle->remainingSendByteCount <= 2U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
                     handle->remainingSendByteCount = 0;
-                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                    base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
                 /* For all words except the last word */
                 else
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                         ++handle->txData;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
-                    handle->remainingSendByteCount -= 2;
+                    handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -351,9 +401,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData;
@@ -363,7 +414,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     wordToSend = dummyData;
                 }
 
-                if (handle->remainingSendByteCount == 1)
+                if (handle->remainingSendByteCount == 1U)
                 {
                     base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
@@ -373,14 +424,14 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -388,129 +439,66 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
     }
 
-    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer(rxData)*/
     EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcAddr   = (uint32_t)rxAddr;
     transferConfigA.srcOffset = 0;
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
         transferConfigA.destOffset = 1;
     }
     else
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
         transferConfigA.destOffset = 0;
     }
 
     transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-    if (handle->bitsPerFrame <= 8)
+    if (handle->bitsPerFrame <= 8U)
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.minorLoopBytes  = 1;
         transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
     }
     else
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-        transferConfigA.minorLoopBytes = 2;
-        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        transferConfigA.minorLoopBytes  = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
     }
 
     /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
-    handle->nbytes = transferConfigA.minorLoopBytes;
+    handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
 
     EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                           &transferConfigA, NULL);
+                           (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
     EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                 kEDMA_MajorInterruptEnable);
+                                 (uint32_t)kEDMA_MajorInterruptEnable);
 
-    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
-    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
-    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
-    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
-
-    if (handle->remainingSendByteCount > 0)
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*Calculate the last data : handle->lastCommand*/
+    if (((tmpRemainingSendByteCount > 0U) && (1U != (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U))) &&
+         (1U == (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        if (handle->txData)
-        {
-            transferConfigB.srcAddr = (uint32_t)(handle->txData);
-            transferConfigB.srcOffset = 1;
-        }
-        else
-        {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-            transferConfigB.srcOffset = 0;
-        }
-
-        transferConfigB.destAddr = (uint32_t)(&handle->command);
-        transferConfigB.destOffset = 0;
-
-        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-        if (handle->bitsPerFrame <= 8)
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
-
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                majorlink , the majorlink would not trigger the channel_C*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
-            }
-        }
-        else
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                * majorlink*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
-            }
-        }
-
-        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
-    }
-
-    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
-    handle the last data */
-    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
-
-    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
-        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
-         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
-    {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
             uint32_t bufferIndex = 0;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                if (handle->bitsPerFrame <= 8)
+                if (handle->bitsPerFrame <= 8U)
                 {
-                    bufferIndex = handle->remainingSendByteCount - 1;
+                    bufferIndex = handle->remainingSendByteCount - 1U;
                 }
                 else
                 {
-                    bufferIndex = handle->remainingSendByteCount - 2;
+                    bufferIndex = handle->remainingSendByteCount - 2U;
                 }
             }
             else
@@ -518,77 +506,345 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 bufferIndex = handle->remainingSendByteCount;
             }
 
-            if (handle->bitsPerFrame <= 8)
+            uint32_t tmpLastCommand = handle->lastCommand;
+            uint8_t *tmpTxData      = handle->txData;
+
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | tmpTxData[bufferIndex - 1U];
             }
             else
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
-                                      ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
-                                      handle->txData[bufferIndex - 2];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | ((uint32_t)tmpTxData[bufferIndex - 1U] << 8U) |
+                                 tmpTxData[bufferIndex - 2U];
             }
+
+            handle->lastCommand = tmpLastCommand;
         }
         else
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 wordToSend = dummyData;
             }
             else
             {
-                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
             }
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
     }
 
+/* The feature of GASKET is that the SPI supports 8-bit or 16-bit writes to the PUSH TX FIFO,
+ * allowing a single write to the command word followed by multiple writes to the transmit word.
+ * The TX FIFO will save the last command word written, and convert a 8-bit/16-bit write to the
+ * transmit word into a 32-bit write that pushes both the command word and transmit word into
+ * the TX FIFO (PUSH TX FIFO Register In Master Mode)
+ * So, if this feature is supported, we can use use one channel to carry the receive data from
+ * receive regsiter to user data buffer, use the other channel to carry the data from user data buffer
+ * to transmit register,and use the scatter/gather function to prepare the last data.
+ * That is to say, if GASKET feature is supported, we can use only two channels for tansferring data.
+ */
+#if defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET
+    /*  For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to PUSHR register.
+     */
+
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
     if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
-        ((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+        ((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigC.destAddr = (uint32_t)txAddr;
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-        transferConfigC.majorLoopCounts = 1;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t)txAddr;
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
     }
 
-    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)))
+    /*User_Send_Buffer(txData) to PUSHR register. */
+    if (((handle->remainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+        ((handle->remainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U)))
     {
-        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
-        transferConfigC.destAddr = (uint32_t)txAddr;
-
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-
-        if (handle->bitsPerFrame <= 8)
+        if (handle->txData)
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /* For DSPI with separate RX and TX DMA requests, one frame data has been carry
+                 * to handle->command, so need to reduce the pointer of txData.
+                 */
+                transferConfigB.srcAddr =
+                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8U) ? (1U) : (2U)));
+                transferConfigB.srcOffset = 1;
+            }
+            else
+            {
+                /* For DSPI with shared RX and TX DMA requests, one or two frame data have been carry
+                 * to PUSHR register, so no need to change the pointer of txData.
+                 */
+                transferConfigB.srcAddr   = (uint32_t)((uint8_t *)(handle->txData));
+                transferConfigB.srcOffset = 1;
+            }
         }
         else
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)txAddr;
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1U;
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            transferConfigB.majorLoopCounts  = (handle->remainingSendByteCount / 2U) - 1U;
         }
 
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, softwareTCD);
+    }
+    /* If only one word to transmit, only carry the lastcommand. */
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, NULL);
+    }
+
+    /*Start the EDMA channel_A , channel_C. */
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    /* Set the channel link.
+     * For DSPI instances with shared TX and RX DMA requests, setup channel minor link, first receive data from the
+     * receive register, and then carry transmit data to PUSHER register.
+     * For DSPI instance with separate TX and RX DMA requests, there is no need to set up channel link.
+     */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /*Set channel priority*/
+        uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+        uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
+        uint8_t t                   = 0;
+
+        if (channelPriorityLow > channelPriorityHigh)
+        {
+            t                   = channelPriorityLow;
+            channelPriorityLow  = channelPriorityHigh;
+            channelPriorityHigh = t;
+        }
+
+        edma_channel_Preemption_config_t preemption_config_t;
+        preemption_config_t.enableChannelPreemption = true;
+        preemption_config_t.enablePreemptAbility    = true;
+        preemption_config_t.channelPriority         = channelPriorityLow;
+
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+        /*if there is Rx DMA request , carry the 32bits data (handle->command) to user data first , then link to
+          channelC to carry the next data to PUSHER register.(txData to PUSHER) */
+        if (handle->remainingSendByteCount > 0U)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaIntermediaryToTxRegHandle->channel);
+        }
+    }
+
+    DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    /* Setup control info to PUSHER register. */
+    *((uint16_t *)&(base->PUSHR) + 1) = (handle->command >> 16U);
+#else
+
+    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
+    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
+    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
+
+    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
+
+    /*For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to handle->Command*/
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t) & (handle->command);
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*User_Send_Buffer(txData) to intermediary(handle->command)*/
+    if (((((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U))) &&
+         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        if (NULL != handle->txData)
+        {
+            transferConfigB.srcAddr   = (uint32_t)(handle->txData);
+            transferConfigB.srcOffset = 1;
+        }
+        else
+        {
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)(&handle->command);
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                majorlink , the majorlink would not trigger the channel_C*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1U;
+            }
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                 * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U + 1U;
+            }
+        }
+
+        if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, softwareTCD);
+            EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
+                                       handle->edmaIntermediaryToTxRegHandle->channel, false);
+        }
+        else
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+        }
+    }
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                               handle->edmaTxDataToIntermediaryHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
+    handle the last data */
+
+    edma_transfer_config_t transferConfigC;
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*For DSPI instances with shared RX/TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to SPI_PUSHR*/
+    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (tmpRemainingSendByteCount > 0U)))
+    {
+        transferConfigC.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr         = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        transferConfigC.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    if (((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+        ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U)) ||
+        (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        transferConfigC.srcAddr  = (uint32_t)(&(handle->command));
+        transferConfigC.destAddr = (uint32_t)txAddr;
+
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            if (handle->bitsPerFrame <= 8U)
+            {
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1U;
+            }
+            else
+            {
+                transferConfigC.majorLoopCounts = (handle->remainingSendByteCount / 2U) - 1U;
+            }
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, softwareTCD);
+        }
+        else
+        {
+            transferConfigC.majorLoopCounts = 1;
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+        }
+
         EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
                                    handle->edmaIntermediaryToTxRegHandle->channel, false);
     }
     else
     {
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                               handle->edmaIntermediaryToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
     /*Start the EDMA channel_A , channel_B , channel_C transfer*/
@@ -597,84 +853,83 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
-    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid  = handle->edmaTxDataToIntermediaryHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
     if (channelPriorityLow > channelPriorityMid)
     {
-        t = channelPriorityLow;
+        t                  = channelPriorityLow;
         channelPriorityLow = channelPriorityMid;
         channelPriorityMid = t;
     }
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     if (channelPriorityMid > channelPriorityHigh)
     {
-        t = channelPriorityMid;
-        channelPriorityMid = channelPriorityHigh;
+        t                   = channelPriorityMid;
+        channelPriorityMid  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
-    /*Set the channel link.
-    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
-    For DSPI instances with separate RX and TX DMA requests:
-    Rx DMA request -> channel_A
-    Tx DMA request -> channel_C -> channel_B . (so need prepare the first data in "intermediary"  before the DMA
-    transfer and then channel_B is used to prepare the next data to "intermediary" ) */
+    /*Set the channel link.*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
-        to prepare the next 32bits data (User_send_buffer to handle->command) */
-        if (handle->remainingSendByteCount > 1)
+        to prepare the next 32bits data (txData to handle->command) */
+        if (handle->remainingSendByteCount > 1U)
         {
             EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
-                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MinorLink,
+                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MajorLink,
                                 handle->edmaTxDataToIntermediaryHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
     else
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
@@ -684,63 +939,147 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                                 handle->edmaIntermediaryToTxRegHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
-
+#endif
     DSPI_StartTransfer(base);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI base pointer
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferEDMA(base, handle, &tempXfer);
+
+    return status;
+}
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds)
 {
-    assert(edmaHandle);
-    assert(g_dspiEdmaPrivateHandle);
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
 
     dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    if (dspiEdmaPrivateHandle->handle->callback)
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
     EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the master eDMA transfer count.
+ *
+ * This function gets the master eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -756,6 +1095,25 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         dspi_slave_edma_handle_t *handle,
                                         dspi_slave_edma_transfer_callback_t callback,
@@ -763,16 +1121,16 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle)
 {
-    assert(handle);
-    assert(edmaRxRegToRxDataHandle);
-    assert(edmaTxDataToTxRegHandle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+    assert(NULL != edmaTxDataToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].base   = base;
     s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
@@ -782,76 +1140,99 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
 
+/*!
+ * brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
+
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If send/receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
+    handle->state = (uint8_t)kDSPI_Busy;
+
     uint32_t instance = DSPI_GetInstance(base);
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->bitsPerFrame > 8)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
-            if (transfer->dataSize > 1022)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
-        else
+    }
+    else
+    {
+        if (transfer->dataSize > limited_size)
         {
-            if (transfer->dataSize > 511)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
     }
 
     /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize & 0x1))
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
 
-    handle->state = kDSPI_Busy;
-
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint32_t wordToSend    = 0;
+    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint8_t dataFedMax     = 2;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
@@ -862,9 +1243,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     DSPI_StartTransfer(base);
 
@@ -874,14 +1255,15 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* Increment to next data byte */
@@ -891,18 +1273,18 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -910,9 +1292,10 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     /* Increment to next data word*/
@@ -926,14 +1309,14 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 /* Decrement remainingSendByteCount*/
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -942,92 +1325,92 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     }
 
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
-    if (handle->remainingReceiveByteCount > 0)
+    if (handle->remainingReceiveByteCount > 0U)
     {
         EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcAddr   = (uint32_t)rxAddr;
         transferConfigA.srcOffset = 0;
 
-        if (handle->rxData)
+        if (NULL != handle->rxData)
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
             transferConfigA.destOffset = 1;
         }
         else
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
             transferConfigA.destOffset = 0;
         }
 
         transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.minorLoopBytes  = 1;
             transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
         }
         else
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigA.minorLoopBytes = 2;
-            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+            transferConfigA.minorLoopBytes  = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
         }
 
         /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
-        handle->nbytes = transferConfigA.minorLoopBytes;
+        handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
 
         EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                               &transferConfigA, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
         EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                     kEDMA_MajorInterruptEnable);
+                                     (uint32_t)kEDMA_MajorInterruptEnable);
     }
 
-    if (handle->remainingSendByteCount > 0)
+    if (handle->remainingSendByteCount > 0U)
     {
         /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
         EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
 
-        transferConfigC.destAddr = (uint32_t)txAddr;
+        transferConfigC.destAddr   = (uint32_t)txAddr;
         transferConfigC.destOffset = 0;
 
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
-            transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
+            transferConfigC.srcAddr   = (uint32_t)(&(handle->txData[0]));
             transferConfigC.srcOffset = 1;
         }
         else
         {
-            transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
             transferConfigC.srcOffset = 0;
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->txBuffIfNull = DSPI_DUMMY_DATA;
+                handle->txBuffIfNull = dummyData;
             }
             else
             {
-                handle->txBuffIfNull = (DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
+                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
             }
         }
 
         transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigC.minorLoopBytes = 1;
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
+            transferConfigC.minorLoopBytes   = 1;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount;
         }
         else
         {
             transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigC.minorLoopBytes = 2;
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
+            transferConfigC.minorLoopBytes   = 2;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount / 2U;
         }
 
         EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                               &transferConfigC, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
 
         EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
     }
@@ -1035,39 +1418,39 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.
@@ -1077,16 +1460,16 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     Tx DMA request -> channel_C */
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
         }
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
     else
     {
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
 
     return kStatus_Success;
@@ -1097,49 +1480,67 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    bool transferDone,
                                    uint32_t tcds)
 {
-    assert(edmaHandle);
-    assert(g_dspiEdmaPrivateHandle);
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
 
     dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    if (dspiEdmaPrivateHandle->handle->callback)
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred so far by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -41,14 +19,20 @@
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
@@ -185,6 +169,21 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief DSPI master aborts a transfer which is using eDMA.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
@@ -119,16 +119,21 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_spi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_spi.c
@@ -1,38 +1,22 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_spi.h"
 
 /*******************************************************************************
- * Definitons
+ * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.spi"
+#endif
+
 /*! @brief SPI transfer state, which is used for SPI transactiaonl APIs' internal state. */
 enum _spi_transfer_states_t
 {
@@ -46,12 +30,6 @@ typedef void (*spi_isr_t)(SPI_Type *base, spi_master_handle_t *spiHandle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get the instance for SPI module.
- *
- * @param base SPI base address
- */
-uint32_t SPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Sends a buffer of data bytes in non-blocking way.
@@ -72,12 +50,21 @@ static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size);
 static void SPI_ReadNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size);
 
 /*!
+ * @brief Get the waterrmark value for this SPI instance.
+ *
+ * @param base SPI base pointer
+ * @return Watermark value for the SPI instance.
+ */
+static uint8_t SPI_GetWatermark(SPI_Type *base);
+
+/*!
  * @brief Send a piece of data for SPI.
  *
  * This function computes the number of data to be written into D register or Tx FIFO,
  * and write the data into it. At the same time, this function updates the values in
  * master handle structure.
  *
+ * @param base SPI base pointer
  * @param handle Pointer to SPI master handle structure.
  */
 static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle);
@@ -89,9 +76,18 @@ static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle);
  * and write the data to destination address. At the same time, this function updates
  * the values in master handle structure.
  *
+ * @param base SPI base pointer
  * @param handle Pointer to SPI master handle structure.
  */
 static void SPI_ReceiveTransfer(SPI_Type *base, spi_master_handle_t *handle);
+
+/*!
+ * @brief Common IRQ handler for SPI.
+ *
+ * @param base SPI base pointer.
+ * @param instance SPI instance number.
+ */
+static void SPI_CommonIRQHandler(SPI_Type *base, uint32_t instance);
 /*******************************************************************************
  * Variables
  ******************************************************************************/
@@ -101,21 +97,31 @@ static spi_master_handle_t *s_spiHandle[FSL_FEATURE_SOC_SPI_COUNT];
 static SPI_Type *const s_spiBases[] = SPI_BASE_PTRS;
 /*! @brief IRQ name array */
 static const IRQn_Type s_spiIRQ[] = SPI_IRQS;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Clock array name */
 static const clock_ip_name_t s_spiClock[] = SPI_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointer to master IRQ handler for each instance. */
-static spi_isr_t s_spiIsr;
+static spi_isr_t s_spiMasterIsr;
+static spi_isr_t s_spiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_spiDummyData[ARRAY_SIZE(s_spiBases)] = {0};
 /*******************************************************************************
  * Code
  ******************************************************************************/
+/*!
+ * brief Get the instance for SPI module.
+ *
+ * param base SPI base address
+ */
 uint32_t SPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_SPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_spiBases); instance++)
     {
         if (s_spiBases[instance] == base)
         {
@@ -123,15 +129,28 @@ uint32_t SPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_SPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_spiBases));
 
     return instance;
 }
 
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base SPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void SPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance        = SPI_GetInstance(base);
+    g_spiDummyData[instance] = dummyData;
+}
+
 static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 {
-    uint32_t i = 0;
+    uint32_t i            = 0;
     uint8_t bytesPerFrame = 1U;
+    uint32_t instance     = SPI_GetInstance(base);
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
     /* Check if 16 bits or 8 bits */
@@ -155,13 +174,13 @@ static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
                 base->DL = *buffer++;
             }
 #else
-            base->D = *buffer++;
+            base->D   = *buffer++;
 #endif /* FSL_FEATURE_SPI_16BIT_TRANSFERS */
         }
         /* Send dummy data */
         else
         {
-            SPI_WriteData(base, SPI_DUMMYDATA);
+            SPI_WriteData(base, ((uint32_t)g_spiDummyData[instance] << 8 | g_spiDummyData[instance]));
         }
         i += bytesPerFrame;
     }
@@ -169,7 +188,7 @@ static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 
 static void SPI_ReadNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 {
-    uint32_t i = 0;
+    uint32_t i            = 0;
     uint8_t bytesPerFrame = 1U;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
@@ -205,18 +224,68 @@ static void SPI_ReadNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
     }
 }
 
+/* Get the watermark value of transfer. Please note that the entery width of FIFO is 16 bits. */
+static uint8_t SPI_GetWatermark(SPI_Type *base)
+{
+    uint8_t ret = 0;
+#if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
+    uint8_t rxSize = 0U;
+    /* Get the number to be sent if there is FIFO */
+    if (FSL_FEATURE_SPI_FIFO_SIZEn(base) != 0)
+    {
+        rxSize = (base->C3 & SPI_C3_RNFULLF_MARK_MASK) >> SPI_C3_RNFULLF_MARK_SHIFT;
+        if (rxSize == 0U)
+        {
+            ret = FSL_FEATURE_SPI_FIFO_SIZEn(base) * 3U / 4U;
+        }
+        else
+        {
+            ret = FSL_FEATURE_SPI_FIFO_SIZEn(base) / 2U;
+        }
+    }
+    /* If no FIFO, just set the watermark to 1 */
+    else
+    {
+        ret = 1U;
+    }
+#else
+    ret = 1U;
+#endif /* FSL_FEATURE_SPI_HAS_FIFO */
+    return ret;
+}
+
+static void SPI_SendInitialTransfer(SPI_Type *base, spi_master_handle_t *handle)
+{
+    uint8_t bytestoTransfer = handle->bytePerFrame;
+
+#if defined(FSL_FEATURE_SPI_HAS_FIFO) && (FSL_FEATURE_SPI_HAS_FIFO)
+    if (handle->watermark > 1)
+    {
+        /* In the first time to send data to FIFO, if transfer size is not larger than
+         * the FIFO size, send all data to FIFO, or send data to make the FIFO full.
+         * Besides, The FIFO's entry width is 16 bits, need to translate it to bytes.
+         */
+        bytestoTransfer = MIN(handle->txRemainingBytes, (FSL_FEATURE_SPI_FIFO_SIZEn(base) * 2));
+    }
+#endif
+
+    SPI_WriteNonBlocking(base, handle->txData, bytestoTransfer);
+
+    /* Update handle information */
+    if (handle->txData)
+    {
+        handle->txData += bytestoTransfer;
+    }
+    handle->txRemainingBytes -= bytestoTransfer;
+}
+
 static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle)
 {
-    uint8_t bytes = MIN((handle->watermark * 2U), handle->txRemainingBytes);
+    uint8_t bytes = handle->bytePerFrame;
 
     /* Read S register and ensure SPTEF is 1, otherwise the write would be ignored. */
     if (handle->watermark == 1U)
     {
-        if (bytes != 0U)
-        {
-            bytes = handle->bytePerFrame;
-        }
-
         /* Send data */
         if (base->C1 & SPI_C1_MSTR_MASK)
         {
@@ -231,11 +300,11 @@ static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle)
                 }
                 handle->txRemainingBytes -= bytes;
             }
-    }
-    else
-    {
+        }
+        else
+        {
             /* As a slave, send data until SPTEF cleared */
-            while ((base->S & SPI_S_SPTEF_MASK) && (handle->txRemainingBytes > 0))
+            while ((base->S & SPI_S_SPTEF_MASK) && (handle->txRemainingBytes >= bytes))
             {
                 SPI_WriteNonBlocking(base, handle->txData, bytes);
 
@@ -253,56 +322,96 @@ static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle)
     /* If use FIFO */
     else
     {
-        if (base->S & SPI_S_TNEAREF_MASK)
-        {
-            SPI_WriteNonBlocking(base, handle->txData, bytes);
+        /* The FIFO's entry width is 16 bits, need to translate it to bytes. */
+        uint8_t bytestoTransfer = handle->watermark * 2;
 
-            /* Update handle information */
-            if (handle->txData)
-            {
-                handle->txData += bytes;
-            }
-            handle->txRemainingBytes -= bytes;
+        if (handle->txRemainingBytes < 8U)
+        {
+            bytestoTransfer = handle->txRemainingBytes;
         }
+
+        SPI_WriteNonBlocking(base, handle->txData, bytestoTransfer);
+
+        /* Update handle information */
+        if (handle->txData)
+        {
+            handle->txData += bytestoTransfer;
+        }
+        handle->txRemainingBytes -= bytestoTransfer;
     }
 #endif
 }
 
 static void SPI_ReceiveTransfer(SPI_Type *base, spi_master_handle_t *handle)
 {
-    uint8_t bytes = MIN((handle->watermark * 2U), handle->rxRemainingBytes);
-    uint8_t val = 1U;
+    uint8_t bytes = handle->bytePerFrame;
 
     /* Read S register and ensure SPRF is 1, otherwise the write would be ignored. */
     if (handle->watermark == 1U)
     {
-        val = base->S & SPI_S_SPRF_MASK;
-        if (bytes != 0U)
+        if (base->S & SPI_S_SPRF_MASK)
         {
-            bytes = handle->bytePerFrame;
+            SPI_ReadNonBlocking(base, handle->rxData, bytes);
+
+            /* Update information in handle */
+            if (handle->rxData)
+            {
+                handle->rxData += bytes;
+            }
+            handle->rxRemainingBytes -= bytes;
         }
     }
-
-    if (val)
+#if defined(FSL_FEATURE_SPI_HAS_FIFO) && (FSL_FEATURE_SPI_HAS_FIFO)
+    /* If use FIFO */
+    else
     {
-        SPI_ReadNonBlocking(base, handle->rxData, bytes);
-
-        /* Update information in handle */
-        if (handle->rxData)
+        /* While rx fifo not empty and remaining data can also trigger the last interrupt */
+        while ((base->S & SPI_S_RFIFOEF_MASK) == 0U)
         {
-            handle->rxData += bytes;
+            SPI_ReadNonBlocking(base, handle->rxData, bytes);
+
+            /* Update information in handle */
+            if (handle->rxData)
+            {
+                handle->rxData += bytes;
+            }
+            handle->rxRemainingBytes -= bytes;
+
+            /* If the reamining data equals to watermark, leave to last interrupt */
+            if (handle->rxRemainingBytes == (handle->watermark * 2U))
+            {
+                break;
+            }
         }
-        handle->rxRemainingBytes -= bytes;
     }
+#endif
 }
 
+/*!
+ * brief  Sets the SPI master configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in SPI_MasterInit().
+ * User may use the initialized structure unchanged in SPI_MasterInit(), or modify
+ * some fields of the structure before calling SPI_MasterInit(). After calling this API,
+ * the master is ready to transfer.
+ * Example:
+   code
+   spi_master_config_t config;
+   SPI_MasterGetDefaultConfig(&config);
+   endcode
+ *
+ * param config pointer to master config structure
+ */
 void SPI_MasterGetDefaultConfig(spi_master_config_t *config)
 {
-    config->enableMaster = true;
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+    config->enableMaster         = true;
     config->enableStopInWaitMode = false;
-    config->polarity = kSPI_ClockPolarityActiveHigh;
-    config->phase = kSPI_ClockPhaseFirstEdge;
-    config->direction = kSPI_MsbFirst;
+    config->polarity             = kSPI_ClockPolarityActiveHigh;
+    config->phase                = kSPI_ClockPhaseFirstEdge;
+    config->direction            = kSPI_MsbFirst;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
     config->dataMode = kSPI_8BitMode;
@@ -313,17 +422,37 @@ void SPI_MasterGetDefaultConfig(spi_master_config_t *config)
     config->rxWatermark = kSPI_RxFifoOneHalfFull;
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
-    config->pinMode = kSPI_PinModeNormal;
-    config->outputMode = kSPI_SlaveSelectAutomaticOutput;
+    config->pinMode      = kSPI_PinModeNormal;
+    config->outputMode   = kSPI_SlaveSelectAutomaticOutput;
     config->baudRate_Bps = 500000U;
 }
 
+/*!
+ * brief Initializes the SPI with master configuration.
+ *
+ * The configuration structure can be filled by user from scratch, or be set with default
+ * values by SPI_MasterGetDefaultConfig(). After calling this API, the slave is ready to transfer.
+ * Example
+   code
+   spi_master_config_t config = {
+   .baudRate_Bps = 400000,
+   ...
+   };
+   SPI_MasterInit(SPI0, &config);
+   endcode
+ *
+ * param base SPI base pointer
+ * param config pointer to master configuration structure
+ * param srcClock_Hz Source clock frequency.
+ */
 void SPI_MasterInit(SPI_Type *base, const spi_master_config_t *config, uint32_t srcClock_Hz)
 {
     assert(config && srcClock_Hz);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Open clock gate for SPI and open interrupt */
     CLOCK_EnableClock(s_spiClock[SPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     /* Disable SPI before configuration */
     base->C1 &= ~SPI_C1_SPE_MASK;
@@ -354,6 +483,9 @@ void SPI_MasterInit(SPI_Type *base, const spi_master_config_t *config, uint32_t 
     /* Set baud rate */
     SPI_MasterSetBaudRate(base, config->baudRate_Bps, srcClock_Hz);
 
+    /* Set the dummy data, this data will usefull when tx buffer is NULL. */
+    SPI_SetDummyData(base, SPI_DUMMYDATA);
+
     /* Enable SPI */
     if (config->enableMaster)
     {
@@ -361,12 +493,28 @@ void SPI_MasterInit(SPI_Type *base, const spi_master_config_t *config, uint32_t 
     }
 }
 
+/*!
+ * brief  Sets the SPI slave configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in SPI_SlaveInit().
+ * Modify some fields of the structure before calling SPI_SlaveInit().
+ * Example:
+   code
+   spi_slave_config_t config;
+   SPI_SlaveGetDefaultConfig(&config);
+   endcode
+ *
+ * param config pointer to slave configuration structure
+ */
 void SPI_SlaveGetDefaultConfig(spi_slave_config_t *config)
 {
-    config->enableSlave = true;
-    config->polarity = kSPI_ClockPolarityActiveHigh;
-    config->phase = kSPI_ClockPhaseFirstEdge;
-    config->direction = kSPI_MsbFirst;
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+    config->enableSlave          = true;
+    config->polarity             = kSPI_ClockPolarityActiveHigh;
+    config->phase                = kSPI_ClockPhaseFirstEdge;
+    config->direction            = kSPI_MsbFirst;
     config->enableStopInWaitMode = false;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
@@ -377,14 +525,37 @@ void SPI_SlaveGetDefaultConfig(spi_slave_config_t *config)
     config->txWatermark = kSPI_TxFifoOneHalfEmpty;
     config->rxWatermark = kSPI_RxFifoOneHalfFull;
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
+    config->pinMode = kSPI_PinModeNormal;
 }
 
+/*!
+ * brief Initializes the SPI with slave configuration.
+ *
+ * The configuration structure can be filled by user from scratch or be set with
+ * default values by SPI_SlaveGetDefaultConfig().
+ * After calling this API, the slave is ready to transfer.
+ * Example
+   code
+    spi_slave_config_t config = {
+    .polarity = kSPIClockPolarity_ActiveHigh;
+    .phase = kSPIClockPhase_FirstEdge;
+    .direction = kSPIMsbFirst;
+    ...
+    };
+    SPI_MasterInit(SPI0, &config);
+   endcode
+ *
+ * param base SPI base pointer
+ * param config pointer to master configuration structure
+ */
 void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
 {
     assert(config);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Open clock gate for SPI and open interrupt */
     CLOCK_EnableClock(s_spiClock[SPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     /* Disable SPI before configuration */
     base->C1 &= ~SPI_C1_SPE_MASK;
@@ -395,9 +566,11 @@ void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
 
 /* Configure data mode if needed */
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
-    base->C2 = SPI_C2_SPIMODE(config->dataMode) | SPI_C2_SPISWAI(config->enableStopInWaitMode);
+    base->C2 = SPI_C2_SPIMODE(config->dataMode) | SPI_C2_SPISWAI(config->enableStopInWaitMode) |
+               SPI_C2_BIDIROE(config->pinMode >> 1U) | SPI_C2_SPC0(config->pinMode & 1U);
 #else
-    base->C2 = SPI_C2_SPISWAI(config->enableStopInWaitMode);
+    base->C2 = SPI_C2_SPISWAI(config->enableStopInWaitMode) | SPI_C2_BIDIROE(config->pinMode >> 1U) |
+               SPI_C2_SPC0(config->pinMode & 1U);
 #endif /* FSL_FEATURE_SPI_16BIT_TRANSFERS */
 
 /* Set watermark */
@@ -409,6 +582,9 @@ void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
     }
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
+    /* Set the dummy data, this data will usefull when tx buffer is NULL. */
+    SPI_SetDummyData(base, SPI_DUMMYDATA);
+
     /* Enable SPI */
     if (config->enableSlave)
     {
@@ -416,15 +592,31 @@ void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
     }
 }
 
+/*!
+ * brief De-initializes the SPI.
+ *
+ * Calling this API resets the SPI module, gates the SPI clock.
+ * The SPI module can't work unless calling the SPI_MasterInit/SPI_SlaveInit to initialize module.
+ *
+ * param base SPI base pointer
+ */
 void SPI_Deinit(SPI_Type *base)
 {
     /* Disable SPI module before shutting down */
     base->C1 &= ~SPI_C1_SPE_MASK;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Gate the clock */
     CLOCK_DisableClock(s_spiClock[SPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
+/*!
+ * brief Gets the status flag.
+ *
+ * param base SPI base pointer
+ * return SPI Status, use status flag to AND #_spi_flags could get the related status.
+ */
 uint32_t SPI_GetStatusFlags(SPI_Type *base)
 {
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
@@ -441,6 +633,17 @@ uint32_t SPI_GetStatusFlags(SPI_Type *base)
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 }
 
+/*!
+ * brief Enables the interrupt for the SPI.
+ *
+ * param base SPI base pointer
+ * param mask SPI interrupt source. The parameter can be any combination of the following values:
+ *        arg kSPI_RxFullAndModfInterruptEnable
+ *        arg kSPI_TxEmptyInterruptEnable
+ *        arg kSPI_MatchInterruptEnable
+ *        arg kSPI_RxFifoNearFullInterruptEnable
+ *        arg kSPI_TxFifoNearEmptyInterruptEnable
+ */
 void SPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
     /* Rx full interrupt */
@@ -480,6 +683,17 @@ void SPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 }
 
+/*!
+ * brief Disables the interrupt for the SPI.
+ *
+ * param base SPI base pointer
+ * param mask SPI interrupt source. The parameter can be any combination of the following values:
+ *        arg kSPI_RxFullAndModfInterruptEnable
+ *        arg kSPI_TxEmptyInterruptEnable
+ *        arg kSPI_MatchInterruptEnable
+ *        arg kSPI_RxFifoNearFullInterruptEnable
+ *        arg kSPI_TxFifoNearEmptyInterruptEnable
+ */
 void SPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 {
     /* Rx full interrupt */
@@ -518,6 +732,13 @@ void SPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 }
 
+/*!
+ * brief Sets the baud rate for SPI transfer. This is only used in master.
+ *
+ * param base SPI base pointer
+ * param baudRate_Bps baud rate needed in Hz.
+ * param srcClock_Hz SPI source clock frequency in Hz.
+ */
 void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
 {
     uint32_t prescaler;
@@ -535,7 +756,7 @@ void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
 
     /* Set the maximum divisor bit settings for each of the following divisors */
     bestPrescaler = 7U;
-    bestDivisor = 8U;
+    bestDivisor   = 8U;
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
     for (prescaler = 0; (prescaler <= 7) && min_diff; prescaler++)
@@ -556,9 +777,9 @@ void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
                 if (min_diff > diff)
                 {
                     /* A better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestDivisor = rateDivisor;
+                    bestDivisor   = rateDivisor;
                 }
             }
 
@@ -571,9 +792,18 @@ void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
     base->BR = SPI_BR_SPR(bestDivisor) | SPI_BR_SPPR(bestPrescaler);
 }
 
+/*!
+ * brief Sends a buffer of data bytes using a blocking method.
+ *
+ * note This function blocks via polling until all bytes have been sent.
+ *
+ * param base SPI base pointer
+ * param buffer The data bytes to send
+ * param size The number of data bytes to send
+ */
 void SPI_WriteBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 {
-    uint32_t i = 0;
+    uint32_t i            = 0;
     uint8_t bytesPerFrame = 1U;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
@@ -596,6 +826,12 @@ void SPI_WriteBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 }
 
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
+/*!
+ * brief Enables or disables the FIFO if there is a FIFO.
+ *
+ * param base SPI base pointer
+ * param enable True means enable FIFO, false means disable FIFO.
+ */
 void SPI_EnableFIFO(SPI_Type *base, bool enable)
 {
     if (FSL_FEATURE_SPI_FIFO_SIZEn(base) != 0U)
@@ -612,6 +848,12 @@ void SPI_EnableFIFO(SPI_Type *base, bool enable)
 }
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
+/*!
+ * brief Writes a data into the SPI data register.
+ *
+ * param base SPI base pointer
+ * param data needs to be write.
+ */
 void SPI_WriteData(SPI_Type *base, uint16_t data)
 {
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && (FSL_FEATURE_SPI_16BIT_TRANSFERS)
@@ -622,6 +864,12 @@ void SPI_WriteData(SPI_Type *base, uint16_t data)
 #endif
 }
 
+/*!
+ * brief Gets a data from the SPI data register.
+ *
+ * param base SPI base pointer
+ * return Data in the register.
+ */
 uint16_t SPI_ReadData(SPI_Type *base)
 {
     uint16_t val = 0;
@@ -634,6 +882,14 @@ uint16_t SPI_ReadData(SPI_Type *base)
     return val;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * param base SPI base pointer
+ * param xfer pointer to spi_xfer_config_t structure
+ * retval kStatus_Success Successfully start a transfer.
+ * retval kStatus_InvalidArgument Input argument is invalid.
+ */
 status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
 {
     assert(xfer);
@@ -650,10 +906,6 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
     /* Check if 16 bits or 8 bits */
     bytesPerFrame = ((base->C2 & SPI_C2_SPIMODE_MASK) >> SPI_C2_SPIMODE_SHIFT) + 1U;
 #endif
-
-    /* Disable SPI and then enable it, this is used to clear S register */
-    base->C1 &= ~SPI_C1_SPE_MASK;
-    base->C1 |= SPI_C1_SPE_MASK;
 
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
 
@@ -696,6 +948,17 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the SPI master handle.
+ *
+ * This function initializes the SPI master handle which can be used for other SPI master transactional APIs. Usually,
+ * for a specified SPI instance, call this API once to get the initialized handle.
+ *
+ * param base SPI peripheral base address.
+ * param handle SPI handle pointer.
+ * param callback Callback function.
+ * param userData User data.
+ */
 void SPI_MasterTransferCreateHandle(SPI_Type *base,
                                     spi_master_handle_t *handle,
                                     spi_master_callback_t callback,
@@ -705,35 +968,15 @@ void SPI_MasterTransferCreateHandle(SPI_Type *base,
 
     uint8_t instance = SPI_GetInstance(base);
 
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
+
     /* Initialize the handle */
     s_spiHandle[instance] = handle;
-    handle->callback = callback;
-    handle->userData = userData;
-    s_spiIsr = SPI_MasterTransferHandleIRQ;
-
-#if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
-    uint8_t txSize = 0U;
-    /* Get the number to be sent if there is FIFO */
-    if (FSL_FEATURE_SPI_FIFO_SIZEn(base) != 0)
-    {
-        txSize = (base->C3 & SPI_C3_TNEAREF_MARK_MASK) >> SPI_C3_TNEAREF_MARK_SHIFT;
-        if (txSize == 0U)
-        {
-            handle->watermark = FSL_FEATURE_SPI_FIFO_SIZEn(base) * 3U / 4U;
-        }
-        else
-        {
-            handle->watermark = FSL_FEATURE_SPI_FIFO_SIZEn(base) / 2U;
-        }
-    }
-    /* If no FIFO, just set the watermark to 1 */
-    else
-    {
-        handle->watermark = 1U;
-    }
-#else
-    handle->watermark = 1U;
-#endif /* FSL_FEATURE_SPI_HAS_FIFO */
+    handle->callback      = callback;
+    handle->userData      = userData;
+    s_spiMasterIsr        = SPI_MasterTransferHandleIRQ;
+    handle->watermark     = SPI_GetWatermark(base);
 
 /* Get the bytes per frame */
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && (FSL_FEATURE_SPI_16BIT_TRANSFERS)
@@ -746,6 +989,20 @@ void SPI_MasterTransferCreateHandle(SPI_Type *base,
     EnableIRQ(s_spiIRQ[instance]);
 }
 
+/*!
+ * brief Performs a non-blocking SPI interrupt transfer.
+ *
+ * note The API immediately returns after transfer initialization is finished.
+ * Call SPI_GetStatusIRQ() to get the transfer status.
+ * note If SPI transfer data frame size is 16 bits, the transfer size cannot be an odd number.
+ *
+ * param base SPI peripheral base address.
+ * param handle pointer to spi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to spi_xfer_config_t structure
+ * retval kStatus_Success Successfully start a transfer.
+ * retval kStatus_InvalidArgument Input argument is invalid.
+ * retval kStatus_SPI_Busy SPI is not idle, is running another transfer.
+ */
 status_t SPI_MasterTransferNonBlocking(SPI_Type *base, spi_master_handle_t *handle, spi_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -763,47 +1020,76 @@ status_t SPI_MasterTransferNonBlocking(SPI_Type *base, spi_master_handle_t *hand
     }
 
     /* Set the handle information */
-    handle->txData = xfer->txData;
-    handle->rxData = xfer->rxData;
-    handle->transferSize = xfer->dataSize;
+    handle->txData           = xfer->txData;
+    handle->rxData           = xfer->rxData;
+    handle->transferSize     = xfer->dataSize;
     handle->txRemainingBytes = xfer->dataSize;
     handle->rxRemainingBytes = xfer->dataSize;
 
     /* Set the SPI state to busy */
     handle->state = kSPI_Busy;
 
-    /* Disable SPI and then enable it, this is used to clear S register*/
-    base->C1 &= ~SPI_C1_SPE_MASK;
-    base->C1 |= SPI_C1_SPE_MASK;
-
 /* Enable Interrupt, only enable Rx interrupt, use rx interrupt to driver SPI transfer */
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
+
+    handle->watermark = SPI_GetWatermark(base);
+
+    /* If the size of the transfer size less than watermark, set watermark to 1 */
+    if (xfer->dataSize < handle->watermark * 2U)
+    {
+        handle->watermark = 1U;
+    }
+
+    /* According to watermark size, enable interrupts */
     if (handle->watermark > 1U)
     {
+        SPI_EnableFIFO(base, true);
+        /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
+        while ((base->S & SPI_S_TNEAREF_MASK) != SPI_S_TNEAREF_MASK)
+        {
+        }
+        SPI_SendInitialTransfer(base, handle);
         /* Enable Rx near full interrupt */
         SPI_EnableInterrupts(base, kSPI_RxFifoNearFullInterruptEnable);
     }
     else
     {
+        SPI_EnableFIFO(base, false);
+        while ((base->S & SPI_S_SPTEF_MASK) != SPI_S_SPTEF_MASK)
+        {
+        }
+        /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
+        SPI_SendInitialTransfer(base, handle);
         SPI_EnableInterrupts(base, kSPI_RxFullAndModfInterruptEnable);
     }
 #else
+    while ((base->S & SPI_S_SPTEF_MASK) != SPI_S_SPTEF_MASK)
+    {
+    }
+    /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
+    SPI_SendInitialTransfer(base, handle);
     SPI_EnableInterrupts(base, kSPI_RxFullAndModfInterruptEnable);
 #endif
-
-    /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
-    SPI_SendTransfer(base, handle);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the bytes of the SPI interrupt transferred.
+ *
+ * param base SPI peripheral base address.
+ * param handle Pointer to SPI transfer handle, this should be a static variable.
+ * param count Transferred bytes of SPI master.
+ * retval kStatus_SPI_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is not a non-blocking transaction currently in progress.
+ */
 status_t SPI_MasterTransferGetCount(SPI_Type *base, spi_master_handle_t *handle, size_t *count)
 {
     assert(handle);
 
     status_t status = kStatus_Success;
 
-    if (handle->state != kStatus_SPI_Busy)
+    if (handle->state != kSPI_Busy)
     {
         status = kStatus_NoTransferInProgress;
     }
@@ -823,6 +1109,12 @@ status_t SPI_MasterTransferGetCount(SPI_Type *base, spi_master_handle_t *handle,
     return status;
 }
 
+/*!
+ * brief Aborts an SPI transfer using interrupt.
+ *
+ * param base SPI peripheral base address.
+ * param handle Pointer to SPI transfer handle, this should be a static variable.
+ */
 void SPI_MasterTransferAbort(SPI_Type *base, spi_master_handle_t *handle)
 {
     assert(handle);
@@ -849,6 +1141,12 @@ void SPI_MasterTransferAbort(SPI_Type *base, spi_master_handle_t *handle)
     handle->txRemainingBytes = 0;
 }
 
+/*!
+ * brief Interrupts the handler for the SPI.
+ *
+ * param base SPI peripheral base address.
+ * param handle pointer to spi_master_handle_t structure which stores the transfer state.
+ */
 void SPI_MasterTransferHandleIRQ(SPI_Type *base, spi_master_handle_t *handle)
 {
     assert(handle);
@@ -878,6 +1176,17 @@ void SPI_MasterTransferHandleIRQ(SPI_Type *base, spi_master_handle_t *handle)
     }
 }
 
+/*!
+ * brief Initializes the SPI slave handle.
+ *
+ * This function initializes the SPI slave handle which can be used for other SPI slave transactional APIs. Usually,
+ * for a specified SPI instance, call this API once to get the initialized handle.
+ *
+ * param base SPI peripheral base address.
+ * param handle SPI handle pointer.
+ * param callback Callback function.
+ * param userData User data.
+ */
 void SPI_SlaveTransferCreateHandle(SPI_Type *base,
                                    spi_slave_handle_t *handle,
                                    spi_slave_callback_t callback,
@@ -888,9 +1197,15 @@ void SPI_SlaveTransferCreateHandle(SPI_Type *base,
     /* Slave create handle share same logic with master create handle, the only difference
     is the Isr pointer. */
     SPI_MasterTransferCreateHandle(base, handle, callback, userData);
-    s_spiIsr = SPI_SlaveTransferHandleIRQ;
+    s_spiSlaveIsr = SPI_SlaveTransferHandleIRQ;
 }
 
+/*!
+ * brief Interrupts a handler for the SPI slave.
+ *
+ * param base SPI peripheral base address.
+ * param handle pointer to spi_slave_handle_t structure which stores the transfer state
+ */
 void SPI_SlaveTransferHandleIRQ(SPI_Type *base, spi_slave_handle_t *handle)
 {
     assert(handle);
@@ -920,11 +1235,28 @@ void SPI_SlaveTransferHandleIRQ(SPI_Type *base, spi_slave_handle_t *handle)
     }
 }
 
+static void SPI_CommonIRQHandler(SPI_Type *base, uint32_t instance)
+{
+    if (base->C1 & SPI_C1_MSTR_MASK)
+    {
+        s_spiMasterIsr(base, s_spiHandle[instance]);
+    }
+    else
+    {
+        s_spiSlaveIsr(base, s_spiHandle[instance]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
 #if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
     assert(s_spiHandle[0]);
-    s_spiIsr(SPI0, s_spiHandle[0]);
+    SPI_CommonIRQHandler(SPI0, 0);
 }
 #endif
 
@@ -932,7 +1264,7 @@ void SPI0_DriverIRQHandler(void)
 void SPI1_DriverIRQHandler(void)
 {
     assert(s_spiHandle[1]);
-    s_spiIsr(SPI1, s_spiHandle[1]);
+    SPI_CommonIRQHandler(SPI1, 1);
 }
 #endif
 
@@ -940,6 +1272,6 @@ void SPI1_DriverIRQHandler(void)
 void SPI2_DriverIRQHandler(void)
 {
     assert(s_spiHandle[2]);
-    s_spiIsr(SPI0, s_spiHandle[2]);
+    SPI_CommonIRQHandler(SPI2, 2);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_spi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_spi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used tom  endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SPI_H_
 #define _FSL_SPI_H_
@@ -37,15 +15,14 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief SPI driver version 2.0.1. */
-#define FSL_SPI_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*! @brief SPI driver version 2.0.4. */
+#define FSL_SPI_DRIVER_VERSION (MAKE_VERSION(2, 0, 4))
 /*@}*/
 
 #ifndef SPI_DUMMYDATA
@@ -53,12 +30,15 @@
 #define SPI_DUMMYDATA (0xFFU)
 #endif
 
+/*! @brief Global variable for dummy data value setting. */
+extern volatile uint8_t g_spiDummyData[];
+
 /*! @brief Return status for the SPI driver.*/
 enum _spi_status
 {
-    kStatus_SPI_Busy = MAKE_STATUS(kStatusGroup_SPI, 0), /*!< SPI bus is busy */
-    kStatus_SPI_Idle = MAKE_STATUS(kStatusGroup_SPI, 1), /*!< SPI is idle */
-    kStatus_SPI_Error = MAKE_STATUS(kStatusGroup_SPI, 2) /*!< SPI  error */
+    kStatus_SPI_Busy  = MAKE_STATUS(kStatusGroup_SPI, 0), /*!< SPI bus is busy */
+    kStatus_SPI_Idle  = MAKE_STATUS(kStatusGroup_SPI, 1), /*!< SPI is idle */
+    kStatus_SPI_Error = MAKE_STATUS(kStatusGroup_SPI, 2)  /*!< SPI  error */
 };
 
 /*! @brief SPI clock polarity configuration.*/
@@ -87,16 +67,16 @@ typedef enum _spi_shift_direction
 /*! @brief SPI slave select output mode options.*/
 typedef enum _spi_ss_output_mode
 {
-    kSPI_SlaveSelectAsGpio = 0x0U,         /*!< Slave select pin configured as GPIO. */
-    kSPI_SlaveSelectFaultInput = 0x2U,     /*!< Slave select pin configured for fault detection. */
-    kSPI_SlaveSelectAutomaticOutput = 0x3U /*!< Slave select pin configured for automatic SPI output. */
+    kSPI_SlaveSelectAsGpio          = 0x0U, /*!< Slave select pin configured as GPIO. */
+    kSPI_SlaveSelectFaultInput      = 0x2U, /*!< Slave select pin configured for fault detection. */
+    kSPI_SlaveSelectAutomaticOutput = 0x3U  /*!< Slave select pin configured for automatic SPI output. */
 } spi_ss_output_mode_t;
 
 /*! @brief SPI pin mode options.*/
 typedef enum _spi_pin_mode
 {
     kSPI_PinModeNormal = 0x0U, /*!< Pins operate in normal, single-direction mode.*/
-    kSPI_PinModeInput = 0x1U,  /*!< Bidirectional mode. Master: MOSI pin is input;
+    kSPI_PinModeInput  = 0x1U, /*!< Bidirectional mode. Master: MOSI pin is input;
                                 *   Slave: MISO pin is input. */
     kSPI_PinModeOutput = 0x3U  /*!< Bidirectional mode. Master: MOSI pin is output;
                                 *   Slave: MISO pin is output. */
@@ -113,10 +93,10 @@ typedef enum _spi_data_bitcount_mode
 enum _spi_interrupt_enable
 {
     kSPI_RxFullAndModfInterruptEnable = 0x1U, /*!< Receive buffer full (SPRF) and mode fault (MODF) interrupt */
-    kSPI_TxEmptyInterruptEnable = 0x2U,       /*!< Transmit buffer empty interrupt */
-    kSPI_MatchInterruptEnable = 0x4U,         /*!< Match interrupt */
+    kSPI_TxEmptyInterruptEnable       = 0x2U, /*!< Transmit buffer empty interrupt */
+    kSPI_MatchInterruptEnable         = 0x4U, /*!< Match interrupt */
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
-    kSPI_RxFifoNearFullInterruptEnable = 0x8U,   /*!< Receive FIFO nearly full interrupt */
+    kSPI_RxFifoNearFullInterruptEnable  = 0x8U,  /*!< Receive FIFO nearly full interrupt */
     kSPI_TxFifoNearEmptyInterruptEnable = 0x10U, /*!< Transmit FIFO nearly empty interrupt */
 #endif                                           /* FSL_FEATURE_SPI_HAS_FIFO */
 };
@@ -124,44 +104,44 @@ enum _spi_interrupt_enable
 /*! @brief SPI status flags.*/
 enum _spi_flags
 {
-    kSPI_RxBufferFullFlag = SPI_S_SPRF_MASK,   /*!< Read buffer full flag */
-    kSPI_MatchFlag = SPI_S_SPMF_MASK,          /*!< Match flag */
+    kSPI_RxBufferFullFlag  = SPI_S_SPRF_MASK,  /*!< Read buffer full flag */
+    kSPI_MatchFlag         = SPI_S_SPMF_MASK,  /*!< Match flag */
     kSPI_TxBufferEmptyFlag = SPI_S_SPTEF_MASK, /*!< Transmit buffer empty flag */
-    kSPI_ModeFaultFlag = SPI_S_MODF_MASK,      /*!< Mode fault flag */
+    kSPI_ModeFaultFlag     = SPI_S_MODF_MASK,  /*!< Mode fault flag */
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
-    kSPI_RxFifoNearFullFlag = SPI_S_RNFULLF_MASK,  /*!< Rx FIFO near full */
-    kSPI_TxFifoNearEmptyFlag = SPI_S_TNEAREF_MASK, /*!< Tx FIFO near empty */
-    kSPI_TxFifoFullFlag = SPI_S_TXFULLF_MASK,      /*!< Tx FIFO full */
-    kSPI_RxFifoEmptyFlag = SPI_S_RFIFOEF_MASK,     /*!< Rx FIFO empty */
-    kSPI_TxFifoError = SPI_CI_TXFERR_MASK << 8U,   /*!< Tx FIFO error */
-    kSPI_RxFifoError = SPI_CI_RXFERR_MASK << 8U,   /*!< Rx FIFO error */
-    kSPI_TxOverflow = SPI_CI_TXFOF_MASK << 8U,     /*!< Tx FIFO Overflow */
-    kSPI_RxOverflow = SPI_CI_RXFOF_MASK << 8U      /*!< Rx FIFO Overflow */
-#endif                                             /* FSL_FEATURE_SPI_HAS_FIFO */
+    kSPI_RxFifoNearFullFlag  = SPI_S_RNFULLF_MASK,       /*!< Rx FIFO near full */
+    kSPI_TxFifoNearEmptyFlag = SPI_S_TNEAREF_MASK,       /*!< Tx FIFO near empty */
+    kSPI_TxFifoFullFlag      = SPI_S_TXFULLF_MASK,       /*!< Tx FIFO full */
+    kSPI_RxFifoEmptyFlag     = SPI_S_RFIFOEF_MASK,       /*!< Rx FIFO empty */
+    kSPI_TxFifoError         = SPI_CI_TXFERR_MASK << 8U, /*!< Tx FIFO error */
+    kSPI_RxFifoError         = SPI_CI_RXFERR_MASK << 8U, /*!< Rx FIFO error */
+    kSPI_TxOverflow          = SPI_CI_TXFOF_MASK << 8U,  /*!< Tx FIFO Overflow */
+    kSPI_RxOverflow          = SPI_CI_RXFOF_MASK << 8U   /*!< Rx FIFO Overflow */
+#endif                                                   /* FSL_FEATURE_SPI_HAS_FIFO */
 };
 
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
 /*! @brief SPI FIFO write-1-to-clear interrupt flags.*/
 typedef enum _spi_w1c_interrupt
 {
-    kSPI_RxFifoFullClearInterrupt = SPI_CI_SPRFCI_MASK,    /*!< Receive FIFO full interrupt */
-    kSPI_TxFifoEmptyClearInterrupt = SPI_CI_SPTEFCI_MASK,  /*!< Transmit FIFO empty interrupt */
-    kSPI_RxNearFullClearInterrupt = SPI_CI_RNFULLFCI_MASK, /*!< Receive FIFO nearly full interrupt */
-    kSPI_TxNearEmptyClearInterrupt = SPI_CI_TNEAREFCI_MASK /*!< Transmit FIFO nearly empty interrupt */
+    kSPI_RxFifoFullClearInterrupt  = SPI_CI_SPRFCI_MASK,    /*!< Receive FIFO full interrupt */
+    kSPI_TxFifoEmptyClearInterrupt = SPI_CI_SPTEFCI_MASK,   /*!< Transmit FIFO empty interrupt */
+    kSPI_RxNearFullClearInterrupt  = SPI_CI_RNFULLFCI_MASK, /*!< Receive FIFO nearly full interrupt */
+    kSPI_TxNearEmptyClearInterrupt = SPI_CI_TNEAREFCI_MASK  /*!< Transmit FIFO nearly empty interrupt */
 } spi_w1c_interrupt_t;
 
 /*! @brief SPI TX FIFO watermark settings.*/
 typedef enum _spi_txfifo_watermark
 {
     kSPI_TxFifoOneFourthEmpty = 0, /*!< SPI tx watermark at 1/4 FIFO size */
-    kSPI_TxFifoOneHalfEmpty = 1    /*!< SPI tx watermark at 1/2 FIFO size */
+    kSPI_TxFifoOneHalfEmpty   = 1  /*!< SPI tx watermark at 1/2 FIFO size */
 } spi_txfifo_watermark_t;
 
 /*! @brief SPI RX FIFO watermark settings.*/
 typedef enum _spi_rxfifo_watermark
 {
     kSPI_RxFifoThreeFourthsFull = 0, /*!< SPI rx watermark at 3/4 FIFO size */
-    kSPI_RxFifoOneHalfFull = 1       /*!< SPI rx watermark at 1/2 FIFO size */
+    kSPI_RxFifoOneHalfFull      = 1  /*!< SPI rx watermark at 1/2 FIFO size */
 } spi_rxfifo_watermark_t;
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
@@ -169,8 +149,8 @@ typedef enum _spi_rxfifo_watermark
 /*! @brief SPI DMA source*/
 enum _spi_dma_enable_t
 {
-    kSPI_TxDmaEnable = SPI_C2_TXDMAE_MASK,                        /*!< Tx DMA request source */
-    kSPI_RxDmaEnable = SPI_C2_RXDMAE_MASK,                        /*!< Rx DMA request source */
+    kSPI_TxDmaEnable  = SPI_C2_TXDMAE_MASK,                       /*!< Tx DMA request source */
+    kSPI_RxDmaEnable  = SPI_C2_RXDMAE_MASK,                       /*!< Rx DMA request source */
     kSPI_DmaAllEnable = (SPI_C2_TXDMAE_MASK | SPI_C2_RXDMAE_MASK) /*!< All DMA request source*/
 };
 #endif /* FSL_FEATURE_SPI_HAS_DMA_SUPPORT */
@@ -210,6 +190,7 @@ typedef struct _spi_slave_config
     spi_txfifo_watermark_t txWatermark; /*!< Tx watermark settings */
     spi_rxfifo_watermark_t rxWatermark; /*!< Rx watermark settings */
 #endif                                  /* FSL_FEATURE_SPI_HAS_FIFO */
+    spi_pin_mode_t pinMode;             /*!< SPI pin mode select */
 } spi_slave_config_t;
 
 /*! @brief SPI transfer structure */
@@ -479,6 +460,27 @@ static inline uint32_t SPI_GetDataRegisterAddress(SPI_Type *base)
  */
 
 /*!
+ * @brief Get the instance for SPI module.
+ *
+ * @param base SPI base address
+ */
+uint32_t SPI_GetInstance(SPI_Type *base);
+
+/*!
+ * @brief Sets the pin mode for transfer.
+ *
+ * @param base SPI base pointer
+ * @param pinMode pin mode for transfer AND #_spi_pin_mode could get the related configuration.
+ */
+static inline void SPI_SetPinMode(SPI_Type *base, spi_pin_mode_t pinMode)
+{
+    /* Clear SPC0 and BIDIROE bit. */
+    base->C2 &= ~(SPI_C2_BIDIROE_MASK | SPI_C2_SPC0_MASK);
+    /* Set pin mode for transfer. */
+    base->C2 |= SPI_C2_BIDIROE(pinMode >> 1U) | SPI_C2_SPC0(pinMode & 1U);
+}
+
+/*!
  * @brief Sets the baud rate for SPI transfer. This is only used in master.
  *
  * @param base SPI base pointer
@@ -544,6 +546,13 @@ void SPI_WriteData(SPI_Type *base, uint16_t data);
  */
 uint16_t SPI_ReadData(SPI_Type *base);
 
+/*!
+ * @brief Set up the dummy data.
+ *
+ * @param base SPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void SPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
 /*! @} */
 
 /*!
@@ -582,11 +591,7 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer);
  *
  * @note The API immediately returns after transfer initialization is finished.
  * Call SPI_GetStatusIRQ() to get the transfer status.
- * @note If using the SPI with FIFO for the interrupt transfer, the transfer size is the integer times of the watermark.
- * Otherwise,
- * the last data may be lost because it cannot generate an interrupt request. Users can also call the functional API to
- * get the last
- * received data.
+ * @note If SPI transfer data frame size is 16 bits, the transfer size cannot be an odd number.
  *
  * @param base SPI peripheral base address.
  * @param handle pointer to spi_master_handle_t structure which stores the transfer state
@@ -636,8 +641,8 @@ void SPI_MasterTransferHandleIRQ(SPI_Type *base, spi_master_handle_t *handle);
  * @param userData User data.
  */
 void SPI_SlaveTransferCreateHandle(SPI_Type *base,
-                                                 spi_slave_handle_t *handle,
-                                                 spi_slave_callback_t callback,
+                                   spi_slave_handle_t *handle,
+                                   spi_slave_callback_t callback,
                                    void *userData);
 
 /*!
@@ -645,11 +650,7 @@ void SPI_SlaveTransferCreateHandle(SPI_Type *base,
  *
  * @note The API returns immediately after the transfer initialization is finished.
  * Call SPI_GetStatusIRQ() to get the transfer status.
- * @note If using the SPI with FIFO for the interrupt transfer, the transfer size is the integer times the watermark.
- * Otherwise,
- * the last data may be lost because it cannot generate an interrupt request. Call the functional API to get the last
- * several
- * receive data.
+ * @note If SPI transfer data frame size is 16 bits, the transfer size cannot be an odd number.
  *
  * @param base SPI peripheral base address.
  * @param handle pointer to spi_master_handle_t structure which stores the transfer state

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_spi_dma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_spi_dma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SPI_DMA_H_
 #define _FSL_SPI_DMA_H_
@@ -38,10 +16,15 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief SPI DMA driver version 2.0.4. */
+#define FSL_SPI_DMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 4))
+/*@}*/
 
 typedef struct _spi_dma_handle spi_dma_handle_t;
 
@@ -55,7 +38,7 @@ struct _spi_dma_handle
     bool rxInProgress;           /*!< Receive transfer finished */
     dma_handle_t *txHandle;      /*!< DMA handler for SPI send */
     dma_handle_t *rxHandle;      /*!< DMA handler for SPI receive */
-    uint8_t bytesPerFrame;       /*!< Bytes in a frame for SPI tranfer */
+    uint8_t bytesPerFrame;       /*!< Bytes in a frame for SPI transfer */
     spi_dma_callback_t callback; /*!< Callback for SPI DMA transfer */
     void *userData;              /*!< User Data for SPI DMA callback */
     uint32_t state;              /*!< Internal state of SPI DMA transfer */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
@@ -116,16 +116,18 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    SPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    SPI_MasterTransferBlocking(spi_address[obj->instance], &(spi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total
+    });
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_spi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_spi.c
@@ -1,38 +1,22 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_spi.h"
 
 /*******************************************************************************
- * Definitons
+ * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.spi"
+#endif
+
 /*! @brief SPI transfer state, which is used for SPI transactiaonl APIs' internal state. */
 enum _spi_transfer_states_t
 {
@@ -46,12 +30,6 @@ typedef void (*spi_isr_t)(SPI_Type *base, spi_master_handle_t *spiHandle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get the instance for SPI module.
- *
- * @param base SPI base address
- */
-uint32_t SPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Sends a buffer of data bytes in non-blocking way.
@@ -72,12 +50,21 @@ static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size);
 static void SPI_ReadNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size);
 
 /*!
+ * @brief Get the waterrmark value for this SPI instance.
+ *
+ * @param base SPI base pointer
+ * @return Watermark value for the SPI instance.
+ */
+static uint8_t SPI_GetWatermark(SPI_Type *base);
+
+/*!
  * @brief Send a piece of data for SPI.
  *
  * This function computes the number of data to be written into D register or Tx FIFO,
  * and write the data into it. At the same time, this function updates the values in
  * master handle structure.
  *
+ * @param base SPI base pointer
  * @param handle Pointer to SPI master handle structure.
  */
 static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle);
@@ -89,9 +76,18 @@ static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle);
  * and write the data to destination address. At the same time, this function updates
  * the values in master handle structure.
  *
+ * @param base SPI base pointer
  * @param handle Pointer to SPI master handle structure.
  */
 static void SPI_ReceiveTransfer(SPI_Type *base, spi_master_handle_t *handle);
+
+/*!
+ * @brief Common IRQ handler for SPI.
+ *
+ * @param base SPI base pointer.
+ * @param instance SPI instance number.
+ */
+static void SPI_CommonIRQHandler(SPI_Type *base, uint32_t instance);
 /*******************************************************************************
  * Variables
  ******************************************************************************/
@@ -101,21 +97,31 @@ static spi_master_handle_t *s_spiHandle[FSL_FEATURE_SOC_SPI_COUNT];
 static SPI_Type *const s_spiBases[] = SPI_BASE_PTRS;
 /*! @brief IRQ name array */
 static const IRQn_Type s_spiIRQ[] = SPI_IRQS;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Clock array name */
 static const clock_ip_name_t s_spiClock[] = SPI_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointer to master IRQ handler for each instance. */
-static spi_isr_t s_spiIsr;
+static spi_isr_t s_spiMasterIsr;
+static spi_isr_t s_spiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_spiDummyData[ARRAY_SIZE(s_spiBases)] = {0};
 /*******************************************************************************
  * Code
  ******************************************************************************/
+/*!
+ * brief Get the instance for SPI module.
+ *
+ * param base SPI base address
+ */
 uint32_t SPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_SPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_spiBases); instance++)
     {
         if (s_spiBases[instance] == base)
         {
@@ -123,15 +129,28 @@ uint32_t SPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_SPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_spiBases));
 
     return instance;
 }
 
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base SPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void SPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance        = SPI_GetInstance(base);
+    g_spiDummyData[instance] = dummyData;
+}
+
 static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 {
-    uint32_t i = 0;
+    uint32_t i            = 0;
     uint8_t bytesPerFrame = 1U;
+    uint32_t instance     = SPI_GetInstance(base);
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
     /* Check if 16 bits or 8 bits */
@@ -155,13 +174,13 @@ static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
                 base->DL = *buffer++;
             }
 #else
-            base->D = *buffer++;
+            base->D   = *buffer++;
 #endif /* FSL_FEATURE_SPI_16BIT_TRANSFERS */
         }
         /* Send dummy data */
         else
         {
-            SPI_WriteData(base, SPI_DUMMYDATA);
+            SPI_WriteData(base, ((uint32_t)g_spiDummyData[instance] << 8 | g_spiDummyData[instance]));
         }
         i += bytesPerFrame;
     }
@@ -169,7 +188,7 @@ static void SPI_WriteNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 
 static void SPI_ReadNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 {
-    uint32_t i = 0;
+    uint32_t i            = 0;
     uint8_t bytesPerFrame = 1U;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
@@ -205,18 +224,68 @@ static void SPI_ReadNonBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
     }
 }
 
+/* Get the watermark value of transfer. Please note that the entery width of FIFO is 16 bits. */
+static uint8_t SPI_GetWatermark(SPI_Type *base)
+{
+    uint8_t ret = 0;
+#if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
+    uint8_t rxSize = 0U;
+    /* Get the number to be sent if there is FIFO */
+    if (FSL_FEATURE_SPI_FIFO_SIZEn(base) != 0)
+    {
+        rxSize = (base->C3 & SPI_C3_RNFULLF_MARK_MASK) >> SPI_C3_RNFULLF_MARK_SHIFT;
+        if (rxSize == 0U)
+        {
+            ret = FSL_FEATURE_SPI_FIFO_SIZEn(base) * 3U / 4U;
+        }
+        else
+        {
+            ret = FSL_FEATURE_SPI_FIFO_SIZEn(base) / 2U;
+        }
+    }
+    /* If no FIFO, just set the watermark to 1 */
+    else
+    {
+        ret = 1U;
+    }
+#else
+    ret = 1U;
+#endif /* FSL_FEATURE_SPI_HAS_FIFO */
+    return ret;
+}
+
+static void SPI_SendInitialTransfer(SPI_Type *base, spi_master_handle_t *handle)
+{
+    uint8_t bytestoTransfer = handle->bytePerFrame;
+
+#if defined(FSL_FEATURE_SPI_HAS_FIFO) && (FSL_FEATURE_SPI_HAS_FIFO)
+    if (handle->watermark > 1)
+    {
+        /* In the first time to send data to FIFO, if transfer size is not larger than
+         * the FIFO size, send all data to FIFO, or send data to make the FIFO full.
+         * Besides, The FIFO's entry width is 16 bits, need to translate it to bytes.
+         */
+        bytestoTransfer = MIN(handle->txRemainingBytes, (FSL_FEATURE_SPI_FIFO_SIZEn(base) * 2));
+    }
+#endif
+
+    SPI_WriteNonBlocking(base, handle->txData, bytestoTransfer);
+
+    /* Update handle information */
+    if (handle->txData)
+    {
+        handle->txData += bytestoTransfer;
+    }
+    handle->txRemainingBytes -= bytestoTransfer;
+}
+
 static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle)
 {
-    uint8_t bytes = MIN((handle->watermark * 2U), handle->txRemainingBytes);
+    uint8_t bytes = handle->bytePerFrame;
 
     /* Read S register and ensure SPTEF is 1, otherwise the write would be ignored. */
     if (handle->watermark == 1U)
     {
-        if (bytes != 0U)
-        {
-            bytes = handle->bytePerFrame;
-        }
-
         /* Send data */
         if (base->C1 & SPI_C1_MSTR_MASK)
         {
@@ -235,7 +304,7 @@ static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle)
         else
         {
             /* As a slave, send data until SPTEF cleared */
-            while ((base->S & SPI_S_SPTEF_MASK) && (handle->txRemainingBytes > 0))
+            while ((base->S & SPI_S_SPTEF_MASK) && (handle->txRemainingBytes >= bytes))
             {
                 SPI_WriteNonBlocking(base, handle->txData, bytes);
 
@@ -253,56 +322,96 @@ static void SPI_SendTransfer(SPI_Type *base, spi_master_handle_t *handle)
     /* If use FIFO */
     else
     {
-        if (base->S & SPI_S_TNEAREF_MASK)
-        {
-            SPI_WriteNonBlocking(base, handle->txData, bytes);
+        /* The FIFO's entry width is 16 bits, need to translate it to bytes. */
+        uint8_t bytestoTransfer = handle->watermark * 2;
 
-            /* Update handle information */
-            if (handle->txData)
-            {
-                handle->txData += bytes;
-            }
-            handle->txRemainingBytes -= bytes;
+        if (handle->txRemainingBytes < 8U)
+        {
+            bytestoTransfer = handle->txRemainingBytes;
         }
+
+        SPI_WriteNonBlocking(base, handle->txData, bytestoTransfer);
+
+        /* Update handle information */
+        if (handle->txData)
+        {
+            handle->txData += bytestoTransfer;
+        }
+        handle->txRemainingBytes -= bytestoTransfer;
     }
 #endif
 }
 
 static void SPI_ReceiveTransfer(SPI_Type *base, spi_master_handle_t *handle)
 {
-    uint8_t bytes = MIN((handle->watermark * 2U), handle->rxRemainingBytes);
-    uint8_t val = 1U;
+    uint8_t bytes = handle->bytePerFrame;
 
     /* Read S register and ensure SPRF is 1, otherwise the write would be ignored. */
     if (handle->watermark == 1U)
     {
-        val = base->S & SPI_S_SPRF_MASK;
-        if (bytes != 0U)
+        if (base->S & SPI_S_SPRF_MASK)
         {
-            bytes = handle->bytePerFrame;
+            SPI_ReadNonBlocking(base, handle->rxData, bytes);
+
+            /* Update information in handle */
+            if (handle->rxData)
+            {
+                handle->rxData += bytes;
+            }
+            handle->rxRemainingBytes -= bytes;
         }
     }
-
-    if (val)
+#if defined(FSL_FEATURE_SPI_HAS_FIFO) && (FSL_FEATURE_SPI_HAS_FIFO)
+    /* If use FIFO */
+    else
     {
-        SPI_ReadNonBlocking(base, handle->rxData, bytes);
-
-        /* Update information in handle */
-        if (handle->rxData)
+        /* While rx fifo not empty and remaining data can also trigger the last interrupt */
+        while ((base->S & SPI_S_RFIFOEF_MASK) == 0U)
         {
-            handle->rxData += bytes;
+            SPI_ReadNonBlocking(base, handle->rxData, bytes);
+
+            /* Update information in handle */
+            if (handle->rxData)
+            {
+                handle->rxData += bytes;
+            }
+            handle->rxRemainingBytes -= bytes;
+
+            /* If the reamining data equals to watermark, leave to last interrupt */
+            if (handle->rxRemainingBytes == (handle->watermark * 2U))
+            {
+                break;
+            }
         }
-        handle->rxRemainingBytes -= bytes;
     }
+#endif
 }
 
+/*!
+ * brief  Sets the SPI master configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in SPI_MasterInit().
+ * User may use the initialized structure unchanged in SPI_MasterInit(), or modify
+ * some fields of the structure before calling SPI_MasterInit(). After calling this API,
+ * the master is ready to transfer.
+ * Example:
+   code
+   spi_master_config_t config;
+   SPI_MasterGetDefaultConfig(&config);
+   endcode
+ *
+ * param config pointer to master config structure
+ */
 void SPI_MasterGetDefaultConfig(spi_master_config_t *config)
 {
-    config->enableMaster = true;
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+    config->enableMaster         = true;
     config->enableStopInWaitMode = false;
-    config->polarity = kSPI_ClockPolarityActiveHigh;
-    config->phase = kSPI_ClockPhaseFirstEdge;
-    config->direction = kSPI_MsbFirst;
+    config->polarity             = kSPI_ClockPolarityActiveHigh;
+    config->phase                = kSPI_ClockPhaseFirstEdge;
+    config->direction            = kSPI_MsbFirst;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
     config->dataMode = kSPI_8BitMode;
@@ -313,17 +422,37 @@ void SPI_MasterGetDefaultConfig(spi_master_config_t *config)
     config->rxWatermark = kSPI_RxFifoOneHalfFull;
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
-    config->pinMode = kSPI_PinModeNormal;
-    config->outputMode = kSPI_SlaveSelectAutomaticOutput;
+    config->pinMode      = kSPI_PinModeNormal;
+    config->outputMode   = kSPI_SlaveSelectAutomaticOutput;
     config->baudRate_Bps = 500000U;
 }
 
+/*!
+ * brief Initializes the SPI with master configuration.
+ *
+ * The configuration structure can be filled by user from scratch, or be set with default
+ * values by SPI_MasterGetDefaultConfig(). After calling this API, the slave is ready to transfer.
+ * Example
+   code
+   spi_master_config_t config = {
+   .baudRate_Bps = 400000,
+   ...
+   };
+   SPI_MasterInit(SPI0, &config);
+   endcode
+ *
+ * param base SPI base pointer
+ * param config pointer to master configuration structure
+ * param srcClock_Hz Source clock frequency.
+ */
 void SPI_MasterInit(SPI_Type *base, const spi_master_config_t *config, uint32_t srcClock_Hz)
 {
     assert(config && srcClock_Hz);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Open clock gate for SPI and open interrupt */
     CLOCK_EnableClock(s_spiClock[SPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     /* Disable SPI before configuration */
     base->C1 &= ~SPI_C1_SPE_MASK;
@@ -354,6 +483,9 @@ void SPI_MasterInit(SPI_Type *base, const spi_master_config_t *config, uint32_t 
     /* Set baud rate */
     SPI_MasterSetBaudRate(base, config->baudRate_Bps, srcClock_Hz);
 
+    /* Set the dummy data, this data will usefull when tx buffer is NULL. */
+    SPI_SetDummyData(base, SPI_DUMMYDATA);
+
     /* Enable SPI */
     if (config->enableMaster)
     {
@@ -361,12 +493,28 @@ void SPI_MasterInit(SPI_Type *base, const spi_master_config_t *config, uint32_t 
     }
 }
 
+/*!
+ * brief  Sets the SPI slave configuration structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in SPI_SlaveInit().
+ * Modify some fields of the structure before calling SPI_SlaveInit().
+ * Example:
+   code
+   spi_slave_config_t config;
+   SPI_SlaveGetDefaultConfig(&config);
+   endcode
+ *
+ * param config pointer to slave configuration structure
+ */
 void SPI_SlaveGetDefaultConfig(spi_slave_config_t *config)
 {
-    config->enableSlave = true;
-    config->polarity = kSPI_ClockPolarityActiveHigh;
-    config->phase = kSPI_ClockPhaseFirstEdge;
-    config->direction = kSPI_MsbFirst;
+    /* Initializes the configure structure to zero. */
+    memset(config, 0, sizeof(*config));
+
+    config->enableSlave          = true;
+    config->polarity             = kSPI_ClockPolarityActiveHigh;
+    config->phase                = kSPI_ClockPhaseFirstEdge;
+    config->direction            = kSPI_MsbFirst;
     config->enableStopInWaitMode = false;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
@@ -377,14 +525,37 @@ void SPI_SlaveGetDefaultConfig(spi_slave_config_t *config)
     config->txWatermark = kSPI_TxFifoOneHalfEmpty;
     config->rxWatermark = kSPI_RxFifoOneHalfFull;
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
+    config->pinMode = kSPI_PinModeNormal;
 }
 
+/*!
+ * brief Initializes the SPI with slave configuration.
+ *
+ * The configuration structure can be filled by user from scratch or be set with
+ * default values by SPI_SlaveGetDefaultConfig().
+ * After calling this API, the slave is ready to transfer.
+ * Example
+   code
+    spi_slave_config_t config = {
+    .polarity = kSPIClockPolarity_ActiveHigh;
+    .phase = kSPIClockPhase_FirstEdge;
+    .direction = kSPIMsbFirst;
+    ...
+    };
+    SPI_MasterInit(SPI0, &config);
+   endcode
+ *
+ * param base SPI base pointer
+ * param config pointer to master configuration structure
+ */
 void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
 {
     assert(config);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Open clock gate for SPI and open interrupt */
     CLOCK_EnableClock(s_spiClock[SPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     /* Disable SPI before configuration */
     base->C1 &= ~SPI_C1_SPE_MASK;
@@ -395,9 +566,11 @@ void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
 
 /* Configure data mode if needed */
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
-    base->C2 = SPI_C2_SPIMODE(config->dataMode) | SPI_C2_SPISWAI(config->enableStopInWaitMode);
+    base->C2 = SPI_C2_SPIMODE(config->dataMode) | SPI_C2_SPISWAI(config->enableStopInWaitMode) |
+               SPI_C2_BIDIROE(config->pinMode >> 1U) | SPI_C2_SPC0(config->pinMode & 1U);
 #else
-    base->C2 = SPI_C2_SPISWAI(config->enableStopInWaitMode);
+    base->C2 = SPI_C2_SPISWAI(config->enableStopInWaitMode) | SPI_C2_BIDIROE(config->pinMode >> 1U) |
+               SPI_C2_SPC0(config->pinMode & 1U);
 #endif /* FSL_FEATURE_SPI_16BIT_TRANSFERS */
 
 /* Set watermark */
@@ -409,6 +582,9 @@ void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
     }
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
+    /* Set the dummy data, this data will usefull when tx buffer is NULL. */
+    SPI_SetDummyData(base, SPI_DUMMYDATA);
+
     /* Enable SPI */
     if (config->enableSlave)
     {
@@ -416,15 +592,31 @@ void SPI_SlaveInit(SPI_Type *base, const spi_slave_config_t *config)
     }
 }
 
+/*!
+ * brief De-initializes the SPI.
+ *
+ * Calling this API resets the SPI module, gates the SPI clock.
+ * The SPI module can't work unless calling the SPI_MasterInit/SPI_SlaveInit to initialize module.
+ *
+ * param base SPI base pointer
+ */
 void SPI_Deinit(SPI_Type *base)
 {
     /* Disable SPI module before shutting down */
     base->C1 &= ~SPI_C1_SPE_MASK;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Gate the clock */
     CLOCK_DisableClock(s_spiClock[SPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
+/*!
+ * brief Gets the status flag.
+ *
+ * param base SPI base pointer
+ * return SPI Status, use status flag to AND #_spi_flags could get the related status.
+ */
 uint32_t SPI_GetStatusFlags(SPI_Type *base)
 {
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
@@ -441,6 +633,17 @@ uint32_t SPI_GetStatusFlags(SPI_Type *base)
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 }
 
+/*!
+ * brief Enables the interrupt for the SPI.
+ *
+ * param base SPI base pointer
+ * param mask SPI interrupt source. The parameter can be any combination of the following values:
+ *        arg kSPI_RxFullAndModfInterruptEnable
+ *        arg kSPI_TxEmptyInterruptEnable
+ *        arg kSPI_MatchInterruptEnable
+ *        arg kSPI_RxFifoNearFullInterruptEnable
+ *        arg kSPI_TxFifoNearEmptyInterruptEnable
+ */
 void SPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
     /* Rx full interrupt */
@@ -480,6 +683,17 @@ void SPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 }
 
+/*!
+ * brief Disables the interrupt for the SPI.
+ *
+ * param base SPI base pointer
+ * param mask SPI interrupt source. The parameter can be any combination of the following values:
+ *        arg kSPI_RxFullAndModfInterruptEnable
+ *        arg kSPI_TxEmptyInterruptEnable
+ *        arg kSPI_MatchInterruptEnable
+ *        arg kSPI_RxFifoNearFullInterruptEnable
+ *        arg kSPI_TxFifoNearEmptyInterruptEnable
+ */
 void SPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 {
     /* Rx full interrupt */
@@ -518,6 +732,13 @@ void SPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 }
 
+/*!
+ * brief Sets the baud rate for SPI transfer. This is only used in master.
+ *
+ * param base SPI base pointer
+ * param baudRate_Bps baud rate needed in Hz.
+ * param srcClock_Hz SPI source clock frequency in Hz.
+ */
 void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
 {
     uint32_t prescaler;
@@ -535,7 +756,7 @@ void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
 
     /* Set the maximum divisor bit settings for each of the following divisors */
     bestPrescaler = 7U;
-    bestDivisor = 8U;
+    bestDivisor   = 8U;
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
     for (prescaler = 0; (prescaler <= 7) && min_diff; prescaler++)
@@ -556,9 +777,9 @@ void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
                 if (min_diff > diff)
                 {
                     /* A better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestDivisor = rateDivisor;
+                    bestDivisor   = rateDivisor;
                 }
             }
 
@@ -571,9 +792,18 @@ void SPI_MasterSetBaudRate(SPI_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
     base->BR = SPI_BR_SPR(bestDivisor) | SPI_BR_SPPR(bestPrescaler);
 }
 
+/*!
+ * brief Sends a buffer of data bytes using a blocking method.
+ *
+ * note This function blocks via polling until all bytes have been sent.
+ *
+ * param base SPI base pointer
+ * param buffer The data bytes to send
+ * param size The number of data bytes to send
+ */
 void SPI_WriteBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 {
-    uint32_t i = 0;
+    uint32_t i            = 0;
     uint8_t bytesPerFrame = 1U;
 
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && FSL_FEATURE_SPI_16BIT_TRANSFERS
@@ -596,6 +826,12 @@ void SPI_WriteBlocking(SPI_Type *base, uint8_t *buffer, size_t size)
 }
 
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
+/*!
+ * brief Enables or disables the FIFO if there is a FIFO.
+ *
+ * param base SPI base pointer
+ * param enable True means enable FIFO, false means disable FIFO.
+ */
 void SPI_EnableFIFO(SPI_Type *base, bool enable)
 {
     if (FSL_FEATURE_SPI_FIFO_SIZEn(base) != 0U)
@@ -612,6 +848,12 @@ void SPI_EnableFIFO(SPI_Type *base, bool enable)
 }
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
+/*!
+ * brief Writes a data into the SPI data register.
+ *
+ * param base SPI base pointer
+ * param data needs to be write.
+ */
 void SPI_WriteData(SPI_Type *base, uint16_t data)
 {
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && (FSL_FEATURE_SPI_16BIT_TRANSFERS)
@@ -622,6 +864,12 @@ void SPI_WriteData(SPI_Type *base, uint16_t data)
 #endif
 }
 
+/*!
+ * brief Gets a data from the SPI data register.
+ *
+ * param base SPI base pointer
+ * return Data in the register.
+ */
 uint16_t SPI_ReadData(SPI_Type *base)
 {
     uint16_t val = 0;
@@ -634,6 +882,14 @@ uint16_t SPI_ReadData(SPI_Type *base)
     return val;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * param base SPI base pointer
+ * param xfer pointer to spi_xfer_config_t structure
+ * retval kStatus_Success Successfully start a transfer.
+ * retval kStatus_InvalidArgument Input argument is invalid.
+ */
 status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
 {
     assert(xfer);
@@ -650,10 +906,6 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
     /* Check if 16 bits or 8 bits */
     bytesPerFrame = ((base->C2 & SPI_C2_SPIMODE_MASK) >> SPI_C2_SPIMODE_SHIFT) + 1U;
 #endif
-
-    /* Disable SPI and then enable it, this is used to clear S register */
-    base->C1 &= ~SPI_C1_SPE_MASK;
-    base->C1 |= SPI_C1_SPE_MASK;
 
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
 
@@ -696,6 +948,17 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the SPI master handle.
+ *
+ * This function initializes the SPI master handle which can be used for other SPI master transactional APIs. Usually,
+ * for a specified SPI instance, call this API once to get the initialized handle.
+ *
+ * param base SPI peripheral base address.
+ * param handle SPI handle pointer.
+ * param callback Callback function.
+ * param userData User data.
+ */
 void SPI_MasterTransferCreateHandle(SPI_Type *base,
                                     spi_master_handle_t *handle,
                                     spi_master_callback_t callback,
@@ -705,35 +968,15 @@ void SPI_MasterTransferCreateHandle(SPI_Type *base,
 
     uint8_t instance = SPI_GetInstance(base);
 
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
+
     /* Initialize the handle */
     s_spiHandle[instance] = handle;
-    handle->callback = callback;
-    handle->userData = userData;
-    s_spiIsr = SPI_MasterTransferHandleIRQ;
-
-#if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
-    uint8_t txSize = 0U;
-    /* Get the number to be sent if there is FIFO */
-    if (FSL_FEATURE_SPI_FIFO_SIZEn(base) != 0)
-    {
-        txSize = (base->C3 & SPI_C3_TNEAREF_MARK_MASK) >> SPI_C3_TNEAREF_MARK_SHIFT;
-        if (txSize == 0U)
-        {
-            handle->watermark = FSL_FEATURE_SPI_FIFO_SIZEn(base) * 3U / 4U;
-        }
-        else
-        {
-            handle->watermark = FSL_FEATURE_SPI_FIFO_SIZEn(base) / 2U;
-        }
-    }
-    /* If no FIFO, just set the watermark to 1 */
-    else
-    {
-        handle->watermark = 1U;
-    }
-#else
-    handle->watermark = 1U;
-#endif /* FSL_FEATURE_SPI_HAS_FIFO */
+    handle->callback      = callback;
+    handle->userData      = userData;
+    s_spiMasterIsr        = SPI_MasterTransferHandleIRQ;
+    handle->watermark     = SPI_GetWatermark(base);
 
 /* Get the bytes per frame */
 #if defined(FSL_FEATURE_SPI_16BIT_TRANSFERS) && (FSL_FEATURE_SPI_16BIT_TRANSFERS)
@@ -746,6 +989,20 @@ void SPI_MasterTransferCreateHandle(SPI_Type *base,
     EnableIRQ(s_spiIRQ[instance]);
 }
 
+/*!
+ * brief Performs a non-blocking SPI interrupt transfer.
+ *
+ * note The API immediately returns after transfer initialization is finished.
+ * Call SPI_GetStatusIRQ() to get the transfer status.
+ * note If SPI transfer data frame size is 16 bits, the transfer size cannot be an odd number.
+ *
+ * param base SPI peripheral base address.
+ * param handle pointer to spi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to spi_xfer_config_t structure
+ * retval kStatus_Success Successfully start a transfer.
+ * retval kStatus_InvalidArgument Input argument is invalid.
+ * retval kStatus_SPI_Busy SPI is not idle, is running another transfer.
+ */
 status_t SPI_MasterTransferNonBlocking(SPI_Type *base, spi_master_handle_t *handle, spi_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -763,47 +1020,76 @@ status_t SPI_MasterTransferNonBlocking(SPI_Type *base, spi_master_handle_t *hand
     }
 
     /* Set the handle information */
-    handle->txData = xfer->txData;
-    handle->rxData = xfer->rxData;
-    handle->transferSize = xfer->dataSize;
+    handle->txData           = xfer->txData;
+    handle->rxData           = xfer->rxData;
+    handle->transferSize     = xfer->dataSize;
     handle->txRemainingBytes = xfer->dataSize;
     handle->rxRemainingBytes = xfer->dataSize;
 
     /* Set the SPI state to busy */
     handle->state = kSPI_Busy;
 
-    /* Disable SPI and then enable it, this is used to clear S register*/
-    base->C1 &= ~SPI_C1_SPE_MASK;
-    base->C1 |= SPI_C1_SPE_MASK;
-
 /* Enable Interrupt, only enable Rx interrupt, use rx interrupt to driver SPI transfer */
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
+
+    handle->watermark = SPI_GetWatermark(base);
+
+    /* If the size of the transfer size less than watermark, set watermark to 1 */
+    if (xfer->dataSize < handle->watermark * 2U)
+    {
+        handle->watermark = 1U;
+    }
+
+    /* According to watermark size, enable interrupts */
     if (handle->watermark > 1U)
     {
+        SPI_EnableFIFO(base, true);
+        /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
+        while ((base->S & SPI_S_TNEAREF_MASK) != SPI_S_TNEAREF_MASK)
+        {
+        }
+        SPI_SendInitialTransfer(base, handle);
         /* Enable Rx near full interrupt */
         SPI_EnableInterrupts(base, kSPI_RxFifoNearFullInterruptEnable);
     }
     else
     {
+        SPI_EnableFIFO(base, false);
+        while ((base->S & SPI_S_SPTEF_MASK) != SPI_S_SPTEF_MASK)
+        {
+        }
+        /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
+        SPI_SendInitialTransfer(base, handle);
         SPI_EnableInterrupts(base, kSPI_RxFullAndModfInterruptEnable);
     }
 #else
+    while ((base->S & SPI_S_SPTEF_MASK) != SPI_S_SPTEF_MASK)
+    {
+    }
+    /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
+    SPI_SendInitialTransfer(base, handle);
     SPI_EnableInterrupts(base, kSPI_RxFullAndModfInterruptEnable);
 #endif
-
-    /* First send a piece of data to Tx Data or FIFO to start a SPI transfer */
-    SPI_SendTransfer(base, handle);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the bytes of the SPI interrupt transferred.
+ *
+ * param base SPI peripheral base address.
+ * param handle Pointer to SPI transfer handle, this should be a static variable.
+ * param count Transferred bytes of SPI master.
+ * retval kStatus_SPI_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is not a non-blocking transaction currently in progress.
+ */
 status_t SPI_MasterTransferGetCount(SPI_Type *base, spi_master_handle_t *handle, size_t *count)
 {
     assert(handle);
 
     status_t status = kStatus_Success;
 
-    if (handle->state != kStatus_SPI_Busy)
+    if (handle->state != kSPI_Busy)
     {
         status = kStatus_NoTransferInProgress;
     }
@@ -823,6 +1109,12 @@ status_t SPI_MasterTransferGetCount(SPI_Type *base, spi_master_handle_t *handle,
     return status;
 }
 
+/*!
+ * brief Aborts an SPI transfer using interrupt.
+ *
+ * param base SPI peripheral base address.
+ * param handle Pointer to SPI transfer handle, this should be a static variable.
+ */
 void SPI_MasterTransferAbort(SPI_Type *base, spi_master_handle_t *handle)
 {
     assert(handle);
@@ -849,6 +1141,12 @@ void SPI_MasterTransferAbort(SPI_Type *base, spi_master_handle_t *handle)
     handle->txRemainingBytes = 0;
 }
 
+/*!
+ * brief Interrupts the handler for the SPI.
+ *
+ * param base SPI peripheral base address.
+ * param handle pointer to spi_master_handle_t structure which stores the transfer state.
+ */
 void SPI_MasterTransferHandleIRQ(SPI_Type *base, spi_master_handle_t *handle)
 {
     assert(handle);
@@ -878,6 +1176,17 @@ void SPI_MasterTransferHandleIRQ(SPI_Type *base, spi_master_handle_t *handle)
     }
 }
 
+/*!
+ * brief Initializes the SPI slave handle.
+ *
+ * This function initializes the SPI slave handle which can be used for other SPI slave transactional APIs. Usually,
+ * for a specified SPI instance, call this API once to get the initialized handle.
+ *
+ * param base SPI peripheral base address.
+ * param handle SPI handle pointer.
+ * param callback Callback function.
+ * param userData User data.
+ */
 void SPI_SlaveTransferCreateHandle(SPI_Type *base,
                                    spi_slave_handle_t *handle,
                                    spi_slave_callback_t callback,
@@ -888,9 +1197,15 @@ void SPI_SlaveTransferCreateHandle(SPI_Type *base,
     /* Slave create handle share same logic with master create handle, the only difference
     is the Isr pointer. */
     SPI_MasterTransferCreateHandle(base, handle, callback, userData);
-    s_spiIsr = SPI_SlaveTransferHandleIRQ;
+    s_spiSlaveIsr = SPI_SlaveTransferHandleIRQ;
 }
 
+/*!
+ * brief Interrupts a handler for the SPI slave.
+ *
+ * param base SPI peripheral base address.
+ * param handle pointer to spi_slave_handle_t structure which stores the transfer state
+ */
 void SPI_SlaveTransferHandleIRQ(SPI_Type *base, spi_slave_handle_t *handle)
 {
     assert(handle);
@@ -920,11 +1235,28 @@ void SPI_SlaveTransferHandleIRQ(SPI_Type *base, spi_slave_handle_t *handle)
     }
 }
 
+static void SPI_CommonIRQHandler(SPI_Type *base, uint32_t instance)
+{
+    if (base->C1 & SPI_C1_MSTR_MASK)
+    {
+        s_spiMasterIsr(base, s_spiHandle[instance]);
+    }
+    else
+    {
+        s_spiSlaveIsr(base, s_spiHandle[instance]);
+    }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
+}
+
 #if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
     assert(s_spiHandle[0]);
-    s_spiIsr(SPI0, s_spiHandle[0]);
+    SPI_CommonIRQHandler(SPI0, 0);
 }
 #endif
 
@@ -932,7 +1264,7 @@ void SPI0_DriverIRQHandler(void)
 void SPI1_DriverIRQHandler(void)
 {
     assert(s_spiHandle[1]);
-    s_spiIsr(SPI1, s_spiHandle[1]);
+    SPI_CommonIRQHandler(SPI1, 1);
 }
 #endif
 
@@ -940,6 +1272,6 @@ void SPI1_DriverIRQHandler(void)
 void SPI2_DriverIRQHandler(void)
 {
     assert(s_spiHandle[2]);
-    s_spiIsr(SPI0, s_spiHandle[2]);
+    SPI_CommonIRQHandler(SPI2, 2);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_spi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_spi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used tom  endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SPI_H_
 #define _FSL_SPI_H_
@@ -37,15 +15,14 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief SPI driver version 2.0.1. */
-#define FSL_SPI_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*! @brief SPI driver version 2.0.4. */
+#define FSL_SPI_DRIVER_VERSION (MAKE_VERSION(2, 0, 4))
 /*@}*/
 
 #ifndef SPI_DUMMYDATA
@@ -53,12 +30,15 @@
 #define SPI_DUMMYDATA (0xFFU)
 #endif
 
+/*! @brief Global variable for dummy data value setting. */
+extern volatile uint8_t g_spiDummyData[];
+
 /*! @brief Return status for the SPI driver.*/
 enum _spi_status
 {
-    kStatus_SPI_Busy = MAKE_STATUS(kStatusGroup_SPI, 0), /*!< SPI bus is busy */
-    kStatus_SPI_Idle = MAKE_STATUS(kStatusGroup_SPI, 1), /*!< SPI is idle */
-    kStatus_SPI_Error = MAKE_STATUS(kStatusGroup_SPI, 2) /*!< SPI  error */
+    kStatus_SPI_Busy  = MAKE_STATUS(kStatusGroup_SPI, 0), /*!< SPI bus is busy */
+    kStatus_SPI_Idle  = MAKE_STATUS(kStatusGroup_SPI, 1), /*!< SPI is idle */
+    kStatus_SPI_Error = MAKE_STATUS(kStatusGroup_SPI, 2)  /*!< SPI  error */
 };
 
 /*! @brief SPI clock polarity configuration.*/
@@ -87,16 +67,16 @@ typedef enum _spi_shift_direction
 /*! @brief SPI slave select output mode options.*/
 typedef enum _spi_ss_output_mode
 {
-    kSPI_SlaveSelectAsGpio = 0x0U,         /*!< Slave select pin configured as GPIO. */
-    kSPI_SlaveSelectFaultInput = 0x2U,     /*!< Slave select pin configured for fault detection. */
-    kSPI_SlaveSelectAutomaticOutput = 0x3U /*!< Slave select pin configured for automatic SPI output. */
+    kSPI_SlaveSelectAsGpio          = 0x0U, /*!< Slave select pin configured as GPIO. */
+    kSPI_SlaveSelectFaultInput      = 0x2U, /*!< Slave select pin configured for fault detection. */
+    kSPI_SlaveSelectAutomaticOutput = 0x3U  /*!< Slave select pin configured for automatic SPI output. */
 } spi_ss_output_mode_t;
 
 /*! @brief SPI pin mode options.*/
 typedef enum _spi_pin_mode
 {
     kSPI_PinModeNormal = 0x0U, /*!< Pins operate in normal, single-direction mode.*/
-    kSPI_PinModeInput = 0x1U,  /*!< Bidirectional mode. Master: MOSI pin is input;
+    kSPI_PinModeInput  = 0x1U, /*!< Bidirectional mode. Master: MOSI pin is input;
                                 *   Slave: MISO pin is input. */
     kSPI_PinModeOutput = 0x3U  /*!< Bidirectional mode. Master: MOSI pin is output;
                                 *   Slave: MISO pin is output. */
@@ -113,10 +93,10 @@ typedef enum _spi_data_bitcount_mode
 enum _spi_interrupt_enable
 {
     kSPI_RxFullAndModfInterruptEnable = 0x1U, /*!< Receive buffer full (SPRF) and mode fault (MODF) interrupt */
-    kSPI_TxEmptyInterruptEnable = 0x2U,       /*!< Transmit buffer empty interrupt */
-    kSPI_MatchInterruptEnable = 0x4U,         /*!< Match interrupt */
+    kSPI_TxEmptyInterruptEnable       = 0x2U, /*!< Transmit buffer empty interrupt */
+    kSPI_MatchInterruptEnable         = 0x4U, /*!< Match interrupt */
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
-    kSPI_RxFifoNearFullInterruptEnable = 0x8U,   /*!< Receive FIFO nearly full interrupt */
+    kSPI_RxFifoNearFullInterruptEnable  = 0x8U,  /*!< Receive FIFO nearly full interrupt */
     kSPI_TxFifoNearEmptyInterruptEnable = 0x10U, /*!< Transmit FIFO nearly empty interrupt */
 #endif                                           /* FSL_FEATURE_SPI_HAS_FIFO */
 };
@@ -124,44 +104,44 @@ enum _spi_interrupt_enable
 /*! @brief SPI status flags.*/
 enum _spi_flags
 {
-    kSPI_RxBufferFullFlag = SPI_S_SPRF_MASK,   /*!< Read buffer full flag */
-    kSPI_MatchFlag = SPI_S_SPMF_MASK,          /*!< Match flag */
+    kSPI_RxBufferFullFlag  = SPI_S_SPRF_MASK,  /*!< Read buffer full flag */
+    kSPI_MatchFlag         = SPI_S_SPMF_MASK,  /*!< Match flag */
     kSPI_TxBufferEmptyFlag = SPI_S_SPTEF_MASK, /*!< Transmit buffer empty flag */
-    kSPI_ModeFaultFlag = SPI_S_MODF_MASK,      /*!< Mode fault flag */
+    kSPI_ModeFaultFlag     = SPI_S_MODF_MASK,  /*!< Mode fault flag */
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
-    kSPI_RxFifoNearFullFlag = SPI_S_RNFULLF_MASK,  /*!< Rx FIFO near full */
-    kSPI_TxFifoNearEmptyFlag = SPI_S_TNEAREF_MASK, /*!< Tx FIFO near empty */
-    kSPI_TxFifoFullFlag = SPI_S_TXFULLF_MASK,      /*!< Tx FIFO full */
-    kSPI_RxFifoEmptyFlag = SPI_S_RFIFOEF_MASK,     /*!< Rx FIFO empty */
-    kSPI_TxFifoError = SPI_CI_TXFERR_MASK << 8U,   /*!< Tx FIFO error */
-    kSPI_RxFifoError = SPI_CI_RXFERR_MASK << 8U,   /*!< Rx FIFO error */
-    kSPI_TxOverflow = SPI_CI_TXFOF_MASK << 8U,     /*!< Tx FIFO Overflow */
-    kSPI_RxOverflow = SPI_CI_RXFOF_MASK << 8U      /*!< Rx FIFO Overflow */
-#endif                                             /* FSL_FEATURE_SPI_HAS_FIFO */
+    kSPI_RxFifoNearFullFlag  = SPI_S_RNFULLF_MASK,       /*!< Rx FIFO near full */
+    kSPI_TxFifoNearEmptyFlag = SPI_S_TNEAREF_MASK,       /*!< Tx FIFO near empty */
+    kSPI_TxFifoFullFlag      = SPI_S_TXFULLF_MASK,       /*!< Tx FIFO full */
+    kSPI_RxFifoEmptyFlag     = SPI_S_RFIFOEF_MASK,       /*!< Rx FIFO empty */
+    kSPI_TxFifoError         = SPI_CI_TXFERR_MASK << 8U, /*!< Tx FIFO error */
+    kSPI_RxFifoError         = SPI_CI_RXFERR_MASK << 8U, /*!< Rx FIFO error */
+    kSPI_TxOverflow          = SPI_CI_TXFOF_MASK << 8U,  /*!< Tx FIFO Overflow */
+    kSPI_RxOverflow          = SPI_CI_RXFOF_MASK << 8U   /*!< Rx FIFO Overflow */
+#endif                                                   /* FSL_FEATURE_SPI_HAS_FIFO */
 };
 
 #if defined(FSL_FEATURE_SPI_HAS_FIFO) && FSL_FEATURE_SPI_HAS_FIFO
 /*! @brief SPI FIFO write-1-to-clear interrupt flags.*/
 typedef enum _spi_w1c_interrupt
 {
-    kSPI_RxFifoFullClearInterrupt = SPI_CI_SPRFCI_MASK,    /*!< Receive FIFO full interrupt */
-    kSPI_TxFifoEmptyClearInterrupt = SPI_CI_SPTEFCI_MASK,  /*!< Transmit FIFO empty interrupt */
-    kSPI_RxNearFullClearInterrupt = SPI_CI_RNFULLFCI_MASK, /*!< Receive FIFO nearly full interrupt */
-    kSPI_TxNearEmptyClearInterrupt = SPI_CI_TNEAREFCI_MASK /*!< Transmit FIFO nearly empty interrupt */
+    kSPI_RxFifoFullClearInterrupt  = SPI_CI_SPRFCI_MASK,    /*!< Receive FIFO full interrupt */
+    kSPI_TxFifoEmptyClearInterrupt = SPI_CI_SPTEFCI_MASK,   /*!< Transmit FIFO empty interrupt */
+    kSPI_RxNearFullClearInterrupt  = SPI_CI_RNFULLFCI_MASK, /*!< Receive FIFO nearly full interrupt */
+    kSPI_TxNearEmptyClearInterrupt = SPI_CI_TNEAREFCI_MASK  /*!< Transmit FIFO nearly empty interrupt */
 } spi_w1c_interrupt_t;
 
 /*! @brief SPI TX FIFO watermark settings.*/
 typedef enum _spi_txfifo_watermark
 {
     kSPI_TxFifoOneFourthEmpty = 0, /*!< SPI tx watermark at 1/4 FIFO size */
-    kSPI_TxFifoOneHalfEmpty = 1    /*!< SPI tx watermark at 1/2 FIFO size */
+    kSPI_TxFifoOneHalfEmpty   = 1  /*!< SPI tx watermark at 1/2 FIFO size */
 } spi_txfifo_watermark_t;
 
 /*! @brief SPI RX FIFO watermark settings.*/
 typedef enum _spi_rxfifo_watermark
 {
     kSPI_RxFifoThreeFourthsFull = 0, /*!< SPI rx watermark at 3/4 FIFO size */
-    kSPI_RxFifoOneHalfFull = 1       /*!< SPI rx watermark at 1/2 FIFO size */
+    kSPI_RxFifoOneHalfFull      = 1  /*!< SPI rx watermark at 1/2 FIFO size */
 } spi_rxfifo_watermark_t;
 #endif /* FSL_FEATURE_SPI_HAS_FIFO */
 
@@ -169,8 +149,8 @@ typedef enum _spi_rxfifo_watermark
 /*! @brief SPI DMA source*/
 enum _spi_dma_enable_t
 {
-    kSPI_TxDmaEnable = SPI_C2_TXDMAE_MASK,                        /*!< Tx DMA request source */
-    kSPI_RxDmaEnable = SPI_C2_RXDMAE_MASK,                        /*!< Rx DMA request source */
+    kSPI_TxDmaEnable  = SPI_C2_TXDMAE_MASK,                       /*!< Tx DMA request source */
+    kSPI_RxDmaEnable  = SPI_C2_RXDMAE_MASK,                       /*!< Rx DMA request source */
     kSPI_DmaAllEnable = (SPI_C2_TXDMAE_MASK | SPI_C2_RXDMAE_MASK) /*!< All DMA request source*/
 };
 #endif /* FSL_FEATURE_SPI_HAS_DMA_SUPPORT */
@@ -210,6 +190,7 @@ typedef struct _spi_slave_config
     spi_txfifo_watermark_t txWatermark; /*!< Tx watermark settings */
     spi_rxfifo_watermark_t rxWatermark; /*!< Rx watermark settings */
 #endif                                  /* FSL_FEATURE_SPI_HAS_FIFO */
+    spi_pin_mode_t pinMode;             /*!< SPI pin mode select */
 } spi_slave_config_t;
 
 /*! @brief SPI transfer structure */
@@ -479,6 +460,27 @@ static inline uint32_t SPI_GetDataRegisterAddress(SPI_Type *base)
  */
 
 /*!
+ * @brief Get the instance for SPI module.
+ *
+ * @param base SPI base address
+ */
+uint32_t SPI_GetInstance(SPI_Type *base);
+
+/*!
+ * @brief Sets the pin mode for transfer.
+ *
+ * @param base SPI base pointer
+ * @param pinMode pin mode for transfer AND #_spi_pin_mode could get the related configuration.
+ */
+static inline void SPI_SetPinMode(SPI_Type *base, spi_pin_mode_t pinMode)
+{
+    /* Clear SPC0 and BIDIROE bit. */
+    base->C2 &= ~(SPI_C2_BIDIROE_MASK | SPI_C2_SPC0_MASK);
+    /* Set pin mode for transfer. */
+    base->C2 |= SPI_C2_BIDIROE(pinMode >> 1U) | SPI_C2_SPC0(pinMode & 1U);
+}
+
+/*!
  * @brief Sets the baud rate for SPI transfer. This is only used in master.
  *
  * @param base SPI base pointer
@@ -544,6 +546,13 @@ void SPI_WriteData(SPI_Type *base, uint16_t data);
  */
 uint16_t SPI_ReadData(SPI_Type *base);
 
+/*!
+ * @brief Set up the dummy data.
+ *
+ * @param base SPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void SPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
 /*! @} */
 
 /*!
@@ -582,11 +591,7 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer);
  *
  * @note The API immediately returns after transfer initialization is finished.
  * Call SPI_GetStatusIRQ() to get the transfer status.
- * @note If using the SPI with FIFO for the interrupt transfer, the transfer size is the integer times of the watermark.
- * Otherwise,
- * the last data may be lost because it cannot generate an interrupt request. Users can also call the functional API to
- * get the last
- * received data.
+ * @note If SPI transfer data frame size is 16 bits, the transfer size cannot be an odd number.
  *
  * @param base SPI peripheral base address.
  * @param handle pointer to spi_master_handle_t structure which stores the transfer state
@@ -636,8 +641,8 @@ void SPI_MasterTransferHandleIRQ(SPI_Type *base, spi_master_handle_t *handle);
  * @param userData User data.
  */
 void SPI_SlaveTransferCreateHandle(SPI_Type *base,
-                                                 spi_slave_handle_t *handle,
-                                                 spi_slave_callback_t callback,
+                                   spi_slave_handle_t *handle,
+                                   spi_slave_callback_t callback,
                                    void *userData);
 
 /*!
@@ -645,11 +650,7 @@ void SPI_SlaveTransferCreateHandle(SPI_Type *base,
  *
  * @note The API returns immediately after the transfer initialization is finished.
  * Call SPI_GetStatusIRQ() to get the transfer status.
- * @note If using the SPI with FIFO for the interrupt transfer, the transfer size is the integer times the watermark.
- * Otherwise,
- * the last data may be lost because it cannot generate an interrupt request. Call the functional API to get the last
- * several
- * receive data.
+ * @note If SPI transfer data frame size is 16 bits, the transfer size cannot be an odd number.
  *
  * @param base SPI peripheral base address.
  * @param handle pointer to spi_master_handle_t structure which stores the transfer state

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_spi_dma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_spi_dma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SPI_DMA_H_
 #define _FSL_SPI_DMA_H_
@@ -38,10 +16,15 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief SPI DMA driver version 2.0.4. */
+#define FSL_SPI_DMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 4))
+/*@}*/
 
 typedef struct _spi_dma_handle spi_dma_handle_t;
 
@@ -55,7 +38,7 @@ struct _spi_dma_handle
     bool rxInProgress;           /*!< Receive transfer finished */
     dma_handle_t *txHandle;      /*!< DMA handler for SPI send */
     dma_handle_t *rxHandle;      /*!< DMA handler for SPI receive */
-    uint8_t bytesPerFrame;       /*!< Bytes in a frame for SPI tranfer */
+    uint8_t bytesPerFrame;       /*!< Bytes in a frame for SPI transfer */
     spi_dma_callback_t callback; /*!< Callback for SPI DMA transfer */
     void *userData;              /*!< User Data for SPI DMA callback */
     uint32_t state;              /*!< Internal state of SPI DMA transfer */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
@@ -116,16 +116,18 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    SPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    SPI_MasterTransferBlocking(spi_address[obj->instance], &(spi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total
+    });
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi.c
@@ -1,38 +1,22 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi.h"
 
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -65,27 +42,27 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
 
 /*!
  * @brief Master fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Master finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Slave fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
  * @brief Slave finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -100,7 +77,7 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param);
 /*!
  * @brief Master prepare the transfer.
  * Basically it set up dspi_master_handle .
- * This is not a public API as it is called from other driver functions. fsl_dspi_edma.c also call this function.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
 
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -123,11 +100,13 @@ static SPI_Type *const s_dspiBases[] = SPI_BASE_PTRS;
 /*! @brief Pointers to dspi IRQ number for each instance. */
 static IRQn_Type const s_dspiIRQ[] = SPI_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to dspi clocks for each instance. */
 static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to dspi handles for each instance. */
-static void *g_dspiHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
@@ -135,15 +114,22 @@ static dspi_master_isr_t s_dspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_DSPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_dspiBases); instance++)
     {
         if (s_dspiBases[instance] == base)
         {
@@ -151,20 +137,80 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_DSPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_dspiBases));
 
     return instance;
 }
 
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+{
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
+}
+
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
+    assert(NULL != masterConfig);
+
     uint32_t temp;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -173,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -185,48 +229,92 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
-    masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    assert(NULL != masterConfig);
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
+    masterConfig->ctarConfig.bitsPerFrame = 8;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
+
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
+    assert(NULL != slaveConfig);
+
     uint32_t temp = 0;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
@@ -239,40 +327,66 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
 
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    slaveConfig->whichCtar = kDSPI_Ctar0;
-    slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    assert(NULL != slaveConfig);
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
+    slaveConfig->ctarConfig.bitsPerFrame = 8;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
     DSPI_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* disable DSPI clock */
     CLOCK_DisableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pcs_polarity_config_t activeLowOrHigh)
@@ -293,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -312,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -378,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -402,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -424,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -455,83 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    assert(NULL != command);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    assert(NULL != command);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
+
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -540,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -556,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -574,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -621,34 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        if (rxData != NULL)
-                        {
-                            *(rxData) = DSPI_ReadData(base);
-                            rxData++;
-                        }
-                        else
-                        {
-                            DSPI_ReadData(base);
-                        }
-                        remainingReceiveByteCount--;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -660,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -701,54 +1013,39 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *(rxData) = DSPI_ReadData(base);
-                        rxData++;
-                    }
-                    else
-                    {
-                        DSPI_ReadData(base);
-                    }
-                    remainingReceiveByteCount--;
+                        if (rxData != NULL)
+                        {
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
+                            rxData++;
+                        }
+                        else
+                        {
+                            (void)DSPI_ReadData(base);
+                        }
+                        remainingReceiveByteCount--;
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        wordReceived = DSPI_ReadData(base);
-
-                        if (rxData != NULL)
-                        {
-                            *rxData = wordReceived;
-                            ++rxData;
-                            *rxData = wordReceived >> 8;
-                            ++rxData;
-                        }
-                        remainingReceiveByteCount -= 2;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -756,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -769,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -822,24 +1120,28 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    wordReceived = DSPI_ReadData(base);
-
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *rxData = wordReceived;
-                        ++rxData;
-                        *rxData = wordReceived >> 8;
-                        ++rxData;
-                    }
-                    remainingReceiveByteCount -= 2;
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        if (rxData != NULL)
+                        {
+                            *rxData = (uint8_t)wordReceived;
+                            ++rxData;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
+                            ++rxData;
+                        }
+                        remainingReceiveByteCount -= 2U;
+
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
@@ -850,28 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    dspi_command_data_config_t commandStruct;
+    assert(NULL != handle);
+    assert(NULL != transfer);
+
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -879,61 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
-    DSPI_StartTransfer(base);
-
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
-    DSPI_MasterTransferFillUpTxFifo(base, handle);
 
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_StartTransfer(base);
+
+    /* Fill up the Tx FIFO to trigger the transfer. */
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -945,11 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -958,40 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
-
-    /* The transfer is complete.*/
-    handle->state = kDSPI_Idle;
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -999,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1007,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1023,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1058,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1068,82 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1152,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1180,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1212,85 +1736,107 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (NULL != handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (NULL != handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
+    }
 
     DSPI_StartTransfer(base);
 
     /* Prepare data to transmit */
     DSPI_SlaveTransferFillUpTxFifo(base, handle);
 
-    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
-
-    /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
-
-    if (handle->rxData)
-    {
-        /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
-    }
-    if (handle->txData)
-    {
-        /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
-    }
-
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1302,22 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1335,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1382,24 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1408,65 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
-
-    handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1484,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1500,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1573,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1606,52 +2188,57 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 0)
+#if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 1)
+#if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 2)
+#if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 3)
+#if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 4)
+#if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 5)
+#if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -37,54 +15,55 @@
  * @{
  */
 
-
 /**********************************************************************************************************************
  * Definitions
  *********************************************************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.1.1. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 1))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
-/*! @brief DSPI dummy data if no Tx data.*/
-#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for tx if there is not txData. */
+#ifndef DSPI_DUMMY_DATA
+/*! @brief DSPI dummy data if there is no Tx data.*/
+#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for Tx if there is no txData. */
+#endif
 
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out Of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All status above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -101,12 +80,13 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
- * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in Modified Transfer Format. This field is valid
- * only when CPHA bit in CTAR register is 0.
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is
+ * valid
+ * only when the CPHA bit in the CTAR register is 0.
  */
 typedef enum _dspi_master_sample_point
 {
@@ -130,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -165,36 +145,37 @@ typedef enum _dspi_clock_phase
 typedef enum _dspi_shift_direction
 {
     kDSPI_MsbFirst = 0U, /*!< Data transfers start with most significant bit.*/
-    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.*/
+    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.
+                              Shifting out of LSB is not supported for slave */
 } dspi_shift_direction_t;
 
 /*! @brief DSPI delay type selection.*/
 typedef enum _dspi_delay_type
 {
     kDSPI_PcsToSck = 1U,  /*!< Pcs-to-SCK delay. */
-    kDSPI_LastSckToPcs,   /*!< Last SCK edge to Pcs delay. */
+    kDSPI_LastSckToPcs,   /*!< The last SCK edge to Pcs delay. */
     kDSPI_BetweenTransfer /*!< Delay between transfers. */
 } dspi_delay_type_t;
 
 /*! @brief DSPI Clock and Transfer Attributes Register (CTAR) selection.*/
 typedef enum _dspi_ctar_selection
 {
-    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode, note that CTAR0 and CTAR0_SLAVE are the
+    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode; note that CTAR0 and CTAR0_SLAVE are the
                          same register address. */
     kDSPI_Ctar1 = 1U, /*!< CTAR1 selection option for master mode only. */
-    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only , note that some device do not support CTAR2. */
-    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only , note that some device do not support CTAR3. */
-    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only , note that some device do not support CTAR4. */
-    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only , note that some device do not support CTAR5. */
-    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only , note that some device do not support CTAR6. */
-    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only , note that some device do not support CTAR7. */
+    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only; note that some devices do not support CTAR2. */
+    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only; note that some devices do not support CTAR3. */
+    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only; note that some devices do not support CTAR4. */
+    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only; note that some devices do not support CTAR5. */
+    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only; note that some devices do not support CTAR6. */
+    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only; note that some devices do not support CTAR7. */
 } dspi_ctar_selection_t;
 
-#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro , internal used. */
-#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro , internal used. */
-#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro , internal used. */
-#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro , internal used. */
-/*! @brief Can use this enumeration for DSPI master transfer configFlags. */
+#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro; used internally. */
+#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro; used internally. */
+#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro; used internally. */
+#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI master transfer configFlags. */
 enum _dspi_transfer_config_flag_for_master
 {
     kDSPI_MasterCtar0 = 0U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR0 setting. */
@@ -213,13 +194,14 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Is PCS signal continuous. */
-    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Is PCS signal active after last frame transfer.*/
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterActiveAfterTransfer =
+        1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
-#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro , internal used. */
-#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro , internal used. */
-/*! @brief Can use this enum for DSPI slave transfer configFlags. */
+#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro; used internally. */
+#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI slave transfer configFlags. */
 enum _dspi_transfer_config_flag_for_slave
 {
     kDSPI_SlaveCtar0 = 0U << DSPI_SLAVE_CTAR_SHIFT, /*!< DSPI slave transfer use CTAR0 setting. */
@@ -234,15 +216,15 @@ enum _dspi_transfer_state
     kDSPI_Error        /*!< Transfer error. */
 };
 
-/*! @brief DSPI master command date configuration used for SPIx_PUSHR.*/
+/*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
     bool isEndOfQueue;               /*!< Signals that the current transfer is the last in the queue.*/
-    bool clearTransferCount;         /*!< Clears SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
+    bool clearTransferCount;         /*!< Clears the SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
 } dspi_command_data_config_t;
 
 /*! @brief DSPI master ctar configuration structure.*/
@@ -254,33 +236,33 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time with nanosecond , set to 0 sets the minimum
-                                               delay. It sets the boundary value if out of range that can be set.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< Last SCK to PCS delay time with nanosecond , set to 0 sets the
-                                               minimum delay.It sets the boundary value if out of range that can be
-                                               set.*/
-    uint32_t betweenTransferDelayInNanoSec; /*!< After SCK delay time with nanosecond , set to 0 sets the minimum
-                                             delay.It sets the boundary value if out of range that can be set.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
+
+    uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                             delay. It also sets the boundary value if out of range.*/
 } dspi_master_ctar_config_t;
 
 /*! @brief DSPI master configuration structure.*/
 typedef struct _dspi_master_config
 {
-    dspi_ctar_selection_t whichCtar;      /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;      /*!< The desired CTAR to use. */
     dspi_master_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    dspi_which_pcs_t whichPcs;                     /*!< Desired Peripheral Chip Select (pcs). */
-    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< Desired PCS active high or low. */
+    dspi_which_pcs_t whichPcs;                     /*!< The desired Peripheral Chip Select (pcs). */
+    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< The desired PCS active high or low. */
 
-    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable . Note that continuous SCK is only
+    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                      supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite; /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                     data is ignored, the data from the transfer that generated the overflow
-                                     is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                     shift to the shift register. */
+    bool enableRxFifoOverWrite; /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                     data is ignored and the data from the transfer that generated the overflow
+                                     is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                     shift register. */
 
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                  Format. It's valid only when CPHA=0. */
 } dspi_master_config_t;
 
@@ -290,34 +272,34 @@ typedef struct _dspi_slave_ctar_config
     uint32_t bitsPerFrame;      /*!< Bits per frame, minimum 4, maximum 16.*/
     dspi_clock_polarity_t cpol; /*!< Clock polarity. */
     dspi_clock_phase_t cpha;    /*!< Clock phase. */
-                                /*!< Slave only supports MSB , does not support LSB.*/
+                                /*!< Slave only supports MSB and does not support LSB.*/
 } dspi_slave_ctar_config_t;
 
 /*! @brief DSPI slave configuration structure.*/
 typedef struct _dspi_slave_config
 {
-    dspi_ctar_selection_t whichCtar;     /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;     /*!< The desired CTAR to use. */
     dspi_slave_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that continuous SCK is only
+    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                                  supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite;             /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                                 data is ignored, the data from the transfer that generated the overflow
-                                                 is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                                 shift to the shift register. */
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableRxFifoOverWrite;             /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                                 data is ignored and the data from the transfer that generated the overflow
+                                                 is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                                 shift register. */
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                Format. It's valid only when CPHA=0. */
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -352,47 +334,60 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags , set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
+    volatile uint8_t state; /*!< DSPI transfer state, see _dspi_transfer_state.*/
 
     dspi_master_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                           /*!< Callback user data. */
 };
 
-/*! @brief DSPI slave transfer handle structure used for transactional API. */
+/*! @brief DSPI slave transfer handle structure used for the transactional API. */
 struct _dspi_slave_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame;          /*!< The desired number of bits per frame. */
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     volatile uint8_t state; /*!< DSPI transfer state.*/
 
@@ -417,18 +412,18 @@ extern "C" {
 /*!
  * @brief Initializes the DSPI master.
  *
- * This function initializes the DSPI master configuration. An example use case is as follows:
+ * This function initializes the DSPI master configuration. This is an example use case.
  *  @code
  *   dspi_master_config_t  masterConfig;
  *   masterConfig.whichCtar                                = kDSPI_Ctar0;
- *   masterConfig.ctarConfig.baudRate                      = 500000000;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
  *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
  *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
  *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
  *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
- *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
  *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
  *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
  *   masterConfig.enableContinuousSCK                      = false;
@@ -439,8 +434,8 @@ extern "C" {
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param masterConfig Pointer to structure dspi_master_config_t.
- * @param srcClock_Hz Module source input clock in Hertz
+ * @param masterConfig Pointer to the structure dspi_master_config_t.
+ * @param srcClock_Hz Module source input clock in Hertz.
  */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
@@ -448,8 +443,8 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
  * @brief Sets the dspi_master_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
- * User may use the initialized structure unchanged in DSPI_MasterInit() or modify the structure
- * before calling DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
  * Example:
  * @code
  *  dspi_master_config_t  masterConfig;
@@ -462,7 +457,7 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
 /*!
  * @brief DSPI slave configuration.
  *
- * This function initializes the DSPI slave configuration. An example use case is as follows:
+ * This function initializes the DSPI slave configuration. This is an example use case.
  *  @code
  *   dspi_slave_config_t  slaveConfig;
  *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
@@ -477,22 +472,22 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param slaveConfig Pointer to structure dspi_master_config_t.
+ * @param slaveConfig Pointer to the structure dspi_master_config_t.
  */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
 
 /*!
- * @brief Sets the dspi_slave_config_t structure to default values.
+ * @brief Sets the dspi_slave_config_t structure to a default value.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
- * User may use the initialized structure unchanged in DSPI_SlaveInit(), or modify the structure
- * before calling DSPI_SlaveInit().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
  * @code
  *  dspi_slave_config_t  slaveConfig;
  *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
  * @endcode
- * @param slaveConfig pointer to dspi_slave_config_t structure.
+ * @param slaveConfig Pointer to the dspi_slave_config_t structure.
  */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig);
 
@@ -506,7 +501,7 @@ void DSPI_Deinit(SPI_Type *base);
  * @brief Enables the DSPI peripheral and sets the MCR MDIS to 0.
  *
  * @param base DSPI peripheral address.
- * @param enable pass true to enable module, false to disable module.
+ * @param enable Pass true to enable module, false to disable module.
  */
 static inline void DSPI_Enable(SPI_Type *base, bool enable)
 {
@@ -522,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -532,7 +527,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 /*!
  * @brief Gets the DSPI status flag state.
  * @param base DSPI peripheral address.
- * @return The DSPI status(in SR register).
+ * @return DSPI status (in SR register).
  */
 static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
 {
@@ -545,13 +540,13 @@ static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
  * This function  clears the desired status bit by using a write-1-to-clear. The user passes in the base and the
  * desired status bit to clear.  The list of status bits is defined in the dspi_status_and_interrupt_request_t. The
  * function uses these bit positions in its algorithm to clear the desired flag state.
- * Example usage:
+ * This is an example.
  * @code
  *  DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag|kDSPI_EndOfQueueFlag);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param statusFlags The status flag , used from type dspi_flags.
+ * @param statusFlags The status flag used from the type dspi_flags.
  */
 static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 {
@@ -560,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -570,15 +565,16 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 /*!
  * @brief Enables the DSPI interrupts.
  *
- * This function configures the various interrupt masks of the DSPI.  The parameters are base and an interrupt mask.
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
  * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
  *
  * @code
  *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
 
@@ -590,7 +586,7 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 {
@@ -599,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -609,13 +605,13 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Enables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  DSPI_EnableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -625,13 +621,13 @@ static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Disables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  SPI_DisableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_DisableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -679,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -705,12 +707,19 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
  *
- * This function sets the module to begin data transfer in either master or slave mode.
+ * This function sets the module to start data transfer in either master or slave mode.
  *
  * @param base DSPI peripheral address.
  */
@@ -719,9 +728,9 @@ static inline void DSPI_StartTransfer(SPI_Type *base)
     base->MCR &= ~SPI_MCR_HALT_MASK;
 }
 /*!
- * @brief Stops (halts) DSPI transfers and sets HALT bit in MCR.
+ * @brief Stops DSPI transfers and sets the HALT bit in MCR.
  *
- * This function stops data transfers in either master or slave mode.
+ * This function stops data transfers in either master or slave modes.
  *
  * @param base DSPI peripheral address.
  */
@@ -731,44 +740,44 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
 }
 
 /*!
- * @brief Enables (or disables) the DSPI FIFOs.
+ * @brief Enables or disables the DSPI FIFOs.
  *
- * This function  allows the caller to disable/enable the Tx and Rx FIFOs (independently).
- * Note that to disable, the caller must pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
- * the caller must pass in a logic 1 (true).
+ * This function  allows the caller to disable/enable the Tx and Rx FIFOs independently.
+ * Note that to disable, pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
+ * pass in a logic 1 (true).
  *
  * @param base DSPI peripheral address.
- * @param enableTxFifo Disables (false) the TX FIFO, else enables (true) the TX FIFO
- * @param enableRxFifo Disables (false) the RX FIFO, else enables (true) the RX FIFO
+ * @param enableTxFifo Disables (false) the TX FIFO; Otherwise, enables (true) the TX FIFO
+ * @param enableRxFifo Disables (false) the RX FIFO; Otherwise, enables (true) the RX FIFO
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Flushes the DSPI FIFOs.
  *
  * @param base DSPI peripheral address.
- * @param flushTxFifo Flushes (true) the Tx FIFO, else do not flush (false) the Tx FIFO
- * @param flushRxFifo Flushes (true) the Rx FIFO, else do not flush (false) the Rx FIFO
+ * @param flushTxFifo Flushes (true) the Tx FIFO; Otherwise, does not flush (false) the Tx FIFO
+ * @param flushRxFifo Flushes (true) the Rx FIFO; Otherwise, does not flush (false) the Rx FIFO
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Configures the DSPI peripheral chip select polarity simultaneously.
- * For example, PCS0 and PCS1 set to active low and other PCS set to active high. Note that the number of
+ * For example, PCS0 and PCS1 are set to active low and other PCS is set to active high. Note that the number of
  * PCSs is specific to the device.
  * @code
  *  DSPI_SetAllPcsPolarity(base, kDSPI_Pcs0ActiveLow | kDSPI_Pcs1ActiveLow);
    @endcode
  * @param base DSPI peripheral address.
- * @param mask The PCS polarity mask ,  can use the enum _dspi_pcs_polarity.
+ * @param mask The PCS polarity mask; use the enum _dspi_pcs_polarity.
  */
 static inline void DSPI_SetAllPcsPolarity(SPI_Type *base, uint32_t mask)
 {
@@ -797,19 +806,19 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
  * @brief Manually configures the delay prescaler and scaler for a particular CTAR.
  *
  * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
- * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT)and scalar (DT).
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes the delay to configure along with the prescaler and scaler value.
- * This allows the user to directly set the prescaler/scaler values if they have pre-calculated them or if they simply
- * wish to manually increment either value.
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
  *
  * @param base DSPI peripheral address.
  * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
  * @param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
  * @param scaler The scaler delay value (can be any integer between 0 to 15).
- * @param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * @param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
  */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay);
@@ -817,15 +826,15 @@ void DSPI_MasterSetDelayScaler(
 /*!
  * @brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
  *
- * This function calculates the values for:
+ * This function calculates the values for the following.
  * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
  * After SCK delay pre-scalar (PASC) and scalar (ASC), or
- * Delay after transfer pre-scalar (PDT)and scalar (DT).
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes which delay they want to configure along with the desired delay value in nanoseconds.  The function
- * calculates the values needed for the prescaler and scaler and returning the actual calculated delay as an exact
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
  * delay match may not be possible. In this case, the closest match is calculated without going below the desired
  * delay value input.
  * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
@@ -849,11 +858,11 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
  * @brief Writes data into the data buffer for master mode.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_data_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -865,7 +874,7 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
    @endcode
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
@@ -879,14 +888,14 @@ static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config
  * @brief Sets the dspi_command_data_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
- * User may use the initialized structure unchanged in DSPI_MasterWrite_xx() or modify the structure
- * before calling DSPI_MasterWrite_xx().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
  * @code
  *  dspi_command_data_config_t  command;
  *  DSPI_GetDefaultDataCommandConfig(&command);
  * @endcode
- * @param command pointer to dspi_command_data_config_t structure.
+ * @param command Pointer to the dspi_command_data_config_t structure.
  */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
 
@@ -894,11 +903,11 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  * @brief Writes data into the data buffer master mode and waits till complete to return.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -911,10 +920,10 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
- * receive data is available when transmit completes.
+ * the received data is available when the transmit completes.
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data);
@@ -929,10 +938,10 @@ void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *co
  * improve performance in cases where the command structure is constant. For example, the user calls this function
  * before starting a transfer to generate the command word. When they are ready to transmit the data, they OR
  * this formatted command word with the desired data to transmit. This process increases transmit performance when
- * compared to calling send functions such as DSPI_HAL_WriteDataMastermode which format the command word each time a
+ * compared to calling send functions, such as DSPI_HAL_WriteDataMastermode,  which format the command word each time a
  * data word is to be sent.
  *
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @return The command word formatted to the PUSHR data register bit field.
  */
 static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t *command)
@@ -945,43 +954,44 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
 
 /*!
  * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
- *        buffer, master mode and waits till complete to return.
+ *        buffer master mode and waits till complete to return.
  *
- * In this function, the user must append the 16-bit data to the 16-bit command info then provide the total 32-bit word
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
  * as the data to send.
- * The command portion provides characteristics of the data such as the optional continuous chip select operation
-* between
- * transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
  * @code
  *  dataWord = <16-bit command> | <16-bit data>;
- *  DSPI_HAL_WriteCommandDataMastermodeBlocking(base, dataWord);
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
  * @endcode
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
- * Because the SPI is a synchronous protocol, the receive data is available when transmit completes.
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
- * @param data The data word (command and data combined) to be sent
+ * @param data The data word (command and data combined) to be sent.
  */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data);
 
@@ -1021,8 +1031,16 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 }
 
 /*!
+ * @brief Set up the dummy data.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1033,13 +1051,13 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 /*!
  * @brief Initializes the DSPI master handle.
  *
- * This function initializes the DSPI handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance,  call this API once to get the initialized handle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_handle_t.
- * @param callback dspi callback.
- * @param userData callback function parameter.
+ * @param callback DSPI callback.
+ * @param userData Callback function parameter.
  */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
@@ -1049,12 +1067,11 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using polling.
  *
- * This function transfers data with polling. This is a blocking function, which does not return until all transfers
- * have been
- * completed.
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
  *
  * @param base DSPI peripheral base address.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
@@ -1063,15 +1080,43 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @brief DSPI master transfer data using interrupts.
  *
  * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
- data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1079,19 +1124,19 @@ status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *ha
  * This function gets the master transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count);
 
 /*!
- * @brief DSPI master aborts transfer using an interrupt.
+ * @brief DSPI master aborts a transfer using an interrupt.
  *
  * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1101,7 +1146,7 @@ void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1111,10 +1156,10 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
  * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * @param handle DSPI handle pointer to dspi_slave_handle_t.
+ * @param handle DSPI handle pointer to the dspi_slave_handle_t.
  * @param base DSPI peripheral base address.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData Callback function parameter.
  */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
@@ -1125,12 +1170,11 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
  * @brief DSPI slave transfers data using an interrupt.
  *
  * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
- * data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer);
@@ -1141,8 +1185,8 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
  * This function gets the slave transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count);
@@ -1150,10 +1194,10 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 /*!
  * @brief DSPI slave aborts a transfer using an interrupt.
  *
- * This function aborts transfer using an interrupt.
+ * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -1163,19 +1207,29 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi_edma.c
@@ -1,42 +1,25 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi_edma.h"
 
 /***********************************************************************************************************************
-* Definitons
-***********************************************************************************************************************/
+ * Definitions
+ ***********************************************************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi_edma"
+#endif
 
 /*!
-* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_master_edma_private_handle
 {
     SPI_Type *base;                    /*!< DSPI peripheral base address. */
@@ -44,8 +27,8 @@ typedef struct _dspi_master_edma_private_handle
 } dspi_master_edma_private_handle_t;
 
 /*!
-* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_slave_edma_private_handle
 {
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
@@ -53,46 +36,58 @@ typedef struct _dspi_slave_edma_private_handle
 } dspi_slave_edma_private_handle_t;
 
 /***********************************************************************************************************************
-* Prototypes
-***********************************************************************************************************************/
+ * Prototypes
+ ***********************************************************************************************************************/
 /*!
-* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
 /*!
-* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
-/*!
-* @brief Get instance number for DSPI module.
-*
-* This is not a public API and it's extern from fsl_dspi.c.
-*
-* @param base DSPI peripheral base address
-*/
-extern uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /***********************************************************************************************************************
-* Variables
-***********************************************************************************************************************/
+ * Variables
+ ***********************************************************************************************************************/
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 
 /***********************************************************************************************************************
-* Code
-***********************************************************************************************************************/
+ * Code
+ ***********************************************************************************************************************/
 
+/*!
+ * brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          dspi_master_edma_handle_t *handle,
                                          dspi_master_edma_transfer_callback_t callback,
@@ -101,51 +96,72 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          edma_handle_t *edmaTxDataToIntermediaryHandle,
                                          edma_handle_t *edmaIntermediaryToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+#if (!(defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET))
+    assert(NULL != edmaTxDataToIntermediaryHandle);
+#endif
+    assert(NULL != edmaIntermediaryToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].base   = base;
     s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
     handle->userData = userData;
 
-    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaRxRegToRxDataHandle        = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
-    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+    handle->edmaIntermediaryToTxRegHandle  = edmaIntermediaryToTxRegHandle;
 }
 
+/*!
+ * brief DSPI master transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    uint32_t instance = DSPI_GetInstance(base);
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
-    uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    uint32_t instance                = DSPI_GetInstance(base);
+    uint16_t wordToSend              = 0;
+    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint8_t dataAlreadyFed           = 0;
+    uint8_t dataFedMax               = 2;
+    uint32_t tmpMCR                  = 0;
+    size_t tmpRemainingSendByteCount = 0;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
@@ -154,33 +170,33 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
 
     edma_transfer_config_t transferConfigA;
     edma_transfer_config_t transferConfigB;
-    edma_transfer_config_t transferConfigC;
 
-    handle->txBuffIfNull = ((uint32_t)DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-
-    handle->state = kDSPI_Busy;
+    handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
 
     dspi_command_data_config_t commandStruct;
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -188,98 +204,123 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    /* this limits the amount of data we can transfer due to the linked channel.
-    * The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (handle->bitsPerFrame > 8)
+    /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (transfer->dataSize > 1022)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
     else
     {
-        if (transfer->dataSize > 511)
+        if (transfer->dataSize > limited_size)
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
+    {
+        handle->state = (uint8_t)kDSPI_Idle;
+        return kStatus_InvalidArgument;
+    }
+
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
                      &s_dspiMasterEdmaPrivateHandle[instance]);
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
+    /*
+    (1)For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
+    channel_A minor link to channel_B , channel_B minor link to channel_C.
+
+    Already pushed 1 or 2 data in SPI_PUSHR , then start the DMA tansfer.
+    channel_A:SPI_POPR to rxData,
+    channel_B:next txData to handle->command (low 16 bits),
+    channel_C:handle->command (32 bits) to SPI_PUSHR, and use the scatter/gather to transfer the last data
+    (handle->lastCommand to SPI_PUSHR).
+
+    (2)For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C -> channel_B .
+    channel_C major link to channel_B.
+    So need prepare the first data in "intermediary"  before the DMA
+    transfer and then channel_B is used to prepare the next data to "intermediary"
+
+    channel_A:SPI_POPR to rxData,
+    channel_C: handle->command (32 bits) to SPI_PUSHR,
+    channel_B: next txData to handle->command (low 16 bits), and use the scatter/gather to prepare the last data
+    (handle->lastCommand to handle->Command).
+    */
 
     /*If dspi has separate dma request , prepare the first data in "intermediary" .
     else (dspi has shared dma request) , send first 2 data if there is fifo or send first 1 data if there is no fifo*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
-        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
-        */
+         * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+         */
 
         /*Prepare the firt data*/
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
             /* If it's the last word */
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
-                {
-                    if (handle->isThereExtraByte)
-                    {
-                        wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                    }
-                    else
-                    {
-                        wordToSend = *(handle->txData);
-                        ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                    }
-                }
-                else
-                {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                }
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
-            }
-            else /* For all words except the last word , frame > 8bits */
-            {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
+                }
+                else
+                {
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                }
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
+            }
+            else /* For all words except the last word , frame > 8bits */
+            {
+                if (NULL != handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* increment to next data byte */
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     ++handle->txData; /* increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData; /* increment to next data word*/
@@ -289,9 +330,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
             }
             else
             {
@@ -301,66 +343,57 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     }
 
     else /*dspi has shared dma request*/
-
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->remainingSendByteCount <= 2)
+                if (handle->remainingSendByteCount <= 2U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
-                        if (handle->isThereExtraByte)
-                        {
-                            wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                        }
-                        else
-                        {
-                            wordToSend = *(handle->txData);
-                            ++handle->txData;
-                            wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        }
+                        wordToSend = *(handle->txData);
+                        ++handle->txData;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
                     handle->remainingSendByteCount = 0;
-                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                    base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
                 /* For all words except the last word */
                 else
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                         ++handle->txData;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
-                    handle->remainingSendByteCount -= 2;
+                    handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -368,9 +401,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData;
@@ -380,7 +414,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     wordToSend = dummyData;
                 }
 
-                if (handle->remainingSendByteCount == 1)
+                if (handle->remainingSendByteCount == 1U)
                 {
                     base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
@@ -390,14 +424,14 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -405,125 +439,66 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
     }
 
-    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer(rxData)*/
     EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcAddr   = (uint32_t)rxAddr;
     transferConfigA.srcOffset = 0;
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
         transferConfigA.destOffset = 1;
     }
     else
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
         transferConfigA.destOffset = 0;
     }
 
     transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-    if (handle->bitsPerFrame <= 8)
+    if (handle->bitsPerFrame <= 8U)
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.minorLoopBytes  = 1;
         transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
     }
     else
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-        transferConfigA.minorLoopBytes = 2;
-        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        transferConfigA.minorLoopBytes  = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
     }
+
+    /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+    handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
     EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                           &transferConfigA, NULL);
+                           (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
     EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                 kEDMA_MajorInterruptEnable);
+                                 (uint32_t)kEDMA_MajorInterruptEnable);
 
-    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
-    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
-    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
-    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
-
-    if (handle->remainingSendByteCount > 0)
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*Calculate the last data : handle->lastCommand*/
+    if (((tmpRemainingSendByteCount > 0U) && (1U != (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U))) &&
+         (1U == (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        if (handle->txData)
-        {
-            transferConfigB.srcAddr = (uint32_t)(handle->txData);
-            transferConfigB.srcOffset = 1;
-        }
-        else
-        {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-            transferConfigB.srcOffset = 0;
-        }
-
-        transferConfigB.destAddr = (uint32_t)(&handle->command);
-        transferConfigB.destOffset = 0;
-
-        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-        if (handle->bitsPerFrame <= 8)
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
-
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                majorlink , the majorlink would not trigger the channel_C*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
-            }
-        }
-        else
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                * majorlink*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
-            }
-        }
-
-        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
-    }
-
-    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
-    handle the last data */
-    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
-
-    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
-        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
-         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
-    {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
             uint32_t bufferIndex = 0;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                if (handle->bitsPerFrame <= 8)
+                if (handle->bitsPerFrame <= 8U)
                 {
-                    bufferIndex = handle->remainingSendByteCount - 1;
+                    bufferIndex = handle->remainingSendByteCount - 1U;
                 }
                 else
                 {
-                    bufferIndex = handle->remainingSendByteCount - 2;
+                    bufferIndex = handle->remainingSendByteCount - 2U;
                 }
             }
             else
@@ -531,85 +506,345 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 bufferIndex = handle->remainingSendByteCount;
             }
 
-            if (handle->bitsPerFrame <= 8)
+            uint32_t tmpLastCommand = handle->lastCommand;
+            uint8_t *tmpTxData      = handle->txData;
+
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | tmpTxData[bufferIndex - 1U];
             }
             else
             {
-                if (handle->isThereExtraByte)
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 2] |
-                                          ((uint32_t)dummyData << 8);
-                }
-                else
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
-                                          ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
-                                          handle->txData[bufferIndex - 2];
-                }
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | ((uint32_t)tmpTxData[bufferIndex - 1U] << 8U) |
+                                 tmpTxData[bufferIndex - 2U];
             }
+
+            handle->lastCommand = tmpLastCommand;
         }
         else
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 wordToSend = dummyData;
             }
             else
             {
-                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
             }
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
     }
 
+/* The feature of GASKET is that the SPI supports 8-bit or 16-bit writes to the PUSH TX FIFO,
+ * allowing a single write to the command word followed by multiple writes to the transmit word.
+ * The TX FIFO will save the last command word written, and convert a 8-bit/16-bit write to the
+ * transmit word into a 32-bit write that pushes both the command word and transmit word into
+ * the TX FIFO (PUSH TX FIFO Register In Master Mode)
+ * So, if this feature is supported, we can use use one channel to carry the receive data from
+ * receive regsiter to user data buffer, use the other channel to carry the data from user data buffer
+ * to transmit register,and use the scatter/gather function to prepare the last data.
+ * That is to say, if GASKET feature is supported, we can use only two channels for tansferring data.
+ */
+#if defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET
+    /*  For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to PUSHR register.
+     */
+
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
     if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
-        ((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+        ((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigC.destAddr = (uint32_t)txAddr;
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-        transferConfigC.majorLoopCounts = 1;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t)txAddr;
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
     }
 
-    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)))
+    /*User_Send_Buffer(txData) to PUSHR register. */
+    if (((handle->remainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+        ((handle->remainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U)))
     {
-        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
-        transferConfigC.destAddr = (uint32_t)txAddr;
-
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-
-        if (handle->bitsPerFrame <= 8)
+        if (handle->txData)
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /* For DSPI with separate RX and TX DMA requests, one frame data has been carry
+                 * to handle->command, so need to reduce the pointer of txData.
+                 */
+                transferConfigB.srcAddr =
+                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8U) ? (1U) : (2U)));
+                transferConfigB.srcOffset = 1;
+            }
+            else
+            {
+                /* For DSPI with shared RX and TX DMA requests, one or two frame data have been carry
+                 * to PUSHR register, so no need to change the pointer of txData.
+                 */
+                transferConfigB.srcAddr   = (uint32_t)((uint8_t *)(handle->txData));
+                transferConfigB.srcOffset = 1;
+            }
         }
         else
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)txAddr;
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1U;
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            transferConfigB.majorLoopCounts  = (handle->remainingSendByteCount / 2U) - 1U;
         }
 
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, softwareTCD);
+    }
+    /* If only one word to transmit, only carry the lastcommand. */
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, NULL);
+    }
+
+    /*Start the EDMA channel_A , channel_C. */
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    /* Set the channel link.
+     * For DSPI instances with shared TX and RX DMA requests, setup channel minor link, first receive data from the
+     * receive register, and then carry transmit data to PUSHER register.
+     * For DSPI instance with separate TX and RX DMA requests, there is no need to set up channel link.
+     */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /*Set channel priority*/
+        uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+        uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
+        uint8_t t                   = 0;
+
+        if (channelPriorityLow > channelPriorityHigh)
+        {
+            t                   = channelPriorityLow;
+            channelPriorityLow  = channelPriorityHigh;
+            channelPriorityHigh = t;
+        }
+
+        edma_channel_Preemption_config_t preemption_config_t;
+        preemption_config_t.enableChannelPreemption = true;
+        preemption_config_t.enablePreemptAbility    = true;
+        preemption_config_t.channelPriority         = channelPriorityLow;
+
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+        /*if there is Rx DMA request , carry the 32bits data (handle->command) to user data first , then link to
+          channelC to carry the next data to PUSHER register.(txData to PUSHER) */
+        if (handle->remainingSendByteCount > 0U)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaIntermediaryToTxRegHandle->channel);
+        }
+    }
+
+    DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    /* Setup control info to PUSHER register. */
+    *((uint16_t *)&(base->PUSHR) + 1) = (handle->command >> 16U);
+#else
+
+    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
+    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
+    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
+
+    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
+
+    /*For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to handle->Command*/
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t) & (handle->command);
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*User_Send_Buffer(txData) to intermediary(handle->command)*/
+    if (((((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U))) &&
+         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        if (NULL != handle->txData)
+        {
+            transferConfigB.srcAddr   = (uint32_t)(handle->txData);
+            transferConfigB.srcOffset = 1;
+        }
+        else
+        {
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)(&handle->command);
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                majorlink , the majorlink would not trigger the channel_C*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1U;
+            }
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                 * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U + 1U;
+            }
+        }
+
+        if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, softwareTCD);
+            EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
+                                       handle->edmaIntermediaryToTxRegHandle->channel, false);
+        }
+        else
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+        }
+    }
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                               handle->edmaTxDataToIntermediaryHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
+    handle the last data */
+
+    edma_transfer_config_t transferConfigC;
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*For DSPI instances with shared RX/TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to SPI_PUSHR*/
+    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (tmpRemainingSendByteCount > 0U)))
+    {
+        transferConfigC.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr         = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        transferConfigC.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    if (((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+        ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U)) ||
+        (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        transferConfigC.srcAddr  = (uint32_t)(&(handle->command));
+        transferConfigC.destAddr = (uint32_t)txAddr;
+
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            if (handle->bitsPerFrame <= 8U)
+            {
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1U;
+            }
+            else
+            {
+                transferConfigC.majorLoopCounts = (handle->remainingSendByteCount / 2U) - 1U;
+            }
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, softwareTCD);
+        }
+        else
+        {
+            transferConfigC.majorLoopCounts = 1;
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+        }
+
         EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
                                    handle->edmaIntermediaryToTxRegHandle->channel, false);
     }
     else
     {
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                               handle->edmaIntermediaryToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
     /*Start the EDMA channel_A , channel_B , channel_C transfer*/
@@ -618,165 +853,233 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
-    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid  = handle->edmaTxDataToIntermediaryHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
     if (channelPriorityLow > channelPriorityMid)
     {
-        t = channelPriorityLow;
+        t                  = channelPriorityLow;
         channelPriorityLow = channelPriorityMid;
         channelPriorityMid = t;
     }
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     if (channelPriorityMid > channelPriorityHigh)
     {
-        t = channelPriorityMid;
-        channelPriorityMid = channelPriorityHigh;
+        t                   = channelPriorityMid;
+        channelPriorityMid  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
-    /*Set the channel link.
-    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
-    For DSPI instances with separate RX and TX DMA requests:
-    Rx DMA request -> channel_A
-    Tx DMA request -> channel_C -> channel_B . (so need prepare the first data in "intermediary"  before the DMA
-    transfer and then channel_B is used to prepare the next data to "intermediary" ) */
+    /*Set the channel link.*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
-        to prepare the next 32bits data (User_send_buffer to handle->command) */
-        if (handle->remainingSendByteCount > 1)
+        to prepare the next 32bits data (txData to handle->command) */
+        if (handle->remainingSendByteCount > 1U)
         {
             EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
-                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MinorLink,
+                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MajorLink,
                                 handle->edmaTxDataToIntermediaryHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
     else
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                    kEDMA_MajorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-            }
 
             EDMA_SetChannelLink(handle->edmaTxDataToIntermediaryHandle->base,
                                 handle->edmaTxDataToIntermediaryHandle->channel, kEDMA_MinorLink,
                                 handle->edmaIntermediaryToTxRegHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
-
+#endif
     DSPI_StartTransfer(base);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI base pointer
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferEDMA(base, handle, &tempXfer);
+
+    return status;
+}
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
     EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the master eDMA transfer count.
+ *
+ * This function gets the master eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -784,13 +1087,33 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         dspi_slave_edma_handle_t *handle,
                                         dspi_slave_edma_transfer_callback_t callback,
@@ -798,14 +1121,16 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+    assert(NULL != edmaTxDataToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].base   = base;
     s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
@@ -815,88 +1140,99 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
 
+/*!
+ * brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
+
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If send/receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    edma_tcd_t *softwareTCD = (edma_tcd_t *)((uint32_t)(&handle->dspiSoftwareTCD[1]) & (~0x1FU));
+    handle->state = (uint8_t)kDSPI_Busy;
 
     uint32_t instance = DSPI_GetInstance(base);
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->bitsPerFrame > 8)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
-            if (transfer->dataSize > 1022)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
-        else
+    }
+    else
+    {
+        if (transfer->dataSize > limited_size)
         {
-            if (transfer->dataSize > 511)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
     }
 
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize < 2))
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
 
-    handle->state = kDSPI_Busy;
-
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
-    handle->errorCount = 0;
+    handle->totalByteCount            = transfer->dataSize;
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
-
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint32_t wordToSend    = 0;
+    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint8_t dataFedMax     = 2;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
@@ -907,9 +1243,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     DSPI_StartTransfer(base);
 
@@ -919,42 +1255,36 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* Increment to next data byte */
-                    if ((handle->remainingSendByteCount == 2) && (handle->isThereExtraByte))
-                    {
-                        wordToSend |= (unsigned)(dummyData) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
-                    else
-                    {
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
+
+                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    ++handle->txData; /* Increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -962,9 +1292,10 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     /* Increment to next data word*/
@@ -978,14 +1309,14 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 /* Decrement remainingSendByteCount*/
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -994,179 +1325,132 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     }
 
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
-    if (handle->remainingReceiveByteCount > 0)
+    if (handle->remainingReceiveByteCount > 0U)
     {
         EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcAddr   = (uint32_t)rxAddr;
         transferConfigA.srcOffset = 0;
 
-        if (handle->rxData)
+        if (NULL != handle->rxData)
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
             transferConfigA.destOffset = 1;
         }
         else
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
             transferConfigA.destOffset = 0;
         }
 
         transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.minorLoopBytes  = 1;
             transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
         }
         else
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigA.minorLoopBytes = 2;
-            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+            transferConfigA.minorLoopBytes  = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
         }
+
+        /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+        handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
         EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                               &transferConfigA, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
         EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                     kEDMA_MajorInterruptEnable);
+                                     (uint32_t)kEDMA_MajorInterruptEnable);
     }
 
-    if (handle->remainingSendByteCount > 0)
+    if (handle->remainingSendByteCount > 0U)
     {
         /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
         EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
 
-        /*If there is extra byte , it would use the */
-        if (handle->isThereExtraByte)
-        {
-            if (handle->txData)
-            {
-                handle->txLastData =
-                    handle->txData[handle->remainingSendByteCount - 2] | ((uint32_t)DSPI_DUMMY_DATA << 8);
-            }
-            else
-            {
-                handle->txLastData = DSPI_DUMMY_DATA | ((uint32_t)DSPI_DUMMY_DATA << 8);
-            }
-            transferConfigC.srcAddr = (uint32_t)(&(handle->txLastData));
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.srcOffset = 0;
-            transferConfigC.destOffset = 0;
-            transferConfigC.minorLoopBytes = 4;
-            transferConfigC.majorLoopCounts = 1;
+        transferConfigC.destAddr   = (uint32_t)txAddr;
+        transferConfigC.destOffset = 0;
 
-            EDMA_TcdReset(softwareTCD);
-            EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
-        }
-
-        /*Set another  transferConfigC*/
-        if ((handle->isThereExtraByte) && (handle->remainingSendByteCount == 2))
+        if (NULL != handle->txData)
         {
-            EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                   &transferConfigC, NULL);
+            transferConfigC.srcAddr   = (uint32_t)(&(handle->txData[0]));
+            transferConfigC.srcOffset = 1;
         }
         else
         {
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.destOffset = 0;
-
-            if (handle->txData)
+            transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigC.srcOffset = 0;
+            if (handle->bitsPerFrame <= 8U)
             {
-                transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
-                transferConfigC.srcOffset = 1;
+                handle->txBuffIfNull = dummyData;
             }
             else
             {
-                transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-                transferConfigC.srcOffset = 0;
-                if (handle->bitsPerFrame <= 8)
-                {
-                    handle->txBuffIfNull = DSPI_DUMMY_DATA;
-                }
-                else
-                {
-                    handle->txBuffIfNull = (DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-                }
+                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
             }
-
-            transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-            if (handle->bitsPerFrame <= 8)
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
-                transferConfigC.minorLoopBytes = 1;
-                transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
-            }
-            else
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
-                transferConfigC.minorLoopBytes = 2;
-                if (handle->isThereExtraByte)
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-                }
-                else
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
-                }
-            }
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, softwareTCD);
-                EDMA_EnableAutoStopRequest(handle->edmaTxDataToTxRegHandle->base,
-                                           handle->edmaTxDataToTxRegHandle->channel, false);
-            }
-            else
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, NULL);
-            }
-
-            EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
         }
+
+        transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigC.minorLoopBytes   = 1;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount;
+        }
+        else
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigC.minorLoopBytes   = 2;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount / 2U;
+        }
+
+        EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+
+        EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
     }
 
     EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.
@@ -1176,16 +1460,16 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     Tx DMA request -> channel_C */
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
         }
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
     else
     {
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
 
     return kStatus_Success;
@@ -1196,58 +1480,67 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    bool transferDone,
                                    uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred so far by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1255,7 +1548,8 @@ status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -37,28 +15,33 @@
  * @{
  */
 
-
 /***********************************************************************************************************************
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI master.
+ * @param handle A pointer to the handle for the DSPI master.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
                                                      dspi_master_edma_handle_t *handle,
@@ -68,37 +51,38 @@ typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI slave.
+ * @param handle A pointer to the handle for the DSPI slave.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_slave_edma_transfer_callback_t)(SPI_Type *base,
                                                     dspi_slave_edma_handle_t *handle,
                                                     status_t status,
                                                     void *userData);
 
-/*! @brief DSPI master eDMA transfer handle structure used for transactional API. */
+/*! @brief DSPI master eDMA transfer handle structure used for the transactional API. */
 struct _dspi_master_edma_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer; /*!< Indicates whether the PCS signal keeps active after the last frame transfer.*/
+
+    uint8_t nbytes;         /*!< eDMA minor byte transfer count initially configured. */
+    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
-
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     dspi_master_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                                /*!< Callback user data. */
@@ -110,33 +94,30 @@ struct _dspi_master_edma_handle
     edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
-/*! @brief DSPI slave eDMA transfer handle structure used for transactional API.*/
+/*! @brief DSPI slave eDMA transfer handle structure used for the transactional API.*/
 struct _dspi_slave_edma_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame; /*!< The desired number of bits per frame. */
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
     uint32_t txLastData;   /*!< Used if there is an extra byte when 16bits per frame for DMA purpose.*/
 
-    volatile uint8_t state; /*!< DSPI transfer state.*/
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
-    uint32_t errorCount; /*!< Error count for slave transfer.*/
+    volatile uint8_t state; /*!< DSPI transfer state.*/
 
     dspi_slave_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                               /*!< Callback user data. */
 
     edma_handle_t *edmaRxRegToRxDataHandle; /*!<edma_handle_t handle point used for RxReg to RxData buff*/
     edma_handle_t *edmaTxDataToTxRegHandle; /*!<edma_handle_t handle point used for TxData to TxReg*/
-
-    edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
 /***********************************************************************************************************************
@@ -152,17 +133,18 @@ extern "C" {
  * @brief Initializes the DSPI master eDMA handle.
  *
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
- * specified DSPI instance, user need only call this API once to get the initialized handle.
+ * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request source.
- * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
- * (2)For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
  * @param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
@@ -178,34 +160,49 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI master aborts a transfer which using eDMA.
+ * @brief Transfers a block of data using a eDMA method.
  *
- * This function aborts a transfer which using eDMA.
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle);
 
 /*!
  * @brief Gets the master eDMA transfer count.
  *
- * This function get the master eDMA transfer count.
+ * This function gets the master eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count);
@@ -216,7 +213,8 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request source.
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
  * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaTxDataToTxRegHandle.
  * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
@@ -224,7 +222,7 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_slave_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
  */
@@ -238,25 +236,25 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI slave transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
- * Note that slave EDMA transfer cannot support the situation that transfer_size is 1 when the bitsPerFrame is greater
- * than 8 .
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI slave aborts a transfer which using eDMA.
+ * @brief DSPI slave aborts a transfer which is using eDMA.
  *
- * This function aborts a transfer which using eDMA.
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle);
 
@@ -266,8 +264,8 @@ void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handl
  * This function gets the slave eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred so far by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_edma.c
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "fsl_edma.h"
 
@@ -63,11 +63,13 @@ static void EDMA_InstallTCD(DMA_Type *base, uint32_t channel, edma_tcd_t *tcd);
 /*! @brief Array to map EDMA instance number to base pointer. */
 static DMA_Type *const s_edmaBases[] = DMA_BASE_PTRS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Array to map EDMA instance number to clock name. */
 static const clock_ip_name_t s_edmaClockName[] = EDMA_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Array to map EDMA instance number to IRQ number. */
-static const IRQn_Type s_edmaIRQNumber[] = DMA_CHN_IRQS;
+static const IRQn_Type s_edmaIRQNumber[][FSL_FEATURE_EDMA_MODULE_CHANNEL] = DMA_CHN_IRQS;
 
 /*! @brief Pointers to transfer handle for each EDMA channel. */
 static edma_handle_t *s_EDMAHandle[FSL_FEATURE_EDMA_MODULE_CHANNEL * FSL_FEATURE_SOC_EDMA_COUNT];
@@ -81,7 +83,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_EDMA_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_edmaBases); instance++)
     {
         if (s_edmaBases[instance] == base)
         {
@@ -89,7 +91,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_EDMA_COUNT);
+    assert(instance < ARRAY_SIZE(s_edmaBases));
 
     return instance;
 }
@@ -122,8 +124,10 @@ void EDMA_Init(DMA_Type *base, const edma_config_t *config)
 
     uint32_t tmpreg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Ungate EDMA periphral clock */
     CLOCK_EnableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
     /* Configure EDMA peripheral according to the configuration structure. */
     tmpreg = base->CR;
     tmpreg &= ~(DMA_CR_ERCA_MASK | DMA_CR_HOE_MASK | DMA_CR_CLM_MASK | DMA_CR_EDBG_MASK);
@@ -134,8 +138,10 @@ void EDMA_Init(DMA_Type *base, const edma_config_t *config)
 
 void EDMA_Deinit(DMA_Type *base)
 {
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Gate EDMA periphral clock */
     CLOCK_DisableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void EDMA_GetDefaultConfig(edma_config_t *config)
@@ -409,46 +415,32 @@ void EDMA_TcdDisableInterrupts(edma_tcd_t *tcd, uint32_t mask)
     }
 }
 
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel)
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel)
 {
     assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
 
-    uint32_t nbytes = 0;
-    uint32_t remainingBytes = 0;
+    uint32_t remainingCount = 0;
 
     if (DMA_CSR_DONE_MASK & base->TCD[channel].CSR)
     {
-        remainingBytes = 0;
+        remainingCount = 0;
     }
     else
     {
-        /* Calculate the nbytes */
-        if (base->TCD[channel].NBYTES_MLOFFYES & (DMA_NBYTES_MLOFFYES_SMLOE_MASK | DMA_NBYTES_MLOFFYES_DMLOE_MASK))
-        {
-            nbytes = (base->TCD[channel].NBYTES_MLOFFYES & DMA_NBYTES_MLOFFYES_NBYTES_MASK) >>
-                     DMA_NBYTES_MLOFFYES_NBYTES_SHIFT;
-        }
-        else
-        {
-            nbytes =
-                (base->TCD[channel].NBYTES_MLOFFNO & DMA_NBYTES_MLOFFNO_NBYTES_MASK) >> DMA_NBYTES_MLOFFNO_NBYTES_SHIFT;
-        }
         /* Calculate the unfinished bytes */
         if (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_ELINK_MASK)
         {
-            remainingBytes = ((base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >>
-                              DMA_CITER_ELINKYES_CITER_SHIFT) *
-                             nbytes;
+            remainingCount =
+                (base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >> DMA_CITER_ELINKYES_CITER_SHIFT;
         }
         else
         {
-            remainingBytes =
-                ((base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT) *
-                nbytes;
+            remainingCount =
+                (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT;
         }
     }
 
-    return remainingBytes;
+    return remainingCount;
 }
 
 uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel)
@@ -497,14 +489,19 @@ void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel)
     uint32_t channelIndex;
     edma_tcd_t *tcdRegs;
 
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
+
     handle->base = base;
     handle->channel = channel;
     /* Get the DMA instance number */
     edmaInstance = EDMA_GetInstance(base);
     channelIndex = (edmaInstance * FSL_FEATURE_EDMA_MODULE_CHANNEL) + channel;
     s_EDMAHandle[channelIndex] = handle;
+
     /* Enable NVIC interrupt */
-    EnableIRQ(s_edmaIRQNumber[channelIndex]);
+    EnableIRQ(s_edmaIRQNumber[edmaInstance][channel]);
+
     /*
        Reset TCD registers to zero. Unlike the EDMA_TcdReset(DREQ will be set),
        CSR will be 0. Because in order to suit EDMA busy check mechanism in
@@ -829,7 +826,7 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
     {
         (handle->callback)(handle, handle->userData, true, 0);
     }
-    else /* Use the TCD queue. */
+    else /* Use the TCD queue. Please refer to the API descriptions in the eDMA header file for detailed information. */
     {
         uint32_t sga = handle->base->TCD[handle->channel].DLAST_SGA;
         uint32_t sga_index;
@@ -839,19 +836,19 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
 
         /* Check if transfer is already finished. */
         transfer_done = ((handle->base->TCD[handle->channel].CSR & DMA_CSR_DONE_MASK) != 0);
-        /* Get the offset of the current transfer TCD blcoks. */
+        /* Get the offset of the next transfer TCD blcoks to be loaded into the eDMA engine. */
         sga -= (uint32_t)handle->tcdPool;
-        /* Get the index of the current transfer TCD blcoks. */
+        /* Get the index of the next transfer TCD blcoks to be loaded into the eDMA engine. */
         sga_index = sga / sizeof(edma_tcd_t);
         /* Adjust header positions. */
         if (transfer_done)
         {
-            /* New header shall point to the next TCD (current one is already finished) */
+            /* New header shall point to the next TCD to be loaded (current one is already finished) */
             new_header = sga_index;
         }
         else
         {
-            /* New header shall point to this descriptor (not finished yet) */
+            /* New header shall point to this descriptor currently loaded (not finished yet) */
             new_header = sga_index ? sga_index - 1U : handle->tcdSize - 1U;
         }
         /* Calculate the number of finished TCDs */
@@ -863,7 +860,7 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
             }
             else
             {
-                /* Internal error occurs. */
+                /* No TCD in the memory are going to be loaded or internal error occurs. */
                 tcds_done = 0;
             }
         }
@@ -875,9 +872,9 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
                 tcds_done += handle->tcdSize;
             }
         }
-        /* Advance header to the point beyond the last finished TCD block. */
+        /* Advance header which points to the TCD to be loaded into the eDMA engine from memory. */
         handle->header = new_header;
-        /* Release TCD blocks. */
+        /* Release TCD blocks. tcdUsed is the TCD number which can be used/loaded in the memory pool. */
         handle->tcdUsed -= tcds_done;
         /* Invoke callback function. */
         if (handle->callback)
@@ -937,12 +934,260 @@ void DMA0_37_DriverIRQHandler(void)
         EDMA_HandleIRQ(s_EDMAHandle[7]);
     }
 }
+
+#if defined(DMA1)
+void DMA1_04_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA1_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA1_26_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA1_37_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+#endif
 #endif /* 8 channels (Shared) */
+
+/* 16 channels (Shared): K32H844P */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 16U
+
+void DMA0_08_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+}
+
+void DMA0_19_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+}
+
+void DMA0_210_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+}
+
+void DMA0_311_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+}
+
+void DMA0_412_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA0_513_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA0_614_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA0_715_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+
+#if defined(DMA1)
+void DMA1_08_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+}
+
+void DMA1_19_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+}
+
+void DMA1_210_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+}
+
+void DMA1_311_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+}
+
+void DMA1_412_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA1_513_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA1_614_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA1_715_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif
+#endif /* 16 channels (Shared) */
 
 /* 32 channels (Shared): k80 */
 #if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
 
-void DMA0_DMA16_IRQHandler(void)
+void DMA0_DMA16_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -954,7 +1199,7 @@ void DMA0_DMA16_IRQHandler(void)
     }
 }
 
-void DMA1_DMA17_IRQHandler(void)
+void DMA1_DMA17_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -966,7 +1211,7 @@ void DMA1_DMA17_IRQHandler(void)
     }
 }
 
-void DMA2_DMA18_IRQHandler(void)
+void DMA2_DMA18_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -978,7 +1223,7 @@ void DMA2_DMA18_IRQHandler(void)
     }
 }
 
-void DMA3_DMA19_IRQHandler(void)
+void DMA3_DMA19_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -990,7 +1235,7 @@ void DMA3_DMA19_IRQHandler(void)
     }
 }
 
-void DMA4_DMA20_IRQHandler(void)
+void DMA4_DMA20_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1002,7 +1247,7 @@ void DMA4_DMA20_IRQHandler(void)
     }
 }
 
-void DMA5_DMA21_IRQHandler(void)
+void DMA5_DMA21_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1014,7 +1259,7 @@ void DMA5_DMA21_IRQHandler(void)
     }
 }
 
-void DMA6_DMA22_IRQHandler(void)
+void DMA6_DMA22_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1026,7 +1271,7 @@ void DMA6_DMA22_IRQHandler(void)
     }
 }
 
-void DMA7_DMA23_IRQHandler(void)
+void DMA7_DMA23_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1038,7 +1283,7 @@ void DMA7_DMA23_IRQHandler(void)
     }
 }
 
-void DMA8_DMA24_IRQHandler(void)
+void DMA8_DMA24_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1050,7 +1295,7 @@ void DMA8_DMA24_IRQHandler(void)
     }
 }
 
-void DMA9_DMA25_IRQHandler(void)
+void DMA9_DMA25_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1062,7 +1307,7 @@ void DMA9_DMA25_IRQHandler(void)
     }
 }
 
-void DMA10_DMA26_IRQHandler(void)
+void DMA10_DMA26_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1074,7 +1319,7 @@ void DMA10_DMA26_IRQHandler(void)
     }
 }
 
-void DMA11_DMA27_IRQHandler(void)
+void DMA11_DMA27_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1086,7 +1331,7 @@ void DMA11_DMA27_IRQHandler(void)
     }
 }
 
-void DMA12_DMA28_IRQHandler(void)
+void DMA12_DMA28_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1098,7 +1343,7 @@ void DMA12_DMA28_IRQHandler(void)
     }
 }
 
-void DMA13_DMA29_IRQHandler(void)
+void DMA13_DMA29_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1110,7 +1355,7 @@ void DMA13_DMA29_IRQHandler(void)
     }
 }
 
-void DMA14_DMA30_IRQHandler(void)
+void DMA14_DMA30_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1122,7 +1367,7 @@ void DMA14_DMA30_IRQHandler(void)
     }
 }
 
-void DMA15_DMA31_IRQHandler(void)
+void DMA15_DMA31_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1134,6 +1379,202 @@ void DMA15_DMA31_IRQHandler(void)
     }
 }
 #endif /* 32 channels (Shared) */
+
+/* 32 channels (Shared): MCIMX7U5_M4 */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
+
+void DMA0_0_4_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+}
+
+void DMA0_1_5_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+}
+
+void DMA0_2_6_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+}
+
+void DMA0_3_7_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+}
+
+void DMA0_8_12_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA0_9_13_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA0_10_14_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA0_11_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+
+void DMA0_16_20_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 16U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 20U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+}
+
+void DMA0_17_21_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 17U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 21U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+}
+
+void DMA0_18_22_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 18U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 22U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+}
+
+void DMA0_19_23_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 19U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 23U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+}
+
+void DMA0_24_28_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 24U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 28U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA0_25_29_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 25U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 29U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA0_26_30_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 26U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 30U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA0_27_31_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 27U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 31U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif /* 32 channels (Shared): MCIMX7U5 */
 
 /* 4 channels (No Shared): kv10  */
 #if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 0

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_edma.h
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #ifndef _FSL_EDMA_H_
 #define _FSL_EDMA_H_
@@ -45,7 +45,7 @@
 /*! @name Driver version */
 /*@{*/
 /*! @brief eDMA driver version */
-#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 1)) /*!< Version 2.0.1. */
+#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 1)) /*!< Version 2.1.1. */
 /*@}*/
 
 /*! @brief Compute the offset unit from DCHPRI3 */
@@ -77,28 +77,28 @@ typedef enum _edma_modulo
     kEDMA_Modulo128bytes,       /*!< Circular buffer size is 128 bytes. */
     kEDMA_Modulo256bytes,       /*!< Circular buffer size is 256 bytes. */
     kEDMA_Modulo512bytes,       /*!< Circular buffer size is 512 bytes. */
-    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1K bytes. */
-    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2K bytes. */
-    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4K bytes. */
-    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8K bytes. */
-    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16K bytes. */
-    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32K bytes. */
-    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64K bytes. */
-    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128K bytes. */
-    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256K bytes. */
-    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512K bytes. */
-    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1M bytes. */
-    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2M bytes. */
-    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4M bytes. */
-    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8M bytes. */
-    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16M bytes. */
-    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32M bytes. */
-    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64M bytes. */
-    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128M bytes. */
-    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256M bytes. */
-    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512M bytes. */
-    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1G bytes. */
-    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2G bytes. */
+    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1 K bytes. */
+    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2 K bytes. */
+    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4 K bytes. */
+    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8 K bytes. */
+    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16 K bytes. */
+    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32 K bytes. */
+    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64 K bytes. */
+    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128 K bytes. */
+    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256 K bytes. */
+    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512 K bytes. */
+    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1 M bytes. */
+    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2 M bytes. */
+    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4 M bytes. */
+    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8 M bytes. */
+    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16 M bytes. */
+    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32 M bytes. */
+    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64 M bytes. */
+    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128 M bytes. */
+    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256 M bytes. */
+    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512 M bytes. */
+    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1 G bytes. */
+    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2 G bytes. */
 } edma_modulo_t;
 
 /*! @brief Bandwidth control */
@@ -177,7 +177,7 @@ typedef struct _edma_config
                                            the link channel is itself. */
     bool enableHaltOnError;           /*!< Enable (true) transfer halt on error. Any error causes the HALT bit to set.
                                            Subsequently, all service requests are ignored until the HALT bit is cleared.*/
-    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method, or fixed priority
+    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method or fixed priority
                                            arbitration is used for channel selection */
     bool enableDebugMode; /*!< Enable(true) eDMA debug mode. When in debug mode, the eDMA stalls the start of
                                a new channel. Executing channels are allowed to complete. */
@@ -211,15 +211,15 @@ typedef struct _edma_transfer_config
                                                 form the next-state value as each source read is completed. */
     int16_t destOffset;                    /*!< Sign-extended offset applied to the current destination address to
                                                 form the next-state value as each destination write is completed. */
-    uint16_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
+    uint32_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
     uint32_t majorLoopCounts;              /*!< Major loop iteration count. */
 } edma_transfer_config_t;
 
 /*! @brief eDMA channel priority configuration */
 typedef struct _edma_channel_Preemption_config
 {
-    bool enableChannelPreemption; /*!< If true: channel can be suspended by other channel with higher priority */
-    bool enablePreemptAbility;    /*!< If true: channel can suspend other channel with low priority */
+    bool enableChannelPreemption; /*!< If true: a channel can be suspended by other channel with higher priority */
+    bool enablePreemptAbility;    /*!< If true: a channel can suspend other channel with low priority */
     uint8_t channelPriority;      /*!< Channel priority */
 } edma_channel_Preemption_config_t;
 
@@ -228,7 +228,7 @@ typedef struct _edma_minor_offset_config
 {
     bool enableSrcMinorOffset;  /*!< Enable(true) or Disable(false) source minor loop offset. */
     bool enableDestMinorOffset; /*!< Enable(true) or Disable(false) destination minor loop offset. */
-    uint32_t minorOffset;       /*!< Offset for minor loop mapping. */
+    uint32_t minorOffset;       /*!< Offset for a minor loop mapping. */
 } edma_minor_offset_config_t;
 
 /*!
@@ -255,20 +255,21 @@ typedef struct _edma_tcd
 /*! @brief Callback for eDMA */
 struct _edma_handle;
 
-/*! @brief Define Callback function for eDMA. */
+/*! @brief Define callback function for eDMA. */
 typedef void (*edma_callback)(struct _edma_handle *handle, void *userData, bool transferDone, uint32_t tcds);
 
 /*! @brief eDMA transfer handle structure */
 typedef struct _edma_handle
 {
-    edma_callback callback;  /*!< Callback function for major count exhausted. */
-    void *userData;          /*!< Callback function parameter. */
-    DMA_Type *base;          /*!< eDMA peripheral base address. */
-    edma_tcd_t *tcdPool;     /*!< Pointer to memory stored TCDs. */
-    uint8_t channel;         /*!< eDMA channel number. */
-    volatile int8_t header;  /*!< The first TCD index. */
-    volatile int8_t tail;    /*!< The last TCD index. */
-    volatile int8_t tcdUsed; /*!< The number of used TCD slots. */
+    edma_callback callback; /*!< Callback function for major count exhausted. */
+    void *userData;         /*!< Callback function parameter. */
+    DMA_Type *base;         /*!< eDMA peripheral base address. */
+    edma_tcd_t *tcdPool;    /*!< Pointer to memory stored TCDs. */
+    uint8_t channel;        /*!< eDMA channel number. */
+    volatile int8_t header; /*!< The first TCD index. Should point to the next TCD to be loaded into the eDMA engine. */
+    volatile int8_t tail;   /*!< The last TCD index. Should point to the next TCD to be stored into the memory pool. */
+    volatile int8_t tcdUsed; /*!< The number of used TCD slots. Should reflect the number of TCDs can be used/loaded in
+                                the memory. */
     volatile int8_t tcdSize; /*!< The total number of TCD slots in the queue. */
     uint8_t flags;           /*!< The status of the current channel. */
 } edma_handle_t;
@@ -281,24 +282,24 @@ extern "C" {
 #endif /* __cplusplus */
 
 /*!
- * @name eDMA initialization and De-initialization
+ * @name eDMA initialization and de-initialization
  * @{
  */
 
 /*!
- * @brief Initializes eDMA peripheral.
+ * @brief Initializes the eDMA peripheral.
  *
  * This function ungates the eDMA clock and configures the eDMA peripheral according
  * to the configuration structure.
  *
  * @param base eDMA peripheral base address.
- * @param config Pointer to configuration structure, see "edma_config_t".
- * @note This function enable the minor loop map feature.
+ * @param config A pointer to the configuration structure, see "edma_config_t".
+ * @note This function enables the minor loop map feature.
  */
 void EDMA_Init(DMA_Type *base, const edma_config_t *config);
 
 /*!
- * @brief Deinitializes eDMA peripheral.
+ * @brief Deinitializes the eDMA peripheral.
  *
  * This function gates the eDMA clock.
  *
@@ -309,8 +310,8 @@ void EDMA_Deinit(DMA_Type *base);
 /*!
  * @brief Gets the eDMA default configuration structure.
  *
- * This function sets the configuration structure to a default value.
- * The default configuration is set to the following value:
+ * This function sets the configuration structure to default values.
+ * The default configuration is set to the following values.
  * @code
  *   config.enableContinuousLinkMode = false;
  *   config.enableHaltOnError = true;
@@ -318,7 +319,7 @@ void EDMA_Deinit(DMA_Type *base);
  *   config.enableDebugMode = false;
  * @endcode
  *
- * @param config Pointer to eDMA configuration structure.
+ * @param config A pointer to the eDMA configuration structure.
  */
 void EDMA_GetDefaultConfig(edma_config_t *config);
 
@@ -329,13 +330,13 @@ void EDMA_GetDefaultConfig(edma_config_t *config);
  */
 
 /*!
- * @brief Sets all TCD registers to a default value.
+ * @brief Sets all TCD registers to default values.
  *
- * This function sets TCD registers for this channel to default value.
+ * This function sets TCD registers for this channel to default values.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @note This function must not be called while the channel transfer is on-going,
+ * @note This function must not be called while the channel transfer is ongoing
  *       or it causes unpredictable results.
  * @note This function enables the auto stop request feature.
  */
@@ -364,7 +365,7 @@ void EDMA_ResetChannel(DMA_Type *base, uint32_t channel);
  *                do not want to enable scatter/gather feature.
  * @note If nextTcd is not NULL, it means scatter gather feature is enabled
  *       and DREQ bit is cleared in the previous transfer configuration, which
- *       is set in eDMA_ResetChannel.
+ *       is set in the eDMA_ResetChannel.
  */
 void EDMA_SetTransferConfig(DMA_Type *base,
                             uint32_t channel,
@@ -374,12 +375,12 @@ void EDMA_SetTransferConfig(DMA_Type *base,
 /*!
  * @brief Configures the eDMA minor offset feature.
  *
- * Minor offset means signed-extended value added to source address or destination
+ * The minor offset means that the signed-extended value is added to the source address or destination
  * address after each minor loop.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param config Pointer to Minor offset configuration structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_minor_offset_config_t *config);
 
@@ -390,7 +391,7 @@ void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_mino
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number
- * @param config Pointer to channel preemption configuration structure.
+ * @param config A pointer to the channel preemption configuration structure.
  */
 static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
                                                    uint32_t channel,
@@ -407,13 +408,13 @@ static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
 /*!
  * @brief Sets the channel link for the eDMA transfer.
  *
- * This function configures  minor link or major link mode. The minor link means that the channel link is
+ * This function configures either the minor link or the major link mode. The minor link means that the channel link is
  * triggered every time CITER decreases by 1. The major link means that the channel link is triggered when the CITER is
  * exhausted.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param type Channel link type, it can be one of:
+ * @param type A channel link type, which can be one of the following:
  *   @arg kEDMA_LinkNone
  *   @arg kEDMA_MinorLink
  *   @arg kEDMA_MajorLink
@@ -425,13 +426,13 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 /*!
  * @brief Sets the bandwidth for the eDMA transfer.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
  * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -439,7 +440,7 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWidth);
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA transfer.
+ * @brief Sets the source modulo and the destination modulo for the eDMA transfer.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
@@ -447,8 +448,8 @@ void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWi
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -458,7 +459,7 @@ void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, e
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable(ture) or disable(false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -475,7 +476,7 @@ static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, boo
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable (true) or disable (false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAutoStopRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -499,7 +500,7 @@ void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mas
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param mask The mask of interrupt source to be set. Use
+ * @param mask The mask of the interrupt source to be set. Use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
@@ -523,8 +524,8 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
 /*!
  * @brief Configures the eDMA TCD transfer attribute.
  *
- * TCD is a transfer control descriptor. The content of the TCD is the same as hardware TCD registers.
- * STCD is used in scatter-gather mode.
+ * The TCD is a transfer control descriptor. The content of the TCD is the same as the hardware TCD registers.
+ * The STCD is used in the scatter-gather mode.
  * This function configures the TCD transfer attribute, including source address, destination address,
  * transfer size, address offset, and so on. It also configures the scatter gather feature if the
  * user supplies the next TCD address.
@@ -542,7 +543,7 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
  * @param config Pointer to eDMA transfer configuration structure.
  * @param nextTcd Pointer to the next TCD structure. It can be NULL if users
  *                do not want to enable scatter/gather feature.
- * @note TCD address should be 32 bytes aligned, or it causes an eDMA error.
+ * @note TCD address should be 32 bytes aligned or it causes an eDMA error.
  * @note If the nextTcd is not NULL, the scatter gather feature is enabled
  *       and DREQ bit is cleared in the previous transfer configuration, which
  *       is set in the EDMA_TcdReset.
@@ -552,16 +553,16 @@ void EDMA_TcdSetTransferConfig(edma_tcd_t *tcd, const edma_transfer_config_t *co
 /*!
  * @brief Configures the eDMA TCD minor offset feature.
  *
- * Minor offset is a signed-extended value added to the source address or destination
+ * A minor offset is a signed-extended value added to the source address or a destination
  * address after each minor loop.
  *
- * @param tcd Point to the TCD structure.
- * @param config Pointer to Minor offset configuration structure.
+ * @param tcd A point to the TCD structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_TcdSetMinorOffsetConfig(edma_tcd_t *tcd, const edma_minor_offset_config_t *config);
 
 /*!
- * @brief Sets the channel link for eDMA TCD.
+ * @brief Sets the channel link for the eDMA TCD.
  *
  * This function configures either a minor link or a major link. The minor link means the channel link is
  * triggered every time CITER decreases by 1. The major link means that the channel link  is triggered when the CITER is
@@ -580,11 +581,11 @@ void EDMA_TcdSetChannelLink(edma_tcd_t *tcd, edma_channel_link_type_t type, uint
 /*!
  * @brief Sets the bandwidth for the eDMA TCD.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
- * until the minor count is exhausted. Bandwidth forces the eDMA to stall after the completion of
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
- * @param tcd Point to the TCD structure.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param tcd A pointer to the TCD structure.
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -598,15 +599,15 @@ static inline void EDMA_TcdSetBandWidth(edma_tcd_t *tcd, edma_bandwidth_t bandWi
 }
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA TCD.
+ * @brief Sets the source modulo and the destination modulo for the eDMA TCD.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
  * queue easily.
  *
- * @param tcd Point to the TCD structure.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param tcd A pointer to the TCD structure.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -615,8 +616,8 @@ void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t d
  *
  * If enabling the auto stop request, the eDMA hardware automatically disables the hardware channel request.
  *
- * @param tcd Point to the TCD structure.
- * @param enable The command for enable(ture) or disable(false).
+ * @param tcd A pointer to the TCD structure.
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_TcdEnableAutoStopRequest(edma_tcd_t *tcd, bool enable)
 {
@@ -681,7 +682,7 @@ static inline void EDMA_DisableChannelRequest(DMA_Type *base, uint32_t channel)
 }
 
 /*!
- * @brief Starts the eDMA transfer by software trigger.
+ * @brief Starts the eDMA transfer by using the software trigger.
  *
  * This function starts a minor loop transfer.
  *
@@ -702,25 +703,34 @@ static inline void EDMA_TriggerChannelStart(DMA_Type *base, uint32_t channel)
  */
 
 /*!
- * @brief Gets the Remaining bytes from the eDMA current channel TCD.
+ * @brief Gets the remaining major loop count from the eDMA current channel TCD.
  *
  * This function checks the TCD (Task Control Descriptor) status for a specified
- * eDMA channel and returns the the number of bytes that have not finished.
+ * eDMA channel and returns the the number of major loop count that has not finished.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @return Bytes have not been transferred yet for the current TCD.
- * @note This function can only be used to get unfinished bytes of transfer without
- *       the next TCD, or it might be inaccuracy.
+ * @return Major loop count which has not been transferred yet for the current TCD.
+ * @note 1. This function can only be used to get unfinished major loop count of transfer without
+ *          the next TCD, or it might be inaccuracy.
+ *       2. The unfinished/remaining transfer bytes cannot be obtained directly from registers while
+ *          the channel is running.
+ *          Because to calculate the remaining bytes, the initial NBYTES configured in DMA_TCDn_NBYTES_MLNO
+ *          register is needed while the eDMA IP does not support getting it while a channel is active.
+ *          In another word, the NBYTES value reading is always the actual (decrementing) NBYTES value the dma_engine
+ *          is working with while a channel is running.
+ *          Consequently, to get the remaining transfer bytes, a software-saved initial value of NBYTES (for example
+ *          copied before enabling the channel) is needed. The formula to calculate it is shown below:
+ *          RemainingBytes = RemainingMajorLoopCount * NBYTES(initially configured)
  */
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel);
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel);
 
 /*!
  * @brief Gets the eDMA channel error status flags.
  *
  * @param base eDMA peripheral base address.
  * @return The mask of error status flags. Users need to use the
- *         _edma_error_status_flags type to decode the return variables.
+*         _edma_error_status_flags type to decode the return variables.
  */
 static inline uint32_t EDMA_GetErrorStatusFlags(DMA_Type *base)
 {
@@ -755,8 +765,8 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 /*!
  * @brief Creates the eDMA handle.
  *
- * This function is called if using transaction API for eDMA. This function
- * initializes the internal state of eDMA handle.
+ * This function is called if using the transactional API for eDMA. This function
+ * initializes the internal state of the eDMA handle.
  *
  * @param handle eDMA handle pointer. The eDMA handle stores callback function and
  *               parameters.
@@ -766,12 +776,12 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel);
 
 /*!
- * @brief Installs the TCDs memory pool into eDMA handle.
+ * @brief Installs the TCDs memory pool into the eDMA handle.
  *
  * This function is called after the EDMA_CreateHandle to use scatter/gather feature.
  *
  * @param handle eDMA handle pointer.
- * @param tcdPool Memory pool to store TCDs. It must be 32 bytes aligned.
+ * @param tcdPool A memory pool to store TCDs. It must be 32 bytes aligned.
  * @param tcdSize The number of TCD slots.
  */
 void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t tcdSize);
@@ -779,12 +789,12 @@ void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t 
 /*!
  * @brief Installs a callback function for the eDMA transfer.
  *
- * This callback is called in eDMA IRQ handler. Use the callback to do something after
+ * This callback is called in the eDMA IRQ handler. Use the callback to do something after
  * the current major loop transfer completes.
  *
  * @param handle eDMA handle pointer.
  * @param callback eDMA callback function pointer.
- * @param userData Parameter for callback function.
+ * @param userData A parameter for the callback function.
  */
 void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userData);
 
@@ -802,8 +812,8 @@ void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userD
  * @param transferBytes eDMA transfer bytes to be transferred.
  * @param type eDMA transfer type.
  * @note The data address and the data width must be consistent. For example, if the SRC
- *       is 4 bytes, so the source address must be 4 bytes aligned, or it shall result in
- *       source address error(SAE).
+ *       is 4 bytes, the source address must be 4 bytes aligned, or it results in
+ *       source address error (SAE).
  */
 void EDMA_PrepareTransfer(edma_transfer_config_t *config,
                           void *srcAddr,
@@ -818,7 +828,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
  * @brief Submits the eDMA transfer request.
  *
  * This function submits the eDMA transfer request according to the transfer configuration structure.
- * If the user submits the transfer request repeatedly, this function packs an unprocessed request as
+ * If submitting the transfer request repeatedly, this function packs an unprocessed request as
  * a TCD and enables scatter/gather feature to process it in the next time.
  *
  * @param handle eDMA handle pointer.
@@ -830,7 +840,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
 status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t *config);
 
 /*!
- * @brief eDMA start transfer.
+ * @brief eDMA starts transfer.
  *
  * This function enables the channel request. Users can call this function after submitting the transfer request
  * or before submitting the transfer request.
@@ -840,7 +850,7 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
 void EDMA_StartTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA stop transfer.
+ * @brief eDMA stops transfer.
  *
  * This function disables the channel request to pause the transfer. Users can call EDMA_StartTransfer()
  * again to resume the transfer.
@@ -850,7 +860,7 @@ void EDMA_StartTransfer(edma_handle_t *handle);
 void EDMA_StopTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA abort transfer.
+ * @brief eDMA aborts transfer.
  *
  * This function disables the channel request and clear transfer status bits.
  * Users can submit another transfer after calling this API.
@@ -860,10 +870,30 @@ void EDMA_StopTransfer(edma_handle_t *handle);
 void EDMA_AbortTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA IRQ handler for current major loop transfer complete.
+ * @brief eDMA IRQ handler for the current major loop transfer completion.
  *
- * This function clears the channel major interrupt flag and call
+ * This function clears the channel major interrupt flag and calls
  * the callback function if it is not NULL.
+ *
+ * Note:
+ * For the case using TCD queue, when the major iteration count is exhausted, additional operations are performed.
+ * These include the final address adjustments and reloading of the BITER field into the CITER.
+ * Assertion of an optional interrupt request also occurs at this time, as does a possible fetch of a new TCD from
+ * memory using the scatter/gather address pointer included in the descriptor (if scatter/gather is enabled).
+ *
+ * For instance, when the time interrupt of TCD[0] happens, the TCD[1] has already been loaded into the eDMA engine.
+ * As sga and sga_index are calculated based on the DLAST_SGA bitfield lies in the TCD_CSR register, the sga_index
+ * in this case should be 2 (DLAST_SGA of TCD[1] stores the address of TCD[2]). Thus, the "tcdUsed" updated should be
+ * (tcdUsed - 2U) which indicates the number of TCDs can be loaded in the memory pool (because TCD[0] and TCD[1] have
+ * been loaded into the eDMA engine at this point already.).
+ *
+ * For the last two continuous ISRs in a scatter/gather process, they  both load the last TCD (The last ISR does not
+ * load a new TCD) from the memory pool to the eDMA engine when major loop completes.
+ * Therefore, ensure that the header and tcdUsed updated are identical for them.
+ * tcdUsed are both 0 in this case as no TCD to be loaded.
+ *
+ * See the "eDMA basic data flow" in the eDMA Functional description section of the Reference Manual for
+ * further details.
  *
  * @param handle eDMA handle pointer.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_camera_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_camera_edma.c
@@ -170,6 +170,9 @@ status_t FLEXIO_CAMERA_TransferReceiveEDMA(FLEXIO_CAMERA_Type *base,
         EDMA_PrepareTransfer(&xferConfig, (void *)FLEXIO_CAMERA_GetRxBufferAddress(base), 32, (void *)xfer->dataAddress,
                              32, 32, xfer->dataNum, kEDMA_PeripheralToMemory);
 
+        /* Store the initially configured eDMA minor byte transfer count into the FLEXIO CAMERA handle */
+        handle->nbytes = 32;
+
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->rxEdmaHandle, &xferConfig);
         EDMA_StartTransfer(handle->rxEdmaHandle);
@@ -207,7 +210,9 @@ status_t FLEXIO_CAMERA_TransferGetReceiveCountEDMA(FLEXIO_CAMERA_Type *base,
 
     if (kFLEXIO_CAMERA_RxBusy == handle->rxState)
     {
-        *count = (handle->rxSize - EDMA_GetRemainingBytes(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel));
+        *count = (handle->rxSize -
+                  (uint32_t)handle->nbytes *
+                      EDMA_GetRemainingMajorLoopCount(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel));
     }
     else
     {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_camera_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_camera_edma.h
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -47,21 +46,22 @@
 /*! @brief Forward declaration of the handle typedef. */
 typedef struct _flexio_camera_edma_handle flexio_camera_edma_handle_t;
 
-/*! @brief CAMERA transfer callback function. */
+/*! @brief Camera transfer callback function. */
 typedef void (*flexio_camera_edma_transfer_callback_t)(FLEXIO_CAMERA_Type *base,
                                                        flexio_camera_edma_handle_t *handle,
                                                        status_t status,
                                                        void *userData);
 
 /*!
-* @brief CAMERA eDMA handle
+* @brief Camera eDMA handle
 */
 struct _flexio_camera_edma_handle
 {
     flexio_camera_edma_transfer_callback_t callback; /*!< Callback function. */
-    void *userData;                                  /*!< CAMERA callback function parameter.*/
+    void *userData;                                  /*!< Camera callback function parameter.*/
     size_t rxSize;                                   /*!< Total bytes to be received. */
     edma_handle_t *rxEdmaHandle;                     /*!< The eDMA RX channel used. */
+    uint8_t nbytes;                                  /*!< eDMA minor byte transfer count initially configured. */
     volatile uint8_t rxState;                        /*!< RX transfer state */
 };
 
@@ -79,15 +79,15 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes the camera handle, which is used in transactional functions.
+ * @brief Initializes the Camera handle, which is used in transactional functions.
  *
- * @param base pointer to FLEXIO_CAMERA_Type.
+ * @param base Pointer to the FLEXIO_CAMERA_Type.
  * @param handle Pointer to flexio_camera_edma_handle_t structure.
  * @param callback The callback function.
  * @param userData The parameter of the callback function.
  * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
  * @retval kStatus_Success Successfully create the handle.
- * @retval kStatus_OutOfRange The FlexIO camera eDMA type/handle table out of range.
+ * @retval kStatus_OutOfRange The FlexIO Camera eDMA type/handle table out of range.
  */
 status_t FLEXIO_CAMERA_TransferCreateHandleEDMA(FLEXIO_CAMERA_Type *base,
                                                 flexio_camera_edma_handle_t *handle,
@@ -103,7 +103,7 @@ status_t FLEXIO_CAMERA_TransferCreateHandleEDMA(FLEXIO_CAMERA_Type *base,
  *
  * @param base Pointer to the FLEXIO_CAMERA_Type.
  * @param handle Pointer to the flexio_camera_edma_handle_t structure.
- * @param xfer CAMERA eDMA transfer structure, see #flexio_camera_transfer_t.
+ * @param xfer Camera eDMA transfer structure, see #flexio_camera_transfer_t.
  * @retval kStatus_Success if succeeded, others failed.
  * @retval kStatus_CAMERA_RxBusy Previous transfer on going.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_i2s_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_i2s_edma.c
@@ -225,6 +225,9 @@ status_t FLEXIO_I2S_TransferSendEDMA(FLEXIO_I2S_Type *base,
     EDMA_PrepareTransfer(&config, xfer->data, handle->bytesPerFrame, (void *)destAddr, handle->bytesPerFrame,
                          handle->bytesPerFrame, xfer->dataSize, kEDMA_MemoryToPeripheral);
 
+    /* Store the initially configured eDMA minor byte transfer count into the FLEXIO I2S handle */
+    handle->nbytes = handle->bytesPerFrame;
+
     EDMA_SubmitTransfer(handle->dmaHandle, &config);
 
     /* Start DMA transfer */
@@ -271,6 +274,9 @@ status_t FLEXIO_I2S_TransferReceiveEDMA(FLEXIO_I2S_Type *base,
     /* Prepare edma configure */
     EDMA_PrepareTransfer(&config, (void *)srcAddr, handle->bytesPerFrame, xfer->data, handle->bytesPerFrame,
                          handle->bytesPerFrame, xfer->dataSize, kEDMA_PeripheralToMemory);
+
+    /* Store the initially configured eDMA minor byte transfer count into the FLEXIO I2S handle */
+    handle->nbytes = handle->bytesPerFrame;
 
     EDMA_SubmitTransfer(handle->dmaHandle, &config);
 
@@ -327,7 +333,8 @@ status_t FLEXIO_I2S_TransferGetSendCountEDMA(FLEXIO_I2S_Type *base, flexio_i2s_e
     else
     {
         *count = handle->transferSize[handle->queueDriver] -
-                 EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel);
+                 (uint32_t)handle->nbytes *
+                     EDMA_GetRemainingMajorLoopCount(handle->dmaHandle->base, handle->dmaHandle->channel);
     }
 
     return status;
@@ -346,7 +353,8 @@ status_t FLEXIO_I2S_TransferGetReceiveCountEDMA(FLEXIO_I2S_Type *base, flexio_i2
     else
     {
         *count = handle->transferSize[handle->queueDriver] -
-                 EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel);
+                 (uint32_t)handle->nbytes *
+                     EDMA_GetRemainingMajorLoopCount(handle->dmaHandle->base, handle->dmaHandle->channel);
     }
 
     return status;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_i2s_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_i2s_edma.h
@@ -38,7 +38,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -56,6 +55,7 @@ struct _flexio_i2s_edma_handle
 {
     edma_handle_t *dmaHandle;                        /*!< DMA handler for FlexIO I2S send */
     uint8_t bytesPerFrame;                           /*!< Bytes in a frame */
+    uint8_t nbytes;                                  /*!< eDMA minor byte transfer count initially configured. */
     uint32_t state;                                  /*!< Internal state for FlexIO I2S eDMA transfer */
     flexio_i2s_edma_callback_t callback;             /*!< Callback for users while transfer finish or error occurred */
     void *userData;                                  /*!< User callback parameter */
@@ -83,13 +83,13 @@ extern "C" {
  *
  * This function initializes the FlexIO I2S master DMA handle which can be used for other FlexIO I2S master
  * transactional APIs.
- * Usually, for a specified FlexIO I2S instance, user need only call this API once to get the initialized handle.
+ * Usually, for a specified FlexIO I2S instance, call this API once to get the initialized handle.
  *
  * @param base FlexIO I2S peripheral base address.
  * @param handle FlexIO I2S eDMA handle pointer.
  * @param callback FlexIO I2S eDMA callback function called while finished a block.
  * @param userData User parameter for callback.
- * @param dmaHandle eDMA handle for FlexIO I2S. This handle shall be a static value allocated by users.
+ * @param dmaHandle eDMA handle for FlexIO I2S. This handle is a static value allocated by users.
  */
 void FLEXIO_I2S_TransferTxCreateHandleEDMA(FLEXIO_I2S_Type *base,
                                            flexio_i2s_edma_handle_t *handle,
@@ -102,13 +102,13 @@ void FLEXIO_I2S_TransferTxCreateHandleEDMA(FLEXIO_I2S_Type *base,
  *
  * This function initializes the FlexIO I2S slave DMA handle which can be used for other FlexIO I2S master transactional
  * APIs.
- * Usually, for a specified FlexIO I2S instance, user need only call this API once to get the initialized handle.
+ * Usually, for a specified FlexIO I2S instance, call this API once to get the initialized handle.
  *
  * @param base FlexIO I2S peripheral base address.
  * @param handle FlexIO I2S eDMA handle pointer.
  * @param callback FlexIO I2S eDMA callback function called while finished a block.
  * @param userData User parameter for callback.
- * @param dmaHandle eDMA handle for FlexIO I2S. This handle shall be a static value allocated by users.
+ * @param dmaHandle eDMA handle for FlexIO I2S. This handle is a static value allocated by users.
  */
 void FLEXIO_I2S_TransferRxCreateHandleEDMA(FLEXIO_I2S_Type *base,
                                            flexio_i2s_edma_handle_t *handle,
@@ -120,7 +120,7 @@ void FLEXIO_I2S_TransferRxCreateHandleEDMA(FLEXIO_I2S_Type *base,
  * @brief Configures the FlexIO I2S Tx audio format.
  *
  * Audio format can be changed in run-time of FlexIO I2S. This function configures the sample rate and audio data
- * format to be transferred. This function also sets eDMA parameter according to format.
+ * format to be transferred. This function also sets the eDMA parameter according to format.
  *
  * @param base FlexIO I2S peripheral base address.
  * @param handle FlexIO I2S eDMA handle pointer
@@ -137,8 +137,8 @@ void FLEXIO_I2S_TransferSetFormatEDMA(FLEXIO_I2S_Type *base,
 /*!
  * @brief Performs a non-blocking FlexIO I2S transfer using DMA.
  *
- * @note This interface returned immediately after transfer initiates, users should call
- * FLEXIO_I2S_GetTransferStatus to poll the transfer status to check whether FlexIO I2S transfer finished.
+ * @note This interface returned immediately after transfer initiates. Users should call
+ * FLEXIO_I2S_GetTransferStatus to poll the transfer status and check whether the FlexIO I2S transfer is finished.
  *
  * @param base FlexIO I2S peripheral base address.
  * @param handle FlexIO I2S DMA handle pointer.
@@ -154,8 +154,8 @@ status_t FLEXIO_I2S_TransferSendEDMA(FLEXIO_I2S_Type *base,
 /*!
  * @brief Performs a non-blocking FlexIO I2S receive using eDMA.
  *
- * @note This interface returned immediately after transfer initiates, users should call
- * FLEXIO_I2S_GetReceiveRemainingBytes to poll the transfer status to check whether FlexIO I2S transfer finished.
+ * @note This interface returned immediately after transfer initiates. Users should call
+ * FLEXIO_I2S_GetReceiveRemainingBytes to poll the transfer status and check whether the FlexIO I2S transfer is finished.
  *
  * @param base FlexIO I2S peripheral base address.
  * @param handle FlexIO I2S DMA handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_spi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_spi_edma.h
@@ -38,7 +38,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -65,6 +64,7 @@ typedef void (*flexio_spi_slave_edma_transfer_callback_t)(FLEXIO_SPI_Type *base,
 struct _flexio_spi_master_edma_handle
 {
     size_t transferSize;                                 /*!< Total bytes to be transferred. */
+    uint8_t nbytes;                                      /*!< eDMA minor byte transfer count initially configured. */
     bool txInProgress;                                   /*!< Send transfer in progress */
     bool rxInProgress;                                   /*!< Receive transfer in progress */
     edma_handle_t *txHandle;                             /*!< DMA handler for SPI send */
@@ -86,14 +86,14 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes the FLEXO SPI master eDMA handle.
+ * @brief Initializes the FlexIO SPI master eDMA handle.
  *
- * This function initializes the FLEXO SPI master eDMA handle which can be used for other FLEXO SPI master transactional
+ * This function initializes the FlexIO SPI master eDMA handle which can be used for other FlexIO SPI master transactional
  * APIs.
- * For a specified FLEXO SPI instance, call this API once to get the initialized handle.
+ * For a specified FlexIO SPI instance, call this API once to get the initialized handle.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
- * @param handle pointer to flexio_spi_master_edma_handle_t structure to store the transfer state.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
+ * @param handle Pointer to flexio_spi_master_edma_handle_t structure to store the transfer state.
  * @param callback SPI callback, NULL means no callback.
  * @param userData callback function parameter.
  * @param txHandle User requested eDMA handle for FlexIO SPI RX eDMA transfer.
@@ -112,11 +112,11 @@ status_t FLEXIO_SPI_MasterTransferCreateHandleEDMA(FLEXIO_SPI_Type *base,
  * @brief Performs a non-blocking FlexIO SPI transfer using eDMA.
  *
  * @note This interface returns immediately after transfer initiates. Call
- * FLEXIO_SPI_MasterGetTransferCountEDMA to poll the transfer status to check
- * whether FlexIO SPI transfer finished.
+ * FLEXIO_SPI_MasterGetTransferCountEDMA to poll the transfer status and check
+ * whether the FlexIO SPI transfer is finished.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
- * @param handle pointer to flexio_spi_master_edma_handle_t structure to store the transfer state.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
+ * @param handle Pointer to flexio_spi_master_edma_handle_t structure to store the transfer state.
  * @param xfer Pointer to FlexIO SPI transfer structure.
  * @retval kStatus_Success Successfully start a transfer.
  * @retval kStatus_InvalidArgument Input argument is invalid.
@@ -129,7 +129,7 @@ status_t FLEXIO_SPI_MasterTransferEDMA(FLEXIO_SPI_Type *base,
 /*!
  * @brief Aborts a FlexIO SPI transfer using eDMA.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
  * @param handle FlexIO SPI eDMA handle pointer.
  */
 void FLEXIO_SPI_MasterTransferAbortEDMA(FLEXIO_SPI_Type *base, flexio_spi_master_edma_handle_t *handle);
@@ -137,7 +137,7 @@ void FLEXIO_SPI_MasterTransferAbortEDMA(FLEXIO_SPI_Type *base, flexio_spi_master
 /*!
  * @brief Gets the remaining bytes for FlexIO SPI eDMA transfer.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
  * @param handle FlexIO SPI eDMA handle pointer.
  * @param count Number of bytes transferred so far by the non-blocking transaction.
  */
@@ -150,8 +150,8 @@ status_t FLEXIO_SPI_MasterTransferGetCountEDMA(FLEXIO_SPI_Type *base,
  *
  * This function initializes the FlexIO SPI slave eDMA handle.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
- * @param handle pointer to flexio_spi_slave_edma_handle_t structure to store the transfer state.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
+ * @param handle Pointer to flexio_spi_slave_edma_handle_t structure to store the transfer state.
  * @param callback SPI callback, NULL means no callback.
  * @param userData callback function parameter.
  * @param txHandle User requested eDMA handle for FlexIO SPI TX eDMA transfer.
@@ -171,11 +171,11 @@ static inline void FLEXIO_SPI_SlaveTransferCreateHandleEDMA(FLEXIO_SPI_Type *bas
  * @brief Performs a non-blocking FlexIO SPI transfer using eDMA.
  *
  * @note This interface returns immediately after transfer initiates. Call
- * FLEXIO_SPI_SlaveGetTransferCountEDMA to poll the transfer status to
- * check whether FlexIO SPI transfer finished.
+ * FLEXIO_SPI_SlaveGetTransferCountEDMA to poll the transfer status and
+ * check whether the FlexIO SPI transfer is finished.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
- * @param handle pointer to flexio_spi_slave_edma_handle_t structure to store the transfer state.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
+ * @param handle Pointer to flexio_spi_slave_edma_handle_t structure to store the transfer state.
  * @param xfer Pointer to FlexIO SPI transfer structure.
  * @retval kStatus_Success Successfully start a transfer.
  * @retval kStatus_InvalidArgument Input argument is invalid.
@@ -188,8 +188,8 @@ status_t FLEXIO_SPI_SlaveTransferEDMA(FLEXIO_SPI_Type *base,
 /*!
  * @brief Aborts a FlexIO SPI transfer using eDMA.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
- * @param handle pointer to flexio_spi_slave_edma_handle_t structure to store the transfer state.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
+ * @param handle Pointer to flexio_spi_slave_edma_handle_t structure to store the transfer state.
  */
 static inline void FLEXIO_SPI_SlaveTransferAbortEDMA(FLEXIO_SPI_Type *base, flexio_spi_slave_edma_handle_t *handle)
 {
@@ -199,7 +199,7 @@ static inline void FLEXIO_SPI_SlaveTransferAbortEDMA(FLEXIO_SPI_Type *base, flex
 /*!
  * @brief Gets the remaining bytes to be transferred for FlexIO SPI eDMA.
  *
- * @param base pointer to FLEXIO_SPI_Type structure.
+ * @param base Pointer to FLEXIO_SPI_Type structure.
  * @param handle FlexIO SPI eDMA handle pointer.
  * @param count Number of bytes transferred so far by the non-blocking transaction.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_uart_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flexio_uart_edma.h
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -61,11 +60,13 @@ struct _flexio_uart_edma_handle
     flexio_uart_edma_transfer_callback_t callback; /*!< Callback function. */
     void *userData;                                /*!< UART callback function parameter.*/
 
-    size_t txSize; /*!< Total bytes to be sent. */
-    size_t rxSize; /*!< Total bytes to be received. */
+    size_t txDataSizeAll; /*!< Total bytes to be sent. */
+    size_t rxDataSizeAll; /*!< Total bytes to be received. */
 
     edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
     edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
+
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
     volatile uint8_t txState; /*!< TX transfer state. */
     volatile uint8_t rxState; /*!< RX transfer state */
@@ -87,7 +88,7 @@ extern "C" {
 /*!
  * @brief Initializes the UART handle which is used in transactional functions.
  *
- * @param base pointer to FLEXIO_UART_Type.
+ * @param base Pointer to FLEXIO_UART_Type.
  * @param handle Pointer to flexio_uart_edma_handle_t structure.
  * @param callback The callback function.
  * @param userData The parameter of the callback function.
@@ -107,9 +108,9 @@ status_t FLEXIO_UART_TransferCreateHandleEDMA(FLEXIO_UART_Type *base,
  * @brief Sends data using eDMA.
  *
  * This function sends data using eDMA. This is a non-blocking function, which returns
- * right away. When all data have been sent out, the send callback function is called.
+ * right away. When all data is sent out, the send callback function is called.
  *
- * @param base pointer to FLEXIO_UART_Type
+ * @param base Pointer to FLEXIO_UART_Type
  * @param handle UART handle pointer.
  * @param xfer UART eDMA transfer structure, see #flexio_uart_transfer_t.
  * @retval kStatus_Success if succeed, others failed.
@@ -123,9 +124,9 @@ status_t FLEXIO_UART_TransferSendEDMA(FLEXIO_UART_Type *base,
  * @brief Receives data using eDMA.
  *
  * This function receives data using eDMA. This is a non-blocking function, which returns
- * right away. When all data have been received, the receive callback function is called.
+ * right away. When all data is received, the receive callback function is called.
  *
- * @param base pointer to FLEXIO_UART_Type
+ * @param base Pointer to FLEXIO_UART_Type
  * @param handle Pointer to flexio_uart_edma_handle_t structure
  * @param xfer UART eDMA transfer structure, see #flexio_uart_transfer_t.
  * @retval kStatus_Success if succeed, others failed.
@@ -140,7 +141,7 @@ status_t FLEXIO_UART_TransferReceiveEDMA(FLEXIO_UART_Type *base,
  *
  * This function aborts sent data which using eDMA.
  *
- * @param base pointer to FLEXIO_UART_Type
+ * @param base Pointer to FLEXIO_UART_Type
  * @param handle Pointer to flexio_uart_edma_handle_t structure
  */
 void FLEXIO_UART_TransferAbortSendEDMA(FLEXIO_UART_Type *base, flexio_uart_edma_handle_t *handle);
@@ -150,30 +151,34 @@ void FLEXIO_UART_TransferAbortSendEDMA(FLEXIO_UART_Type *base, flexio_uart_edma_
  *
  * This function aborts the receive data which using eDMA.
  *
- * @param base pointer to FLEXIO_UART_Type
+ * @param base Pointer to FLEXIO_UART_Type
  * @param handle Pointer to flexio_uart_edma_handle_t structure
  */
 void FLEXIO_UART_TransferAbortReceiveEDMA(FLEXIO_UART_Type *base, flexio_uart_edma_handle_t *handle);
 
 /*!
- * @brief Gets the number of bytes still not sent out.
+ * @brief Gets the number of bytes sent out.
  *
- * This function gets the number of bytes still not sent out.
+ * This function gets the number of bytes sent out.
  *
- * @param base pointer to FLEXIO_UART_Type
+ * @param base Pointer to FLEXIO_UART_Type
  * @param handle Pointer to flexio_uart_edma_handle_t structure
  * @param count Number of bytes sent so far by the non-blocking transaction.
+ * @retval kStatus_NoTransferInProgress transfer has finished or no transfer in progress.
+ * @retval kStatus_Success Successfully return the count.
  */
 status_t FLEXIO_UART_TransferGetSendCountEDMA(FLEXIO_UART_Type *base, flexio_uart_edma_handle_t *handle, size_t *count);
 
 /*!
- * @brief Gets the number of bytes still not received.
+ * @brief Gets the number of bytes received.
  *
- * This function gets the number of bytes still not received.
+ * This function gets the number of bytes received.
  *
- * @param base pointer to FLEXIO_UART_Type
+ * @param base Pointer to FLEXIO_UART_Type
  * @param handle Pointer to flexio_uart_edma_handle_t structure
- * @param count Number of bytes sent so far by the non-blocking transaction.
+ * @param count Number of bytes received so far by the non-blocking transaction.
+ * @retval kStatus_NoTransferInProgress transfer has finished or no transfer in progress.
+ * @retval kStatus_Success Successfully return the count.
  */
 status_t FLEXIO_UART_TransferGetReceiveCountEDMA(FLEXIO_UART_Type *base,
                                                  flexio_uart_edma_handle_t *handle,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_i2c.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -76,6 +76,19 @@ typedef void (*i2c_isr_t)(I2C_Type *base, void *i2cHandle);
 uint32_t I2C_GetInstance(I2C_Type *base);
 
 /*!
+* @brief Set SCL/SDA hold time, this API receives SCL stop hold time, calculate the
+* closest SCL divider and MULT value for the SDA hold time, SCL start and SCL stop
+* hold time. To reduce the ROM size, SDA/SCL hold value mapping table is not provided,
+* assume SCL divider = SCL stop hold value *2 to get the closest SCL divider value and MULT
+* value, then the related SDA hold time, SCL start and SCL stop hold time is used.
+*
+* @param base I2C peripheral base address.
+* @param sourceClock_Hz I2C functional clock frequency in Hertz.
+* @param sclStopHoldTime_ns SCL stop hold time in ns.
+*/
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz);
+
+/*!
  * @brief Set up master transfer, send slave address and decide the initial
  * transfer state.
  *
@@ -137,8 +150,10 @@ static I2C_Type *const s_i2cBases[] = I2C_BASE_PTRS;
 /*! @brief Pointers to i2c IRQ number for each instance. */
 static const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to i2c clocks for each instance. */
 static const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static i2c_isr_t s_i2cMasterIsr;
@@ -155,7 +170,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_I2C_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -163,16 +178,63 @@ uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_I2C_COUNT);
+    assert(instance < ARRAY_SIZE(s_i2cBases));
 
     return instance;
+}
+
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedSclHoldTime;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult = 0u;
+    uint32_t bestIcr = 0u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    /* SDA hold time = bus period (s) * mul * SDA hold value. */
+    /* SCL start hold time = bus period (s) * mul * SCL start hold value. */
+    /* SCL stop hold time = bus period (s) * mul * SCL stop hold value. */
+
+    for (mult = 0u; (mult <= 2u) && (bestError != 0); ++mult)
+    {
+        multiplier = 1u << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(s_i2cDividerTable[0]); ++i)
+        {
+            /* Assume SCL hold(stop) value = s_i2cDividerTable[i]/2. */
+            computedSclHoldTime = ((multiplier * s_i2cDividerTable[i]) * 500000000U) / sourceClock_Hz;
+            absError = sclStopHoldTime_ns > computedSclHoldTime ? (sclStopHoldTime_ns - computedSclHoldTime) :
+                                                                  (computedSclHoldTime - sclStopHoldTime_ns);
+
+            if (absError < bestError)
+            {
+                bestMult = mult;
+                bestIcr = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
 }
 
 static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
 {
     status_t result = kStatus_Success;
     i2c_direction_t direction = xfer->direction;
-    uint16_t timeout = UINT16_MAX;
 
     /* Initialize the handle transfer information. */
     handle->transfer = *xfer;
@@ -183,27 +245,13 @@ static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t
     /* Initial transfer state. */
     if (handle->transfer.subaddressSize > 0)
     {
-        handle->state = kSendCommandState;
         if (xfer->direction == kI2C_Read)
         {
             direction = kI2C_Write;
         }
     }
-    else
-    {
-        handle->state = kCheckAddressState;
-    }
 
-    /* Wait until the data register is ready for transmit. */
-    while ((!(base->S & kI2C_TransferCompleteFlag)) && (--timeout))
-    {
-    }
-
-    /* Failed to start the transfer. */
-    if (timeout == 0)
-    {
-        return kStatus_I2C_Timeout;
-    }
+    handle->state = kCheckAddressState;
 
     /* Clear all status before transfer. */
     I2C_MasterClearStatusFlags(base, kClearFlags);
@@ -265,32 +313,39 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
         result = kStatus_Success;
     }
 
-    if (result)
-    {
-        return result;
-    }
-
     /* Handle Check address state to check the slave address is Acked in slave
        probe application. */
     if (handle->state == kCheckAddressState)
     {
         if (statusFlags & kI2C_ReceiveNakFlag)
         {
-            return kStatus_I2C_Nak;
+            result = kStatus_I2C_Addr_Nak;
         }
         else
         {
-            if (handle->transfer.direction == kI2C_Write)
+            if (handle->transfer.subaddressSize > 0)
             {
-                /* Next state, send data. */
-                handle->state = kSendDataState;
+                handle->state = kSendCommandState;
             }
             else
             {
-                /* Next state, receive data begin. */
-                handle->state = kReceiveDataBeginState;
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Next state, send data. */
+                    handle->state = kSendDataState;
+                }
+                else
+                {
+                    /* Next state, receive data begin. */
+                    handle->state = kReceiveDataBeginState;
+                }
             }
         }
+    }
+
+    if (result)
+    {
+        return result;
     }
 
     /* Run state machine. */
@@ -375,6 +430,10 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
                     {
                         result = I2C_MasterStop(base);
                     }
+                    else
+                    {
+                        base->C1 |= I2C_C1_TX_MASK;
+                    }
                 }
 
                 /* Send NAK at the last receive byte. */
@@ -407,6 +466,7 @@ static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle)
     {
         s_i2cSlaveIsr(base, handle);
     }
+    __DSB();
 }
 
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz)
@@ -415,14 +475,26 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Temporary register for filter read. */
     uint8_t fltReg;
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    uint8_t c2Reg;
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
     uint8_t s2Reg;
 #endif
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Enable I2C clock. */
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Disable I2C prior to configuring it. */
     base->C1 &= ~(I2C_C1_IICEN_MASK);
@@ -432,14 +504,6 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Configure baud rate. */
     I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
-
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Configure high drive feature. */
-    c2Reg = base->C2;
-    c2Reg &= ~(I2C_C2_HDRS_MASK);
-    c2Reg |= I2C_C2_HDRS(masterConfig->enableHighDrive);
-    base->C2 = c2Reg;
-#endif
 
     /* Read out the FLT register. */
     fltReg = base->FLT;
@@ -472,8 +536,10 @@ void I2C_MasterDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
@@ -482,11 +548,6 @@ void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
 
     /* Default baud rate at 100kbps. */
     masterConfig->baudRate_Bps = 100000U;
-
-/* Default pin high drive is disabled. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    masterConfig->enableHighDrive = false;
-#endif
 
 /* Default stop hold enable is disabled. */
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
@@ -654,7 +715,7 @@ status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_
         base->F = savedMult & (~I2C_F_MULT_MASK);
 
         /* We are already in a transfer, so send a repeated start. */
-        base->C1 |= I2C_C1_RSTA_MASK;
+        base->C1 |= I2C_C1_RSTA_MASK | I2C_C1_TX_MASK;
 
         /* Restore the multiplier factor. */
         base->F = savedMult;
@@ -721,7 +782,7 @@ uint32_t I2C_MasterGetStatusFlags(I2C_Type *base)
     return statusFlags;
 }
 
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     uint8_t statusFlags = 0;
@@ -772,10 +833,19 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
         }
     }
 
+    if (((result == kStatus_Success) && (!(flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
+    {
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Send stop. */
+        result = I2C_MasterStop(base);
+    }
+
     return result;
 }
 
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     volatile uint8_t dummy = 0;
@@ -817,8 +887,16 @@ status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
         /* Single byte use case. */
         if (rxSize == 0)
         {
-            /* Read the final byte. */
-            result = I2C_MasterStop(base);
+            if (!(flags & kI2C_TransferNoStopFlag))
+            {
+                /* Issue STOP command before reading last byte. */
+                result = I2C_MasterStop(base);
+            }
+            else
+            {
+                /* Change direction to Tx to avoid extra clocks. */
+                base->C1 |= I2C_C1_TX_MASK;
+            }
         }
 
         if (rxSize == 1)
@@ -871,72 +949,6 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
         return result;
     }
 
-    /* Send subaddress. */
-    if (xfer->subaddressSize)
-    {
-        do
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear interrupt pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            xfer->subaddressSize--;
-            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
-
-        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
-
-        if (xfer->direction == kI2C_Read)
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            /* Send repeated start and slave address. */
-            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
-
-            /* Return if error. */
-            if (result)
-            {
-                return result;
-            }
-        }
-    }
-
-    /* Wait until address + command transfer complete. */
     while (!(base->S & kI2C_IntPendingFlag))
     {
     }
@@ -949,32 +961,92 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
     {
         if (result == kStatus_I2C_Nak)
         {
+            result = kStatus_I2C_Addr_Nak;
+
             I2C_MasterStop(base);
         }
 
         return result;
     }
 
+    /* Send subaddress. */
+    if (xfer->subaddressSize)
+    {
+        do
+        {
+            /* Clear interrupt pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            xfer->subaddressSize--;
+            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
+
+        if (xfer->direction == kI2C_Read)
+        {
+            /* Clear pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Send repeated start and slave address. */
+            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
+
+            /* Return if error. */
+            if (result)
+            {
+                return result;
+            }
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    result = kStatus_I2C_Addr_Nak;
+
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+        }
+    }
+
     /* Transmit data. */
     if ((xfer->direction == kI2C_Write) && (xfer->dataSize > 0))
     {
         /* Send Data. */
-        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize);
-
-        if (((result == kStatus_Success) && (!(xfer->flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
-        {
-            /* Clear the IICIF flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Send stop. */
-            result = I2C_MasterStop(base);
-        }
+        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     /* Receive Data. */
     if ((xfer->direction == kI2C_Read) && (xfer->dataSize > 0))
     {
-        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize);
+        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     return result;
@@ -1037,11 +1109,37 @@ void I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle)
 {
     assert(handle);
 
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
     /* Disable interrupt. */
     I2C_DisableInterrupts(base, kI2C_GlobalInterruptEnable);
 
     /* Reset the state to idle. */
     handle->state = kIdleState;
+
+    /* Send STOP signal. */
+    if (handle->transfer.direction == kI2C_Read)
+    {
+        base->C1 |= I2C_C1_TXAK_MASK;
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+        dummy = base->D;
+    }
+    else
+    {
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+    }
 }
 
 status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count)
@@ -1075,7 +1173,8 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     if (isDone || result)
     {
         /* Send stop command if transfer done or received Nak. */
-        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak))
+        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak) ||
+            (result == kStatus_I2C_Addr_Nak))
         {
             /* Ensure stop command is a need. */
             if ((base->C1 & I2C_C1_MST_MASK))
@@ -1101,13 +1200,28 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz)
 {
     assert(slaveConfig);
 
     uint8_t tmpReg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Configure addressing mode. */
     switch (slaveConfig->addressingMode)
@@ -1132,14 +1246,10 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg &= ~I2C_C1_WUEN_MASK;
     base->C1 = tmpReg | I2C_C1_WUEN(slaveConfig->enableWakeUp) | I2C_C1_IICEN(slaveConfig->enableSlave);
 
-    /* Configure general call & baud rate control & high drive feature. */
+    /* Configure general call & baud rate control. */
     tmpReg = base->C2;
     tmpReg &= ~(I2C_C2_SBRC_MASK | I2C_C2_GCAEN_MASK);
     tmpReg |= I2C_C2_SBRC(slaveConfig->enableBaudRateCtl) | I2C_C2_GCAEN(slaveConfig->enableGeneralCall);
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    tmpReg &= ~I2C_C2_HDRS_MASK;
-    tmpReg |= I2C_C2_HDRS(slaveConfig->enableHighDrive);
-#endif
     base->C2 = tmpReg;
 
 /* Enable/Disable double buffering. */
@@ -1147,6 +1257,9 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg = base->S2 & (~I2C_S2_DFEN_MASK);
     base->S2 = tmpReg | I2C_S2_DFEN(slaveConfig->enableDoubleBuffering);
 #endif
+
+    /* Set hold time. */
+    I2C_SetHoldTime(base, slaveConfig->sclStopHoldTime_ns, srcClock_Hz);
 }
 
 void I2C_SlaveDeinit(I2C_Type *base)
@@ -1154,8 +1267,10 @@ void I2C_SlaveDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
@@ -1171,11 +1286,6 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
     /* Slave address match waking up MCU from low power mode is disabled. */
     slaveConfig->enableWakeUp = false;
 
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Default pin high drive is disabled. */
-    slaveConfig->enableHighDrive = false;
-#endif
-
     /* Independent slave mode baud rate at maximum frequency is disabled. */
     slaveConfig->enableBaudRateCtl = false;
 
@@ -1183,6 +1293,9 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
     slaveConfig->enableDoubleBuffering = true;
 #endif
+
+    /* Set default SCL stop hold time to 4us which is minimum requirement in I2C spec. */
+    slaveConfig->sclStopHoldTime_ns = 4000;
 
     /* Enable the I2C peripheral. */
     slaveConfig->enableSlave = true;
@@ -1215,7 +1328,7 @@ status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t tx
     /* Read dummy to release bus. */
     dummy = base->D;
 
-    result = I2C_MasterWriteBlocking(base, txBuff, txSize);
+    result = I2C_MasterWriteBlocking(base, txBuff, txSize, kI2C_TransferDefaultFlag);
 
     /* Switch to receive mode. */
     base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
@@ -1323,7 +1436,7 @@ status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle
         handle->isBusy = true;
 
         /* Set up event mask. tx and rx are always enabled. */
-        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent;
+        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent | kI2C_SlaveGenaralcallEvent;
 
         /* Clear all flags. */
         I2C_SlaveClearStatusFlags(base, kClearFlags);
@@ -1412,7 +1525,10 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
             }
         }
 
-        return;
+        if (!(status & kI2C_AddressMatchFlag))
+        {
+            return;
+        }
     }
 #endif /* I2C_HAS_STOP_DETECT */
 
@@ -1482,11 +1598,6 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
         handle->isBusy = true;
         xfer->event = kI2C_SlaveAddressMatchEvent;
 
-        if ((handle->eventMask & xfer->event) && (handle->callback))
-        {
-            handle->callback(base, xfer, handle->userData);
-        }
-
         /* Slave transmit, master reading from slave. */
         if (status & kI2C_TransferDirectionFlag)
         {
@@ -1502,6 +1613,16 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
 
             /* Read dummy to release the bus. */
             dummy = base->D;
+
+            if (dummy == 0)
+            {
+                xfer->event = kI2C_SlaveGenaralcallEvent;
+            }
+        }
+
+        if ((handle->eventMask & xfer->event) && (handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
         }
     }
     /* Check transfer complete flag. */
@@ -1607,27 +1728,30 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
+#if defined(I2C0)
 void I2C0_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C0, s_i2cHandle[0]);
 }
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 1)
+#if defined(I2C1)
 void I2C1_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C1, s_i2cHandle[1]);
 }
-#endif /* I2C COUNT > 1 */
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 2)
+#if defined(I2C2)
 void I2C2_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C2, s_i2cHandle[2]);
 }
-#endif /* I2C COUNT > 2 */
-#if (FSL_FEATURE_SOC_I2C_COUNT > 3)
+#endif
+
+#if defined(I2C3)
 void I2C3_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C3, s_i2cHandle[3]);
 }
-#endif /* I2C COUNT > 3 */
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_i2c.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,15 +37,14 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief I2C driver version 2.0.1. */
-#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*! @brief I2C driver version 2.0.3. */
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 3))
 /*@}*/
 
 #if (defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT || \
@@ -61,6 +60,7 @@ enum _i2c_status
     kStatus_I2C_Nak = MAKE_STATUS(kStatusGroup_I2C, 2),             /*!< NAK received during transfer. */
     kStatus_I2C_ArbitrationLost = MAKE_STATUS(kStatusGroup_I2C, 3), /*!< Arbitration lost during transfer. */
     kStatus_I2C_Timeout = MAKE_STATUS(kStatusGroup_I2C, 4),         /*!< Wait event timeout. */
+    kStatus_I2C_Addr_Nak = MAKE_STATUS(kStatusGroup_I2C, 5),        /*!< NAK received during the address probe. */
 };
 
 /*!
@@ -108,11 +108,11 @@ enum _i2c_interrupt_enable
 #endif                                                       /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
 };
 
-/*! @brief Direction of master and slave transfers. */
+/*! @brief The direction of master and slave transfers. */
 typedef enum _i2c_direction
 {
-    kI2C_Write = 0x0U, /*!< Master transmit to slave. */
-    kI2C_Read = 0x1U,  /*!< Master receive from slave. */
+    kI2C_Write = 0x0U, /*!< Master transmits to the slave. */
+    kI2C_Read = 0x1U,  /*!< Master receives from the slave. */
 } i2c_direction_t;
 
 /*! @brief Addressing mode. */
@@ -125,17 +125,17 @@ typedef enum _i2c_slave_address_mode
 /*! @brief I2C transfer control flag. */
 enum _i2c_master_transfer_flags
 {
-    kI2C_TransferDefaultFlag = 0x0U,       /*!< Transfer starts with a start signal, stops with a stop signal. */
-    kI2C_TransferNoStartFlag = 0x1U,       /*!< Transfer starts without a start signal. */
-    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< Transfer starts with a repeated start signal. */
-    kI2C_TransferNoStopFlag = 0x4U,        /*!< Transfer ends without a stop signal. */
+    kI2C_TransferDefaultFlag = 0x0U,       /*!< A transfer starts with a start signal, stops with a stop signal. */
+    kI2C_TransferNoStartFlag = 0x1U,       /*!< A transfer starts without a start signal. */
+    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< A transfer starts with a repeated start signal. */
+    kI2C_TransferNoStopFlag = 0x4U,        /*!< A transfer ends without a stop signal. */
 };
 
 /*!
  * @brief Set of events sent to the callback for nonblocking slave transfers.
  *
  * These event enumerations are used for two related purposes. First, a bit mask created by OR'ing together
- * events is passed to I2C_SlaveTransferNonBlocking() in order to specify which events to enable.
+ * events is passed to I2C_SlaveTransferNonBlocking() to specify which events to enable.
  * Then, when the slave callback is invoked, it is passed the current event through its @a transfer
  * parameter.
  *
@@ -144,36 +144,34 @@ enum _i2c_master_transfer_flags
 typedef enum _i2c_slave_transfer_event
 {
     kI2C_SlaveAddressMatchEvent = 0x01U, /*!< Received the slave address after a start or repeated start. */
-    kI2C_SlaveTransmitEvent = 0x02U,     /*!< Callback is requested to provide data to transmit
+    kI2C_SlaveTransmitEvent = 0x02U,     /*!< A callback is requested to provide data to transmit
                                                 (slave-transmitter role). */
-    kI2C_SlaveReceiveEvent = 0x04U,      /*!< Callback is requested to provide a buffer in which to place received
+    kI2C_SlaveReceiveEvent = 0x04U,      /*!< A callback is requested to provide a buffer in which to place received
                                                  data (slave-receiver role). */
-    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< Callback needs to either transmit an ACK or NACK. */
+    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< A callback needs to either transmit an ACK or NACK. */
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
     kI2C_SlaveStartEvent = 0x10U, /*!< A start/repeated start was detected. */
 #endif
-    kI2C_SlaveCompletionEvent = 0x20U, /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveCompletionEvent = 0x20U,  /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveGenaralcallEvent = 0x40U, /*!< Received the general call address after a start or repeated start. */
 
-    /*! Bit mask of all available events. */
+    /*! A bit mask of all available events. */
     kI2C_SlaveAllEvents = kI2C_SlaveAddressMatchEvent | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent |
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
                           kI2C_SlaveStartEvent |
 #endif
-                          kI2C_SlaveCompletionEvent,
+                          kI2C_SlaveCompletionEvent | kI2C_SlaveGenaralcallEvent,
 } i2c_slave_transfer_event_t;
 
 /*! @brief I2C master user configuration. */
 typedef struct _i2c_master_config
 {
     bool enableMaster; /*!< Enables the I2C peripheral at initialization time. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
     bool enableStopHold; /*!< Controls the stop hold enable. */
 #endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
-    bool enableDoubleBuffering; /*!< Controls double buffer enable, notice that
+    bool enableDoubleBuffering; /*!< Controls double buffer enable; notice that
                                      enabling the double buffer disables the clock stretch. */
 #endif
     uint32_t baudRate_Bps;     /*!< Baud rate configuration of I2C peripheral. */
@@ -184,19 +182,20 @@ typedef struct _i2c_master_config
 typedef struct _i2c_slave_config
 {
     bool enableSlave;       /*!< Enables the I2C peripheral at initialization time. */
-    bool enableGeneralCall; /*!< Enable general call addressing mode. */
+    bool enableGeneralCall; /*!< Enables the general call addressing mode. */
     bool enableWakeUp;      /*!< Enables/disables waking up MCU from low-power mode. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
-    bool enableDoubleBuffering; /*!< Controls double buffer enable, notice that
+    bool enableDoubleBuffering; /*!< Controls a double buffer enable; notice that
                                      enabling the double buffer disables the clock stretch. */
 #endif
     bool enableBaudRateCtl; /*!< Enables/disables independent slave baud rate on SCL in very fast I2C modes. */
-    uint16_t slaveAddress;  /*!< Slave address configuration. */
-    uint16_t upperAddress;  /*!< Maximum boundary slave address used in range matching mode. */
-    i2c_slave_address_mode_t addressingMode; /*!< Addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint16_t slaveAddress;  /*!< A slave address configuration. */
+    uint16_t upperAddress;  /*!< A maximum boundary slave address used in a range matching mode. */
+    i2c_slave_address_mode_t
+        addressingMode;          /*!< An addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint32_t sclStopHoldTime_ns; /*!< the delay from the rising edge of SCL (I2C clock) to the rising edge of SDA (I2C
+                                    data) while SCL is high (stop condition), SDA hold time and SCL start hold time
+                                    are also configured according to the SCL stop hold time. */
 } i2c_slave_config_t;
 
 /*! @brief I2C master handle typedef. */
@@ -214,13 +213,13 @@ typedef struct _i2c_slave_handle i2c_slave_handle_t;
 /*! @brief I2C master transfer structure. */
 typedef struct _i2c_master_transfer
 {
-    uint32_t flags;            /*!< Transfer flag which controls the transfer. */
+    uint32_t flags;            /*!< A transfer flag which controls the transfer. */
     uint8_t slaveAddress;      /*!< 7-bit slave address. */
-    i2c_direction_t direction; /*!< Transfer direction, read or write. */
-    uint32_t subaddress;       /*!< Sub address. Transferred MSB first. */
-    uint8_t subaddressSize;    /*!< Size of command buffer. */
-    uint8_t *volatile data;    /*!< Transfer buffer. */
-    volatile size_t dataSize;  /*!< Transfer size. */
+    i2c_direction_t direction; /*!< A transfer direction, read or write. */
+    uint32_t subaddress;       /*!< A sub address. Transferred MSB first. */
+    uint8_t subaddressSize;    /*!< A size of the command buffer. */
+    uint8_t *volatile data;    /*!< A transfer buffer. */
+    volatile size_t dataSize;  /*!< A transfer size. */
 } i2c_master_transfer_t;
 
 /*! @brief I2C master handle structure. */
@@ -228,20 +227,21 @@ struct _i2c_master_handle
 {
     i2c_master_transfer_t transfer;                    /*!< I2C master transfer copy. */
     size_t transferSize;                               /*!< Total bytes to be transferred. */
-    uint8_t state;                                     /*!< Transfer state maintained during transfer. */
-    i2c_master_transfer_callback_t completionCallback; /*!< Callback function called when transfer finished. */
-    void *userData;                                    /*!< Callback parameter passed to callback function. */
+    uint8_t state;                                     /*!< A transfer state maintained during transfer. */
+    i2c_master_transfer_callback_t completionCallback; /*!< A callback function called when the transfer is finished. */
+    void *userData;                                    /*!< A callback parameter passed to the callback function. */
 };
 
 /*! @brief I2C slave transfer structure. */
 typedef struct _i2c_slave_transfer
 {
-    i2c_slave_transfer_event_t event; /*!< Reason the callback is being invoked. */
-    uint8_t *volatile data;           /*!< Transfer buffer. */
-    volatile size_t dataSize;         /*!< Transfer size. */
+    i2c_slave_transfer_event_t event; /*!< A reason that the callback is invoked. */
+    uint8_t *volatile data;           /*!< A transfer buffer. */
+    volatile size_t dataSize;         /*!< A transfer size. */
     status_t completionStatus;        /*!< Success or error code describing how the transfer completed. Only applies for
                                          #kI2C_SlaveCompletionEvent. */
-    size_t transferredCount;          /*!< Number of bytes actually transferred since start or last repeated start. */
+    size_t transferredCount; /*!< A number of bytes actually transferred since the start or since the last repeated
+                                start. */
 } i2c_slave_transfer_t;
 
 /*! @brief I2C slave transfer callback typedef. */
@@ -250,11 +250,11 @@ typedef void (*i2c_slave_transfer_callback_t)(I2C_Type *base, i2c_slave_transfer
 /*! @brief I2C slave handle structure. */
 struct _i2c_slave_handle
 {
-    bool isBusy;                            /*!< Whether transfer is busy. */
+    volatile bool isBusy;                   /*!< Indicates whether a transfer is busy. */
     i2c_slave_transfer_t transfer;          /*!< I2C slave transfer copy. */
-    uint32_t eventMask;                     /*!< Mask of enabled events. */
-    i2c_slave_transfer_callback_t callback; /*!< Callback function called at transfer event. */
-    void *userData;                         /*!< Callback parameter passed to callback. */
+    uint32_t eventMask;                     /*!< A mask of enabled events. */
+    i2c_slave_transfer_callback_t callback; /*!< A callback function called at the transfer event. */
+    void *userData;                         /*!< A callback parameter passed to the callback. */
 };
 
 /*******************************************************************************
@@ -274,12 +274,12 @@ extern "C" {
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
  * and configure the I2C with master configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module may cause a hard fault
- * because clock is not enabled. The configuration structure can be filled by user
- * from scratch, or be set with default values by I2C_MasterGetDefaultConfig().
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can be custom filled
+ * or it can be set with default values by using the I2C_MasterGetDefaultConfig().
  * After calling this API, the master is ready to transfer.
- * Example:
+ * This is an example.
  * @code
  * i2c_master_config_t config = {
  * .enableMaster = true,
@@ -292,20 +292,20 @@ extern "C" {
  * @endcode
  *
  * @param base I2C base pointer
- * @param masterConfig pointer to master configuration structure
+ * @param masterConfig A pointer to the master configuration structure
  * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
- * and initializes the I2C with slave configuration.
+ * and initialize the I2C with the slave configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module can cause a hard fault
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
  * because the clock is not enabled. The configuration structure can partly be set
- * with default values by I2C_SlaveGetDefaultConfig(), or can be filled by the user.
- * Example
+ * with default values by I2C_SlaveGetDefaultConfig() or it can be custom filled by the user.
+ * This is an example.
  * @code
  * i2c_slave_config_t config = {
  * .enableSlave = true,
@@ -314,15 +314,17 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
  * .slaveAddress = 0x1DU,
  * .enableWakeUp = false,
  * .enablehighDrive = false,
- * .enableBaudRateCtl = false
+ * .enableBaudRateCtl = false,
+ * .sclStopHoldTime_ns = 4000
  * };
- * I2C_SlaveInit(I2C0, &config);
+ * I2C_SlaveInit(I2C0, &config, 12000000U);
  * @endcode
  *
  * @param base I2C base pointer
- * @param slaveConfig pointer to slave configuration structure
+ * @param slaveConfig A pointer to the slave configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig);
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
@@ -342,28 +344,28 @@ void I2C_SlaveDeinit(I2C_Type *base);
  * @brief  Sets the I2C master configuration structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
- * Use the initialized structure unchanged in I2C_MasterConfigure(), or modify some fields of
- * the structure before calling I2C_MasterConfigure().
- * Example:
+ * Use the initialized structure unchanged in the I2C_MasterConfigure() or modify
+ * the structure before calling the I2C_MasterConfigure().
+ * This is an example.
  * @code
  * i2c_master_config_t config;
  * I2C_MasterGetDefaultConfig(&config);
  * @endcode
- * @param masterConfig Pointer to the master configuration structure.
+ * @param masterConfig A pointer to the master configuration structure.
 */
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig);
 
 /*!
  * @brief  Sets the I2C slave configuration structure to default values.
  *
- * The purpose of this API is to get the configuration structure initialized for use in I2C_SlaveConfigure().
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_SlaveConfigure().
  * Modify fields of the structure before calling the I2C_SlaveConfigure().
- * Example:
+ * This is an example.
  * @code
  * i2c_slave_config_t config;
  * I2C_SlaveGetDefaultConfig(&config);
  * @endcode
- * @param slaveConfig Pointer to the slave configuration structure.
+ * @param slaveConfig A pointer to the slave configuration structure.
  */
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
 
@@ -371,7 +373,7 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
  * @brief Enables or disabless the I2C peripheral operation.
  *
  * @param base I2C base pointer
- * @param enable pass true to enable module, false to disable module
+ * @param enable Pass true to enable and false to disable the module.
  */
 static inline void I2C_Enable(I2C_Type *base, bool enable)
 {
@@ -414,7 +416,7 @@ static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag.
  *
  * @param base I2C base pointer
  * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
@@ -449,7 +451,7 @@ static inline void I2C_MasterClearStatusFlags(I2C_Type *base, uint32_t statusMas
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
  *
   * @param base I2C base pointer
   * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
@@ -581,19 +583,21 @@ status_t I2C_MasterStop(I2C_Type *base);
 status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
 
 /*!
- * @brief Performs a polling send transaction on the I2C bus without a STOP signal.
+ * @brief Performs a polling send transaction on the I2C bus.
  *
  * @param base  The I2C peripheral base pointer.
  * @param txBuff The pointer to the data to be transferred.
  * @param txSize The length in bytes of the data to be transferred.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
  * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags);
 
 /*!
- * @brief Performs a polling receive transaction on the I2C bus with a STOP signal.
+ * @brief Performs a polling receive transaction on the I2C bus.
  *
  * @note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
  * Without stopping the bus prior for the final read, the bus issues another read, resulting
@@ -602,10 +606,12 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
  * @param base I2C peripheral base pointer.
  * @param rxBuff The pointer to the data to store the received data.
  * @param rxSize The length in bytes of the data to be received.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
  */
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags);
 
 /*!
  * @brief Performs a polling send transaction on the I2C bus.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_i2c_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_i2c_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -56,13 +55,14 @@ typedef void (*i2c_master_edma_transfer_callback_t)(I2C_Type *base,
 /*! @brief I2C master eDMA transfer structure. */
 struct _i2c_master_edma_handle
 {
-    i2c_master_transfer_t transfer; /*!< I2C master transfer struct. */
+    i2c_master_transfer_t transfer; /*!< I2C master transfer structure. */
     size_t transferSize;            /*!< Total bytes to be transferred. */
+    uint8_t nbytes;                 /*!< eDMA minor byte transfer count initially configured. */
     uint8_t state;                  /*!< I2C master transfer status. */
     edma_handle_t *dmaHandle;       /*!< The eDMA handler used. */
     i2c_master_edma_transfer_callback_t
-        completionCallback; /*!< Callback function called after eDMA transfer finished. */
-    void *userData;         /*!< Callback parameter passed to callback function. */
+        completionCallback; /*!< A callback function called after the eDMA transfer is finished. */
+    void *userData;         /*!< A callback parameter passed to the callback function. */
 };
 
 /*******************************************************************************
@@ -79,12 +79,12 @@ extern "C" {
  */
 
 /*!
- * @brief Init the I2C handle which is used in transcational functions.
+ * @brief Initializes the I2C handle which is used in transcational functions.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param callback pointer to user callback function.
- * @param userData user param passed to the callback function.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param callback A pointer to the user callback function.
+ * @param userData A user parameter passed to the callback function.
  * @param edmaHandle eDMA handle pointer.
  */
 void I2C_MasterCreateEDMAHandle(I2C_Type *base,
@@ -97,30 +97,30 @@ void I2C_MasterCreateEDMAHandle(I2C_Type *base,
  * @brief Performs a master eDMA non-blocking transfer on the I2C bus.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param xfer pointer to transfer structure of i2c_master_transfer_t.
- * @retval kStatus_Success Sucessully complete the data transmission.
- * @retval kStatus_I2C_Busy Previous transmission still not finished.
- * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param xfer A pointer to the transfer structure of i2c_master_transfer_t.
+ * @retval kStatus_Success Sucessfully completed the data transmission.
+ * @retval kStatus_I2C_Busy A previous transmission is still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, waits for a signal timeout.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
- * @retval kStataus_I2C_Nak Transfer error, receive Nak during transfer.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
 status_t I2C_MasterTransferEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, i2c_master_transfer_t *xfer);
 
 /*!
- * @brief Get master transfer status during a eDMA non-blocking transfer.
+ * @brief Gets a master transfer status during the eDMA non-blocking transfer.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  */
 status_t I2C_MasterTransferGetCountEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, size_t *count);
 
 /*!
- * @brief Abort a master eDMA non-blocking transfer in a early time.
+ * @brief Aborts a master eDMA non-blocking transfer early.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
  */
 void I2C_MasterTransferAbortEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_lpuart.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_lpuart.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,29 +37,27 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief LPUART driver version 2.2.1. */
-#define FSL_LPUART_DRIVER_VERSION (MAKE_VERSION(2, 2, 1))
+/*! @brief LPUART driver version 2.2.3. */
+#define FSL_LPUART_DRIVER_VERSION (MAKE_VERSION(2, 2, 3))
 /*@}*/
 
 /*! @brief Error codes for the LPUART driver. */
 enum _lpuart_status
 {
-    kStatus_LPUART_TxBusy = MAKE_STATUS(kStatusGroup_LPUART, 0),              /*!< TX busy */
-    kStatus_LPUART_RxBusy = MAKE_STATUS(kStatusGroup_LPUART, 1),              /*!< RX busy */
-    kStatus_LPUART_TxIdle = MAKE_STATUS(kStatusGroup_LPUART, 2),              /*!< LPUART transmitter is idle. */
-    kStatus_LPUART_RxIdle = MAKE_STATUS(kStatusGroup_LPUART, 3),              /*!< LPUART receiver is idle. */
-    kStatus_LPUART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 4), /*!< TX FIFO watermark too large  */
-    kStatus_LPUART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 5), /*!< RX FIFO watermark too large  */
-    kStatus_LPUART_FlagCannotClearManually =
-        MAKE_STATUS(kStatusGroup_LPUART, 6),                    /*!< Some flag can't manually clear */
-    kStatus_LPUART_Error = MAKE_STATUS(kStatusGroup_LPUART, 7), /*!< Error happens on LPUART. */
+    kStatus_LPUART_TxBusy = MAKE_STATUS(kStatusGroup_LPUART, 0),                  /*!< TX busy */
+    kStatus_LPUART_RxBusy = MAKE_STATUS(kStatusGroup_LPUART, 1),                  /*!< RX busy */
+    kStatus_LPUART_TxIdle = MAKE_STATUS(kStatusGroup_LPUART, 2),                  /*!< LPUART transmitter is idle. */
+    kStatus_LPUART_RxIdle = MAKE_STATUS(kStatusGroup_LPUART, 3),                  /*!< LPUART receiver is idle. */
+    kStatus_LPUART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 4),     /*!< TX FIFO watermark too large  */
+    kStatus_LPUART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 5),     /*!< RX FIFO watermark too large  */
+    kStatus_LPUART_FlagCannotClearManually = MAKE_STATUS(kStatusGroup_LPUART, 6), /*!< Some flag can't manually clear */
+    kStatus_LPUART_Error = MAKE_STATUS(kStatusGroup_LPUART, 7),                   /*!< Error happens on LPUART. */
     kStatus_LPUART_RxRingBufferOverrun =
         MAKE_STATUS(kStatusGroup_LPUART, 8), /*!< LPUART RX software ring buffer overrun. */
     kStatus_LPUART_RxHardwareOverrun = MAKE_STATUS(kStatusGroup_LPUART, 9), /*!< LPUART RX receiver overrun. */
@@ -67,7 +65,7 @@ enum _lpuart_status
     kStatus_LPUART_FramingError = MAKE_STATUS(kStatusGroup_LPUART, 11),     /*!< LPUART framing error. */
     kStatus_LPUART_ParityError = MAKE_STATUS(kStatusGroup_LPUART, 12),      /*!< LPUART parity error. */
     kStatus_LPUART_BaudrateNotSupport =
-        MAKE_STATUS(kStatusGroup_LPUART, 13),                               /*!< Baudrate is not support in current clock source */
+        MAKE_STATUS(kStatusGroup_LPUART, 13), /*!< Baudrate is not support in current clock source */
 };
 
 /*! @brief LPUART parity mode. */
@@ -81,9 +79,9 @@ typedef enum _lpuart_parity_mode
 /*! @brief LPUART data bits count. */
 typedef enum _lpuart_data_bits
 {
-    kLPUART_EightDataBits = 0x0U,     /*!< Eight data bit */
+    kLPUART_EightDataBits = 0x0U, /*!< Eight data bit */
 #if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
-    kLPUART_SevenDataBits = 0x1U,     /*!< Seven data bit */
+    kLPUART_SevenDataBits = 0x1U, /*!< Seven data bit */
 #endif
 } lpuart_data_bits_t;
 
@@ -168,13 +166,13 @@ enum _lpuart_flags
 #endif
 };
 
-/*! @brief LPUART configure structure. */
+/*! @brief LPUART configuration structure. */
 typedef struct _lpuart_config
 {
-    uint32_t baudRate_Bps;           /*!< LPUART baud rate  */
-    lpuart_parity_mode_t parityMode; /*!< Parity mode, disabled (default), even, odd */
+    uint32_t baudRate_Bps;            /*!< LPUART baud rate  */
+    lpuart_parity_mode_t parityMode;  /*!< Parity mode, disabled (default), even, odd */
     lpuart_data_bits_t dataBitsCount; /*!< Data bits count, eight (default), seven */
-    bool isMsb; /*!< Data bits order, LSB (default), MSB */
+    bool isMsb;                       /*!< Data bits order, LSB (default), MSB */
 #if defined(FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT
     lpuart_stop_bit_count_t stopBitCount; /*!< Number of stop bits, 1 stop bit (default) or 2 stop bits  */
 #endif
@@ -233,35 +231,58 @@ struct _lpuart_handle
 extern "C" {
 #endif /* _cplusplus */
 
+#if defined(FSL_FEATURE_LPUART_HAS_GLOBAL) && FSL_FEATURE_LPUART_HAS_GLOBAL
+
+/*!
+ * @name Software Reset
+ * @{
+ */
+
+/*!
+ * @brief Resets the LPUART using software.
+ *
+ * This function resets all internal logic and registers except the Global Register.
+ * Remains set until cleared by software.
+ *
+ * @param base LPUART peripheral base address.
+ */
+static inline void LPUART_SoftwareReset(LPUART_Type *base)
+{
+    base->GLOBAL |= LPUART_GLOBAL_RST_MASK;
+    base->GLOBAL &= ~LPUART_GLOBAL_RST_MASK;
+}
+/* @} */
+#endif /*FSL_FEATURE_LPUART_HAS_GLOBAL*/
+
 /*!
  * @name Initialization and deinitialization
  * @{
  */
 
 /*!
-* @brief Initializes an LPUART instance with the user configuration structure and the peripheral clock.
-*
-* This function configures the LPUART module with  user-defined settings. Call the LPUART_GetDefaultConfig() function
-* to configure the configuration structure and get the default configuration.
-* The example below shows how to use this API to configure the LPUART.
-* @code
-*  lpuart_config_t lpuartConfig;
-*  lpuartConfig.baudRate_Bps = 115200U;
-*  lpuartConfig.parityMode = kLPUART_ParityDisabled;
-*  lpuartConfig.dataBitsCount = kLPUART_EightDataBits;
-*  lpuartConfig.isMsb = false;
-*  lpuartConfig.stopBitCount = kLPUART_OneStopBit;
-*  lpuartConfig.txFifoWatermark = 0;
-*  lpuartConfig.rxFifoWatermark = 1;
-*  LPUART_Init(LPUART1, &lpuartConfig, 20000000U);
-* @endcode
-*
-* @param base LPUART peripheral base address.
-* @param config Pointer to a user-defined configuration structure.
-* @param srcClock_Hz LPUART clock source frequency in HZ.
-* @retval kStatus_LPUART_BaudrateNotSupport Baudrate is not support in current clock source.
-* @retval kStatus_Success LPUART initialize succeed
-*/
+ * @brief Initializes an LPUART instance with the user configuration structure and the peripheral clock.
+ *
+ * This function configures the LPUART module with user-defined settings. Call the LPUART_GetDefaultConfig() function
+ * to configure the configuration structure and get the default configuration.
+ * The example below shows how to use this API to configure the LPUART.
+ * @code
+ *  lpuart_config_t lpuartConfig;
+ *  lpuartConfig.baudRate_Bps = 115200U;
+ *  lpuartConfig.parityMode = kLPUART_ParityDisabled;
+ *  lpuartConfig.dataBitsCount = kLPUART_EightDataBits;
+ *  lpuartConfig.isMsb = false;
+ *  lpuartConfig.stopBitCount = kLPUART_OneStopBit;
+ *  lpuartConfig.txFifoWatermark = 0;
+ *  lpuartConfig.rxFifoWatermark = 1;
+ *  LPUART_Init(LPUART1, &lpuartConfig, 20000000U);
+ * @endcode
+ *
+ * @param base LPUART peripheral base address.
+ * @param config Pointer to a user-defined configuration structure.
+ * @param srcClock_Hz LPUART clock source frequency in HZ.
+ * @retval kStatus_LPUART_BaudrateNotSupport Baudrate is not support in current clock source.
+ * @retval kStatus_Success LPUART initialize succeed
+ */
 status_t LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcClock_Hz);
 
 /*!
@@ -536,10 +557,10 @@ static inline void LPUART_WriteByte(LPUART_Type *base, uint8_t data)
 }
 
 /*!
- * @brief Reads the RX register.
+ * @brief Reads the receiver register.
  *
  * This function reads data from the receiver register directly. The upper layer must
- * ensure that the RX register is full or that the RX FIFO has data before calling this function.
+ * ensure that the receiver register is full or that the RX FIFO has data before calling this function.
  *
  * @param base LPUART peripheral base address.
  * @return Data read from data register.
@@ -548,8 +569,9 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 {
 #if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
     uint32_t ctrl = base->CTRL;
-    bool isSevenDataBits = ((ctrl & LPUART_CTRL_M7_MASK) ||
-            ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
+    bool isSevenDataBits =
+        ((ctrl & LPUART_CTRL_M7_MASK) ||
+         ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
 
     if (isSevenDataBits)
     {
@@ -565,10 +587,10 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 }
 
 /*!
- * @brief Writes to transmitter register using a blocking method.
+ * @brief Writes to the transmitter register using a blocking method.
  *
  * This function polls the transmitter register, waits for the register to be empty or  for TX FIFO to have
- * room and then writes data to the transmitter buffer.
+ * room, and writes data to the transmitter buffer.
  *
  * @note This function does not check whether all data has been sent out to the bus.
  * Before disabling the transmitter, check the kLPUART_TransmissionCompleteFlag to ensure that the transmit is
@@ -581,10 +603,10 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 void LPUART_WriteBlocking(LPUART_Type *base, const uint8_t *data, size_t length);
 
 /*!
-* @brief Reads the RX data register using a blocking method.
+* @brief Reads the receiver data register using a blocking method.
  *
- * This function polls the RX register, waits for the RX register full or RX FIFO
- * has data then reads data from the TX register.
+ * This function polls the receiver register, waits for the receiver register full or receiver FIFO
+ * has data, and reads data from the TX register.
  *
  * @param base LPUART peripheral base address.
  * @param data Start address of the buffer to store the received data.
@@ -670,7 +692,7 @@ void LPUART_TransferStartRingBuffer(LPUART_Type *base,
                                     size_t ringBufferSize);
 
 /*!
- * @brief Abort the background transfer and uninstall the ring buffer.
+ * @brief Aborts the background transfer and uninstalls the ring buffer.
  *
  * This function aborts the background transfer and uninstalls the ring buffer.
  *
@@ -683,7 +705,7 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle);
  * @brief Aborts the interrupt-driven data transmit.
  *
  * This function aborts the interrupt driven data sending. The user can get the remainBtyes to find out
- * how many bytes are still not sent out.
+ * how many bytes are not sent out.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -691,10 +713,10 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle);
 void LPUART_TransferAbortSend(LPUART_Type *base, lpuart_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to LPUART TX register.
+ * @brief Gets the number of bytes that have been written to the LPUART transmitter register.
  *
  * This function gets the number of bytes that have been written to LPUART TX
- * register by interrupt method.
+ * register by an interrupt method.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -748,7 +770,7 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
 void LPUART_TransferAbortReceive(LPUART_Type *base, lpuart_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of bytes that have been received.
  *
  * This function gets the number of bytes that have been received.
  *

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_lpuart_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_lpuart_edma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -219,6 +219,9 @@ status_t LPUART_SendEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, lpuart
         EDMA_PrepareTransfer(&xferConfig, xfer->data, sizeof(uint8_t), (void *)LPUART_GetDataRegisterAddress(base),
                              sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_MemoryToPeripheral);
 
+        /* Store the initially configured eDMA minor byte transfer count into the LPUART handle */
+        handle->nbytes = sizeof(uint8_t);
+
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->txEdmaHandle, &xferConfig);
         EDMA_StartTransfer(handle->txEdmaHandle);
@@ -256,6 +259,9 @@ status_t LPUART_ReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, lpu
         /* Prepare transfer. */
         EDMA_PrepareTransfer(&xferConfig, (void *)LPUART_GetDataRegisterAddress(base), sizeof(uint8_t), xfer->data,
                              sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_PeripheralToMemory);
+
+        /* Store the initially configured eDMA minor byte transfer count into the LPUART handle */
+        handle->nbytes = sizeof(uint8_t);
 
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->rxEdmaHandle, &xferConfig);
@@ -309,7 +315,9 @@ status_t LPUART_TransferGetReceiveCountEDMA(LPUART_Type *base, lpuart_edma_handl
         return kStatus_NoTransferInProgress;
     }
 
-    *count = handle->rxDataSizeAll - EDMA_GetRemainingBytes(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
+    *count = handle->rxDataSizeAll -
+             (uint32_t)handle->nbytes *
+                 EDMA_GetRemainingMajorLoopCount(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
 
     return kStatus_Success;
 }
@@ -325,7 +333,9 @@ status_t LPUART_TransferGetSendCountEDMA(LPUART_Type *base, lpuart_edma_handle_t
         return kStatus_NoTransferInProgress;
     }
 
-    *count = handle->txDataSizeAll - EDMA_GetRemainingBytes(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
+    *count = handle->txDataSizeAll -
+             (uint32_t)handle->nbytes *
+                 EDMA_GetRemainingMajorLoopCount(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
 
     return kStatus_Success;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_lpuart_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_lpuart_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -65,6 +64,8 @@ struct _lpuart_edma_handle
 
     edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
     edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
+
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
     volatile uint8_t txState; /*!< TX transfer state. */
     volatile uint8_t rxState; /*!< RX transfer state */
@@ -93,11 +94,11 @@ extern "C" {
  * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
  */
 void LPUART_TransferCreateHandleEDMA(LPUART_Type *base,
-                             lpuart_edma_handle_t *handle,
-                             lpuart_edma_transfer_callback_t callback,
-                             void *userData,
-                             edma_handle_t *txEdmaHandle,
-                             edma_handle_t *rxEdmaHandle);
+                                     lpuart_edma_handle_t *handle,
+                                     lpuart_edma_transfer_callback_t callback,
+                                     void *userData,
+                                     edma_handle_t *txEdmaHandle,
+                                     edma_handle_t *rxEdmaHandle);
 
 /*!
  * @brief Sends data using eDMA.
@@ -150,9 +151,9 @@ void LPUART_TransferAbortSendEDMA(LPUART_Type *base, lpuart_edma_handle_t *handl
 void LPUART_TransferAbortReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to LPUART TX register.
+ * @brief Gets the number of bytes written to the LPUART TX register.
  *
- * This function gets the number of bytes that have been written to LPUART TX
+ * This function gets the number of bytes written to the LPUART TX
  * register by DMA.
  *
  * @param base LPUART peripheral base address.
@@ -165,9 +166,9 @@ void LPUART_TransferAbortReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *ha
 status_t LPUART_TransferGetSendCountEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, uint32_t *count);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of received bytes.
  *
- * This function gets the number of bytes that have been received.
+ * This function gets the number of received bytes.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_qspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_qspi_edma.h
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -54,6 +53,7 @@ struct _qspi_edma_handle
 {
     edma_handle_t *dmaHandle;      /*!< eDMA handler for QSPI send */
     size_t transferSize;           /*!< Bytes need to transfer. */
+    uint8_t nbytes;                /*!< eDMA minor byte transfer count initially configured. */
     uint8_t count;                 /*!< The transfer data count in a DMA request */
     uint32_t state;                /*!< Internal state for QSPI eDMA transfer */
     qspi_edma_callback_t callback; /*!< Callback for users while transfer finish or error occurred */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
@@ -118,16 +118,21 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi.c
@@ -1,38 +1,22 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi.h"
 
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -65,27 +42,27 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
 
 /*!
  * @brief Master fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Master finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Slave fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
  * @brief Slave finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -100,7 +77,7 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param);
 /*!
  * @brief Master prepare the transfer.
  * Basically it set up dspi_master_handle .
- * This is not a public API as it is called from other driver functions. fsl_dspi_edma.c also call this function.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
 
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -123,11 +100,13 @@ static SPI_Type *const s_dspiBases[] = SPI_BASE_PTRS;
 /*! @brief Pointers to dspi IRQ number for each instance. */
 static IRQn_Type const s_dspiIRQ[] = SPI_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to dspi clocks for each instance. */
 static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to dspi handles for each instance. */
-static void *g_dspiHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
@@ -135,15 +114,22 @@ static dspi_master_isr_t s_dspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_DSPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_dspiBases); instance++)
     {
         if (s_dspiBases[instance] == base)
         {
@@ -151,20 +137,80 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_DSPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_dspiBases));
 
     return instance;
 }
 
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+{
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
+}
+
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
+    assert(NULL != masterConfig);
+
     uint32_t temp;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -173,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -185,48 +229,92 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
-    masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    assert(NULL != masterConfig);
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
+    masterConfig->ctarConfig.bitsPerFrame = 8;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
+
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
+    assert(NULL != slaveConfig);
+
     uint32_t temp = 0;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
@@ -239,40 +327,66 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
 
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    slaveConfig->whichCtar = kDSPI_Ctar0;
-    slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    assert(NULL != slaveConfig);
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
+    slaveConfig->ctarConfig.bitsPerFrame = 8;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
     DSPI_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* disable DSPI clock */
     CLOCK_DisableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pcs_polarity_config_t activeLowOrHigh)
@@ -293,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -312,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -378,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -402,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -424,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -455,83 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    assert(NULL != command);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    assert(NULL != command);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
+
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -540,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -556,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -574,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -621,34 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        if (rxData != NULL)
-                        {
-                            *(rxData) = DSPI_ReadData(base);
-                            rxData++;
-                        }
-                        else
-                        {
-                            DSPI_ReadData(base);
-                        }
-                        remainingReceiveByteCount--;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -660,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -701,54 +1013,39 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *(rxData) = DSPI_ReadData(base);
-                        rxData++;
-                    }
-                    else
-                    {
-                        DSPI_ReadData(base);
-                    }
-                    remainingReceiveByteCount--;
+                        if (rxData != NULL)
+                        {
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
+                            rxData++;
+                        }
+                        else
+                        {
+                            (void)DSPI_ReadData(base);
+                        }
+                        remainingReceiveByteCount--;
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        wordReceived = DSPI_ReadData(base);
-
-                        if (rxData != NULL)
-                        {
-                            *rxData = wordReceived;
-                            ++rxData;
-                            *rxData = wordReceived >> 8;
-                            ++rxData;
-                        }
-                        remainingReceiveByteCount -= 2;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -756,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -769,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -822,24 +1120,28 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    wordReceived = DSPI_ReadData(base);
-
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *rxData = wordReceived;
-                        ++rxData;
-                        *rxData = wordReceived >> 8;
-                        ++rxData;
-                    }
-                    remainingReceiveByteCount -= 2;
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        if (rxData != NULL)
+                        {
+                            *rxData = (uint8_t)wordReceived;
+                            ++rxData;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
+                            ++rxData;
+                        }
+                        remainingReceiveByteCount -= 2U;
+
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
@@ -850,28 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    dspi_command_data_config_t commandStruct;
+    assert(NULL != handle);
+    assert(NULL != transfer);
+
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -879,61 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
-    DSPI_StartTransfer(base);
-
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
-    DSPI_MasterTransferFillUpTxFifo(base, handle);
 
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_StartTransfer(base);
+
+    /* Fill up the Tx FIFO to trigger the transfer. */
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -945,11 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -958,40 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
-
-    /* The transfer is complete.*/
-    handle->state = kDSPI_Idle;
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -999,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1007,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1023,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1058,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1068,82 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1152,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1180,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1212,85 +1736,107 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (NULL != handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (NULL != handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
+    }
 
     DSPI_StartTransfer(base);
 
     /* Prepare data to transmit */
     DSPI_SlaveTransferFillUpTxFifo(base, handle);
 
-    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
-
-    /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
-
-    if (handle->rxData)
-    {
-        /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
-    }
-    if (handle->txData)
-    {
-        /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
-    }
-
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1302,22 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1335,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1382,24 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1408,65 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
-
-    handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1484,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1500,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1573,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1606,52 +2188,57 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 0)
+#if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 1)
+#if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 2)
+#if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 3)
+#if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 4)
+#if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 5)
+#if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -37,54 +15,55 @@
  * @{
  */
 
-
 /**********************************************************************************************************************
  * Definitions
  *********************************************************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.1.1. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 1))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
-/*! @brief DSPI dummy data if no Tx data.*/
-#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for tx if there is not txData. */
+#ifndef DSPI_DUMMY_DATA
+/*! @brief DSPI dummy data if there is no Tx data.*/
+#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for Tx if there is no txData. */
+#endif
 
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out Of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All status above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -101,12 +80,13 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
- * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in Modified Transfer Format. This field is valid
- * only when CPHA bit in CTAR register is 0.
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is
+ * valid
+ * only when the CPHA bit in the CTAR register is 0.
  */
 typedef enum _dspi_master_sample_point
 {
@@ -130,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -165,36 +145,37 @@ typedef enum _dspi_clock_phase
 typedef enum _dspi_shift_direction
 {
     kDSPI_MsbFirst = 0U, /*!< Data transfers start with most significant bit.*/
-    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.*/
+    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.
+                              Shifting out of LSB is not supported for slave */
 } dspi_shift_direction_t;
 
 /*! @brief DSPI delay type selection.*/
 typedef enum _dspi_delay_type
 {
     kDSPI_PcsToSck = 1U,  /*!< Pcs-to-SCK delay. */
-    kDSPI_LastSckToPcs,   /*!< Last SCK edge to Pcs delay. */
+    kDSPI_LastSckToPcs,   /*!< The last SCK edge to Pcs delay. */
     kDSPI_BetweenTransfer /*!< Delay between transfers. */
 } dspi_delay_type_t;
 
 /*! @brief DSPI Clock and Transfer Attributes Register (CTAR) selection.*/
 typedef enum _dspi_ctar_selection
 {
-    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode, note that CTAR0 and CTAR0_SLAVE are the
+    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode; note that CTAR0 and CTAR0_SLAVE are the
                          same register address. */
     kDSPI_Ctar1 = 1U, /*!< CTAR1 selection option for master mode only. */
-    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only , note that some device do not support CTAR2. */
-    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only , note that some device do not support CTAR3. */
-    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only , note that some device do not support CTAR4. */
-    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only , note that some device do not support CTAR5. */
-    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only , note that some device do not support CTAR6. */
-    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only , note that some device do not support CTAR7. */
+    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only; note that some devices do not support CTAR2. */
+    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only; note that some devices do not support CTAR3. */
+    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only; note that some devices do not support CTAR4. */
+    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only; note that some devices do not support CTAR5. */
+    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only; note that some devices do not support CTAR6. */
+    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only; note that some devices do not support CTAR7. */
 } dspi_ctar_selection_t;
 
-#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro , internal used. */
-#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro , internal used. */
-#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro , internal used. */
-#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro , internal used. */
-/*! @brief Can use this enumeration for DSPI master transfer configFlags. */
+#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro; used internally. */
+#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro; used internally. */
+#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro; used internally. */
+#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI master transfer configFlags. */
 enum _dspi_transfer_config_flag_for_master
 {
     kDSPI_MasterCtar0 = 0U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR0 setting. */
@@ -213,13 +194,14 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Is PCS signal continuous. */
-    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Is PCS signal active after last frame transfer.*/
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterActiveAfterTransfer =
+        1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
-#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro , internal used. */
-#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro , internal used. */
-/*! @brief Can use this enum for DSPI slave transfer configFlags. */
+#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro; used internally. */
+#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI slave transfer configFlags. */
 enum _dspi_transfer_config_flag_for_slave
 {
     kDSPI_SlaveCtar0 = 0U << DSPI_SLAVE_CTAR_SHIFT, /*!< DSPI slave transfer use CTAR0 setting. */
@@ -234,15 +216,15 @@ enum _dspi_transfer_state
     kDSPI_Error        /*!< Transfer error. */
 };
 
-/*! @brief DSPI master command date configuration used for SPIx_PUSHR.*/
+/*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
     bool isEndOfQueue;               /*!< Signals that the current transfer is the last in the queue.*/
-    bool clearTransferCount;         /*!< Clears SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
+    bool clearTransferCount;         /*!< Clears the SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
 } dspi_command_data_config_t;
 
 /*! @brief DSPI master ctar configuration structure.*/
@@ -254,33 +236,33 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time with nanosecond , set to 0 sets the minimum
-                                               delay. It sets the boundary value if out of range that can be set.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< Last SCK to PCS delay time with nanosecond , set to 0 sets the
-                                               minimum delay.It sets the boundary value if out of range that can be
-                                               set.*/
-    uint32_t betweenTransferDelayInNanoSec; /*!< After SCK delay time with nanosecond , set to 0 sets the minimum
-                                             delay.It sets the boundary value if out of range that can be set.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
+
+    uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                             delay. It also sets the boundary value if out of range.*/
 } dspi_master_ctar_config_t;
 
 /*! @brief DSPI master configuration structure.*/
 typedef struct _dspi_master_config
 {
-    dspi_ctar_selection_t whichCtar;      /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;      /*!< The desired CTAR to use. */
     dspi_master_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    dspi_which_pcs_t whichPcs;                     /*!< Desired Peripheral Chip Select (pcs). */
-    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< Desired PCS active high or low. */
+    dspi_which_pcs_t whichPcs;                     /*!< The desired Peripheral Chip Select (pcs). */
+    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< The desired PCS active high or low. */
 
-    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable . Note that continuous SCK is only
+    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                      supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite; /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                     data is ignored, the data from the transfer that generated the overflow
-                                     is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                     shift to the shift register. */
+    bool enableRxFifoOverWrite; /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                     data is ignored and the data from the transfer that generated the overflow
+                                     is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                     shift register. */
 
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                  Format. It's valid only when CPHA=0. */
 } dspi_master_config_t;
 
@@ -290,34 +272,34 @@ typedef struct _dspi_slave_ctar_config
     uint32_t bitsPerFrame;      /*!< Bits per frame, minimum 4, maximum 16.*/
     dspi_clock_polarity_t cpol; /*!< Clock polarity. */
     dspi_clock_phase_t cpha;    /*!< Clock phase. */
-                                /*!< Slave only supports MSB , does not support LSB.*/
+                                /*!< Slave only supports MSB and does not support LSB.*/
 } dspi_slave_ctar_config_t;
 
 /*! @brief DSPI slave configuration structure.*/
 typedef struct _dspi_slave_config
 {
-    dspi_ctar_selection_t whichCtar;     /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;     /*!< The desired CTAR to use. */
     dspi_slave_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that continuous SCK is only
+    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                                  supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite;             /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                                 data is ignored, the data from the transfer that generated the overflow
-                                                 is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                                 shift to the shift register. */
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableRxFifoOverWrite;             /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                                 data is ignored and the data from the transfer that generated the overflow
+                                                 is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                                 shift register. */
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                Format. It's valid only when CPHA=0. */
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -352,47 +334,60 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags , set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
+    volatile uint8_t state; /*!< DSPI transfer state, see _dspi_transfer_state.*/
 
     dspi_master_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                           /*!< Callback user data. */
 };
 
-/*! @brief DSPI slave transfer handle structure used for transactional API. */
+/*! @brief DSPI slave transfer handle structure used for the transactional API. */
 struct _dspi_slave_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame;          /*!< The desired number of bits per frame. */
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     volatile uint8_t state; /*!< DSPI transfer state.*/
 
@@ -417,18 +412,18 @@ extern "C" {
 /*!
  * @brief Initializes the DSPI master.
  *
- * This function initializes the DSPI master configuration. An example use case is as follows:
+ * This function initializes the DSPI master configuration. This is an example use case.
  *  @code
  *   dspi_master_config_t  masterConfig;
  *   masterConfig.whichCtar                                = kDSPI_Ctar0;
- *   masterConfig.ctarConfig.baudRate                      = 500000000;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
  *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
  *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
  *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
  *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
- *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
  *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
  *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
  *   masterConfig.enableContinuousSCK                      = false;
@@ -439,8 +434,8 @@ extern "C" {
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param masterConfig Pointer to structure dspi_master_config_t.
- * @param srcClock_Hz Module source input clock in Hertz
+ * @param masterConfig Pointer to the structure dspi_master_config_t.
+ * @param srcClock_Hz Module source input clock in Hertz.
  */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
@@ -448,8 +443,8 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
  * @brief Sets the dspi_master_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
- * User may use the initialized structure unchanged in DSPI_MasterInit() or modify the structure
- * before calling DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
  * Example:
  * @code
  *  dspi_master_config_t  masterConfig;
@@ -462,7 +457,7 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
 /*!
  * @brief DSPI slave configuration.
  *
- * This function initializes the DSPI slave configuration. An example use case is as follows:
+ * This function initializes the DSPI slave configuration. This is an example use case.
  *  @code
  *   dspi_slave_config_t  slaveConfig;
  *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
@@ -477,22 +472,22 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param slaveConfig Pointer to structure dspi_master_config_t.
+ * @param slaveConfig Pointer to the structure dspi_master_config_t.
  */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
 
 /*!
- * @brief Sets the dspi_slave_config_t structure to default values.
+ * @brief Sets the dspi_slave_config_t structure to a default value.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
- * User may use the initialized structure unchanged in DSPI_SlaveInit(), or modify the structure
- * before calling DSPI_SlaveInit().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
  * @code
  *  dspi_slave_config_t  slaveConfig;
  *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
  * @endcode
- * @param slaveConfig pointer to dspi_slave_config_t structure.
+ * @param slaveConfig Pointer to the dspi_slave_config_t structure.
  */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig);
 
@@ -506,7 +501,7 @@ void DSPI_Deinit(SPI_Type *base);
  * @brief Enables the DSPI peripheral and sets the MCR MDIS to 0.
  *
  * @param base DSPI peripheral address.
- * @param enable pass true to enable module, false to disable module.
+ * @param enable Pass true to enable module, false to disable module.
  */
 static inline void DSPI_Enable(SPI_Type *base, bool enable)
 {
@@ -522,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -532,7 +527,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 /*!
  * @brief Gets the DSPI status flag state.
  * @param base DSPI peripheral address.
- * @return The DSPI status(in SR register).
+ * @return DSPI status (in SR register).
  */
 static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
 {
@@ -545,13 +540,13 @@ static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
  * This function  clears the desired status bit by using a write-1-to-clear. The user passes in the base and the
  * desired status bit to clear.  The list of status bits is defined in the dspi_status_and_interrupt_request_t. The
  * function uses these bit positions in its algorithm to clear the desired flag state.
- * Example usage:
+ * This is an example.
  * @code
  *  DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag|kDSPI_EndOfQueueFlag);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param statusFlags The status flag , used from type dspi_flags.
+ * @param statusFlags The status flag used from the type dspi_flags.
  */
 static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 {
@@ -560,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -570,15 +565,16 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 /*!
  * @brief Enables the DSPI interrupts.
  *
- * This function configures the various interrupt masks of the DSPI.  The parameters are base and an interrupt mask.
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
  * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
  *
  * @code
  *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
 
@@ -590,7 +586,7 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 {
@@ -599,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -609,13 +605,13 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Enables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  DSPI_EnableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -625,13 +621,13 @@ static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Disables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  SPI_DisableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_DisableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -679,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -705,12 +707,19 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
  *
- * This function sets the module to begin data transfer in either master or slave mode.
+ * This function sets the module to start data transfer in either master or slave mode.
  *
  * @param base DSPI peripheral address.
  */
@@ -719,9 +728,9 @@ static inline void DSPI_StartTransfer(SPI_Type *base)
     base->MCR &= ~SPI_MCR_HALT_MASK;
 }
 /*!
- * @brief Stops (halts) DSPI transfers and sets HALT bit in MCR.
+ * @brief Stops DSPI transfers and sets the HALT bit in MCR.
  *
- * This function stops data transfers in either master or slave mode.
+ * This function stops data transfers in either master or slave modes.
  *
  * @param base DSPI peripheral address.
  */
@@ -731,44 +740,44 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
 }
 
 /*!
- * @brief Enables (or disables) the DSPI FIFOs.
+ * @brief Enables or disables the DSPI FIFOs.
  *
- * This function  allows the caller to disable/enable the Tx and Rx FIFOs (independently).
- * Note that to disable, the caller must pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
- * the caller must pass in a logic 1 (true).
+ * This function  allows the caller to disable/enable the Tx and Rx FIFOs independently.
+ * Note that to disable, pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
+ * pass in a logic 1 (true).
  *
  * @param base DSPI peripheral address.
- * @param enableTxFifo Disables (false) the TX FIFO, else enables (true) the TX FIFO
- * @param enableRxFifo Disables (false) the RX FIFO, else enables (true) the RX FIFO
+ * @param enableTxFifo Disables (false) the TX FIFO; Otherwise, enables (true) the TX FIFO
+ * @param enableRxFifo Disables (false) the RX FIFO; Otherwise, enables (true) the RX FIFO
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Flushes the DSPI FIFOs.
  *
  * @param base DSPI peripheral address.
- * @param flushTxFifo Flushes (true) the Tx FIFO, else do not flush (false) the Tx FIFO
- * @param flushRxFifo Flushes (true) the Rx FIFO, else do not flush (false) the Rx FIFO
+ * @param flushTxFifo Flushes (true) the Tx FIFO; Otherwise, does not flush (false) the Tx FIFO
+ * @param flushRxFifo Flushes (true) the Rx FIFO; Otherwise, does not flush (false) the Rx FIFO
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Configures the DSPI peripheral chip select polarity simultaneously.
- * For example, PCS0 and PCS1 set to active low and other PCS set to active high. Note that the number of
+ * For example, PCS0 and PCS1 are set to active low and other PCS is set to active high. Note that the number of
  * PCSs is specific to the device.
  * @code
  *  DSPI_SetAllPcsPolarity(base, kDSPI_Pcs0ActiveLow | kDSPI_Pcs1ActiveLow);
    @endcode
  * @param base DSPI peripheral address.
- * @param mask The PCS polarity mask ,  can use the enum _dspi_pcs_polarity.
+ * @param mask The PCS polarity mask; use the enum _dspi_pcs_polarity.
  */
 static inline void DSPI_SetAllPcsPolarity(SPI_Type *base, uint32_t mask)
 {
@@ -797,19 +806,19 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
  * @brief Manually configures the delay prescaler and scaler for a particular CTAR.
  *
  * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
- * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT)and scalar (DT).
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes the delay to configure along with the prescaler and scaler value.
- * This allows the user to directly set the prescaler/scaler values if they have pre-calculated them or if they simply
- * wish to manually increment either value.
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
  *
  * @param base DSPI peripheral address.
  * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
  * @param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
  * @param scaler The scaler delay value (can be any integer between 0 to 15).
- * @param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * @param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
  */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay);
@@ -817,15 +826,15 @@ void DSPI_MasterSetDelayScaler(
 /*!
  * @brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
  *
- * This function calculates the values for:
+ * This function calculates the values for the following.
  * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
  * After SCK delay pre-scalar (PASC) and scalar (ASC), or
- * Delay after transfer pre-scalar (PDT)and scalar (DT).
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes which delay they want to configure along with the desired delay value in nanoseconds.  The function
- * calculates the values needed for the prescaler and scaler and returning the actual calculated delay as an exact
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
  * delay match may not be possible. In this case, the closest match is calculated without going below the desired
  * delay value input.
  * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
@@ -849,11 +858,11 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
  * @brief Writes data into the data buffer for master mode.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_data_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -865,7 +874,7 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
    @endcode
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
@@ -879,14 +888,14 @@ static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config
  * @brief Sets the dspi_command_data_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
- * User may use the initialized structure unchanged in DSPI_MasterWrite_xx() or modify the structure
- * before calling DSPI_MasterWrite_xx().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
  * @code
  *  dspi_command_data_config_t  command;
  *  DSPI_GetDefaultDataCommandConfig(&command);
  * @endcode
- * @param command pointer to dspi_command_data_config_t structure.
+ * @param command Pointer to the dspi_command_data_config_t structure.
  */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
 
@@ -894,11 +903,11 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  * @brief Writes data into the data buffer master mode and waits till complete to return.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -911,10 +920,10 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
- * receive data is available when transmit completes.
+ * the received data is available when the transmit completes.
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data);
@@ -929,10 +938,10 @@ void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *co
  * improve performance in cases where the command structure is constant. For example, the user calls this function
  * before starting a transfer to generate the command word. When they are ready to transmit the data, they OR
  * this formatted command word with the desired data to transmit. This process increases transmit performance when
- * compared to calling send functions such as DSPI_HAL_WriteDataMastermode which format the command word each time a
+ * compared to calling send functions, such as DSPI_HAL_WriteDataMastermode,  which format the command word each time a
  * data word is to be sent.
  *
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @return The command word formatted to the PUSHR data register bit field.
  */
 static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t *command)
@@ -945,43 +954,44 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
 
 /*!
  * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
- *        buffer, master mode and waits till complete to return.
+ *        buffer master mode and waits till complete to return.
  *
- * In this function, the user must append the 16-bit data to the 16-bit command info then provide the total 32-bit word
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
  * as the data to send.
- * The command portion provides characteristics of the data such as the optional continuous chip select operation
-* between
- * transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
  * @code
  *  dataWord = <16-bit command> | <16-bit data>;
- *  DSPI_HAL_WriteCommandDataMastermodeBlocking(base, dataWord);
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
  * @endcode
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
- * Because the SPI is a synchronous protocol, the receive data is available when transmit completes.
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
- * @param data The data word (command and data combined) to be sent
+ * @param data The data word (command and data combined) to be sent.
  */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data);
 
@@ -1021,8 +1031,16 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 }
 
 /*!
+ * @brief Set up the dummy data.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1033,13 +1051,13 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 /*!
  * @brief Initializes the DSPI master handle.
  *
- * This function initializes the DSPI handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance,  call this API once to get the initialized handle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_handle_t.
- * @param callback dspi callback.
- * @param userData callback function parameter.
+ * @param callback DSPI callback.
+ * @param userData Callback function parameter.
  */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
@@ -1049,12 +1067,11 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using polling.
  *
- * This function transfers data with polling. This is a blocking function, which does not return until all transfers
- * have been
- * completed.
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
  *
  * @param base DSPI peripheral base address.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
@@ -1063,15 +1080,43 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @brief DSPI master transfer data using interrupts.
  *
  * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
- data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1079,19 +1124,19 @@ status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *ha
  * This function gets the master transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count);
 
 /*!
- * @brief DSPI master aborts transfer using an interrupt.
+ * @brief DSPI master aborts a transfer using an interrupt.
  *
  * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1101,7 +1146,7 @@ void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1111,10 +1156,10 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
  * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * @param handle DSPI handle pointer to dspi_slave_handle_t.
+ * @param handle DSPI handle pointer to the dspi_slave_handle_t.
  * @param base DSPI peripheral base address.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData Callback function parameter.
  */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
@@ -1125,12 +1170,11 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
  * @brief DSPI slave transfers data using an interrupt.
  *
  * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
- * data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer);
@@ -1141,8 +1185,8 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
  * This function gets the slave transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count);
@@ -1150,10 +1194,10 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 /*!
  * @brief DSPI slave aborts a transfer using an interrupt.
  *
- * This function aborts transfer using an interrupt.
+ * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -1163,19 +1207,29 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi_edma.c
@@ -1,42 +1,25 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi_edma.h"
 
 /***********************************************************************************************************************
-* Definitons
-***********************************************************************************************************************/
+ * Definitions
+ ***********************************************************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi_edma"
+#endif
 
 /*!
-* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_master_edma_private_handle
 {
     SPI_Type *base;                    /*!< DSPI peripheral base address. */
@@ -44,8 +27,8 @@ typedef struct _dspi_master_edma_private_handle
 } dspi_master_edma_private_handle_t;
 
 /*!
-* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_slave_edma_private_handle
 {
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
@@ -53,46 +36,58 @@ typedef struct _dspi_slave_edma_private_handle
 } dspi_slave_edma_private_handle_t;
 
 /***********************************************************************************************************************
-* Prototypes
-***********************************************************************************************************************/
+ * Prototypes
+ ***********************************************************************************************************************/
 /*!
-* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
 /*!
-* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
-/*!
-* @brief Get instance number for DSPI module.
-*
-* This is not a public API and it's extern from fsl_dspi.c.
-*
-* @param base DSPI peripheral base address
-*/
-extern uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /***********************************************************************************************************************
-* Variables
-***********************************************************************************************************************/
+ * Variables
+ ***********************************************************************************************************************/
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 
 /***********************************************************************************************************************
-* Code
-***********************************************************************************************************************/
+ * Code
+ ***********************************************************************************************************************/
 
+/*!
+ * brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          dspi_master_edma_handle_t *handle,
                                          dspi_master_edma_transfer_callback_t callback,
@@ -101,51 +96,72 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          edma_handle_t *edmaTxDataToIntermediaryHandle,
                                          edma_handle_t *edmaIntermediaryToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+#if (!(defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET))
+    assert(NULL != edmaTxDataToIntermediaryHandle);
+#endif
+    assert(NULL != edmaIntermediaryToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].base   = base;
     s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
     handle->userData = userData;
 
-    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaRxRegToRxDataHandle        = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
-    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+    handle->edmaIntermediaryToTxRegHandle  = edmaIntermediaryToTxRegHandle;
 }
 
+/*!
+ * brief DSPI master transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    uint32_t instance = DSPI_GetInstance(base);
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
-    uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    uint32_t instance                = DSPI_GetInstance(base);
+    uint16_t wordToSend              = 0;
+    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint8_t dataAlreadyFed           = 0;
+    uint8_t dataFedMax               = 2;
+    uint32_t tmpMCR                  = 0;
+    size_t tmpRemainingSendByteCount = 0;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
@@ -154,33 +170,33 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
 
     edma_transfer_config_t transferConfigA;
     edma_transfer_config_t transferConfigB;
-    edma_transfer_config_t transferConfigC;
 
-    handle->txBuffIfNull = ((uint32_t)DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-
-    handle->state = kDSPI_Busy;
+    handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
 
     dspi_command_data_config_t commandStruct;
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -188,98 +204,123 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    /* this limits the amount of data we can transfer due to the linked channel.
-    * The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (handle->bitsPerFrame > 8)
+    /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (transfer->dataSize > 1022)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
     else
     {
-        if (transfer->dataSize > 511)
+        if (transfer->dataSize > limited_size)
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
+    {
+        handle->state = (uint8_t)kDSPI_Idle;
+        return kStatus_InvalidArgument;
+    }
+
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
                      &s_dspiMasterEdmaPrivateHandle[instance]);
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
+    /*
+    (1)For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
+    channel_A minor link to channel_B , channel_B minor link to channel_C.
+
+    Already pushed 1 or 2 data in SPI_PUSHR , then start the DMA tansfer.
+    channel_A:SPI_POPR to rxData,
+    channel_B:next txData to handle->command (low 16 bits),
+    channel_C:handle->command (32 bits) to SPI_PUSHR, and use the scatter/gather to transfer the last data
+    (handle->lastCommand to SPI_PUSHR).
+
+    (2)For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C -> channel_B .
+    channel_C major link to channel_B.
+    So need prepare the first data in "intermediary"  before the DMA
+    transfer and then channel_B is used to prepare the next data to "intermediary"
+
+    channel_A:SPI_POPR to rxData,
+    channel_C: handle->command (32 bits) to SPI_PUSHR,
+    channel_B: next txData to handle->command (low 16 bits), and use the scatter/gather to prepare the last data
+    (handle->lastCommand to handle->Command).
+    */
 
     /*If dspi has separate dma request , prepare the first data in "intermediary" .
     else (dspi has shared dma request) , send first 2 data if there is fifo or send first 1 data if there is no fifo*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
-        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
-        */
+         * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+         */
 
         /*Prepare the firt data*/
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
             /* If it's the last word */
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
-                {
-                    if (handle->isThereExtraByte)
-                    {
-                        wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                    }
-                    else
-                    {
-                        wordToSend = *(handle->txData);
-                        ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                    }
-                }
-                else
-                {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                }
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
-            }
-            else /* For all words except the last word , frame > 8bits */
-            {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
+                }
+                else
+                {
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                }
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
+            }
+            else /* For all words except the last word , frame > 8bits */
+            {
+                if (NULL != handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* increment to next data byte */
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     ++handle->txData; /* increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData; /* increment to next data word*/
@@ -289,9 +330,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
             }
             else
             {
@@ -301,66 +343,57 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     }
 
     else /*dspi has shared dma request*/
-
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->remainingSendByteCount <= 2)
+                if (handle->remainingSendByteCount <= 2U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
-                        if (handle->isThereExtraByte)
-                        {
-                            wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                        }
-                        else
-                        {
-                            wordToSend = *(handle->txData);
-                            ++handle->txData;
-                            wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        }
+                        wordToSend = *(handle->txData);
+                        ++handle->txData;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
                     handle->remainingSendByteCount = 0;
-                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                    base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
                 /* For all words except the last word */
                 else
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                         ++handle->txData;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
-                    handle->remainingSendByteCount -= 2;
+                    handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -368,9 +401,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData;
@@ -380,7 +414,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     wordToSend = dummyData;
                 }
 
-                if (handle->remainingSendByteCount == 1)
+                if (handle->remainingSendByteCount == 1U)
                 {
                     base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
@@ -390,14 +424,14 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -405,125 +439,66 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
     }
 
-    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer(rxData)*/
     EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcAddr   = (uint32_t)rxAddr;
     transferConfigA.srcOffset = 0;
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
         transferConfigA.destOffset = 1;
     }
     else
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
         transferConfigA.destOffset = 0;
     }
 
     transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-    if (handle->bitsPerFrame <= 8)
+    if (handle->bitsPerFrame <= 8U)
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.minorLoopBytes  = 1;
         transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
     }
     else
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-        transferConfigA.minorLoopBytes = 2;
-        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        transferConfigA.minorLoopBytes  = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
     }
+
+    /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+    handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
     EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                           &transferConfigA, NULL);
+                           (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
     EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                 kEDMA_MajorInterruptEnable);
+                                 (uint32_t)kEDMA_MajorInterruptEnable);
 
-    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
-    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
-    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
-    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
-
-    if (handle->remainingSendByteCount > 0)
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*Calculate the last data : handle->lastCommand*/
+    if (((tmpRemainingSendByteCount > 0U) && (1U != (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U))) &&
+         (1U == (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        if (handle->txData)
-        {
-            transferConfigB.srcAddr = (uint32_t)(handle->txData);
-            transferConfigB.srcOffset = 1;
-        }
-        else
-        {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-            transferConfigB.srcOffset = 0;
-        }
-
-        transferConfigB.destAddr = (uint32_t)(&handle->command);
-        transferConfigB.destOffset = 0;
-
-        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-        if (handle->bitsPerFrame <= 8)
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
-
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                majorlink , the majorlink would not trigger the channel_C*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
-            }
-        }
-        else
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                * majorlink*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
-            }
-        }
-
-        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
-    }
-
-    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
-    handle the last data */
-    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
-
-    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
-        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
-         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
-    {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
             uint32_t bufferIndex = 0;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                if (handle->bitsPerFrame <= 8)
+                if (handle->bitsPerFrame <= 8U)
                 {
-                    bufferIndex = handle->remainingSendByteCount - 1;
+                    bufferIndex = handle->remainingSendByteCount - 1U;
                 }
                 else
                 {
-                    bufferIndex = handle->remainingSendByteCount - 2;
+                    bufferIndex = handle->remainingSendByteCount - 2U;
                 }
             }
             else
@@ -531,85 +506,345 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 bufferIndex = handle->remainingSendByteCount;
             }
 
-            if (handle->bitsPerFrame <= 8)
+            uint32_t tmpLastCommand = handle->lastCommand;
+            uint8_t *tmpTxData      = handle->txData;
+
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | tmpTxData[bufferIndex - 1U];
             }
             else
             {
-                if (handle->isThereExtraByte)
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 2] |
-                                          ((uint32_t)dummyData << 8);
-                }
-                else
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
-                                          ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
-                                          handle->txData[bufferIndex - 2];
-                }
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | ((uint32_t)tmpTxData[bufferIndex - 1U] << 8U) |
+                                 tmpTxData[bufferIndex - 2U];
             }
+
+            handle->lastCommand = tmpLastCommand;
         }
         else
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 wordToSend = dummyData;
             }
             else
             {
-                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
             }
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
     }
 
+/* The feature of GASKET is that the SPI supports 8-bit or 16-bit writes to the PUSH TX FIFO,
+ * allowing a single write to the command word followed by multiple writes to the transmit word.
+ * The TX FIFO will save the last command word written, and convert a 8-bit/16-bit write to the
+ * transmit word into a 32-bit write that pushes both the command word and transmit word into
+ * the TX FIFO (PUSH TX FIFO Register In Master Mode)
+ * So, if this feature is supported, we can use use one channel to carry the receive data from
+ * receive regsiter to user data buffer, use the other channel to carry the data from user data buffer
+ * to transmit register,and use the scatter/gather function to prepare the last data.
+ * That is to say, if GASKET feature is supported, we can use only two channels for tansferring data.
+ */
+#if defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET
+    /*  For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to PUSHR register.
+     */
+
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
     if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
-        ((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+        ((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigC.destAddr = (uint32_t)txAddr;
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-        transferConfigC.majorLoopCounts = 1;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t)txAddr;
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
     }
 
-    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)))
+    /*User_Send_Buffer(txData) to PUSHR register. */
+    if (((handle->remainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+        ((handle->remainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U)))
     {
-        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
-        transferConfigC.destAddr = (uint32_t)txAddr;
-
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-
-        if (handle->bitsPerFrame <= 8)
+        if (handle->txData)
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /* For DSPI with separate RX and TX DMA requests, one frame data has been carry
+                 * to handle->command, so need to reduce the pointer of txData.
+                 */
+                transferConfigB.srcAddr =
+                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8U) ? (1U) : (2U)));
+                transferConfigB.srcOffset = 1;
+            }
+            else
+            {
+                /* For DSPI with shared RX and TX DMA requests, one or two frame data have been carry
+                 * to PUSHR register, so no need to change the pointer of txData.
+                 */
+                transferConfigB.srcAddr   = (uint32_t)((uint8_t *)(handle->txData));
+                transferConfigB.srcOffset = 1;
+            }
         }
         else
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)txAddr;
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1U;
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            transferConfigB.majorLoopCounts  = (handle->remainingSendByteCount / 2U) - 1U;
         }
 
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, softwareTCD);
+    }
+    /* If only one word to transmit, only carry the lastcommand. */
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, NULL);
+    }
+
+    /*Start the EDMA channel_A , channel_C. */
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    /* Set the channel link.
+     * For DSPI instances with shared TX and RX DMA requests, setup channel minor link, first receive data from the
+     * receive register, and then carry transmit data to PUSHER register.
+     * For DSPI instance with separate TX and RX DMA requests, there is no need to set up channel link.
+     */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /*Set channel priority*/
+        uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+        uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
+        uint8_t t                   = 0;
+
+        if (channelPriorityLow > channelPriorityHigh)
+        {
+            t                   = channelPriorityLow;
+            channelPriorityLow  = channelPriorityHigh;
+            channelPriorityHigh = t;
+        }
+
+        edma_channel_Preemption_config_t preemption_config_t;
+        preemption_config_t.enableChannelPreemption = true;
+        preemption_config_t.enablePreemptAbility    = true;
+        preemption_config_t.channelPriority         = channelPriorityLow;
+
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+        /*if there is Rx DMA request , carry the 32bits data (handle->command) to user data first , then link to
+          channelC to carry the next data to PUSHER register.(txData to PUSHER) */
+        if (handle->remainingSendByteCount > 0U)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaIntermediaryToTxRegHandle->channel);
+        }
+    }
+
+    DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    /* Setup control info to PUSHER register. */
+    *((uint16_t *)&(base->PUSHR) + 1) = (handle->command >> 16U);
+#else
+
+    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
+    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
+    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
+
+    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
+
+    /*For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to handle->Command*/
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t) & (handle->command);
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*User_Send_Buffer(txData) to intermediary(handle->command)*/
+    if (((((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U))) &&
+         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        if (NULL != handle->txData)
+        {
+            transferConfigB.srcAddr   = (uint32_t)(handle->txData);
+            transferConfigB.srcOffset = 1;
+        }
+        else
+        {
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)(&handle->command);
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                majorlink , the majorlink would not trigger the channel_C*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1U;
+            }
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                 * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U + 1U;
+            }
+        }
+
+        if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, softwareTCD);
+            EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
+                                       handle->edmaIntermediaryToTxRegHandle->channel, false);
+        }
+        else
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+        }
+    }
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                               handle->edmaTxDataToIntermediaryHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
+    handle the last data */
+
+    edma_transfer_config_t transferConfigC;
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*For DSPI instances with shared RX/TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to SPI_PUSHR*/
+    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (tmpRemainingSendByteCount > 0U)))
+    {
+        transferConfigC.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr         = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        transferConfigC.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    if (((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+        ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U)) ||
+        (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        transferConfigC.srcAddr  = (uint32_t)(&(handle->command));
+        transferConfigC.destAddr = (uint32_t)txAddr;
+
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            if (handle->bitsPerFrame <= 8U)
+            {
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1U;
+            }
+            else
+            {
+                transferConfigC.majorLoopCounts = (handle->remainingSendByteCount / 2U) - 1U;
+            }
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, softwareTCD);
+        }
+        else
+        {
+            transferConfigC.majorLoopCounts = 1;
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+        }
+
         EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
                                    handle->edmaIntermediaryToTxRegHandle->channel, false);
     }
     else
     {
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                               handle->edmaIntermediaryToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
     /*Start the EDMA channel_A , channel_B , channel_C transfer*/
@@ -618,165 +853,233 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
-    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid  = handle->edmaTxDataToIntermediaryHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
     if (channelPriorityLow > channelPriorityMid)
     {
-        t = channelPriorityLow;
+        t                  = channelPriorityLow;
         channelPriorityLow = channelPriorityMid;
         channelPriorityMid = t;
     }
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     if (channelPriorityMid > channelPriorityHigh)
     {
-        t = channelPriorityMid;
-        channelPriorityMid = channelPriorityHigh;
+        t                   = channelPriorityMid;
+        channelPriorityMid  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
-    /*Set the channel link.
-    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
-    For DSPI instances with separate RX and TX DMA requests:
-    Rx DMA request -> channel_A
-    Tx DMA request -> channel_C -> channel_B . (so need prepare the first data in "intermediary"  before the DMA
-    transfer and then channel_B is used to prepare the next data to "intermediary" ) */
+    /*Set the channel link.*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
-        to prepare the next 32bits data (User_send_buffer to handle->command) */
-        if (handle->remainingSendByteCount > 1)
+        to prepare the next 32bits data (txData to handle->command) */
+        if (handle->remainingSendByteCount > 1U)
         {
             EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
-                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MinorLink,
+                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MajorLink,
                                 handle->edmaTxDataToIntermediaryHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
     else
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                    kEDMA_MajorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-            }
 
             EDMA_SetChannelLink(handle->edmaTxDataToIntermediaryHandle->base,
                                 handle->edmaTxDataToIntermediaryHandle->channel, kEDMA_MinorLink,
                                 handle->edmaIntermediaryToTxRegHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
-
+#endif
     DSPI_StartTransfer(base);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI base pointer
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferEDMA(base, handle, &tempXfer);
+
+    return status;
+}
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
     EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the master eDMA transfer count.
+ *
+ * This function gets the master eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -784,13 +1087,33 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         dspi_slave_edma_handle_t *handle,
                                         dspi_slave_edma_transfer_callback_t callback,
@@ -798,14 +1121,16 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+    assert(NULL != edmaTxDataToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].base   = base;
     s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
@@ -815,88 +1140,99 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
 
+/*!
+ * brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
+
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If send/receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    edma_tcd_t *softwareTCD = (edma_tcd_t *)((uint32_t)(&handle->dspiSoftwareTCD[1]) & (~0x1FU));
+    handle->state = (uint8_t)kDSPI_Busy;
 
     uint32_t instance = DSPI_GetInstance(base);
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->bitsPerFrame > 8)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
-            if (transfer->dataSize > 1022)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
-        else
+    }
+    else
+    {
+        if (transfer->dataSize > limited_size)
         {
-            if (transfer->dataSize > 511)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
     }
 
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize < 2))
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
 
-    handle->state = kDSPI_Busy;
-
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
-    handle->errorCount = 0;
+    handle->totalByteCount            = transfer->dataSize;
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
-
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint32_t wordToSend    = 0;
+    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint8_t dataFedMax     = 2;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
@@ -907,9 +1243,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     DSPI_StartTransfer(base);
 
@@ -919,42 +1255,36 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* Increment to next data byte */
-                    if ((handle->remainingSendByteCount == 2) && (handle->isThereExtraByte))
-                    {
-                        wordToSend |= (unsigned)(dummyData) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
-                    else
-                    {
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
+
+                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    ++handle->txData; /* Increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -962,9 +1292,10 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     /* Increment to next data word*/
@@ -978,14 +1309,14 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 /* Decrement remainingSendByteCount*/
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -994,179 +1325,132 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     }
 
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
-    if (handle->remainingReceiveByteCount > 0)
+    if (handle->remainingReceiveByteCount > 0U)
     {
         EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcAddr   = (uint32_t)rxAddr;
         transferConfigA.srcOffset = 0;
 
-        if (handle->rxData)
+        if (NULL != handle->rxData)
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
             transferConfigA.destOffset = 1;
         }
         else
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
             transferConfigA.destOffset = 0;
         }
 
         transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.minorLoopBytes  = 1;
             transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
         }
         else
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigA.minorLoopBytes = 2;
-            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+            transferConfigA.minorLoopBytes  = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
         }
+
+        /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+        handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
         EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                               &transferConfigA, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
         EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                     kEDMA_MajorInterruptEnable);
+                                     (uint32_t)kEDMA_MajorInterruptEnable);
     }
 
-    if (handle->remainingSendByteCount > 0)
+    if (handle->remainingSendByteCount > 0U)
     {
         /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
         EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
 
-        /*If there is extra byte , it would use the */
-        if (handle->isThereExtraByte)
-        {
-            if (handle->txData)
-            {
-                handle->txLastData =
-                    handle->txData[handle->remainingSendByteCount - 2] | ((uint32_t)DSPI_DUMMY_DATA << 8);
-            }
-            else
-            {
-                handle->txLastData = DSPI_DUMMY_DATA | ((uint32_t)DSPI_DUMMY_DATA << 8);
-            }
-            transferConfigC.srcAddr = (uint32_t)(&(handle->txLastData));
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.srcOffset = 0;
-            transferConfigC.destOffset = 0;
-            transferConfigC.minorLoopBytes = 4;
-            transferConfigC.majorLoopCounts = 1;
+        transferConfigC.destAddr   = (uint32_t)txAddr;
+        transferConfigC.destOffset = 0;
 
-            EDMA_TcdReset(softwareTCD);
-            EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
-        }
-
-        /*Set another  transferConfigC*/
-        if ((handle->isThereExtraByte) && (handle->remainingSendByteCount == 2))
+        if (NULL != handle->txData)
         {
-            EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                   &transferConfigC, NULL);
+            transferConfigC.srcAddr   = (uint32_t)(&(handle->txData[0]));
+            transferConfigC.srcOffset = 1;
         }
         else
         {
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.destOffset = 0;
-
-            if (handle->txData)
+            transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigC.srcOffset = 0;
+            if (handle->bitsPerFrame <= 8U)
             {
-                transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
-                transferConfigC.srcOffset = 1;
+                handle->txBuffIfNull = dummyData;
             }
             else
             {
-                transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-                transferConfigC.srcOffset = 0;
-                if (handle->bitsPerFrame <= 8)
-                {
-                    handle->txBuffIfNull = DSPI_DUMMY_DATA;
-                }
-                else
-                {
-                    handle->txBuffIfNull = (DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-                }
+                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
             }
-
-            transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-            if (handle->bitsPerFrame <= 8)
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
-                transferConfigC.minorLoopBytes = 1;
-                transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
-            }
-            else
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
-                transferConfigC.minorLoopBytes = 2;
-                if (handle->isThereExtraByte)
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-                }
-                else
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
-                }
-            }
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, softwareTCD);
-                EDMA_EnableAutoStopRequest(handle->edmaTxDataToTxRegHandle->base,
-                                           handle->edmaTxDataToTxRegHandle->channel, false);
-            }
-            else
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, NULL);
-            }
-
-            EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
         }
+
+        transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigC.minorLoopBytes   = 1;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount;
+        }
+        else
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigC.minorLoopBytes   = 2;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount / 2U;
+        }
+
+        EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+
+        EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
     }
 
     EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.
@@ -1176,16 +1460,16 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     Tx DMA request -> channel_C */
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
         }
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
     else
     {
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
 
     return kStatus_Success;
@@ -1196,58 +1480,67 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    bool transferDone,
                                    uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred so far by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1255,7 +1548,8 @@ status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -37,28 +15,33 @@
  * @{
  */
 
-
 /***********************************************************************************************************************
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI master.
+ * @param handle A pointer to the handle for the DSPI master.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
                                                      dspi_master_edma_handle_t *handle,
@@ -68,37 +51,38 @@ typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI slave.
+ * @param handle A pointer to the handle for the DSPI slave.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_slave_edma_transfer_callback_t)(SPI_Type *base,
                                                     dspi_slave_edma_handle_t *handle,
                                                     status_t status,
                                                     void *userData);
 
-/*! @brief DSPI master eDMA transfer handle structure used for transactional API. */
+/*! @brief DSPI master eDMA transfer handle structure used for the transactional API. */
 struct _dspi_master_edma_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer; /*!< Indicates whether the PCS signal keeps active after the last frame transfer.*/
+
+    uint8_t nbytes;         /*!< eDMA minor byte transfer count initially configured. */
+    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
-
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     dspi_master_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                                /*!< Callback user data. */
@@ -110,33 +94,30 @@ struct _dspi_master_edma_handle
     edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
-/*! @brief DSPI slave eDMA transfer handle structure used for transactional API.*/
+/*! @brief DSPI slave eDMA transfer handle structure used for the transactional API.*/
 struct _dspi_slave_edma_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame; /*!< The desired number of bits per frame. */
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
     uint32_t txLastData;   /*!< Used if there is an extra byte when 16bits per frame for DMA purpose.*/
 
-    volatile uint8_t state; /*!< DSPI transfer state.*/
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
-    uint32_t errorCount; /*!< Error count for slave transfer.*/
+    volatile uint8_t state; /*!< DSPI transfer state.*/
 
     dspi_slave_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                               /*!< Callback user data. */
 
     edma_handle_t *edmaRxRegToRxDataHandle; /*!<edma_handle_t handle point used for RxReg to RxData buff*/
     edma_handle_t *edmaTxDataToTxRegHandle; /*!<edma_handle_t handle point used for TxData to TxReg*/
-
-    edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
 /***********************************************************************************************************************
@@ -152,17 +133,18 @@ extern "C" {
  * @brief Initializes the DSPI master eDMA handle.
  *
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
- * specified DSPI instance, user need only call this API once to get the initialized handle.
+ * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request source.
- * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
- * (2)For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
  * @param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
@@ -178,34 +160,49 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI master aborts a transfer which using eDMA.
+ * @brief Transfers a block of data using a eDMA method.
  *
- * This function aborts a transfer which using eDMA.
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle);
 
 /*!
  * @brief Gets the master eDMA transfer count.
  *
- * This function get the master eDMA transfer count.
+ * This function gets the master eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count);
@@ -216,7 +213,8 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request source.
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
  * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaTxDataToTxRegHandle.
  * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
@@ -224,7 +222,7 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_slave_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
  */
@@ -238,25 +236,25 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI slave transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
- * Note that slave EDMA transfer cannot support the situation that transfer_size is 1 when the bitsPerFrame is greater
- * than 8 .
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI slave aborts a transfer which using eDMA.
+ * @brief DSPI slave aborts a transfer which is using eDMA.
  *
- * This function aborts a transfer which using eDMA.
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle);
 
@@ -266,8 +264,8 @@ void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handl
  * This function gets the slave eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred so far by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_edma.c
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "fsl_edma.h"
 
@@ -63,11 +63,13 @@ static void EDMA_InstallTCD(DMA_Type *base, uint32_t channel, edma_tcd_t *tcd);
 /*! @brief Array to map EDMA instance number to base pointer. */
 static DMA_Type *const s_edmaBases[] = DMA_BASE_PTRS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Array to map EDMA instance number to clock name. */
 static const clock_ip_name_t s_edmaClockName[] = EDMA_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Array to map EDMA instance number to IRQ number. */
-static const IRQn_Type s_edmaIRQNumber[] = DMA_CHN_IRQS;
+static const IRQn_Type s_edmaIRQNumber[][FSL_FEATURE_EDMA_MODULE_CHANNEL] = DMA_CHN_IRQS;
 
 /*! @brief Pointers to transfer handle for each EDMA channel. */
 static edma_handle_t *s_EDMAHandle[FSL_FEATURE_EDMA_MODULE_CHANNEL * FSL_FEATURE_SOC_EDMA_COUNT];
@@ -81,7 +83,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_EDMA_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_edmaBases); instance++)
     {
         if (s_edmaBases[instance] == base)
         {
@@ -89,7 +91,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_EDMA_COUNT);
+    assert(instance < ARRAY_SIZE(s_edmaBases));
 
     return instance;
 }
@@ -122,8 +124,10 @@ void EDMA_Init(DMA_Type *base, const edma_config_t *config)
 
     uint32_t tmpreg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Ungate EDMA periphral clock */
     CLOCK_EnableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
     /* Configure EDMA peripheral according to the configuration structure. */
     tmpreg = base->CR;
     tmpreg &= ~(DMA_CR_ERCA_MASK | DMA_CR_HOE_MASK | DMA_CR_CLM_MASK | DMA_CR_EDBG_MASK);
@@ -134,8 +138,10 @@ void EDMA_Init(DMA_Type *base, const edma_config_t *config)
 
 void EDMA_Deinit(DMA_Type *base)
 {
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Gate EDMA periphral clock */
     CLOCK_DisableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void EDMA_GetDefaultConfig(edma_config_t *config)
@@ -409,46 +415,32 @@ void EDMA_TcdDisableInterrupts(edma_tcd_t *tcd, uint32_t mask)
     }
 }
 
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel)
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel)
 {
     assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
 
-    uint32_t nbytes = 0;
-    uint32_t remainingBytes = 0;
+    uint32_t remainingCount = 0;
 
     if (DMA_CSR_DONE_MASK & base->TCD[channel].CSR)
     {
-        remainingBytes = 0;
+        remainingCount = 0;
     }
     else
     {
-        /* Calculate the nbytes */
-        if (base->TCD[channel].NBYTES_MLOFFYES & (DMA_NBYTES_MLOFFYES_SMLOE_MASK | DMA_NBYTES_MLOFFYES_DMLOE_MASK))
-        {
-            nbytes = (base->TCD[channel].NBYTES_MLOFFYES & DMA_NBYTES_MLOFFYES_NBYTES_MASK) >>
-                     DMA_NBYTES_MLOFFYES_NBYTES_SHIFT;
-        }
-        else
-        {
-            nbytes =
-                (base->TCD[channel].NBYTES_MLOFFNO & DMA_NBYTES_MLOFFNO_NBYTES_MASK) >> DMA_NBYTES_MLOFFNO_NBYTES_SHIFT;
-        }
         /* Calculate the unfinished bytes */
         if (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_ELINK_MASK)
         {
-            remainingBytes = ((base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >>
-                              DMA_CITER_ELINKYES_CITER_SHIFT) *
-                             nbytes;
+            remainingCount =
+                (base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >> DMA_CITER_ELINKYES_CITER_SHIFT;
         }
         else
         {
-            remainingBytes =
-                ((base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT) *
-                nbytes;
+            remainingCount =
+                (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT;
         }
     }
 
-    return remainingBytes;
+    return remainingCount;
 }
 
 uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel)
@@ -497,14 +489,19 @@ void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel)
     uint32_t channelIndex;
     edma_tcd_t *tcdRegs;
 
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
+
     handle->base = base;
     handle->channel = channel;
     /* Get the DMA instance number */
     edmaInstance = EDMA_GetInstance(base);
     channelIndex = (edmaInstance * FSL_FEATURE_EDMA_MODULE_CHANNEL) + channel;
     s_EDMAHandle[channelIndex] = handle;
+
     /* Enable NVIC interrupt */
-    EnableIRQ(s_edmaIRQNumber[channelIndex]);
+    EnableIRQ(s_edmaIRQNumber[edmaInstance][channel]);
+
     /*
        Reset TCD registers to zero. Unlike the EDMA_TcdReset(DREQ will be set),
        CSR will be 0. Because in order to suit EDMA busy check mechanism in
@@ -829,7 +826,7 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
     {
         (handle->callback)(handle, handle->userData, true, 0);
     }
-    else /* Use the TCD queue. */
+    else /* Use the TCD queue. Please refer to the API descriptions in the eDMA header file for detailed information. */
     {
         uint32_t sga = handle->base->TCD[handle->channel].DLAST_SGA;
         uint32_t sga_index;
@@ -839,19 +836,19 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
 
         /* Check if transfer is already finished. */
         transfer_done = ((handle->base->TCD[handle->channel].CSR & DMA_CSR_DONE_MASK) != 0);
-        /* Get the offset of the current transfer TCD blcoks. */
+        /* Get the offset of the next transfer TCD blcoks to be loaded into the eDMA engine. */
         sga -= (uint32_t)handle->tcdPool;
-        /* Get the index of the current transfer TCD blcoks. */
+        /* Get the index of the next transfer TCD blcoks to be loaded into the eDMA engine. */
         sga_index = sga / sizeof(edma_tcd_t);
         /* Adjust header positions. */
         if (transfer_done)
         {
-            /* New header shall point to the next TCD (current one is already finished) */
+            /* New header shall point to the next TCD to be loaded (current one is already finished) */
             new_header = sga_index;
         }
         else
         {
-            /* New header shall point to this descriptor (not finished yet) */
+            /* New header shall point to this descriptor currently loaded (not finished yet) */
             new_header = sga_index ? sga_index - 1U : handle->tcdSize - 1U;
         }
         /* Calculate the number of finished TCDs */
@@ -863,7 +860,7 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
             }
             else
             {
-                /* Internal error occurs. */
+                /* No TCD in the memory are going to be loaded or internal error occurs. */
                 tcds_done = 0;
             }
         }
@@ -875,9 +872,9 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
                 tcds_done += handle->tcdSize;
             }
         }
-        /* Advance header to the point beyond the last finished TCD block. */
+        /* Advance header which points to the TCD to be loaded into the eDMA engine from memory. */
         handle->header = new_header;
-        /* Release TCD blocks. */
+        /* Release TCD blocks. tcdUsed is the TCD number which can be used/loaded in the memory pool. */
         handle->tcdUsed -= tcds_done;
         /* Invoke callback function. */
         if (handle->callback)
@@ -937,12 +934,260 @@ void DMA0_37_DriverIRQHandler(void)
         EDMA_HandleIRQ(s_EDMAHandle[7]);
     }
 }
+
+#if defined(DMA1)
+void DMA1_04_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA1_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA1_26_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA1_37_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+#endif
 #endif /* 8 channels (Shared) */
+
+/* 16 channels (Shared): K32H844P */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 16U
+
+void DMA0_08_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+}
+
+void DMA0_19_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+}
+
+void DMA0_210_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+}
+
+void DMA0_311_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+}
+
+void DMA0_412_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA0_513_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA0_614_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA0_715_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+
+#if defined(DMA1)
+void DMA1_08_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+}
+
+void DMA1_19_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+}
+
+void DMA1_210_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+}
+
+void DMA1_311_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+}
+
+void DMA1_412_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA1_513_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA1_614_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA1_715_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif
+#endif /* 16 channels (Shared) */
 
 /* 32 channels (Shared): k80 */
 #if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
 
-void DMA0_DMA16_IRQHandler(void)
+void DMA0_DMA16_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -954,7 +1199,7 @@ void DMA0_DMA16_IRQHandler(void)
     }
 }
 
-void DMA1_DMA17_IRQHandler(void)
+void DMA1_DMA17_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -966,7 +1211,7 @@ void DMA1_DMA17_IRQHandler(void)
     }
 }
 
-void DMA2_DMA18_IRQHandler(void)
+void DMA2_DMA18_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -978,7 +1223,7 @@ void DMA2_DMA18_IRQHandler(void)
     }
 }
 
-void DMA3_DMA19_IRQHandler(void)
+void DMA3_DMA19_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -990,7 +1235,7 @@ void DMA3_DMA19_IRQHandler(void)
     }
 }
 
-void DMA4_DMA20_IRQHandler(void)
+void DMA4_DMA20_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1002,7 +1247,7 @@ void DMA4_DMA20_IRQHandler(void)
     }
 }
 
-void DMA5_DMA21_IRQHandler(void)
+void DMA5_DMA21_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1014,7 +1259,7 @@ void DMA5_DMA21_IRQHandler(void)
     }
 }
 
-void DMA6_DMA22_IRQHandler(void)
+void DMA6_DMA22_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1026,7 +1271,7 @@ void DMA6_DMA22_IRQHandler(void)
     }
 }
 
-void DMA7_DMA23_IRQHandler(void)
+void DMA7_DMA23_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1038,7 +1283,7 @@ void DMA7_DMA23_IRQHandler(void)
     }
 }
 
-void DMA8_DMA24_IRQHandler(void)
+void DMA8_DMA24_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1050,7 +1295,7 @@ void DMA8_DMA24_IRQHandler(void)
     }
 }
 
-void DMA9_DMA25_IRQHandler(void)
+void DMA9_DMA25_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1062,7 +1307,7 @@ void DMA9_DMA25_IRQHandler(void)
     }
 }
 
-void DMA10_DMA26_IRQHandler(void)
+void DMA10_DMA26_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1074,7 +1319,7 @@ void DMA10_DMA26_IRQHandler(void)
     }
 }
 
-void DMA11_DMA27_IRQHandler(void)
+void DMA11_DMA27_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1086,7 +1331,7 @@ void DMA11_DMA27_IRQHandler(void)
     }
 }
 
-void DMA12_DMA28_IRQHandler(void)
+void DMA12_DMA28_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1098,7 +1343,7 @@ void DMA12_DMA28_IRQHandler(void)
     }
 }
 
-void DMA13_DMA29_IRQHandler(void)
+void DMA13_DMA29_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1110,7 +1355,7 @@ void DMA13_DMA29_IRQHandler(void)
     }
 }
 
-void DMA14_DMA30_IRQHandler(void)
+void DMA14_DMA30_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1122,7 +1367,7 @@ void DMA14_DMA30_IRQHandler(void)
     }
 }
 
-void DMA15_DMA31_IRQHandler(void)
+void DMA15_DMA31_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1134,6 +1379,202 @@ void DMA15_DMA31_IRQHandler(void)
     }
 }
 #endif /* 32 channels (Shared) */
+
+/* 32 channels (Shared): MCIMX7U5_M4 */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
+
+void DMA0_0_4_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+}
+
+void DMA0_1_5_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+}
+
+void DMA0_2_6_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+}
+
+void DMA0_3_7_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+}
+
+void DMA0_8_12_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA0_9_13_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA0_10_14_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA0_11_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+
+void DMA0_16_20_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 16U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 20U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+}
+
+void DMA0_17_21_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 17U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 21U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+}
+
+void DMA0_18_22_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 18U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 22U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+}
+
+void DMA0_19_23_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 19U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 23U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+}
+
+void DMA0_24_28_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 24U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 28U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA0_25_29_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 25U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 29U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA0_26_30_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 26U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 30U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA0_27_31_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 27U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 31U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif /* 32 channels (Shared): MCIMX7U5 */
 
 /* 4 channels (No Shared): kv10  */
 #if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 0

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_edma.h
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #ifndef _FSL_EDMA_H_
 #define _FSL_EDMA_H_
@@ -45,7 +45,7 @@
 /*! @name Driver version */
 /*@{*/
 /*! @brief eDMA driver version */
-#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 1)) /*!< Version 2.0.1. */
+#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 1)) /*!< Version 2.1.1. */
 /*@}*/
 
 /*! @brief Compute the offset unit from DCHPRI3 */
@@ -77,28 +77,28 @@ typedef enum _edma_modulo
     kEDMA_Modulo128bytes,       /*!< Circular buffer size is 128 bytes. */
     kEDMA_Modulo256bytes,       /*!< Circular buffer size is 256 bytes. */
     kEDMA_Modulo512bytes,       /*!< Circular buffer size is 512 bytes. */
-    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1K bytes. */
-    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2K bytes. */
-    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4K bytes. */
-    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8K bytes. */
-    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16K bytes. */
-    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32K bytes. */
-    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64K bytes. */
-    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128K bytes. */
-    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256K bytes. */
-    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512K bytes. */
-    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1M bytes. */
-    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2M bytes. */
-    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4M bytes. */
-    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8M bytes. */
-    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16M bytes. */
-    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32M bytes. */
-    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64M bytes. */
-    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128M bytes. */
-    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256M bytes. */
-    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512M bytes. */
-    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1G bytes. */
-    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2G bytes. */
+    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1 K bytes. */
+    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2 K bytes. */
+    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4 K bytes. */
+    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8 K bytes. */
+    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16 K bytes. */
+    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32 K bytes. */
+    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64 K bytes. */
+    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128 K bytes. */
+    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256 K bytes. */
+    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512 K bytes. */
+    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1 M bytes. */
+    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2 M bytes. */
+    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4 M bytes. */
+    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8 M bytes. */
+    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16 M bytes. */
+    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32 M bytes. */
+    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64 M bytes. */
+    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128 M bytes. */
+    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256 M bytes. */
+    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512 M bytes. */
+    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1 G bytes. */
+    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2 G bytes. */
 } edma_modulo_t;
 
 /*! @brief Bandwidth control */
@@ -177,7 +177,7 @@ typedef struct _edma_config
                                            the link channel is itself. */
     bool enableHaltOnError;           /*!< Enable (true) transfer halt on error. Any error causes the HALT bit to set.
                                            Subsequently, all service requests are ignored until the HALT bit is cleared.*/
-    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method, or fixed priority
+    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method or fixed priority
                                            arbitration is used for channel selection */
     bool enableDebugMode; /*!< Enable(true) eDMA debug mode. When in debug mode, the eDMA stalls the start of
                                a new channel. Executing channels are allowed to complete. */
@@ -211,15 +211,15 @@ typedef struct _edma_transfer_config
                                                 form the next-state value as each source read is completed. */
     int16_t destOffset;                    /*!< Sign-extended offset applied to the current destination address to
                                                 form the next-state value as each destination write is completed. */
-    uint16_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
+    uint32_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
     uint32_t majorLoopCounts;              /*!< Major loop iteration count. */
 } edma_transfer_config_t;
 
 /*! @brief eDMA channel priority configuration */
 typedef struct _edma_channel_Preemption_config
 {
-    bool enableChannelPreemption; /*!< If true: channel can be suspended by other channel with higher priority */
-    bool enablePreemptAbility;    /*!< If true: channel can suspend other channel with low priority */
+    bool enableChannelPreemption; /*!< If true: a channel can be suspended by other channel with higher priority */
+    bool enablePreemptAbility;    /*!< If true: a channel can suspend other channel with low priority */
     uint8_t channelPriority;      /*!< Channel priority */
 } edma_channel_Preemption_config_t;
 
@@ -228,7 +228,7 @@ typedef struct _edma_minor_offset_config
 {
     bool enableSrcMinorOffset;  /*!< Enable(true) or Disable(false) source minor loop offset. */
     bool enableDestMinorOffset; /*!< Enable(true) or Disable(false) destination minor loop offset. */
-    uint32_t minorOffset;       /*!< Offset for minor loop mapping. */
+    uint32_t minorOffset;       /*!< Offset for a minor loop mapping. */
 } edma_minor_offset_config_t;
 
 /*!
@@ -255,20 +255,21 @@ typedef struct _edma_tcd
 /*! @brief Callback for eDMA */
 struct _edma_handle;
 
-/*! @brief Define Callback function for eDMA. */
+/*! @brief Define callback function for eDMA. */
 typedef void (*edma_callback)(struct _edma_handle *handle, void *userData, bool transferDone, uint32_t tcds);
 
 /*! @brief eDMA transfer handle structure */
 typedef struct _edma_handle
 {
-    edma_callback callback;  /*!< Callback function for major count exhausted. */
-    void *userData;          /*!< Callback function parameter. */
-    DMA_Type *base;          /*!< eDMA peripheral base address. */
-    edma_tcd_t *tcdPool;     /*!< Pointer to memory stored TCDs. */
-    uint8_t channel;         /*!< eDMA channel number. */
-    volatile int8_t header;  /*!< The first TCD index. */
-    volatile int8_t tail;    /*!< The last TCD index. */
-    volatile int8_t tcdUsed; /*!< The number of used TCD slots. */
+    edma_callback callback; /*!< Callback function for major count exhausted. */
+    void *userData;         /*!< Callback function parameter. */
+    DMA_Type *base;         /*!< eDMA peripheral base address. */
+    edma_tcd_t *tcdPool;    /*!< Pointer to memory stored TCDs. */
+    uint8_t channel;        /*!< eDMA channel number. */
+    volatile int8_t header; /*!< The first TCD index. Should point to the next TCD to be loaded into the eDMA engine. */
+    volatile int8_t tail;   /*!< The last TCD index. Should point to the next TCD to be stored into the memory pool. */
+    volatile int8_t tcdUsed; /*!< The number of used TCD slots. Should reflect the number of TCDs can be used/loaded in
+                                the memory. */
     volatile int8_t tcdSize; /*!< The total number of TCD slots in the queue. */
     uint8_t flags;           /*!< The status of the current channel. */
 } edma_handle_t;
@@ -281,24 +282,24 @@ extern "C" {
 #endif /* __cplusplus */
 
 /*!
- * @name eDMA initialization and De-initialization
+ * @name eDMA initialization and de-initialization
  * @{
  */
 
 /*!
- * @brief Initializes eDMA peripheral.
+ * @brief Initializes the eDMA peripheral.
  *
  * This function ungates the eDMA clock and configures the eDMA peripheral according
  * to the configuration structure.
  *
  * @param base eDMA peripheral base address.
- * @param config Pointer to configuration structure, see "edma_config_t".
- * @note This function enable the minor loop map feature.
+ * @param config A pointer to the configuration structure, see "edma_config_t".
+ * @note This function enables the minor loop map feature.
  */
 void EDMA_Init(DMA_Type *base, const edma_config_t *config);
 
 /*!
- * @brief Deinitializes eDMA peripheral.
+ * @brief Deinitializes the eDMA peripheral.
  *
  * This function gates the eDMA clock.
  *
@@ -309,8 +310,8 @@ void EDMA_Deinit(DMA_Type *base);
 /*!
  * @brief Gets the eDMA default configuration structure.
  *
- * This function sets the configuration structure to a default value.
- * The default configuration is set to the following value:
+ * This function sets the configuration structure to default values.
+ * The default configuration is set to the following values.
  * @code
  *   config.enableContinuousLinkMode = false;
  *   config.enableHaltOnError = true;
@@ -318,7 +319,7 @@ void EDMA_Deinit(DMA_Type *base);
  *   config.enableDebugMode = false;
  * @endcode
  *
- * @param config Pointer to eDMA configuration structure.
+ * @param config A pointer to the eDMA configuration structure.
  */
 void EDMA_GetDefaultConfig(edma_config_t *config);
 
@@ -329,13 +330,13 @@ void EDMA_GetDefaultConfig(edma_config_t *config);
  */
 
 /*!
- * @brief Sets all TCD registers to a default value.
+ * @brief Sets all TCD registers to default values.
  *
- * This function sets TCD registers for this channel to default value.
+ * This function sets TCD registers for this channel to default values.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @note This function must not be called while the channel transfer is on-going,
+ * @note This function must not be called while the channel transfer is ongoing
  *       or it causes unpredictable results.
  * @note This function enables the auto stop request feature.
  */
@@ -364,7 +365,7 @@ void EDMA_ResetChannel(DMA_Type *base, uint32_t channel);
  *                do not want to enable scatter/gather feature.
  * @note If nextTcd is not NULL, it means scatter gather feature is enabled
  *       and DREQ bit is cleared in the previous transfer configuration, which
- *       is set in eDMA_ResetChannel.
+ *       is set in the eDMA_ResetChannel.
  */
 void EDMA_SetTransferConfig(DMA_Type *base,
                             uint32_t channel,
@@ -374,12 +375,12 @@ void EDMA_SetTransferConfig(DMA_Type *base,
 /*!
  * @brief Configures the eDMA minor offset feature.
  *
- * Minor offset means signed-extended value added to source address or destination
+ * The minor offset means that the signed-extended value is added to the source address or destination
  * address after each minor loop.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param config Pointer to Minor offset configuration structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_minor_offset_config_t *config);
 
@@ -390,7 +391,7 @@ void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_mino
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number
- * @param config Pointer to channel preemption configuration structure.
+ * @param config A pointer to the channel preemption configuration structure.
  */
 static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
                                                    uint32_t channel,
@@ -407,13 +408,13 @@ static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
 /*!
  * @brief Sets the channel link for the eDMA transfer.
  *
- * This function configures  minor link or major link mode. The minor link means that the channel link is
+ * This function configures either the minor link or the major link mode. The minor link means that the channel link is
  * triggered every time CITER decreases by 1. The major link means that the channel link is triggered when the CITER is
  * exhausted.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param type Channel link type, it can be one of:
+ * @param type A channel link type, which can be one of the following:
  *   @arg kEDMA_LinkNone
  *   @arg kEDMA_MinorLink
  *   @arg kEDMA_MajorLink
@@ -425,13 +426,13 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 /*!
  * @brief Sets the bandwidth for the eDMA transfer.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
  * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -439,7 +440,7 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWidth);
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA transfer.
+ * @brief Sets the source modulo and the destination modulo for the eDMA transfer.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
@@ -447,8 +448,8 @@ void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWi
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -458,7 +459,7 @@ void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, e
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable(ture) or disable(false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -475,7 +476,7 @@ static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, boo
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable (true) or disable (false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAutoStopRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -499,7 +500,7 @@ void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mas
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param mask The mask of interrupt source to be set. Use
+ * @param mask The mask of the interrupt source to be set. Use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
@@ -523,8 +524,8 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
 /*!
  * @brief Configures the eDMA TCD transfer attribute.
  *
- * TCD is a transfer control descriptor. The content of the TCD is the same as hardware TCD registers.
- * STCD is used in scatter-gather mode.
+ * The TCD is a transfer control descriptor. The content of the TCD is the same as the hardware TCD registers.
+ * The STCD is used in the scatter-gather mode.
  * This function configures the TCD transfer attribute, including source address, destination address,
  * transfer size, address offset, and so on. It also configures the scatter gather feature if the
  * user supplies the next TCD address.
@@ -542,7 +543,7 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
  * @param config Pointer to eDMA transfer configuration structure.
  * @param nextTcd Pointer to the next TCD structure. It can be NULL if users
  *                do not want to enable scatter/gather feature.
- * @note TCD address should be 32 bytes aligned, or it causes an eDMA error.
+ * @note TCD address should be 32 bytes aligned or it causes an eDMA error.
  * @note If the nextTcd is not NULL, the scatter gather feature is enabled
  *       and DREQ bit is cleared in the previous transfer configuration, which
  *       is set in the EDMA_TcdReset.
@@ -552,16 +553,16 @@ void EDMA_TcdSetTransferConfig(edma_tcd_t *tcd, const edma_transfer_config_t *co
 /*!
  * @brief Configures the eDMA TCD minor offset feature.
  *
- * Minor offset is a signed-extended value added to the source address or destination
+ * A minor offset is a signed-extended value added to the source address or a destination
  * address after each minor loop.
  *
- * @param tcd Point to the TCD structure.
- * @param config Pointer to Minor offset configuration structure.
+ * @param tcd A point to the TCD structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_TcdSetMinorOffsetConfig(edma_tcd_t *tcd, const edma_minor_offset_config_t *config);
 
 /*!
- * @brief Sets the channel link for eDMA TCD.
+ * @brief Sets the channel link for the eDMA TCD.
  *
  * This function configures either a minor link or a major link. The minor link means the channel link is
  * triggered every time CITER decreases by 1. The major link means that the channel link  is triggered when the CITER is
@@ -580,11 +581,11 @@ void EDMA_TcdSetChannelLink(edma_tcd_t *tcd, edma_channel_link_type_t type, uint
 /*!
  * @brief Sets the bandwidth for the eDMA TCD.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
- * until the minor count is exhausted. Bandwidth forces the eDMA to stall after the completion of
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
- * @param tcd Point to the TCD structure.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param tcd A pointer to the TCD structure.
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -598,15 +599,15 @@ static inline void EDMA_TcdSetBandWidth(edma_tcd_t *tcd, edma_bandwidth_t bandWi
 }
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA TCD.
+ * @brief Sets the source modulo and the destination modulo for the eDMA TCD.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
  * queue easily.
  *
- * @param tcd Point to the TCD structure.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param tcd A pointer to the TCD structure.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -615,8 +616,8 @@ void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t d
  *
  * If enabling the auto stop request, the eDMA hardware automatically disables the hardware channel request.
  *
- * @param tcd Point to the TCD structure.
- * @param enable The command for enable(ture) or disable(false).
+ * @param tcd A pointer to the TCD structure.
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_TcdEnableAutoStopRequest(edma_tcd_t *tcd, bool enable)
 {
@@ -681,7 +682,7 @@ static inline void EDMA_DisableChannelRequest(DMA_Type *base, uint32_t channel)
 }
 
 /*!
- * @brief Starts the eDMA transfer by software trigger.
+ * @brief Starts the eDMA transfer by using the software trigger.
  *
  * This function starts a minor loop transfer.
  *
@@ -702,25 +703,34 @@ static inline void EDMA_TriggerChannelStart(DMA_Type *base, uint32_t channel)
  */
 
 /*!
- * @brief Gets the Remaining bytes from the eDMA current channel TCD.
+ * @brief Gets the remaining major loop count from the eDMA current channel TCD.
  *
  * This function checks the TCD (Task Control Descriptor) status for a specified
- * eDMA channel and returns the the number of bytes that have not finished.
+ * eDMA channel and returns the the number of major loop count that has not finished.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @return Bytes have not been transferred yet for the current TCD.
- * @note This function can only be used to get unfinished bytes of transfer without
- *       the next TCD, or it might be inaccuracy.
+ * @return Major loop count which has not been transferred yet for the current TCD.
+ * @note 1. This function can only be used to get unfinished major loop count of transfer without
+ *          the next TCD, or it might be inaccuracy.
+ *       2. The unfinished/remaining transfer bytes cannot be obtained directly from registers while
+ *          the channel is running.
+ *          Because to calculate the remaining bytes, the initial NBYTES configured in DMA_TCDn_NBYTES_MLNO
+ *          register is needed while the eDMA IP does not support getting it while a channel is active.
+ *          In another word, the NBYTES value reading is always the actual (decrementing) NBYTES value the dma_engine
+ *          is working with while a channel is running.
+ *          Consequently, to get the remaining transfer bytes, a software-saved initial value of NBYTES (for example
+ *          copied before enabling the channel) is needed. The formula to calculate it is shown below:
+ *          RemainingBytes = RemainingMajorLoopCount * NBYTES(initially configured)
  */
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel);
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel);
 
 /*!
  * @brief Gets the eDMA channel error status flags.
  *
  * @param base eDMA peripheral base address.
  * @return The mask of error status flags. Users need to use the
- *         _edma_error_status_flags type to decode the return variables.
+*         _edma_error_status_flags type to decode the return variables.
  */
 static inline uint32_t EDMA_GetErrorStatusFlags(DMA_Type *base)
 {
@@ -755,8 +765,8 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 /*!
  * @brief Creates the eDMA handle.
  *
- * This function is called if using transaction API for eDMA. This function
- * initializes the internal state of eDMA handle.
+ * This function is called if using the transactional API for eDMA. This function
+ * initializes the internal state of the eDMA handle.
  *
  * @param handle eDMA handle pointer. The eDMA handle stores callback function and
  *               parameters.
@@ -766,12 +776,12 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel);
 
 /*!
- * @brief Installs the TCDs memory pool into eDMA handle.
+ * @brief Installs the TCDs memory pool into the eDMA handle.
  *
  * This function is called after the EDMA_CreateHandle to use scatter/gather feature.
  *
  * @param handle eDMA handle pointer.
- * @param tcdPool Memory pool to store TCDs. It must be 32 bytes aligned.
+ * @param tcdPool A memory pool to store TCDs. It must be 32 bytes aligned.
  * @param tcdSize The number of TCD slots.
  */
 void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t tcdSize);
@@ -779,12 +789,12 @@ void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t 
 /*!
  * @brief Installs a callback function for the eDMA transfer.
  *
- * This callback is called in eDMA IRQ handler. Use the callback to do something after
+ * This callback is called in the eDMA IRQ handler. Use the callback to do something after
  * the current major loop transfer completes.
  *
  * @param handle eDMA handle pointer.
  * @param callback eDMA callback function pointer.
- * @param userData Parameter for callback function.
+ * @param userData A parameter for the callback function.
  */
 void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userData);
 
@@ -802,8 +812,8 @@ void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userD
  * @param transferBytes eDMA transfer bytes to be transferred.
  * @param type eDMA transfer type.
  * @note The data address and the data width must be consistent. For example, if the SRC
- *       is 4 bytes, so the source address must be 4 bytes aligned, or it shall result in
- *       source address error(SAE).
+ *       is 4 bytes, the source address must be 4 bytes aligned, or it results in
+ *       source address error (SAE).
  */
 void EDMA_PrepareTransfer(edma_transfer_config_t *config,
                           void *srcAddr,
@@ -818,7 +828,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
  * @brief Submits the eDMA transfer request.
  *
  * This function submits the eDMA transfer request according to the transfer configuration structure.
- * If the user submits the transfer request repeatedly, this function packs an unprocessed request as
+ * If submitting the transfer request repeatedly, this function packs an unprocessed request as
  * a TCD and enables scatter/gather feature to process it in the next time.
  *
  * @param handle eDMA handle pointer.
@@ -830,7 +840,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
 status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t *config);
 
 /*!
- * @brief eDMA start transfer.
+ * @brief eDMA starts transfer.
  *
  * This function enables the channel request. Users can call this function after submitting the transfer request
  * or before submitting the transfer request.
@@ -840,7 +850,7 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
 void EDMA_StartTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA stop transfer.
+ * @brief eDMA stops transfer.
  *
  * This function disables the channel request to pause the transfer. Users can call EDMA_StartTransfer()
  * again to resume the transfer.
@@ -850,7 +860,7 @@ void EDMA_StartTransfer(edma_handle_t *handle);
 void EDMA_StopTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA abort transfer.
+ * @brief eDMA aborts transfer.
  *
  * This function disables the channel request and clear transfer status bits.
  * Users can submit another transfer after calling this API.
@@ -860,10 +870,30 @@ void EDMA_StopTransfer(edma_handle_t *handle);
 void EDMA_AbortTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA IRQ handler for current major loop transfer complete.
+ * @brief eDMA IRQ handler for the current major loop transfer completion.
  *
- * This function clears the channel major interrupt flag and call
+ * This function clears the channel major interrupt flag and calls
  * the callback function if it is not NULL.
+ *
+ * Note:
+ * For the case using TCD queue, when the major iteration count is exhausted, additional operations are performed.
+ * These include the final address adjustments and reloading of the BITER field into the CITER.
+ * Assertion of an optional interrupt request also occurs at this time, as does a possible fetch of a new TCD from
+ * memory using the scatter/gather address pointer included in the descriptor (if scatter/gather is enabled).
+ *
+ * For instance, when the time interrupt of TCD[0] happens, the TCD[1] has already been loaded into the eDMA engine.
+ * As sga and sga_index are calculated based on the DLAST_SGA bitfield lies in the TCD_CSR register, the sga_index
+ * in this case should be 2 (DLAST_SGA of TCD[1] stores the address of TCD[2]). Thus, the "tcdUsed" updated should be
+ * (tcdUsed - 2U) which indicates the number of TCDs can be loaded in the memory pool (because TCD[0] and TCD[1] have
+ * been loaded into the eDMA engine at this point already.).
+ *
+ * For the last two continuous ISRs in a scatter/gather process, they  both load the last TCD (The last ISR does not
+ * load a new TCD) from the memory pool to the eDMA engine when major loop completes.
+ * Therefore, ensure that the header and tcdUsed updated are identical for them.
+ * tcdUsed are both 0 in this case as no TCD to be loaded.
+ *
+ * See the "eDMA basic data flow" in the eDMA Functional description section of the Reference Manual for
+ * further details.
  *
  * @param handle eDMA handle pointer.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_i2c.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -76,6 +76,19 @@ typedef void (*i2c_isr_t)(I2C_Type *base, void *i2cHandle);
 uint32_t I2C_GetInstance(I2C_Type *base);
 
 /*!
+* @brief Set SCL/SDA hold time, this API receives SCL stop hold time, calculate the
+* closest SCL divider and MULT value for the SDA hold time, SCL start and SCL stop
+* hold time. To reduce the ROM size, SDA/SCL hold value mapping table is not provided,
+* assume SCL divider = SCL stop hold value *2 to get the closest SCL divider value and MULT
+* value, then the related SDA hold time, SCL start and SCL stop hold time is used.
+*
+* @param base I2C peripheral base address.
+* @param sourceClock_Hz I2C functional clock frequency in Hertz.
+* @param sclStopHoldTime_ns SCL stop hold time in ns.
+*/
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz);
+
+/*!
  * @brief Set up master transfer, send slave address and decide the initial
  * transfer state.
  *
@@ -137,8 +150,10 @@ static I2C_Type *const s_i2cBases[] = I2C_BASE_PTRS;
 /*! @brief Pointers to i2c IRQ number for each instance. */
 static const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to i2c clocks for each instance. */
 static const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static i2c_isr_t s_i2cMasterIsr;
@@ -155,7 +170,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_I2C_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -163,16 +178,63 @@ uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_I2C_COUNT);
+    assert(instance < ARRAY_SIZE(s_i2cBases));
 
     return instance;
+}
+
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedSclHoldTime;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult = 0u;
+    uint32_t bestIcr = 0u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    /* SDA hold time = bus period (s) * mul * SDA hold value. */
+    /* SCL start hold time = bus period (s) * mul * SCL start hold value. */
+    /* SCL stop hold time = bus period (s) * mul * SCL stop hold value. */
+
+    for (mult = 0u; (mult <= 2u) && (bestError != 0); ++mult)
+    {
+        multiplier = 1u << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(s_i2cDividerTable[0]); ++i)
+        {
+            /* Assume SCL hold(stop) value = s_i2cDividerTable[i]/2. */
+            computedSclHoldTime = ((multiplier * s_i2cDividerTable[i]) * 500000000U) / sourceClock_Hz;
+            absError = sclStopHoldTime_ns > computedSclHoldTime ? (sclStopHoldTime_ns - computedSclHoldTime) :
+                                                                  (computedSclHoldTime - sclStopHoldTime_ns);
+
+            if (absError < bestError)
+            {
+                bestMult = mult;
+                bestIcr = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
 }
 
 static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
 {
     status_t result = kStatus_Success;
     i2c_direction_t direction = xfer->direction;
-    uint16_t timeout = UINT16_MAX;
 
     /* Initialize the handle transfer information. */
     handle->transfer = *xfer;
@@ -183,27 +245,13 @@ static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t
     /* Initial transfer state. */
     if (handle->transfer.subaddressSize > 0)
     {
-        handle->state = kSendCommandState;
         if (xfer->direction == kI2C_Read)
         {
             direction = kI2C_Write;
         }
     }
-    else
-    {
-        handle->state = kCheckAddressState;
-    }
 
-    /* Wait until the data register is ready for transmit. */
-    while ((!(base->S & kI2C_TransferCompleteFlag)) && (--timeout))
-    {
-    }
-
-    /* Failed to start the transfer. */
-    if (timeout == 0)
-    {
-        return kStatus_I2C_Timeout;
-    }
+    handle->state = kCheckAddressState;
 
     /* Clear all status before transfer. */
     I2C_MasterClearStatusFlags(base, kClearFlags);
@@ -265,32 +313,39 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
         result = kStatus_Success;
     }
 
-    if (result)
-    {
-        return result;
-    }
-
     /* Handle Check address state to check the slave address is Acked in slave
        probe application. */
     if (handle->state == kCheckAddressState)
     {
         if (statusFlags & kI2C_ReceiveNakFlag)
         {
-            return kStatus_I2C_Nak;
+            result = kStatus_I2C_Addr_Nak;
         }
         else
         {
-            if (handle->transfer.direction == kI2C_Write)
+            if (handle->transfer.subaddressSize > 0)
             {
-                /* Next state, send data. */
-                handle->state = kSendDataState;
+                handle->state = kSendCommandState;
             }
             else
             {
-                /* Next state, receive data begin. */
-                handle->state = kReceiveDataBeginState;
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Next state, send data. */
+                    handle->state = kSendDataState;
+                }
+                else
+                {
+                    /* Next state, receive data begin. */
+                    handle->state = kReceiveDataBeginState;
+                }
             }
         }
+    }
+
+    if (result)
+    {
+        return result;
     }
 
     /* Run state machine. */
@@ -375,6 +430,10 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
                     {
                         result = I2C_MasterStop(base);
                     }
+                    else
+                    {
+                        base->C1 |= I2C_C1_TX_MASK;
+                    }
                 }
 
                 /* Send NAK at the last receive byte. */
@@ -407,6 +466,7 @@ static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle)
     {
         s_i2cSlaveIsr(base, handle);
     }
+    __DSB();
 }
 
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz)
@@ -415,14 +475,26 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Temporary register for filter read. */
     uint8_t fltReg;
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    uint8_t c2Reg;
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
     uint8_t s2Reg;
 #endif
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Enable I2C clock. */
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Disable I2C prior to configuring it. */
     base->C1 &= ~(I2C_C1_IICEN_MASK);
@@ -432,14 +504,6 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Configure baud rate. */
     I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
-
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Configure high drive feature. */
-    c2Reg = base->C2;
-    c2Reg &= ~(I2C_C2_HDRS_MASK);
-    c2Reg |= I2C_C2_HDRS(masterConfig->enableHighDrive);
-    base->C2 = c2Reg;
-#endif
 
     /* Read out the FLT register. */
     fltReg = base->FLT;
@@ -472,8 +536,10 @@ void I2C_MasterDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
@@ -482,11 +548,6 @@ void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
 
     /* Default baud rate at 100kbps. */
     masterConfig->baudRate_Bps = 100000U;
-
-/* Default pin high drive is disabled. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    masterConfig->enableHighDrive = false;
-#endif
 
 /* Default stop hold enable is disabled. */
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
@@ -654,7 +715,7 @@ status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_
         base->F = savedMult & (~I2C_F_MULT_MASK);
 
         /* We are already in a transfer, so send a repeated start. */
-        base->C1 |= I2C_C1_RSTA_MASK;
+        base->C1 |= I2C_C1_RSTA_MASK | I2C_C1_TX_MASK;
 
         /* Restore the multiplier factor. */
         base->F = savedMult;
@@ -721,7 +782,7 @@ uint32_t I2C_MasterGetStatusFlags(I2C_Type *base)
     return statusFlags;
 }
 
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     uint8_t statusFlags = 0;
@@ -772,10 +833,19 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
         }
     }
 
+    if (((result == kStatus_Success) && (!(flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
+    {
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Send stop. */
+        result = I2C_MasterStop(base);
+    }
+
     return result;
 }
 
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     volatile uint8_t dummy = 0;
@@ -817,8 +887,16 @@ status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
         /* Single byte use case. */
         if (rxSize == 0)
         {
-            /* Read the final byte. */
-            result = I2C_MasterStop(base);
+            if (!(flags & kI2C_TransferNoStopFlag))
+            {
+                /* Issue STOP command before reading last byte. */
+                result = I2C_MasterStop(base);
+            }
+            else
+            {
+                /* Change direction to Tx to avoid extra clocks. */
+                base->C1 |= I2C_C1_TX_MASK;
+            }
         }
 
         if (rxSize == 1)
@@ -871,72 +949,6 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
         return result;
     }
 
-    /* Send subaddress. */
-    if (xfer->subaddressSize)
-    {
-        do
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear interrupt pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            xfer->subaddressSize--;
-            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
-
-        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
-
-        if (xfer->direction == kI2C_Read)
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            /* Send repeated start and slave address. */
-            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
-
-            /* Return if error. */
-            if (result)
-            {
-                return result;
-            }
-        }
-    }
-
-    /* Wait until address + command transfer complete. */
     while (!(base->S & kI2C_IntPendingFlag))
     {
     }
@@ -949,32 +961,92 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
     {
         if (result == kStatus_I2C_Nak)
         {
+            result = kStatus_I2C_Addr_Nak;
+
             I2C_MasterStop(base);
         }
 
         return result;
     }
 
+    /* Send subaddress. */
+    if (xfer->subaddressSize)
+    {
+        do
+        {
+            /* Clear interrupt pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            xfer->subaddressSize--;
+            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
+
+        if (xfer->direction == kI2C_Read)
+        {
+            /* Clear pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Send repeated start and slave address. */
+            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
+
+            /* Return if error. */
+            if (result)
+            {
+                return result;
+            }
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    result = kStatus_I2C_Addr_Nak;
+
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+        }
+    }
+
     /* Transmit data. */
     if ((xfer->direction == kI2C_Write) && (xfer->dataSize > 0))
     {
         /* Send Data. */
-        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize);
-
-        if (((result == kStatus_Success) && (!(xfer->flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
-        {
-            /* Clear the IICIF flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Send stop. */
-            result = I2C_MasterStop(base);
-        }
+        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     /* Receive Data. */
     if ((xfer->direction == kI2C_Read) && (xfer->dataSize > 0))
     {
-        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize);
+        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     return result;
@@ -1037,11 +1109,37 @@ void I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle)
 {
     assert(handle);
 
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
     /* Disable interrupt. */
     I2C_DisableInterrupts(base, kI2C_GlobalInterruptEnable);
 
     /* Reset the state to idle. */
     handle->state = kIdleState;
+
+    /* Send STOP signal. */
+    if (handle->transfer.direction == kI2C_Read)
+    {
+        base->C1 |= I2C_C1_TXAK_MASK;
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+        dummy = base->D;
+    }
+    else
+    {
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+    }
 }
 
 status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count)
@@ -1075,7 +1173,8 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     if (isDone || result)
     {
         /* Send stop command if transfer done or received Nak. */
-        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak))
+        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak) ||
+            (result == kStatus_I2C_Addr_Nak))
         {
             /* Ensure stop command is a need. */
             if ((base->C1 & I2C_C1_MST_MASK))
@@ -1101,13 +1200,28 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz)
 {
     assert(slaveConfig);
 
     uint8_t tmpReg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Configure addressing mode. */
     switch (slaveConfig->addressingMode)
@@ -1132,14 +1246,10 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg &= ~I2C_C1_WUEN_MASK;
     base->C1 = tmpReg | I2C_C1_WUEN(slaveConfig->enableWakeUp) | I2C_C1_IICEN(slaveConfig->enableSlave);
 
-    /* Configure general call & baud rate control & high drive feature. */
+    /* Configure general call & baud rate control. */
     tmpReg = base->C2;
     tmpReg &= ~(I2C_C2_SBRC_MASK | I2C_C2_GCAEN_MASK);
     tmpReg |= I2C_C2_SBRC(slaveConfig->enableBaudRateCtl) | I2C_C2_GCAEN(slaveConfig->enableGeneralCall);
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    tmpReg &= ~I2C_C2_HDRS_MASK;
-    tmpReg |= I2C_C2_HDRS(slaveConfig->enableHighDrive);
-#endif
     base->C2 = tmpReg;
 
 /* Enable/Disable double buffering. */
@@ -1147,6 +1257,9 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg = base->S2 & (~I2C_S2_DFEN_MASK);
     base->S2 = tmpReg | I2C_S2_DFEN(slaveConfig->enableDoubleBuffering);
 #endif
+
+    /* Set hold time. */
+    I2C_SetHoldTime(base, slaveConfig->sclStopHoldTime_ns, srcClock_Hz);
 }
 
 void I2C_SlaveDeinit(I2C_Type *base)
@@ -1154,8 +1267,10 @@ void I2C_SlaveDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
@@ -1171,11 +1286,6 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
     /* Slave address match waking up MCU from low power mode is disabled. */
     slaveConfig->enableWakeUp = false;
 
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Default pin high drive is disabled. */
-    slaveConfig->enableHighDrive = false;
-#endif
-
     /* Independent slave mode baud rate at maximum frequency is disabled. */
     slaveConfig->enableBaudRateCtl = false;
 
@@ -1183,6 +1293,9 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
     slaveConfig->enableDoubleBuffering = true;
 #endif
+
+    /* Set default SCL stop hold time to 4us which is minimum requirement in I2C spec. */
+    slaveConfig->sclStopHoldTime_ns = 4000;
 
     /* Enable the I2C peripheral. */
     slaveConfig->enableSlave = true;
@@ -1215,7 +1328,7 @@ status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t tx
     /* Read dummy to release bus. */
     dummy = base->D;
 
-    result = I2C_MasterWriteBlocking(base, txBuff, txSize);
+    result = I2C_MasterWriteBlocking(base, txBuff, txSize, kI2C_TransferDefaultFlag);
 
     /* Switch to receive mode. */
     base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
@@ -1323,7 +1436,7 @@ status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle
         handle->isBusy = true;
 
         /* Set up event mask. tx and rx are always enabled. */
-        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent;
+        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent | kI2C_SlaveGenaralcallEvent;
 
         /* Clear all flags. */
         I2C_SlaveClearStatusFlags(base, kClearFlags);
@@ -1412,7 +1525,10 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
             }
         }
 
-        return;
+        if (!(status & kI2C_AddressMatchFlag))
+        {
+            return;
+        }
     }
 #endif /* I2C_HAS_STOP_DETECT */
 
@@ -1482,11 +1598,6 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
         handle->isBusy = true;
         xfer->event = kI2C_SlaveAddressMatchEvent;
 
-        if ((handle->eventMask & xfer->event) && (handle->callback))
-        {
-            handle->callback(base, xfer, handle->userData);
-        }
-
         /* Slave transmit, master reading from slave. */
         if (status & kI2C_TransferDirectionFlag)
         {
@@ -1502,6 +1613,16 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
 
             /* Read dummy to release the bus. */
             dummy = base->D;
+
+            if (dummy == 0)
+            {
+                xfer->event = kI2C_SlaveGenaralcallEvent;
+            }
+        }
+
+        if ((handle->eventMask & xfer->event) && (handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
         }
     }
     /* Check transfer complete flag. */
@@ -1607,27 +1728,30 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
+#if defined(I2C0)
 void I2C0_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C0, s_i2cHandle[0]);
 }
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 1)
+#if defined(I2C1)
 void I2C1_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C1, s_i2cHandle[1]);
 }
-#endif /* I2C COUNT > 1 */
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 2)
+#if defined(I2C2)
 void I2C2_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C2, s_i2cHandle[2]);
 }
-#endif /* I2C COUNT > 2 */
-#if (FSL_FEATURE_SOC_I2C_COUNT > 3)
+#endif
+
+#if defined(I2C3)
 void I2C3_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C3, s_i2cHandle[3]);
 }
-#endif /* I2C COUNT > 3 */
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_i2c.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,15 +37,14 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief I2C driver version 2.0.1. */
-#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*! @brief I2C driver version 2.0.3. */
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 3))
 /*@}*/
 
 #if (defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT || \
@@ -61,6 +60,7 @@ enum _i2c_status
     kStatus_I2C_Nak = MAKE_STATUS(kStatusGroup_I2C, 2),             /*!< NAK received during transfer. */
     kStatus_I2C_ArbitrationLost = MAKE_STATUS(kStatusGroup_I2C, 3), /*!< Arbitration lost during transfer. */
     kStatus_I2C_Timeout = MAKE_STATUS(kStatusGroup_I2C, 4),         /*!< Wait event timeout. */
+    kStatus_I2C_Addr_Nak = MAKE_STATUS(kStatusGroup_I2C, 5),        /*!< NAK received during the address probe. */
 };
 
 /*!
@@ -108,11 +108,11 @@ enum _i2c_interrupt_enable
 #endif                                                       /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
 };
 
-/*! @brief Direction of master and slave transfers. */
+/*! @brief The direction of master and slave transfers. */
 typedef enum _i2c_direction
 {
-    kI2C_Write = 0x0U, /*!< Master transmit to slave. */
-    kI2C_Read = 0x1U,  /*!< Master receive from slave. */
+    kI2C_Write = 0x0U, /*!< Master transmits to the slave. */
+    kI2C_Read = 0x1U,  /*!< Master receives from the slave. */
 } i2c_direction_t;
 
 /*! @brief Addressing mode. */
@@ -125,17 +125,17 @@ typedef enum _i2c_slave_address_mode
 /*! @brief I2C transfer control flag. */
 enum _i2c_master_transfer_flags
 {
-    kI2C_TransferDefaultFlag = 0x0U,       /*!< Transfer starts with a start signal, stops with a stop signal. */
-    kI2C_TransferNoStartFlag = 0x1U,       /*!< Transfer starts without a start signal. */
-    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< Transfer starts with a repeated start signal. */
-    kI2C_TransferNoStopFlag = 0x4U,        /*!< Transfer ends without a stop signal. */
+    kI2C_TransferDefaultFlag = 0x0U,       /*!< A transfer starts with a start signal, stops with a stop signal. */
+    kI2C_TransferNoStartFlag = 0x1U,       /*!< A transfer starts without a start signal. */
+    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< A transfer starts with a repeated start signal. */
+    kI2C_TransferNoStopFlag = 0x4U,        /*!< A transfer ends without a stop signal. */
 };
 
 /*!
  * @brief Set of events sent to the callback for nonblocking slave transfers.
  *
  * These event enumerations are used for two related purposes. First, a bit mask created by OR'ing together
- * events is passed to I2C_SlaveTransferNonBlocking() in order to specify which events to enable.
+ * events is passed to I2C_SlaveTransferNonBlocking() to specify which events to enable.
  * Then, when the slave callback is invoked, it is passed the current event through its @a transfer
  * parameter.
  *
@@ -144,36 +144,34 @@ enum _i2c_master_transfer_flags
 typedef enum _i2c_slave_transfer_event
 {
     kI2C_SlaveAddressMatchEvent = 0x01U, /*!< Received the slave address after a start or repeated start. */
-    kI2C_SlaveTransmitEvent = 0x02U,     /*!< Callback is requested to provide data to transmit
+    kI2C_SlaveTransmitEvent = 0x02U,     /*!< A callback is requested to provide data to transmit
                                                 (slave-transmitter role). */
-    kI2C_SlaveReceiveEvent = 0x04U,      /*!< Callback is requested to provide a buffer in which to place received
+    kI2C_SlaveReceiveEvent = 0x04U,      /*!< A callback is requested to provide a buffer in which to place received
                                                  data (slave-receiver role). */
-    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< Callback needs to either transmit an ACK or NACK. */
+    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< A callback needs to either transmit an ACK or NACK. */
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
     kI2C_SlaveStartEvent = 0x10U, /*!< A start/repeated start was detected. */
 #endif
-    kI2C_SlaveCompletionEvent = 0x20U, /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveCompletionEvent = 0x20U,  /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveGenaralcallEvent = 0x40U, /*!< Received the general call address after a start or repeated start. */
 
-    /*! Bit mask of all available events. */
+    /*! A bit mask of all available events. */
     kI2C_SlaveAllEvents = kI2C_SlaveAddressMatchEvent | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent |
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
                           kI2C_SlaveStartEvent |
 #endif
-                          kI2C_SlaveCompletionEvent,
+                          kI2C_SlaveCompletionEvent | kI2C_SlaveGenaralcallEvent,
 } i2c_slave_transfer_event_t;
 
 /*! @brief I2C master user configuration. */
 typedef struct _i2c_master_config
 {
     bool enableMaster; /*!< Enables the I2C peripheral at initialization time. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
     bool enableStopHold; /*!< Controls the stop hold enable. */
 #endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
-    bool enableDoubleBuffering; /*!< Controls double buffer enable, notice that
+    bool enableDoubleBuffering; /*!< Controls double buffer enable; notice that
                                      enabling the double buffer disables the clock stretch. */
 #endif
     uint32_t baudRate_Bps;     /*!< Baud rate configuration of I2C peripheral. */
@@ -184,19 +182,20 @@ typedef struct _i2c_master_config
 typedef struct _i2c_slave_config
 {
     bool enableSlave;       /*!< Enables the I2C peripheral at initialization time. */
-    bool enableGeneralCall; /*!< Enable general call addressing mode. */
+    bool enableGeneralCall; /*!< Enables the general call addressing mode. */
     bool enableWakeUp;      /*!< Enables/disables waking up MCU from low-power mode. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
-    bool enableDoubleBuffering; /*!< Controls double buffer enable, notice that
+    bool enableDoubleBuffering; /*!< Controls a double buffer enable; notice that
                                      enabling the double buffer disables the clock stretch. */
 #endif
     bool enableBaudRateCtl; /*!< Enables/disables independent slave baud rate on SCL in very fast I2C modes. */
-    uint16_t slaveAddress;  /*!< Slave address configuration. */
-    uint16_t upperAddress;  /*!< Maximum boundary slave address used in range matching mode. */
-    i2c_slave_address_mode_t addressingMode; /*!< Addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint16_t slaveAddress;  /*!< A slave address configuration. */
+    uint16_t upperAddress;  /*!< A maximum boundary slave address used in a range matching mode. */
+    i2c_slave_address_mode_t
+        addressingMode;          /*!< An addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint32_t sclStopHoldTime_ns; /*!< the delay from the rising edge of SCL (I2C clock) to the rising edge of SDA (I2C
+                                    data) while SCL is high (stop condition), SDA hold time and SCL start hold time
+                                    are also configured according to the SCL stop hold time. */
 } i2c_slave_config_t;
 
 /*! @brief I2C master handle typedef. */
@@ -214,13 +213,13 @@ typedef struct _i2c_slave_handle i2c_slave_handle_t;
 /*! @brief I2C master transfer structure. */
 typedef struct _i2c_master_transfer
 {
-    uint32_t flags;            /*!< Transfer flag which controls the transfer. */
+    uint32_t flags;            /*!< A transfer flag which controls the transfer. */
     uint8_t slaveAddress;      /*!< 7-bit slave address. */
-    i2c_direction_t direction; /*!< Transfer direction, read or write. */
-    uint32_t subaddress;       /*!< Sub address. Transferred MSB first. */
-    uint8_t subaddressSize;    /*!< Size of command buffer. */
-    uint8_t *volatile data;    /*!< Transfer buffer. */
-    volatile size_t dataSize;  /*!< Transfer size. */
+    i2c_direction_t direction; /*!< A transfer direction, read or write. */
+    uint32_t subaddress;       /*!< A sub address. Transferred MSB first. */
+    uint8_t subaddressSize;    /*!< A size of the command buffer. */
+    uint8_t *volatile data;    /*!< A transfer buffer. */
+    volatile size_t dataSize;  /*!< A transfer size. */
 } i2c_master_transfer_t;
 
 /*! @brief I2C master handle structure. */
@@ -228,20 +227,21 @@ struct _i2c_master_handle
 {
     i2c_master_transfer_t transfer;                    /*!< I2C master transfer copy. */
     size_t transferSize;                               /*!< Total bytes to be transferred. */
-    uint8_t state;                                     /*!< Transfer state maintained during transfer. */
-    i2c_master_transfer_callback_t completionCallback; /*!< Callback function called when transfer finished. */
-    void *userData;                                    /*!< Callback parameter passed to callback function. */
+    uint8_t state;                                     /*!< A transfer state maintained during transfer. */
+    i2c_master_transfer_callback_t completionCallback; /*!< A callback function called when the transfer is finished. */
+    void *userData;                                    /*!< A callback parameter passed to the callback function. */
 };
 
 /*! @brief I2C slave transfer structure. */
 typedef struct _i2c_slave_transfer
 {
-    i2c_slave_transfer_event_t event; /*!< Reason the callback is being invoked. */
-    uint8_t *volatile data;           /*!< Transfer buffer. */
-    volatile size_t dataSize;         /*!< Transfer size. */
+    i2c_slave_transfer_event_t event; /*!< A reason that the callback is invoked. */
+    uint8_t *volatile data;           /*!< A transfer buffer. */
+    volatile size_t dataSize;         /*!< A transfer size. */
     status_t completionStatus;        /*!< Success or error code describing how the transfer completed. Only applies for
                                          #kI2C_SlaveCompletionEvent. */
-    size_t transferredCount;          /*!< Number of bytes actually transferred since start or last repeated start. */
+    size_t transferredCount; /*!< A number of bytes actually transferred since the start or since the last repeated
+                                start. */
 } i2c_slave_transfer_t;
 
 /*! @brief I2C slave transfer callback typedef. */
@@ -250,11 +250,11 @@ typedef void (*i2c_slave_transfer_callback_t)(I2C_Type *base, i2c_slave_transfer
 /*! @brief I2C slave handle structure. */
 struct _i2c_slave_handle
 {
-    bool isBusy;                            /*!< Whether transfer is busy. */
+    volatile bool isBusy;                   /*!< Indicates whether a transfer is busy. */
     i2c_slave_transfer_t transfer;          /*!< I2C slave transfer copy. */
-    uint32_t eventMask;                     /*!< Mask of enabled events. */
-    i2c_slave_transfer_callback_t callback; /*!< Callback function called at transfer event. */
-    void *userData;                         /*!< Callback parameter passed to callback. */
+    uint32_t eventMask;                     /*!< A mask of enabled events. */
+    i2c_slave_transfer_callback_t callback; /*!< A callback function called at the transfer event. */
+    void *userData;                         /*!< A callback parameter passed to the callback. */
 };
 
 /*******************************************************************************
@@ -274,12 +274,12 @@ extern "C" {
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
  * and configure the I2C with master configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module may cause a hard fault
- * because clock is not enabled. The configuration structure can be filled by user
- * from scratch, or be set with default values by I2C_MasterGetDefaultConfig().
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can be custom filled
+ * or it can be set with default values by using the I2C_MasterGetDefaultConfig().
  * After calling this API, the master is ready to transfer.
- * Example:
+ * This is an example.
  * @code
  * i2c_master_config_t config = {
  * .enableMaster = true,
@@ -292,20 +292,20 @@ extern "C" {
  * @endcode
  *
  * @param base I2C base pointer
- * @param masterConfig pointer to master configuration structure
+ * @param masterConfig A pointer to the master configuration structure
  * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
- * and initializes the I2C with slave configuration.
+ * and initialize the I2C with the slave configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module can cause a hard fault
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
  * because the clock is not enabled. The configuration structure can partly be set
- * with default values by I2C_SlaveGetDefaultConfig(), or can be filled by the user.
- * Example
+ * with default values by I2C_SlaveGetDefaultConfig() or it can be custom filled by the user.
+ * This is an example.
  * @code
  * i2c_slave_config_t config = {
  * .enableSlave = true,
@@ -314,15 +314,17 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
  * .slaveAddress = 0x1DU,
  * .enableWakeUp = false,
  * .enablehighDrive = false,
- * .enableBaudRateCtl = false
+ * .enableBaudRateCtl = false,
+ * .sclStopHoldTime_ns = 4000
  * };
- * I2C_SlaveInit(I2C0, &config);
+ * I2C_SlaveInit(I2C0, &config, 12000000U);
  * @endcode
  *
  * @param base I2C base pointer
- * @param slaveConfig pointer to slave configuration structure
+ * @param slaveConfig A pointer to the slave configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig);
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
@@ -342,28 +344,28 @@ void I2C_SlaveDeinit(I2C_Type *base);
  * @brief  Sets the I2C master configuration structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
- * Use the initialized structure unchanged in I2C_MasterConfigure(), or modify some fields of
- * the structure before calling I2C_MasterConfigure().
- * Example:
+ * Use the initialized structure unchanged in the I2C_MasterConfigure() or modify
+ * the structure before calling the I2C_MasterConfigure().
+ * This is an example.
  * @code
  * i2c_master_config_t config;
  * I2C_MasterGetDefaultConfig(&config);
  * @endcode
- * @param masterConfig Pointer to the master configuration structure.
+ * @param masterConfig A pointer to the master configuration structure.
 */
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig);
 
 /*!
  * @brief  Sets the I2C slave configuration structure to default values.
  *
- * The purpose of this API is to get the configuration structure initialized for use in I2C_SlaveConfigure().
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_SlaveConfigure().
  * Modify fields of the structure before calling the I2C_SlaveConfigure().
- * Example:
+ * This is an example.
  * @code
  * i2c_slave_config_t config;
  * I2C_SlaveGetDefaultConfig(&config);
  * @endcode
- * @param slaveConfig Pointer to the slave configuration structure.
+ * @param slaveConfig A pointer to the slave configuration structure.
  */
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
 
@@ -371,7 +373,7 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
  * @brief Enables or disabless the I2C peripheral operation.
  *
  * @param base I2C base pointer
- * @param enable pass true to enable module, false to disable module
+ * @param enable Pass true to enable and false to disable the module.
  */
 static inline void I2C_Enable(I2C_Type *base, bool enable)
 {
@@ -414,7 +416,7 @@ static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag.
  *
  * @param base I2C base pointer
  * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
@@ -449,7 +451,7 @@ static inline void I2C_MasterClearStatusFlags(I2C_Type *base, uint32_t statusMas
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
  *
   * @param base I2C base pointer
   * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
@@ -581,19 +583,21 @@ status_t I2C_MasterStop(I2C_Type *base);
 status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
 
 /*!
- * @brief Performs a polling send transaction on the I2C bus without a STOP signal.
+ * @brief Performs a polling send transaction on the I2C bus.
  *
  * @param base  The I2C peripheral base pointer.
  * @param txBuff The pointer to the data to be transferred.
  * @param txSize The length in bytes of the data to be transferred.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
  * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags);
 
 /*!
- * @brief Performs a polling receive transaction on the I2C bus with a STOP signal.
+ * @brief Performs a polling receive transaction on the I2C bus.
  *
  * @note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
  * Without stopping the bus prior for the final read, the bus issues another read, resulting
@@ -602,10 +606,12 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
  * @param base I2C peripheral base pointer.
  * @param rxBuff The pointer to the data to store the received data.
  * @param rxSize The length in bytes of the data to be received.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
  */
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags);
 
 /*!
  * @brief Performs a polling send transaction on the I2C bus.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_i2c_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_i2c_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -56,13 +55,14 @@ typedef void (*i2c_master_edma_transfer_callback_t)(I2C_Type *base,
 /*! @brief I2C master eDMA transfer structure. */
 struct _i2c_master_edma_handle
 {
-    i2c_master_transfer_t transfer; /*!< I2C master transfer struct. */
+    i2c_master_transfer_t transfer; /*!< I2C master transfer structure. */
     size_t transferSize;            /*!< Total bytes to be transferred. */
+    uint8_t nbytes;                 /*!< eDMA minor byte transfer count initially configured. */
     uint8_t state;                  /*!< I2C master transfer status. */
     edma_handle_t *dmaHandle;       /*!< The eDMA handler used. */
     i2c_master_edma_transfer_callback_t
-        completionCallback; /*!< Callback function called after eDMA transfer finished. */
-    void *userData;         /*!< Callback parameter passed to callback function. */
+        completionCallback; /*!< A callback function called after the eDMA transfer is finished. */
+    void *userData;         /*!< A callback parameter passed to the callback function. */
 };
 
 /*******************************************************************************
@@ -79,12 +79,12 @@ extern "C" {
  */
 
 /*!
- * @brief Init the I2C handle which is used in transcational functions.
+ * @brief Initializes the I2C handle which is used in transcational functions.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param callback pointer to user callback function.
- * @param userData user param passed to the callback function.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param callback A pointer to the user callback function.
+ * @param userData A user parameter passed to the callback function.
  * @param edmaHandle eDMA handle pointer.
  */
 void I2C_MasterCreateEDMAHandle(I2C_Type *base,
@@ -97,30 +97,30 @@ void I2C_MasterCreateEDMAHandle(I2C_Type *base,
  * @brief Performs a master eDMA non-blocking transfer on the I2C bus.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param xfer pointer to transfer structure of i2c_master_transfer_t.
- * @retval kStatus_Success Sucessully complete the data transmission.
- * @retval kStatus_I2C_Busy Previous transmission still not finished.
- * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param xfer A pointer to the transfer structure of i2c_master_transfer_t.
+ * @retval kStatus_Success Sucessfully completed the data transmission.
+ * @retval kStatus_I2C_Busy A previous transmission is still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, waits for a signal timeout.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
- * @retval kStataus_I2C_Nak Transfer error, receive Nak during transfer.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
 status_t I2C_MasterTransferEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, i2c_master_transfer_t *xfer);
 
 /*!
- * @brief Get master transfer status during a eDMA non-blocking transfer.
+ * @brief Gets a master transfer status during the eDMA non-blocking transfer.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  */
 status_t I2C_MasterTransferGetCountEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, size_t *count);
 
 /*!
- * @brief Abort a master eDMA non-blocking transfer in a early time.
+ * @brief Aborts a master eDMA non-blocking transfer early.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
  */
 void I2C_MasterTransferAbortEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_sai_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_sai_edma.c
@@ -1,40 +1,25 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_sai_edma.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.sai_edma"
+#endif
 
 /*******************************************************************************
  * Definitations
  ******************************************************************************/
 /* Used for 32byte aligned */
-#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)address + 32) & ~0x1FU)
+#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)(address) + 32) & ~0x1FU)
+
+static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
 
 /*<! Structure definition for uart_edma_private_handle_t. The structure is private. */
 typedef struct _sai_edma_private_handle
@@ -50,7 +35,7 @@ enum _sai_edma_transfer_state
 };
 
 /*<! Private handle only used for internally. */
-static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][2];
+static sai_edma_private_handle_t s_edmaPrivateHandle[ARRAY_SIZE(s_saiBases)][2];
 
 /*******************************************************************************
  * Prototypes
@@ -60,7 +45,7 @@ static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][
  *
  * @param base SAI base pointer.
  */
-extern uint32_t SAI_GetInstance(I2S_Type *base);
+static uint32_t SAI_GetInstance(I2S_Type *base);
 
 /*!
  * @brief SAI EDMA callback for send.
@@ -85,6 +70,24 @@ static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done,
 /*******************************************************************************
 * Code
 ******************************************************************************/
+static uint32_t SAI_GetInstance(I2S_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_saiBases); instance++)
+    {
+        if (s_saiBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_saiBases));
+
+    return instance;
+}
+
 static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds)
 {
     sai_edma_private_handle_t *privHandle = (sai_edma_private_handle_t *)userData;
@@ -101,7 +104,9 @@ static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done,
     /* If all data finished, just stop the transfer */
     if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
     {
-        SAI_TransferAbortSendEDMA(privHandle->base, saiHandle);
+        /* Disable DMA enable bit */
+        SAI_TxEnableDMA(privHandle->base, kSAI_FIFORequestDMAEnable, false);
+        EDMA_AbortTransfer(handle);
     }
 }
 
@@ -121,16 +126,34 @@ static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done,
     /* If all data finished, just stop the transfer */
     if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
     {
-        SAI_TransferAbortReceiveEDMA(privHandle->base, saiHandle);
+        /* Disable DMA enable bit */
+        SAI_RxEnableDMA(privHandle->base, kSAI_FIFORequestDMAEnable, false);
+        EDMA_AbortTransfer(handle);
     }
 }
 
+/*!
+ * brief Initializes the SAI eDMA handle.
+ *
+ * This function initializes the SAI master DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param base SAI peripheral base address.
+ * param callback Pointer to user callback function.
+ * param userData User parameter passed to the callback function.
+ * param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
 void SAI_TransferTxCreateHandleEDMA(
     I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
 {
     assert(handle && dmaHandle);
 
     uint32_t instance = SAI_GetInstance(base);
+
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
 
     /* Set sai base to handle */
     handle->dmaHandle = dmaHandle;
@@ -144,18 +167,34 @@ void SAI_TransferTxCreateHandleEDMA(
     s_edmaPrivateHandle[instance][0].handle = handle;
 
     /* Need to use scatter gather */
-    EDMA_InstallTCDMemory(dmaHandle, STCD_ADDR(handle->tcd), SAI_XFER_QUEUE_SIZE);
+    EDMA_InstallTCDMemory(dmaHandle, (edma_tcd_t *)(STCD_ADDR(handle->tcd)), SAI_XFER_QUEUE_SIZE);
 
     /* Install callback for Tx dma channel */
     EDMA_SetCallback(dmaHandle, SAI_TxEDMACallback, &s_edmaPrivateHandle[instance][0]);
 }
 
+/*!
+ * brief Initializes the SAI Rx eDMA handle.
+ *
+ * This function initializes the SAI slave DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param base SAI peripheral base address.
+ * param callback Pointer to user callback function.
+ * param userData User parameter passed to the callback function.
+ * param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
 void SAI_TransferRxCreateHandleEDMA(
     I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
 {
     assert(handle && dmaHandle);
 
     uint32_t instance = SAI_GetInstance(base);
+
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
 
     /* Set sai base to handle */
     handle->dmaHandle = dmaHandle;
@@ -175,6 +214,21 @@ void SAI_TransferRxCreateHandleEDMA(
     EDMA_SetCallback(dmaHandle, SAI_RxEDMACallback, &s_edmaPrivateHandle[instance][1]);
 }
 
+/*!
+ * brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param format Pointer to SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+ * retval kStatus_Success Audio format set successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+*/
 void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
                                  sai_edma_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -187,10 +241,20 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
     SAI_TxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
 
     /* Get the tranfer size from format, this should be used in EDMA configuration */
-    handle->bytesPerFrame = format->bitWidth / 8U;
+    if (format->bitWidth == 24U)
+    {
+        handle->bytesPerFrame = 4U;
+    }
+    else
+    {
+        handle->bytesPerFrame = format->bitWidth / 8U;
+    }
 
     /* Update the data channel SAI used */
     handle->channel = format->channel;
+
+    /* Clear the channel enable bits unitl do a send/receive */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->count = FSL_FEATURE_SAI_FIFO_COUNT - format->watermark;
 #else
@@ -198,6 +262,21 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT */
 }
 
+/*!
+ * brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param format Pointer to SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is the master
+ * clock, this value should equal to masterClockHz in format.
+ * retval kStatus_Success Audio format set successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+*/
 void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
                                  sai_edma_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -210,11 +289,20 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
     SAI_RxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
 
     /* Get the tranfer size from format, this should be used in EDMA configuration */
-    handle->bytesPerFrame = format->bitWidth / 8U;
+    if (format->bitWidth == 24U)
+    {
+        handle->bytesPerFrame = 4U;
+    }
+    else
+    {
+        handle->bytesPerFrame = format->bitWidth / 8U;
+    }
 
     /* Update the data channel SAI used */
     handle->channel = format->channel;
 
+    /* Clear the channel enable bits unitl do a send/receive */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->count = format->watermark;
 #else
@@ -222,6 +310,19 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT */
 }
 
+/*!
+ * brief Performs a non-blocking SAI transfer using DMA.
+ *
+ * note This interface returns immediately after the transfer initiates. Call
+ * SAI_GetTransferStatus to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param xfer Pointer to the DMA transfer structure.
+ * retval kStatus_Success Start a SAI eDMA send successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+ * retval kStatus_TxBusy SAI is busy sending data.
+ */
 status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -253,6 +354,9 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
     EDMA_PrepareTransfer(&config, xfer->data, handle->bytesPerFrame, (void *)destAddr, handle->bytesPerFrame,
                          handle->count * handle->bytesPerFrame, xfer->dataSize, kEDMA_MemoryToPeripheral);
 
+    /* Store the initially configured eDMA minor byte transfer count into the SAI handle */
+    handle->nbytes = handle->count * handle->bytesPerFrame;
+
     EDMA_SubmitTransfer(handle->dmaHandle, &config);
 
     /* Start DMA transfer */
@@ -264,9 +368,25 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
     /* Enable SAI Tx clock */
     SAI_TxEnable(base, true);
 
+    /* Enable the channel FIFO */
+    base->TCR3 |= I2S_TCR3_TCE(1U << handle->channel);
+
     return kStatus_Success;
 }
 
+/*!
+ * brief Performs a non-blocking SAI receive using eDMA.
+ *
+ * note This interface returns immediately after the transfer initiates. Call
+ * the SAI_GetReceiveRemainingBytes to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ * param xfer Pointer to DMA transfer structure.
+ * retval kStatus_Success Start a SAI eDMA receive successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+ * retval kStatus_RxBusy SAI is busy receiving data.
+ */
 status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -298,6 +418,9 @@ status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     EDMA_PrepareTransfer(&config, (void *)srcAddr, handle->bytesPerFrame, xfer->data, handle->bytesPerFrame,
                          handle->count * handle->bytesPerFrame, xfer->dataSize, kEDMA_PeripheralToMemory);
 
+    /* Store the initially configured eDMA minor byte transfer count into the SAI handle */
+    handle->nbytes = handle->count * handle->bytesPerFrame;
+
     EDMA_SubmitTransfer(handle->dmaHandle, &config);
 
     /* Start DMA transfer */
@@ -306,12 +429,24 @@ status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     /* Enable DMA enable bit */
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
 
+    /* Enable the channel FIFO */
+    base->RCR3 |= I2S_RCR3_RCE(1U << handle->channel);
+
     /* Enable SAI Rx clock */
     SAI_RxEnable(base, true);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Aborts a SAI transfer using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateSendEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
 void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
 {
     assert(handle);
@@ -319,13 +454,36 @@ void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
     /* Disable dma */
     EDMA_AbortTransfer(handle->dmaHandle);
 
+    /* Disable the channel FIFO */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
+
     /* Disable DMA enable bit */
     SAI_TxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
+
+    /* Disable Tx */
+    SAI_TxEnable(base, false);
+
+    /* Reset the FIFO pointer, at the same time clear all error flags if set */
+    base->TCSR |= (I2S_TCSR_FR_MASK | I2S_TCSR_SR_MASK);
+    base->TCSR &= ~I2S_TCSR_SR_MASK;
+
+    /* Handle the queue index */
+    memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+    handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
 
     /* Set the handle state */
     handle->state = kSAI_Idle;
 }
 
+/*!
+ * brief Aborts a SAI receive using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateReceiveEDMA.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ */
 void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
 {
     assert(handle);
@@ -333,13 +491,84 @@ void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
     /* Disable dma */
     EDMA_AbortTransfer(handle->dmaHandle);
 
+    /* Disable the channel FIFO */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
+
     /* Disable DMA enable bit */
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
+
+    /* Disable Rx */
+    SAI_RxEnable(base, false);
+
+    /* Reset the FIFO pointer, at the same time clear all error flags if set */
+    base->RCSR |= (I2S_RCSR_FR_MASK | I2S_RCSR_SR_MASK);
+    base->RCSR &= ~I2S_RCSR_SR_MASK;
+
+    /* Handle the queue index */
+    memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+    handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
 
     /* Set the handle state */
     handle->state = kSAI_Idle;
 }
 
+/*!
+ * brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSendEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortSendEDMA(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->tcd, 0U, sizeof(handle->tcd));
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceiveEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortReceiveEDMA(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->tcd, 0U, sizeof(handle->tcd));
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Gets byte count sent by SAI.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param count Bytes count sent by SAI.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
 status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -353,12 +582,22 @@ status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle,
     else
     {
         *count = (handle->transferSize[handle->queueDriver] -
-                  EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+                  (uint32_t)handle->nbytes *
+                      EDMA_GetRemainingMajorLoopCount(handle->dmaHandle->base, handle->dmaHandle->channel));
     }
 
     return status;
 }
 
+/*!
+ * brief Gets byte count received by SAI.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ * param count Bytes count received by SAI.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
 status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -372,7 +611,8 @@ status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *hand
     else
     {
         *count = (handle->transferSize[handle->queueDriver] -
-                  EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+                  (uint32_t)handle->nbytes *
+                      EDMA_GetRemainingMajorLoopCount(handle->dmaHandle->base, handle->dmaHandle->channel));
     }
 
     return status;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_sai_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_sai_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SAI_EDMA_H_
 #define _FSL_SAI_EDMA_H_
@@ -38,10 +16,14 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_SAI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 5)) /*!< Version 2.1.5 */
+/*@}*/
 
 typedef struct _sai_edma_handle sai_edma_handle_t;
 
@@ -51,18 +33,19 @@ typedef void (*sai_edma_callback_t)(I2S_Type *base, sai_edma_handle_t *handle, s
 /*! @brief SAI DMA transfer handle, users should not touch the content of the handle.*/
 struct _sai_edma_handle
 {
-    edma_handle_t *dmaHandle;                     /*!< DMA handler for SAI send */
-    uint8_t bytesPerFrame;                        /*!< Bytes in a frame */
-    uint8_t channel;                              /*!< Which data channel */
-    uint8_t count;                                /*!< The transfer data count in a DMA request */
-    uint32_t state;                               /*!< Internal state for SAI eDMA transfer */
-    sai_edma_callback_t callback;                 /*!< Callback for users while transfer finish or error occurs */
-    void *userData;                               /*!< User callback parameter */
-    edma_tcd_t tcd[SAI_XFER_QUEUE_SIZE + 1U];     /*!< TCD pool for eDMA transfer. */
-    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE]; /*!< Transfer queue storing queued transfer. */
-    size_t transferSize[SAI_XFER_QUEUE_SIZE];     /*!< Data bytes need to transfer */
-    volatile uint8_t queueUser;                   /*!< Index for user to queue transfer. */
-    volatile uint8_t queueDriver;                 /*!< Index for driver to get the transfer data and size */
+    edma_handle_t *dmaHandle;     /*!< DMA handler for SAI send */
+    uint8_t nbytes;               /*!< eDMA minor byte transfer count initially configured. */
+    uint8_t bytesPerFrame;        /*!< Bytes in a frame */
+    uint8_t channel;              /*!< Which data channel */
+    uint8_t count;                /*!< The transfer data count in a DMA request */
+    uint32_t state;               /*!< Internal state for SAI eDMA transfer */
+    sai_edma_callback_t callback; /*!< Callback for users while transfer finish or error occurs */
+    void *userData;               /*!< User callback parameter */
+    uint8_t tcd[(SAI_XFER_QUEUE_SIZE + 1U) * sizeof(edma_tcd_t)]; /*!< TCD pool for eDMA transfer. */
+    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE];                 /*!< Transfer queue storing queued transfer. */
+    size_t transferSize[SAI_XFER_QUEUE_SIZE];                     /*!< Data bytes need to transfer */
+    volatile uint8_t queueUser;                                   /*!< Index for user to queue transfer. */
+    volatile uint8_t queueDriver; /*!< Index for driver to get the transfer data and size */
 };
 
 /*******************************************************************************
@@ -182,7 +165,32 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
 status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer);
 
 /*!
+ * @brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSendEDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
+ * @brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceiveEDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
  * @brief Aborts a SAI transfer using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateSendEDMA.
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.
@@ -191,6 +199,9 @@ void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
 
 /*!
  * @brief Aborts a SAI receive using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateReceiveEDMA.
  *
  * @param base SAI base pointer
  * @param handle SAI eDMA handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_uart_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_uart_edma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -246,6 +246,9 @@ status_t UART_SendEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfe
         EDMA_PrepareTransfer(&xferConfig, xfer->data, sizeof(uint8_t), (void *)UART_GetDataRegisterAddress(base),
                              sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_MemoryToPeripheral);
 
+        /* Store the initially configured eDMA minor byte transfer count into the UART handle */
+        handle->nbytes = sizeof(uint8_t);
+
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->txEdmaHandle, &xferConfig);
         EDMA_StartTransfer(handle->txEdmaHandle);
@@ -283,6 +286,9 @@ status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_tran
         /* Prepare transfer. */
         EDMA_PrepareTransfer(&xferConfig, (void *)UART_GetDataRegisterAddress(base), sizeof(uint8_t), xfer->data,
                              sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_PeripheralToMemory);
+
+        /* Store the initially configured eDMA minor byte transfer count into the UART handle */
+        handle->nbytes = sizeof(uint8_t);
 
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->rxEdmaHandle, &xferConfig);
@@ -336,7 +342,9 @@ status_t UART_TransferGetReceiveCountEDMA(UART_Type *base, uart_edma_handle_t *h
         return kStatus_NoTransferInProgress;
     }
 
-    *count = handle->rxDataSizeAll - EDMA_GetRemainingBytes(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
+    *count = handle->rxDataSizeAll -
+             (uint32_t)handle->nbytes *
+                 EDMA_GetRemainingMajorLoopCount(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
 
     return kStatus_Success;
 }
@@ -352,7 +360,9 @@ status_t UART_TransferGetSendCountEDMA(UART_Type *base, uart_edma_handle_t *hand
         return kStatus_NoTransferInProgress;
     }
 
-    *count = handle->txDataSizeAll - EDMA_GetRemainingBytes(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
+    *count = handle->txDataSizeAll -
+             (uint32_t)handle->nbytes *
+                 EDMA_GetRemainingMajorLoopCount(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
 
     return kStatus_Success;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_uart_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_uart_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -38,7 +38,6 @@
  * @addtogroup uart_edma_driver
  * @{
  */
-
 
 /*******************************************************************************
  * Definitions
@@ -66,6 +65,8 @@ struct _uart_edma_handle
     edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
     edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
 
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
+
     volatile uint8_t txState; /*!< TX transfer state. */
     volatile uint8_t rxState; /*!< RX transfer state */
 };
@@ -86,18 +87,18 @@ extern "C" {
 /*!
  * @brief Initializes the UART handle which is used in transactional functions.
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  * @param callback UART callback, NULL means no callback.
  * @param userData User callback function data.
- * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
- * @param txEdmaHandle User requested DMA handle for TX DMA transfer.
+ * @param rxEdmaHandle User-requested DMA handle for RX DMA transfer.
+ * @param txEdmaHandle User-requested DMA handle for TX DMA transfer.
  */
 void UART_TransferCreateHandleEDMA(UART_Type *base,
-                           uart_edma_handle_t *handle,
-                           uart_edma_transfer_callback_t callback,
-                           void *userData,
-                           edma_handle_t *txEdmaHandle,
-                           edma_handle_t *rxEdmaHandle);
+                                   uart_edma_handle_t *handle,
+                                   uart_edma_transfer_callback_t callback,
+                                   void *userData,
+                                   edma_handle_t *txEdmaHandle,
+                                   edma_handle_t *rxEdmaHandle);
 
 /*!
  * @brief Sends data using eDMA.
@@ -108,23 +109,23 @@ void UART_TransferCreateHandleEDMA(UART_Type *base,
  * @param base UART peripheral base address.
  * @param handle UART handle pointer.
  * @param xfer UART eDMA transfer structure. See #uart_transfer_t.
- * @retval kStatus_Success if succeed, others failed.
- * @retval kStatus_UART_TxBusy Previous transfer on going.
+ * @retval kStatus_Success if succeeded; otherwise failed.
+ * @retval kStatus_UART_TxBusy Previous transfer ongoing.
  * @retval kStatus_InvalidArgument Invalid argument.
  */
 status_t UART_SendEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer);
 
 /*!
- * @brief Receive data using eDMA.
+ * @brief Receives data using eDMA.
  *
  * This function receives data using eDMA. This is a non-blocking function, which returns
  * right away. When all data is received, the receive callback function is called.
  *
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  * @param xfer UART eDMA transfer structure. See #uart_transfer_t.
- * @retval kStatus_Success if succeed, others failed.
- * @retval kStatus_UART_RxBusy Previous transfer on going.
+ * @retval kStatus_Success if succeeded; otherwise failed.
+ * @retval kStatus_UART_RxBusy Previous transfer ongoing.
  * @retval kStatus_InvalidArgument Invalid argument.
  */
 status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer);
@@ -135,7 +136,7 @@ status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_tran
  * This function aborts sent data using eDMA.
  *
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  */
 void UART_TransferAbortSendEDMA(UART_Type *base, uart_edma_handle_t *handle);
 
@@ -145,12 +146,12 @@ void UART_TransferAbortSendEDMA(UART_Type *base, uart_edma_handle_t *handle);
  * This function aborts receive data using eDMA.
  *
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  */
 void UART_TransferAbortReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to UART TX register.
+ * @brief Gets the number of bytes that have been written to UART TX register.
  *
  * This function gets the number of bytes that have been written to UART TX
  * register by DMA.
@@ -165,9 +166,9 @@ void UART_TransferAbortReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle);
 status_t UART_TransferGetSendCountEDMA(UART_Type *base, uart_edma_handle_t *handle, uint32_t *count);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of received bytes.
  *
- * This function gets the number of bytes that have been received.
+ * This function gets the number of received bytes.
  *
  * @param base UART peripheral base address.
  * @param handle UART handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
@@ -141,13 +141,17 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi.c
@@ -1,38 +1,22 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi.h"
 
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -65,27 +42,27 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
 
 /*!
  * @brief Master fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Master finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Slave fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
  * @brief Slave finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -100,7 +77,7 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param);
 /*!
  * @brief Master prepare the transfer.
  * Basically it set up dspi_master_handle .
- * This is not a public API as it is called from other driver functions. fsl_dspi_edma.c also call this function.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
 
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -123,11 +100,13 @@ static SPI_Type *const s_dspiBases[] = SPI_BASE_PTRS;
 /*! @brief Pointers to dspi IRQ number for each instance. */
 static IRQn_Type const s_dspiIRQ[] = SPI_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to dspi clocks for each instance. */
 static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to dspi handles for each instance. */
-static void *g_dspiHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
@@ -135,15 +114,22 @@ static dspi_master_isr_t s_dspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_DSPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_dspiBases); instance++)
     {
         if (s_dspiBases[instance] == base)
         {
@@ -151,20 +137,80 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_DSPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_dspiBases));
 
     return instance;
 }
 
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+{
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
+}
+
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
+    assert(NULL != masterConfig);
+
     uint32_t temp;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -173,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -185,48 +229,92 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
-    masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    assert(NULL != masterConfig);
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
+    masterConfig->ctarConfig.bitsPerFrame = 8;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
+
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
+    assert(NULL != slaveConfig);
+
     uint32_t temp = 0;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
@@ -239,40 +327,66 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
 
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    slaveConfig->whichCtar = kDSPI_Ctar0;
-    slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    assert(NULL != slaveConfig);
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
+    slaveConfig->ctarConfig.bitsPerFrame = 8;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
     DSPI_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* disable DSPI clock */
     CLOCK_DisableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pcs_polarity_config_t activeLowOrHigh)
@@ -293,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -312,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -378,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -402,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -424,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -455,83 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    assert(NULL != command);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    assert(NULL != command);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
+
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -540,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -556,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -574,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -621,34 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        if (rxData != NULL)
-                        {
-                            *(rxData) = DSPI_ReadData(base);
-                            rxData++;
-                        }
-                        else
-                        {
-                            DSPI_ReadData(base);
-                        }
-                        remainingReceiveByteCount--;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -660,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -701,54 +1013,39 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *(rxData) = DSPI_ReadData(base);
-                        rxData++;
-                    }
-                    else
-                    {
-                        DSPI_ReadData(base);
-                    }
-                    remainingReceiveByteCount--;
+                        if (rxData != NULL)
+                        {
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
+                            rxData++;
+                        }
+                        else
+                        {
+                            (void)DSPI_ReadData(base);
+                        }
+                        remainingReceiveByteCount--;
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        wordReceived = DSPI_ReadData(base);
-
-                        if (rxData != NULL)
-                        {
-                            *rxData = wordReceived;
-                            ++rxData;
-                            *rxData = wordReceived >> 8;
-                            ++rxData;
-                        }
-                        remainingReceiveByteCount -= 2;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -756,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -769,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -822,24 +1120,28 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    wordReceived = DSPI_ReadData(base);
-
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *rxData = wordReceived;
-                        ++rxData;
-                        *rxData = wordReceived >> 8;
-                        ++rxData;
-                    }
-                    remainingReceiveByteCount -= 2;
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        if (rxData != NULL)
+                        {
+                            *rxData = (uint8_t)wordReceived;
+                            ++rxData;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
+                            ++rxData;
+                        }
+                        remainingReceiveByteCount -= 2U;
+
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
@@ -850,28 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    dspi_command_data_config_t commandStruct;
+    assert(NULL != handle);
+    assert(NULL != transfer);
+
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -879,61 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
-    DSPI_StartTransfer(base);
-
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
-    DSPI_MasterTransferFillUpTxFifo(base, handle);
 
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_StartTransfer(base);
+
+    /* Fill up the Tx FIFO to trigger the transfer. */
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -945,11 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -958,40 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
-
-    /* The transfer is complete.*/
-    handle->state = kDSPI_Idle;
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -999,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1007,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1023,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1058,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1068,82 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1152,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1180,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1212,85 +1736,107 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (NULL != handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (NULL != handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
+    }
 
     DSPI_StartTransfer(base);
 
     /* Prepare data to transmit */
     DSPI_SlaveTransferFillUpTxFifo(base, handle);
 
-    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
-
-    /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
-
-    if (handle->rxData)
-    {
-        /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
-    }
-    if (handle->txData)
-    {
-        /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
-    }
-
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1302,22 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1335,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1382,24 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1408,65 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
-
-    handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1484,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1500,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1573,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1606,52 +2188,57 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 0)
+#if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 1)
+#if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 2)
+#if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 3)
+#if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 4)
+#if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
 
-#if (FSL_FEATURE_SOC_DSPI_COUNT > 5)
+#if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -37,54 +15,55 @@
  * @{
  */
 
-
 /**********************************************************************************************************************
  * Definitions
  *********************************************************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.1.1. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 1))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
-/*! @brief DSPI dummy data if no Tx data.*/
-#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for tx if there is not txData. */
+#ifndef DSPI_DUMMY_DATA
+/*! @brief DSPI dummy data if there is no Tx data.*/
+#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for Tx if there is no txData. */
+#endif
 
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out Of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All status above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -101,12 +80,13 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
- * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in Modified Transfer Format. This field is valid
- * only when CPHA bit in CTAR register is 0.
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is
+ * valid
+ * only when the CPHA bit in the CTAR register is 0.
  */
 typedef enum _dspi_master_sample_point
 {
@@ -130,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -165,36 +145,37 @@ typedef enum _dspi_clock_phase
 typedef enum _dspi_shift_direction
 {
     kDSPI_MsbFirst = 0U, /*!< Data transfers start with most significant bit.*/
-    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.*/
+    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.
+                              Shifting out of LSB is not supported for slave */
 } dspi_shift_direction_t;
 
 /*! @brief DSPI delay type selection.*/
 typedef enum _dspi_delay_type
 {
     kDSPI_PcsToSck = 1U,  /*!< Pcs-to-SCK delay. */
-    kDSPI_LastSckToPcs,   /*!< Last SCK edge to Pcs delay. */
+    kDSPI_LastSckToPcs,   /*!< The last SCK edge to Pcs delay. */
     kDSPI_BetweenTransfer /*!< Delay between transfers. */
 } dspi_delay_type_t;
 
 /*! @brief DSPI Clock and Transfer Attributes Register (CTAR) selection.*/
 typedef enum _dspi_ctar_selection
 {
-    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode, note that CTAR0 and CTAR0_SLAVE are the
+    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode; note that CTAR0 and CTAR0_SLAVE are the
                          same register address. */
     kDSPI_Ctar1 = 1U, /*!< CTAR1 selection option for master mode only. */
-    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only , note that some device do not support CTAR2. */
-    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only , note that some device do not support CTAR3. */
-    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only , note that some device do not support CTAR4. */
-    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only , note that some device do not support CTAR5. */
-    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only , note that some device do not support CTAR6. */
-    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only , note that some device do not support CTAR7. */
+    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only; note that some devices do not support CTAR2. */
+    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only; note that some devices do not support CTAR3. */
+    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only; note that some devices do not support CTAR4. */
+    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only; note that some devices do not support CTAR5. */
+    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only; note that some devices do not support CTAR6. */
+    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only; note that some devices do not support CTAR7. */
 } dspi_ctar_selection_t;
 
-#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro , internal used. */
-#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro , internal used. */
-#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro , internal used. */
-#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro , internal used. */
-/*! @brief Can use this enumeration for DSPI master transfer configFlags. */
+#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro; used internally. */
+#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro; used internally. */
+#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro; used internally. */
+#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI master transfer configFlags. */
 enum _dspi_transfer_config_flag_for_master
 {
     kDSPI_MasterCtar0 = 0U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR0 setting. */
@@ -213,13 +194,14 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Is PCS signal continuous. */
-    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Is PCS signal active after last frame transfer.*/
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterActiveAfterTransfer =
+        1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
-#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro , internal used. */
-#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro , internal used. */
-/*! @brief Can use this enum for DSPI slave transfer configFlags. */
+#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro; used internally. */
+#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI slave transfer configFlags. */
 enum _dspi_transfer_config_flag_for_slave
 {
     kDSPI_SlaveCtar0 = 0U << DSPI_SLAVE_CTAR_SHIFT, /*!< DSPI slave transfer use CTAR0 setting. */
@@ -234,15 +216,15 @@ enum _dspi_transfer_state
     kDSPI_Error        /*!< Transfer error. */
 };
 
-/*! @brief DSPI master command date configuration used for SPIx_PUSHR.*/
+/*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
     bool isEndOfQueue;               /*!< Signals that the current transfer is the last in the queue.*/
-    bool clearTransferCount;         /*!< Clears SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
+    bool clearTransferCount;         /*!< Clears the SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
 } dspi_command_data_config_t;
 
 /*! @brief DSPI master ctar configuration structure.*/
@@ -254,33 +236,33 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time with nanosecond , set to 0 sets the minimum
-                                               delay. It sets the boundary value if out of range that can be set.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< Last SCK to PCS delay time with nanosecond , set to 0 sets the
-                                               minimum delay.It sets the boundary value if out of range that can be
-                                               set.*/
-    uint32_t betweenTransferDelayInNanoSec; /*!< After SCK delay time with nanosecond , set to 0 sets the minimum
-                                             delay.It sets the boundary value if out of range that can be set.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
+
+    uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                             delay. It also sets the boundary value if out of range.*/
 } dspi_master_ctar_config_t;
 
 /*! @brief DSPI master configuration structure.*/
 typedef struct _dspi_master_config
 {
-    dspi_ctar_selection_t whichCtar;      /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;      /*!< The desired CTAR to use. */
     dspi_master_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    dspi_which_pcs_t whichPcs;                     /*!< Desired Peripheral Chip Select (pcs). */
-    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< Desired PCS active high or low. */
+    dspi_which_pcs_t whichPcs;                     /*!< The desired Peripheral Chip Select (pcs). */
+    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< The desired PCS active high or low. */
 
-    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable . Note that continuous SCK is only
+    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                      supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite; /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                     data is ignored, the data from the transfer that generated the overflow
-                                     is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                     shift to the shift register. */
+    bool enableRxFifoOverWrite; /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                     data is ignored and the data from the transfer that generated the overflow
+                                     is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                     shift register. */
 
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                  Format. It's valid only when CPHA=0. */
 } dspi_master_config_t;
 
@@ -290,34 +272,34 @@ typedef struct _dspi_slave_ctar_config
     uint32_t bitsPerFrame;      /*!< Bits per frame, minimum 4, maximum 16.*/
     dspi_clock_polarity_t cpol; /*!< Clock polarity. */
     dspi_clock_phase_t cpha;    /*!< Clock phase. */
-                                /*!< Slave only supports MSB , does not support LSB.*/
+                                /*!< Slave only supports MSB and does not support LSB.*/
 } dspi_slave_ctar_config_t;
 
 /*! @brief DSPI slave configuration structure.*/
 typedef struct _dspi_slave_config
 {
-    dspi_ctar_selection_t whichCtar;     /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;     /*!< The desired CTAR to use. */
     dspi_slave_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that continuous SCK is only
+    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                                  supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite;             /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                                 data is ignored, the data from the transfer that generated the overflow
-                                                 is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                                 shift to the shift register. */
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableRxFifoOverWrite;             /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                                 data is ignored and the data from the transfer that generated the overflow
+                                                 is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                                 shift register. */
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                Format. It's valid only when CPHA=0. */
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -352,47 +334,60 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags , set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
+    volatile uint8_t state; /*!< DSPI transfer state, see _dspi_transfer_state.*/
 
     dspi_master_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                           /*!< Callback user data. */
 };
 
-/*! @brief DSPI slave transfer handle structure used for transactional API. */
+/*! @brief DSPI slave transfer handle structure used for the transactional API. */
 struct _dspi_slave_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame;          /*!< The desired number of bits per frame. */
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     volatile uint8_t state; /*!< DSPI transfer state.*/
 
@@ -417,18 +412,18 @@ extern "C" {
 /*!
  * @brief Initializes the DSPI master.
  *
- * This function initializes the DSPI master configuration. An example use case is as follows:
+ * This function initializes the DSPI master configuration. This is an example use case.
  *  @code
  *   dspi_master_config_t  masterConfig;
  *   masterConfig.whichCtar                                = kDSPI_Ctar0;
- *   masterConfig.ctarConfig.baudRate                      = 500000000;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
  *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
  *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
  *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
  *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
- *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
  *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
  *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
  *   masterConfig.enableContinuousSCK                      = false;
@@ -439,8 +434,8 @@ extern "C" {
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param masterConfig Pointer to structure dspi_master_config_t.
- * @param srcClock_Hz Module source input clock in Hertz
+ * @param masterConfig Pointer to the structure dspi_master_config_t.
+ * @param srcClock_Hz Module source input clock in Hertz.
  */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
@@ -448,8 +443,8 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
  * @brief Sets the dspi_master_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
- * User may use the initialized structure unchanged in DSPI_MasterInit() or modify the structure
- * before calling DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
  * Example:
  * @code
  *  dspi_master_config_t  masterConfig;
@@ -462,7 +457,7 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
 /*!
  * @brief DSPI slave configuration.
  *
- * This function initializes the DSPI slave configuration. An example use case is as follows:
+ * This function initializes the DSPI slave configuration. This is an example use case.
  *  @code
  *   dspi_slave_config_t  slaveConfig;
  *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
@@ -477,22 +472,22 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param slaveConfig Pointer to structure dspi_master_config_t.
+ * @param slaveConfig Pointer to the structure dspi_master_config_t.
  */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
 
 /*!
- * @brief Sets the dspi_slave_config_t structure to default values.
+ * @brief Sets the dspi_slave_config_t structure to a default value.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
- * User may use the initialized structure unchanged in DSPI_SlaveInit(), or modify the structure
- * before calling DSPI_SlaveInit().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
  * @code
  *  dspi_slave_config_t  slaveConfig;
  *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
  * @endcode
- * @param slaveConfig pointer to dspi_slave_config_t structure.
+ * @param slaveConfig Pointer to the dspi_slave_config_t structure.
  */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig);
 
@@ -506,7 +501,7 @@ void DSPI_Deinit(SPI_Type *base);
  * @brief Enables the DSPI peripheral and sets the MCR MDIS to 0.
  *
  * @param base DSPI peripheral address.
- * @param enable pass true to enable module, false to disable module.
+ * @param enable Pass true to enable module, false to disable module.
  */
 static inline void DSPI_Enable(SPI_Type *base, bool enable)
 {
@@ -522,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -532,7 +527,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 /*!
  * @brief Gets the DSPI status flag state.
  * @param base DSPI peripheral address.
- * @return The DSPI status(in SR register).
+ * @return DSPI status (in SR register).
  */
 static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
 {
@@ -545,13 +540,13 @@ static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
  * This function  clears the desired status bit by using a write-1-to-clear. The user passes in the base and the
  * desired status bit to clear.  The list of status bits is defined in the dspi_status_and_interrupt_request_t. The
  * function uses these bit positions in its algorithm to clear the desired flag state.
- * Example usage:
+ * This is an example.
  * @code
  *  DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag|kDSPI_EndOfQueueFlag);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param statusFlags The status flag , used from type dspi_flags.
+ * @param statusFlags The status flag used from the type dspi_flags.
  */
 static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 {
@@ -560,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -570,15 +565,16 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 /*!
  * @brief Enables the DSPI interrupts.
  *
- * This function configures the various interrupt masks of the DSPI.  The parameters are base and an interrupt mask.
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
  * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
  *
  * @code
  *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
 
@@ -590,7 +586,7 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 {
@@ -599,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -609,13 +605,13 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Enables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  DSPI_EnableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -625,13 +621,13 @@ static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Disables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  SPI_DisableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_DisableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -679,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -705,12 +707,19 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
  *
- * This function sets the module to begin data transfer in either master or slave mode.
+ * This function sets the module to start data transfer in either master or slave mode.
  *
  * @param base DSPI peripheral address.
  */
@@ -719,9 +728,9 @@ static inline void DSPI_StartTransfer(SPI_Type *base)
     base->MCR &= ~SPI_MCR_HALT_MASK;
 }
 /*!
- * @brief Stops (halts) DSPI transfers and sets HALT bit in MCR.
+ * @brief Stops DSPI transfers and sets the HALT bit in MCR.
  *
- * This function stops data transfers in either master or slave mode.
+ * This function stops data transfers in either master or slave modes.
  *
  * @param base DSPI peripheral address.
  */
@@ -731,44 +740,44 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
 }
 
 /*!
- * @brief Enables (or disables) the DSPI FIFOs.
+ * @brief Enables or disables the DSPI FIFOs.
  *
- * This function  allows the caller to disable/enable the Tx and Rx FIFOs (independently).
- * Note that to disable, the caller must pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
- * the caller must pass in a logic 1 (true).
+ * This function  allows the caller to disable/enable the Tx and Rx FIFOs independently.
+ * Note that to disable, pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
+ * pass in a logic 1 (true).
  *
  * @param base DSPI peripheral address.
- * @param enableTxFifo Disables (false) the TX FIFO, else enables (true) the TX FIFO
- * @param enableRxFifo Disables (false) the RX FIFO, else enables (true) the RX FIFO
+ * @param enableTxFifo Disables (false) the TX FIFO; Otherwise, enables (true) the TX FIFO
+ * @param enableRxFifo Disables (false) the RX FIFO; Otherwise, enables (true) the RX FIFO
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Flushes the DSPI FIFOs.
  *
  * @param base DSPI peripheral address.
- * @param flushTxFifo Flushes (true) the Tx FIFO, else do not flush (false) the Tx FIFO
- * @param flushRxFifo Flushes (true) the Rx FIFO, else do not flush (false) the Rx FIFO
+ * @param flushTxFifo Flushes (true) the Tx FIFO; Otherwise, does not flush (false) the Tx FIFO
+ * @param flushRxFifo Flushes (true) the Rx FIFO; Otherwise, does not flush (false) the Rx FIFO
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Configures the DSPI peripheral chip select polarity simultaneously.
- * For example, PCS0 and PCS1 set to active low and other PCS set to active high. Note that the number of
+ * For example, PCS0 and PCS1 are set to active low and other PCS is set to active high. Note that the number of
  * PCSs is specific to the device.
  * @code
  *  DSPI_SetAllPcsPolarity(base, kDSPI_Pcs0ActiveLow | kDSPI_Pcs1ActiveLow);
    @endcode
  * @param base DSPI peripheral address.
- * @param mask The PCS polarity mask ,  can use the enum _dspi_pcs_polarity.
+ * @param mask The PCS polarity mask; use the enum _dspi_pcs_polarity.
  */
 static inline void DSPI_SetAllPcsPolarity(SPI_Type *base, uint32_t mask)
 {
@@ -797,19 +806,19 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
  * @brief Manually configures the delay prescaler and scaler for a particular CTAR.
  *
  * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
- * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT)and scalar (DT).
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes the delay to configure along with the prescaler and scaler value.
- * This allows the user to directly set the prescaler/scaler values if they have pre-calculated them or if they simply
- * wish to manually increment either value.
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
  *
  * @param base DSPI peripheral address.
  * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
  * @param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
  * @param scaler The scaler delay value (can be any integer between 0 to 15).
- * @param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * @param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
  */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay);
@@ -817,15 +826,15 @@ void DSPI_MasterSetDelayScaler(
 /*!
  * @brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
  *
- * This function calculates the values for:
+ * This function calculates the values for the following.
  * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
  * After SCK delay pre-scalar (PASC) and scalar (ASC), or
- * Delay after transfer pre-scalar (PDT)and scalar (DT).
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes which delay they want to configure along with the desired delay value in nanoseconds.  The function
- * calculates the values needed for the prescaler and scaler and returning the actual calculated delay as an exact
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
  * delay match may not be possible. In this case, the closest match is calculated without going below the desired
  * delay value input.
  * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
@@ -849,11 +858,11 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
  * @brief Writes data into the data buffer for master mode.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_data_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -865,7 +874,7 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
    @endcode
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
@@ -879,14 +888,14 @@ static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config
  * @brief Sets the dspi_command_data_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
- * User may use the initialized structure unchanged in DSPI_MasterWrite_xx() or modify the structure
- * before calling DSPI_MasterWrite_xx().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
  * @code
  *  dspi_command_data_config_t  command;
  *  DSPI_GetDefaultDataCommandConfig(&command);
  * @endcode
- * @param command pointer to dspi_command_data_config_t structure.
+ * @param command Pointer to the dspi_command_data_config_t structure.
  */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
 
@@ -894,11 +903,11 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  * @brief Writes data into the data buffer master mode and waits till complete to return.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -911,10 +920,10 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
- * receive data is available when transmit completes.
+ * the received data is available when the transmit completes.
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data);
@@ -929,10 +938,10 @@ void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *co
  * improve performance in cases where the command structure is constant. For example, the user calls this function
  * before starting a transfer to generate the command word. When they are ready to transmit the data, they OR
  * this formatted command word with the desired data to transmit. This process increases transmit performance when
- * compared to calling send functions such as DSPI_HAL_WriteDataMastermode which format the command word each time a
+ * compared to calling send functions, such as DSPI_HAL_WriteDataMastermode,  which format the command word each time a
  * data word is to be sent.
  *
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @return The command word formatted to the PUSHR data register bit field.
  */
 static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t *command)
@@ -945,43 +954,44 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
 
 /*!
  * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
- *        buffer, master mode and waits till complete to return.
+ *        buffer master mode and waits till complete to return.
  *
- * In this function, the user must append the 16-bit data to the 16-bit command info then provide the total 32-bit word
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
  * as the data to send.
- * The command portion provides characteristics of the data such as the optional continuous chip select operation
-* between
- * transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
  * @code
  *  dataWord = <16-bit command> | <16-bit data>;
- *  DSPI_HAL_WriteCommandDataMastermodeBlocking(base, dataWord);
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
  * @endcode
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
- * Because the SPI is a synchronous protocol, the receive data is available when transmit completes.
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
- * @param data The data word (command and data combined) to be sent
+ * @param data The data word (command and data combined) to be sent.
  */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data);
 
@@ -1021,8 +1031,16 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 }
 
 /*!
+ * @brief Set up the dummy data.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1033,13 +1051,13 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 /*!
  * @brief Initializes the DSPI master handle.
  *
- * This function initializes the DSPI handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance,  call this API once to get the initialized handle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_handle_t.
- * @param callback dspi callback.
- * @param userData callback function parameter.
+ * @param callback DSPI callback.
+ * @param userData Callback function parameter.
  */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
@@ -1049,12 +1067,11 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using polling.
  *
- * This function transfers data with polling. This is a blocking function, which does not return until all transfers
- * have been
- * completed.
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
  *
  * @param base DSPI peripheral base address.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
@@ -1063,15 +1080,43 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @brief DSPI master transfer data using interrupts.
  *
  * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
- data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1079,19 +1124,19 @@ status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *ha
  * This function gets the master transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count);
 
 /*!
- * @brief DSPI master aborts transfer using an interrupt.
+ * @brief DSPI master aborts a transfer using an interrupt.
  *
  * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1101,7 +1146,7 @@ void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1111,10 +1156,10 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
  * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * @param handle DSPI handle pointer to dspi_slave_handle_t.
+ * @param handle DSPI handle pointer to the dspi_slave_handle_t.
  * @param base DSPI peripheral base address.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData Callback function parameter.
  */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
@@ -1125,12 +1170,11 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
  * @brief DSPI slave transfers data using an interrupt.
  *
  * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
- * data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer);
@@ -1141,8 +1185,8 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
  * This function gets the slave transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count);
@@ -1150,10 +1194,10 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 /*!
  * @brief DSPI slave aborts a transfer using an interrupt.
  *
- * This function aborts transfer using an interrupt.
+ * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -1163,19 +1207,29 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi_edma.c
@@ -1,42 +1,25 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi_edma.h"
 
 /***********************************************************************************************************************
-* Definitons
-***********************************************************************************************************************/
+ * Definitions
+ ***********************************************************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi_edma"
+#endif
 
 /*!
-* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_master_edma_private_handle
 {
     SPI_Type *base;                    /*!< DSPI peripheral base address. */
@@ -44,8 +27,8 @@ typedef struct _dspi_master_edma_private_handle
 } dspi_master_edma_private_handle_t;
 
 /*!
-* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_slave_edma_private_handle
 {
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
@@ -53,46 +36,58 @@ typedef struct _dspi_slave_edma_private_handle
 } dspi_slave_edma_private_handle_t;
 
 /***********************************************************************************************************************
-* Prototypes
-***********************************************************************************************************************/
+ * Prototypes
+ ***********************************************************************************************************************/
 /*!
-* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
 /*!
-* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
-/*!
-* @brief Get instance number for DSPI module.
-*
-* This is not a public API and it's extern from fsl_dspi.c.
-*
-* @param base DSPI peripheral base address
-*/
-extern uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /***********************************************************************************************************************
-* Variables
-***********************************************************************************************************************/
+ * Variables
+ ***********************************************************************************************************************/
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 
 /***********************************************************************************************************************
-* Code
-***********************************************************************************************************************/
+ * Code
+ ***********************************************************************************************************************/
 
+/*!
+ * brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          dspi_master_edma_handle_t *handle,
                                          dspi_master_edma_transfer_callback_t callback,
@@ -101,51 +96,72 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          edma_handle_t *edmaTxDataToIntermediaryHandle,
                                          edma_handle_t *edmaIntermediaryToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+#if (!(defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET))
+    assert(NULL != edmaTxDataToIntermediaryHandle);
+#endif
+    assert(NULL != edmaIntermediaryToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].base   = base;
     s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
     handle->userData = userData;
 
-    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaRxRegToRxDataHandle        = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
-    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+    handle->edmaIntermediaryToTxRegHandle  = edmaIntermediaryToTxRegHandle;
 }
 
+/*!
+ * brief DSPI master transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    uint32_t instance = DSPI_GetInstance(base);
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
-    uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    uint32_t instance                = DSPI_GetInstance(base);
+    uint16_t wordToSend              = 0;
+    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint8_t dataAlreadyFed           = 0;
+    uint8_t dataFedMax               = 2;
+    uint32_t tmpMCR                  = 0;
+    size_t tmpRemainingSendByteCount = 0;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
@@ -154,33 +170,33 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
 
     edma_transfer_config_t transferConfigA;
     edma_transfer_config_t transferConfigB;
-    edma_transfer_config_t transferConfigC;
 
-    handle->txBuffIfNull = ((uint32_t)DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-
-    handle->state = kDSPI_Busy;
+    handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
 
     dspi_command_data_config_t commandStruct;
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -188,98 +204,123 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    /* this limits the amount of data we can transfer due to the linked channel.
-    * The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (handle->bitsPerFrame > 8)
+    /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (transfer->dataSize > 1022)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
     else
     {
-        if (transfer->dataSize > 511)
+        if (transfer->dataSize > limited_size)
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
+    {
+        handle->state = (uint8_t)kDSPI_Idle;
+        return kStatus_InvalidArgument;
+    }
+
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
                      &s_dspiMasterEdmaPrivateHandle[instance]);
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
+    /*
+    (1)For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
+    channel_A minor link to channel_B , channel_B minor link to channel_C.
+
+    Already pushed 1 or 2 data in SPI_PUSHR , then start the DMA tansfer.
+    channel_A:SPI_POPR to rxData,
+    channel_B:next txData to handle->command (low 16 bits),
+    channel_C:handle->command (32 bits) to SPI_PUSHR, and use the scatter/gather to transfer the last data
+    (handle->lastCommand to SPI_PUSHR).
+
+    (2)For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C -> channel_B .
+    channel_C major link to channel_B.
+    So need prepare the first data in "intermediary"  before the DMA
+    transfer and then channel_B is used to prepare the next data to "intermediary"
+
+    channel_A:SPI_POPR to rxData,
+    channel_C: handle->command (32 bits) to SPI_PUSHR,
+    channel_B: next txData to handle->command (low 16 bits), and use the scatter/gather to prepare the last data
+    (handle->lastCommand to handle->Command).
+    */
 
     /*If dspi has separate dma request , prepare the first data in "intermediary" .
     else (dspi has shared dma request) , send first 2 data if there is fifo or send first 1 data if there is no fifo*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
-        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
-        */
+         * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+         */
 
         /*Prepare the firt data*/
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
             /* If it's the last word */
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
-                {
-                    if (handle->isThereExtraByte)
-                    {
-                        wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                    }
-                    else
-                    {
-                        wordToSend = *(handle->txData);
-                        ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                    }
-                }
-                else
-                {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                }
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
-            }
-            else /* For all words except the last word , frame > 8bits */
-            {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
+                }
+                else
+                {
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                }
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
+            }
+            else /* For all words except the last word , frame > 8bits */
+            {
+                if (NULL != handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* increment to next data byte */
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     ++handle->txData; /* increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData; /* increment to next data word*/
@@ -289,9 +330,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
             }
             else
             {
@@ -301,66 +343,57 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     }
 
     else /*dspi has shared dma request*/
-
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->remainingSendByteCount <= 2)
+                if (handle->remainingSendByteCount <= 2U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
-                        if (handle->isThereExtraByte)
-                        {
-                            wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                        }
-                        else
-                        {
-                            wordToSend = *(handle->txData);
-                            ++handle->txData;
-                            wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        }
+                        wordToSend = *(handle->txData);
+                        ++handle->txData;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
                     handle->remainingSendByteCount = 0;
-                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                    base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
                 /* For all words except the last word */
                 else
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                         ++handle->txData;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
-                    handle->remainingSendByteCount -= 2;
+                    handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -368,9 +401,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData;
@@ -380,7 +414,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     wordToSend = dummyData;
                 }
 
-                if (handle->remainingSendByteCount == 1)
+                if (handle->remainingSendByteCount == 1U)
                 {
                     base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
@@ -390,14 +424,14 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -405,125 +439,66 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
     }
 
-    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer(rxData)*/
     EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcAddr   = (uint32_t)rxAddr;
     transferConfigA.srcOffset = 0;
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
         transferConfigA.destOffset = 1;
     }
     else
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
         transferConfigA.destOffset = 0;
     }
 
     transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-    if (handle->bitsPerFrame <= 8)
+    if (handle->bitsPerFrame <= 8U)
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.minorLoopBytes  = 1;
         transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
     }
     else
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-        transferConfigA.minorLoopBytes = 2;
-        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        transferConfigA.minorLoopBytes  = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
     }
+
+    /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+    handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
     EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                           &transferConfigA, NULL);
+                           (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
     EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                 kEDMA_MajorInterruptEnable);
+                                 (uint32_t)kEDMA_MajorInterruptEnable);
 
-    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
-    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
-    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
-    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
-
-    if (handle->remainingSendByteCount > 0)
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*Calculate the last data : handle->lastCommand*/
+    if (((tmpRemainingSendByteCount > 0U) && (1U != (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U))) &&
+         (1U == (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        if (handle->txData)
-        {
-            transferConfigB.srcAddr = (uint32_t)(handle->txData);
-            transferConfigB.srcOffset = 1;
-        }
-        else
-        {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-            transferConfigB.srcOffset = 0;
-        }
-
-        transferConfigB.destAddr = (uint32_t)(&handle->command);
-        transferConfigB.destOffset = 0;
-
-        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-        if (handle->bitsPerFrame <= 8)
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
-
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                majorlink , the majorlink would not trigger the channel_C*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
-            }
-        }
-        else
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                * majorlink*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
-            }
-        }
-
-        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
-    }
-
-    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
-    handle the last data */
-    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
-
-    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
-        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
-         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
-    {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
             uint32_t bufferIndex = 0;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                if (handle->bitsPerFrame <= 8)
+                if (handle->bitsPerFrame <= 8U)
                 {
-                    bufferIndex = handle->remainingSendByteCount - 1;
+                    bufferIndex = handle->remainingSendByteCount - 1U;
                 }
                 else
                 {
-                    bufferIndex = handle->remainingSendByteCount - 2;
+                    bufferIndex = handle->remainingSendByteCount - 2U;
                 }
             }
             else
@@ -531,85 +506,345 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 bufferIndex = handle->remainingSendByteCount;
             }
 
-            if (handle->bitsPerFrame <= 8)
+            uint32_t tmpLastCommand = handle->lastCommand;
+            uint8_t *tmpTxData      = handle->txData;
+
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | tmpTxData[bufferIndex - 1U];
             }
             else
             {
-                if (handle->isThereExtraByte)
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 2] |
-                                          ((uint32_t)dummyData << 8);
-                }
-                else
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
-                                          ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
-                                          handle->txData[bufferIndex - 2];
-                }
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | ((uint32_t)tmpTxData[bufferIndex - 1U] << 8U) |
+                                 tmpTxData[bufferIndex - 2U];
             }
+
+            handle->lastCommand = tmpLastCommand;
         }
         else
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 wordToSend = dummyData;
             }
             else
             {
-                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
             }
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
     }
 
+/* The feature of GASKET is that the SPI supports 8-bit or 16-bit writes to the PUSH TX FIFO,
+ * allowing a single write to the command word followed by multiple writes to the transmit word.
+ * The TX FIFO will save the last command word written, and convert a 8-bit/16-bit write to the
+ * transmit word into a 32-bit write that pushes both the command word and transmit word into
+ * the TX FIFO (PUSH TX FIFO Register In Master Mode)
+ * So, if this feature is supported, we can use use one channel to carry the receive data from
+ * receive regsiter to user data buffer, use the other channel to carry the data from user data buffer
+ * to transmit register,and use the scatter/gather function to prepare the last data.
+ * That is to say, if GASKET feature is supported, we can use only two channels for tansferring data.
+ */
+#if defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET
+    /*  For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to PUSHR register.
+     */
+
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
     if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
-        ((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+        ((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigC.destAddr = (uint32_t)txAddr;
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-        transferConfigC.majorLoopCounts = 1;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t)txAddr;
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
     }
 
-    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)))
+    /*User_Send_Buffer(txData) to PUSHR register. */
+    if (((handle->remainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+        ((handle->remainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U)))
     {
-        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
-        transferConfigC.destAddr = (uint32_t)txAddr;
-
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-
-        if (handle->bitsPerFrame <= 8)
+        if (handle->txData)
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /* For DSPI with separate RX and TX DMA requests, one frame data has been carry
+                 * to handle->command, so need to reduce the pointer of txData.
+                 */
+                transferConfigB.srcAddr =
+                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8U) ? (1U) : (2U)));
+                transferConfigB.srcOffset = 1;
+            }
+            else
+            {
+                /* For DSPI with shared RX and TX DMA requests, one or two frame data have been carry
+                 * to PUSHR register, so no need to change the pointer of txData.
+                 */
+                transferConfigB.srcAddr   = (uint32_t)((uint8_t *)(handle->txData));
+                transferConfigB.srcOffset = 1;
+            }
         }
         else
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)txAddr;
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1U;
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            transferConfigB.majorLoopCounts  = (handle->remainingSendByteCount / 2U) - 1U;
         }
 
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, softwareTCD);
+    }
+    /* If only one word to transmit, only carry the lastcommand. */
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, NULL);
+    }
+
+    /*Start the EDMA channel_A , channel_C. */
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    /* Set the channel link.
+     * For DSPI instances with shared TX and RX DMA requests, setup channel minor link, first receive data from the
+     * receive register, and then carry transmit data to PUSHER register.
+     * For DSPI instance with separate TX and RX DMA requests, there is no need to set up channel link.
+     */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /*Set channel priority*/
+        uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+        uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
+        uint8_t t                   = 0;
+
+        if (channelPriorityLow > channelPriorityHigh)
+        {
+            t                   = channelPriorityLow;
+            channelPriorityLow  = channelPriorityHigh;
+            channelPriorityHigh = t;
+        }
+
+        edma_channel_Preemption_config_t preemption_config_t;
+        preemption_config_t.enableChannelPreemption = true;
+        preemption_config_t.enablePreemptAbility    = true;
+        preemption_config_t.channelPriority         = channelPriorityLow;
+
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+        /*if there is Rx DMA request , carry the 32bits data (handle->command) to user data first , then link to
+          channelC to carry the next data to PUSHER register.(txData to PUSHER) */
+        if (handle->remainingSendByteCount > 0U)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaIntermediaryToTxRegHandle->channel);
+        }
+    }
+
+    DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    /* Setup control info to PUSHER register. */
+    *((uint16_t *)&(base->PUSHR) + 1) = (handle->command >> 16U);
+#else
+
+    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
+    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
+    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
+
+    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
+
+    /*For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to handle->Command*/
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t) & (handle->command);
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*User_Send_Buffer(txData) to intermediary(handle->command)*/
+    if (((((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U))) &&
+         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        if (NULL != handle->txData)
+        {
+            transferConfigB.srcAddr   = (uint32_t)(handle->txData);
+            transferConfigB.srcOffset = 1;
+        }
+        else
+        {
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)(&handle->command);
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                majorlink , the majorlink would not trigger the channel_C*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1U;
+            }
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                 * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U + 1U;
+            }
+        }
+
+        if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, softwareTCD);
+            EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
+                                       handle->edmaIntermediaryToTxRegHandle->channel, false);
+        }
+        else
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+        }
+    }
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                               handle->edmaTxDataToIntermediaryHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
+    handle the last data */
+
+    edma_transfer_config_t transferConfigC;
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*For DSPI instances with shared RX/TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to SPI_PUSHR*/
+    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (tmpRemainingSendByteCount > 0U)))
+    {
+        transferConfigC.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr         = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        transferConfigC.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    if (((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+        ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U)) ||
+        (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        transferConfigC.srcAddr  = (uint32_t)(&(handle->command));
+        transferConfigC.destAddr = (uint32_t)txAddr;
+
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            if (handle->bitsPerFrame <= 8U)
+            {
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1U;
+            }
+            else
+            {
+                transferConfigC.majorLoopCounts = (handle->remainingSendByteCount / 2U) - 1U;
+            }
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, softwareTCD);
+        }
+        else
+        {
+            transferConfigC.majorLoopCounts = 1;
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+        }
+
         EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
                                    handle->edmaIntermediaryToTxRegHandle->channel, false);
     }
     else
     {
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                               handle->edmaIntermediaryToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
     /*Start the EDMA channel_A , channel_B , channel_C transfer*/
@@ -618,165 +853,233 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
-    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid  = handle->edmaTxDataToIntermediaryHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
     if (channelPriorityLow > channelPriorityMid)
     {
-        t = channelPriorityLow;
+        t                  = channelPriorityLow;
         channelPriorityLow = channelPriorityMid;
         channelPriorityMid = t;
     }
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     if (channelPriorityMid > channelPriorityHigh)
     {
-        t = channelPriorityMid;
-        channelPriorityMid = channelPriorityHigh;
+        t                   = channelPriorityMid;
+        channelPriorityMid  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
-    /*Set the channel link.
-    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
-    For DSPI instances with separate RX and TX DMA requests:
-    Rx DMA request -> channel_A
-    Tx DMA request -> channel_C -> channel_B . (so need prepare the first data in "intermediary"  before the DMA
-    transfer and then channel_B is used to prepare the next data to "intermediary" ) */
+    /*Set the channel link.*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
-        to prepare the next 32bits data (User_send_buffer to handle->command) */
-        if (handle->remainingSendByteCount > 1)
+        to prepare the next 32bits data (txData to handle->command) */
+        if (handle->remainingSendByteCount > 1U)
         {
             EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
-                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MinorLink,
+                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MajorLink,
                                 handle->edmaTxDataToIntermediaryHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
     else
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                    kEDMA_MajorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-            }
 
             EDMA_SetChannelLink(handle->edmaTxDataToIntermediaryHandle->base,
                                 handle->edmaTxDataToIntermediaryHandle->channel, kEDMA_MinorLink,
                                 handle->edmaIntermediaryToTxRegHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
-
+#endif
     DSPI_StartTransfer(base);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI base pointer
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferEDMA(base, handle, &tempXfer);
+
+    return status;
+}
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
     EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the master eDMA transfer count.
+ *
+ * This function gets the master eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -784,13 +1087,33 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         dspi_slave_edma_handle_t *handle,
                                         dspi_slave_edma_transfer_callback_t callback,
@@ -798,14 +1121,16 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+    assert(NULL != edmaTxDataToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].base   = base;
     s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
@@ -815,88 +1140,99 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
 
+/*!
+ * brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
+
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If send/receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    edma_tcd_t *softwareTCD = (edma_tcd_t *)((uint32_t)(&handle->dspiSoftwareTCD[1]) & (~0x1FU));
+    handle->state = (uint8_t)kDSPI_Busy;
 
     uint32_t instance = DSPI_GetInstance(base);
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->bitsPerFrame > 8)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
-            if (transfer->dataSize > 1022)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
-        else
+    }
+    else
+    {
+        if (transfer->dataSize > limited_size)
         {
-            if (transfer->dataSize > 511)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
     }
 
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize < 2))
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
 
-    handle->state = kDSPI_Busy;
-
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
-    handle->errorCount = 0;
+    handle->totalByteCount            = transfer->dataSize;
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
-
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint32_t wordToSend    = 0;
+    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint8_t dataFedMax     = 2;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
@@ -907,9 +1243,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     DSPI_StartTransfer(base);
 
@@ -919,42 +1255,36 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* Increment to next data byte */
-                    if ((handle->remainingSendByteCount == 2) && (handle->isThereExtraByte))
-                    {
-                        wordToSend |= (unsigned)(dummyData) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
-                    else
-                    {
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
+
+                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    ++handle->txData; /* Increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -962,9 +1292,10 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     /* Increment to next data word*/
@@ -978,14 +1309,14 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 /* Decrement remainingSendByteCount*/
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -994,179 +1325,132 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     }
 
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
-    if (handle->remainingReceiveByteCount > 0)
+    if (handle->remainingReceiveByteCount > 0U)
     {
         EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcAddr   = (uint32_t)rxAddr;
         transferConfigA.srcOffset = 0;
 
-        if (handle->rxData)
+        if (NULL != handle->rxData)
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
             transferConfigA.destOffset = 1;
         }
         else
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
             transferConfigA.destOffset = 0;
         }
 
         transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.minorLoopBytes  = 1;
             transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
         }
         else
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigA.minorLoopBytes = 2;
-            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+            transferConfigA.minorLoopBytes  = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
         }
+
+        /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+        handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
         EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                               &transferConfigA, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
         EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                     kEDMA_MajorInterruptEnable);
+                                     (uint32_t)kEDMA_MajorInterruptEnable);
     }
 
-    if (handle->remainingSendByteCount > 0)
+    if (handle->remainingSendByteCount > 0U)
     {
         /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
         EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
 
-        /*If there is extra byte , it would use the */
-        if (handle->isThereExtraByte)
-        {
-            if (handle->txData)
-            {
-                handle->txLastData =
-                    handle->txData[handle->remainingSendByteCount - 2] | ((uint32_t)DSPI_DUMMY_DATA << 8);
-            }
-            else
-            {
-                handle->txLastData = DSPI_DUMMY_DATA | ((uint32_t)DSPI_DUMMY_DATA << 8);
-            }
-            transferConfigC.srcAddr = (uint32_t)(&(handle->txLastData));
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.srcOffset = 0;
-            transferConfigC.destOffset = 0;
-            transferConfigC.minorLoopBytes = 4;
-            transferConfigC.majorLoopCounts = 1;
+        transferConfigC.destAddr   = (uint32_t)txAddr;
+        transferConfigC.destOffset = 0;
 
-            EDMA_TcdReset(softwareTCD);
-            EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
-        }
-
-        /*Set another  transferConfigC*/
-        if ((handle->isThereExtraByte) && (handle->remainingSendByteCount == 2))
+        if (NULL != handle->txData)
         {
-            EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                   &transferConfigC, NULL);
+            transferConfigC.srcAddr   = (uint32_t)(&(handle->txData[0]));
+            transferConfigC.srcOffset = 1;
         }
         else
         {
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.destOffset = 0;
-
-            if (handle->txData)
+            transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigC.srcOffset = 0;
+            if (handle->bitsPerFrame <= 8U)
             {
-                transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
-                transferConfigC.srcOffset = 1;
+                handle->txBuffIfNull = dummyData;
             }
             else
             {
-                transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-                transferConfigC.srcOffset = 0;
-                if (handle->bitsPerFrame <= 8)
-                {
-                    handle->txBuffIfNull = DSPI_DUMMY_DATA;
-                }
-                else
-                {
-                    handle->txBuffIfNull = (DSPI_DUMMY_DATA << 8) | DSPI_DUMMY_DATA;
-                }
+                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
             }
-
-            transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-            if (handle->bitsPerFrame <= 8)
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
-                transferConfigC.minorLoopBytes = 1;
-                transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
-            }
-            else
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
-                transferConfigC.minorLoopBytes = 2;
-                if (handle->isThereExtraByte)
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-                }
-                else
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
-                }
-            }
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, softwareTCD);
-                EDMA_EnableAutoStopRequest(handle->edmaTxDataToTxRegHandle->base,
-                                           handle->edmaTxDataToTxRegHandle->channel, false);
-            }
-            else
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, NULL);
-            }
-
-            EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
         }
+
+        transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigC.minorLoopBytes   = 1;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount;
+        }
+        else
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigC.minorLoopBytes   = 2;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount / 2U;
+        }
+
+        EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+
+        EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
     }
 
     EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.
@@ -1176,16 +1460,16 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     Tx DMA request -> channel_C */
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
         }
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
     else
     {
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
 
     return kStatus_Success;
@@ -1196,58 +1480,67 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    bool transferDone,
                                    uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred so far by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1255,7 +1548,8 @@ status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -37,28 +15,33 @@
  * @{
  */
 
-
 /***********************************************************************************************************************
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI master.
+ * @param handle A pointer to the handle for the DSPI master.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
                                                      dspi_master_edma_handle_t *handle,
@@ -68,37 +51,38 @@ typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI slave.
+ * @param handle A pointer to the handle for the DSPI slave.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_slave_edma_transfer_callback_t)(SPI_Type *base,
                                                     dspi_slave_edma_handle_t *handle,
                                                     status_t status,
                                                     void *userData);
 
-/*! @brief DSPI master eDMA transfer handle structure used for transactional API. */
+/*! @brief DSPI master eDMA transfer handle structure used for the transactional API. */
 struct _dspi_master_edma_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer; /*!< Indicates whether the PCS signal keeps active after the last frame transfer.*/
+
+    uint8_t nbytes;         /*!< eDMA minor byte transfer count initially configured. */
+    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
-
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     dspi_master_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                                /*!< Callback user data. */
@@ -110,33 +94,30 @@ struct _dspi_master_edma_handle
     edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
-/*! @brief DSPI slave eDMA transfer handle structure used for transactional API.*/
+/*! @brief DSPI slave eDMA transfer handle structure used for the transactional API.*/
 struct _dspi_slave_edma_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame; /*!< The desired number of bits per frame. */
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
     uint32_t txLastData;   /*!< Used if there is an extra byte when 16bits per frame for DMA purpose.*/
 
-    volatile uint8_t state; /*!< DSPI transfer state.*/
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
-    uint32_t errorCount; /*!< Error count for slave transfer.*/
+    volatile uint8_t state; /*!< DSPI transfer state.*/
 
     dspi_slave_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                               /*!< Callback user data. */
 
     edma_handle_t *edmaRxRegToRxDataHandle; /*!<edma_handle_t handle point used for RxReg to RxData buff*/
     edma_handle_t *edmaTxDataToTxRegHandle; /*!<edma_handle_t handle point used for TxData to TxReg*/
-
-    edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
 /***********************************************************************************************************************
@@ -152,17 +133,18 @@ extern "C" {
  * @brief Initializes the DSPI master eDMA handle.
  *
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
- * specified DSPI instance, user need only call this API once to get the initialized handle.
+ * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request source.
- * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
- * (2)For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
  * @param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
@@ -178,34 +160,49 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI master aborts a transfer which using eDMA.
+ * @brief Transfers a block of data using a eDMA method.
  *
- * This function aborts a transfer which using eDMA.
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle);
 
 /*!
  * @brief Gets the master eDMA transfer count.
  *
- * This function get the master eDMA transfer count.
+ * This function gets the master eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count);
@@ -216,7 +213,8 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request source.
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
  * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaTxDataToTxRegHandle.
  * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
@@ -224,7 +222,7 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_slave_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
  */
@@ -238,25 +236,25 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI slave transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
- * Note that slave EDMA transfer cannot support the situation that transfer_size is 1 when the bitsPerFrame is greater
- * than 8 .
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI slave aborts a transfer which using eDMA.
+ * @brief DSPI slave aborts a transfer which is using eDMA.
  *
- * This function aborts a transfer which using eDMA.
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle);
 
@@ -266,8 +264,8 @@ void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handl
  * This function gets the slave eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred so far by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_edma.c
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "fsl_edma.h"
 
@@ -63,11 +63,13 @@ static void EDMA_InstallTCD(DMA_Type *base, uint32_t channel, edma_tcd_t *tcd);
 /*! @brief Array to map EDMA instance number to base pointer. */
 static DMA_Type *const s_edmaBases[] = DMA_BASE_PTRS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Array to map EDMA instance number to clock name. */
 static const clock_ip_name_t s_edmaClockName[] = EDMA_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Array to map EDMA instance number to IRQ number. */
-static const IRQn_Type s_edmaIRQNumber[] = DMA_CHN_IRQS;
+static const IRQn_Type s_edmaIRQNumber[][FSL_FEATURE_EDMA_MODULE_CHANNEL] = DMA_CHN_IRQS;
 
 /*! @brief Pointers to transfer handle for each EDMA channel. */
 static edma_handle_t *s_EDMAHandle[FSL_FEATURE_EDMA_MODULE_CHANNEL * FSL_FEATURE_SOC_EDMA_COUNT];
@@ -81,7 +83,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_EDMA_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_edmaBases); instance++)
     {
         if (s_edmaBases[instance] == base)
         {
@@ -89,7 +91,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_EDMA_COUNT);
+    assert(instance < ARRAY_SIZE(s_edmaBases));
 
     return instance;
 }
@@ -122,8 +124,10 @@ void EDMA_Init(DMA_Type *base, const edma_config_t *config)
 
     uint32_t tmpreg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Ungate EDMA periphral clock */
     CLOCK_EnableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
     /* Configure EDMA peripheral according to the configuration structure. */
     tmpreg = base->CR;
     tmpreg &= ~(DMA_CR_ERCA_MASK | DMA_CR_HOE_MASK | DMA_CR_CLM_MASK | DMA_CR_EDBG_MASK);
@@ -134,8 +138,10 @@ void EDMA_Init(DMA_Type *base, const edma_config_t *config)
 
 void EDMA_Deinit(DMA_Type *base)
 {
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Gate EDMA periphral clock */
     CLOCK_DisableClock(s_edmaClockName[EDMA_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void EDMA_GetDefaultConfig(edma_config_t *config)
@@ -409,46 +415,32 @@ void EDMA_TcdDisableInterrupts(edma_tcd_t *tcd, uint32_t mask)
     }
 }
 
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel)
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel)
 {
     assert(channel < FSL_FEATURE_EDMA_MODULE_CHANNEL);
 
-    uint32_t nbytes = 0;
-    uint32_t remainingBytes = 0;
+    uint32_t remainingCount = 0;
 
     if (DMA_CSR_DONE_MASK & base->TCD[channel].CSR)
     {
-        remainingBytes = 0;
+        remainingCount = 0;
     }
     else
     {
-        /* Calculate the nbytes */
-        if (base->TCD[channel].NBYTES_MLOFFYES & (DMA_NBYTES_MLOFFYES_SMLOE_MASK | DMA_NBYTES_MLOFFYES_DMLOE_MASK))
-        {
-            nbytes = (base->TCD[channel].NBYTES_MLOFFYES & DMA_NBYTES_MLOFFYES_NBYTES_MASK) >>
-                     DMA_NBYTES_MLOFFYES_NBYTES_SHIFT;
-        }
-        else
-        {
-            nbytes =
-                (base->TCD[channel].NBYTES_MLOFFNO & DMA_NBYTES_MLOFFNO_NBYTES_MASK) >> DMA_NBYTES_MLOFFNO_NBYTES_SHIFT;
-        }
         /* Calculate the unfinished bytes */
         if (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_ELINK_MASK)
         {
-            remainingBytes = ((base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >>
-                              DMA_CITER_ELINKYES_CITER_SHIFT) *
-                             nbytes;
+            remainingCount =
+                (base->TCD[channel].CITER_ELINKYES & DMA_CITER_ELINKYES_CITER_MASK) >> DMA_CITER_ELINKYES_CITER_SHIFT;
         }
         else
         {
-            remainingBytes =
-                ((base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT) *
-                nbytes;
+            remainingCount =
+                (base->TCD[channel].CITER_ELINKNO & DMA_CITER_ELINKNO_CITER_MASK) >> DMA_CITER_ELINKNO_CITER_SHIFT;
         }
     }
 
-    return remainingBytes;
+    return remainingCount;
 }
 
 uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel)
@@ -497,14 +489,19 @@ void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel)
     uint32_t channelIndex;
     edma_tcd_t *tcdRegs;
 
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
+
     handle->base = base;
     handle->channel = channel;
     /* Get the DMA instance number */
     edmaInstance = EDMA_GetInstance(base);
     channelIndex = (edmaInstance * FSL_FEATURE_EDMA_MODULE_CHANNEL) + channel;
     s_EDMAHandle[channelIndex] = handle;
+
     /* Enable NVIC interrupt */
-    EnableIRQ(s_edmaIRQNumber[channelIndex]);
+    EnableIRQ(s_edmaIRQNumber[edmaInstance][channel]);
+
     /*
        Reset TCD registers to zero. Unlike the EDMA_TcdReset(DREQ will be set),
        CSR will be 0. Because in order to suit EDMA busy check mechanism in
@@ -829,7 +826,7 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
     {
         (handle->callback)(handle, handle->userData, true, 0);
     }
-    else /* Use the TCD queue. */
+    else /* Use the TCD queue. Please refer to the API descriptions in the eDMA header file for detailed information. */
     {
         uint32_t sga = handle->base->TCD[handle->channel].DLAST_SGA;
         uint32_t sga_index;
@@ -839,19 +836,19 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
 
         /* Check if transfer is already finished. */
         transfer_done = ((handle->base->TCD[handle->channel].CSR & DMA_CSR_DONE_MASK) != 0);
-        /* Get the offset of the current transfer TCD blcoks. */
+        /* Get the offset of the next transfer TCD blcoks to be loaded into the eDMA engine. */
         sga -= (uint32_t)handle->tcdPool;
-        /* Get the index of the current transfer TCD blcoks. */
+        /* Get the index of the next transfer TCD blcoks to be loaded into the eDMA engine. */
         sga_index = sga / sizeof(edma_tcd_t);
         /* Adjust header positions. */
         if (transfer_done)
         {
-            /* New header shall point to the next TCD (current one is already finished) */
+            /* New header shall point to the next TCD to be loaded (current one is already finished) */
             new_header = sga_index;
         }
         else
         {
-            /* New header shall point to this descriptor (not finished yet) */
+            /* New header shall point to this descriptor currently loaded (not finished yet) */
             new_header = sga_index ? sga_index - 1U : handle->tcdSize - 1U;
         }
         /* Calculate the number of finished TCDs */
@@ -863,7 +860,7 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
             }
             else
             {
-                /* Internal error occurs. */
+                /* No TCD in the memory are going to be loaded or internal error occurs. */
                 tcds_done = 0;
             }
         }
@@ -875,9 +872,9 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
                 tcds_done += handle->tcdSize;
             }
         }
-        /* Advance header to the point beyond the last finished TCD block. */
+        /* Advance header which points to the TCD to be loaded into the eDMA engine from memory. */
         handle->header = new_header;
-        /* Release TCD blocks. */
+        /* Release TCD blocks. tcdUsed is the TCD number which can be used/loaded in the memory pool. */
         handle->tcdUsed -= tcds_done;
         /* Invoke callback function. */
         if (handle->callback)
@@ -937,12 +934,260 @@ void DMA0_37_DriverIRQHandler(void)
         EDMA_HandleIRQ(s_EDMAHandle[7]);
     }
 }
+
+#if defined(DMA1)
+void DMA1_04_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA1_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA1_26_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA1_37_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+#endif
 #endif /* 8 channels (Shared) */
+
+/* 16 channels (Shared): K32H844P */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 16U
+
+void DMA0_08_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+}
+
+void DMA0_19_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+}
+
+void DMA0_210_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+}
+
+void DMA0_311_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+}
+
+void DMA0_412_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA0_513_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA0_614_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA0_715_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+
+#if defined(DMA1)
+void DMA1_08_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+}
+
+void DMA1_19_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+}
+
+void DMA1_210_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+}
+
+void DMA1_311_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+}
+
+void DMA1_412_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA1_513_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA1_614_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA1_715_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA1, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA1, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif
+#endif /* 16 channels (Shared) */
 
 /* 32 channels (Shared): k80 */
 #if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
 
-void DMA0_DMA16_IRQHandler(void)
+void DMA0_DMA16_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -954,7 +1199,7 @@ void DMA0_DMA16_IRQHandler(void)
     }
 }
 
-void DMA1_DMA17_IRQHandler(void)
+void DMA1_DMA17_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -966,7 +1211,7 @@ void DMA1_DMA17_IRQHandler(void)
     }
 }
 
-void DMA2_DMA18_IRQHandler(void)
+void DMA2_DMA18_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -978,7 +1223,7 @@ void DMA2_DMA18_IRQHandler(void)
     }
 }
 
-void DMA3_DMA19_IRQHandler(void)
+void DMA3_DMA19_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -990,7 +1235,7 @@ void DMA3_DMA19_IRQHandler(void)
     }
 }
 
-void DMA4_DMA20_IRQHandler(void)
+void DMA4_DMA20_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1002,7 +1247,7 @@ void DMA4_DMA20_IRQHandler(void)
     }
 }
 
-void DMA5_DMA21_IRQHandler(void)
+void DMA5_DMA21_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1014,7 +1259,7 @@ void DMA5_DMA21_IRQHandler(void)
     }
 }
 
-void DMA6_DMA22_IRQHandler(void)
+void DMA6_DMA22_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1026,7 +1271,7 @@ void DMA6_DMA22_IRQHandler(void)
     }
 }
 
-void DMA7_DMA23_IRQHandler(void)
+void DMA7_DMA23_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1038,7 +1283,7 @@ void DMA7_DMA23_IRQHandler(void)
     }
 }
 
-void DMA8_DMA24_IRQHandler(void)
+void DMA8_DMA24_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1050,7 +1295,7 @@ void DMA8_DMA24_IRQHandler(void)
     }
 }
 
-void DMA9_DMA25_IRQHandler(void)
+void DMA9_DMA25_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1062,7 +1307,7 @@ void DMA9_DMA25_IRQHandler(void)
     }
 }
 
-void DMA10_DMA26_IRQHandler(void)
+void DMA10_DMA26_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1074,7 +1319,7 @@ void DMA10_DMA26_IRQHandler(void)
     }
 }
 
-void DMA11_DMA27_IRQHandler(void)
+void DMA11_DMA27_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1086,7 +1331,7 @@ void DMA11_DMA27_IRQHandler(void)
     }
 }
 
-void DMA12_DMA28_IRQHandler(void)
+void DMA12_DMA28_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1098,7 +1343,7 @@ void DMA12_DMA28_IRQHandler(void)
     }
 }
 
-void DMA13_DMA29_IRQHandler(void)
+void DMA13_DMA29_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1110,7 +1355,7 @@ void DMA13_DMA29_IRQHandler(void)
     }
 }
 
-void DMA14_DMA30_IRQHandler(void)
+void DMA14_DMA30_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1122,7 +1367,7 @@ void DMA14_DMA30_IRQHandler(void)
     }
 }
 
-void DMA15_DMA31_IRQHandler(void)
+void DMA15_DMA31_DriverIRQHandler(void)
 {
     if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
     {
@@ -1134,6 +1379,202 @@ void DMA15_DMA31_IRQHandler(void)
     }
 }
 #endif /* 32 channels (Shared) */
+
+/* 32 channels (Shared): MCIMX7U5_M4 */
+#if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL == 32U
+
+void DMA0_0_4_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 0U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[0]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 4U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[4]);
+    }
+}
+
+void DMA0_1_5_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 1U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[1]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 5U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[5]);
+    }
+}
+
+void DMA0_2_6_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 2U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[2]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 6U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[6]);
+    }
+}
+
+void DMA0_3_7_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 3U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[3]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 7U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[7]);
+    }
+}
+
+void DMA0_8_12_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 8U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[8]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 12U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[12]);
+    }
+}
+
+void DMA0_9_13_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 9U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[9]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 13U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[13]);
+    }
+}
+
+void DMA0_10_14_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 10U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[10]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 14U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[14]);
+    }
+}
+
+void DMA0_11_15_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 11U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[11]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 15U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[15]);
+    }
+}
+
+void DMA0_16_20_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 16U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[16]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 20U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[20]);
+    }
+}
+
+void DMA0_17_21_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 17U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[17]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 21U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[21]);
+    }
+}
+
+void DMA0_18_22_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 18U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[18]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 22U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[22]);
+    }
+}
+
+void DMA0_19_23_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 19U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[19]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 23U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[23]);
+    }
+}
+
+void DMA0_24_28_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 24U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[24]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 28U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[28]);
+    }
+}
+
+void DMA0_25_29_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 25U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[25]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 29U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[29]);
+    }
+}
+
+void DMA0_26_30_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 26U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[26]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 30U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[30]);
+    }
+}
+
+void DMA0_27_31_DriverIRQHandler(void)
+{
+    if ((EDMA_GetChannelStatusFlags(DMA0, 27U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[27]);
+    }
+    if ((EDMA_GetChannelStatusFlags(DMA0, 31U) & kEDMA_InterruptFlag) != 0U)
+    {
+        EDMA_HandleIRQ(s_EDMAHandle[31]);
+    }
+}
+#endif /* 32 channels (Shared): MCIMX7U5 */
 
 /* 4 channels (No Shared): kv10  */
 #if defined(FSL_FEATURE_EDMA_MODULE_CHANNEL) && FSL_FEATURE_EDMA_MODULE_CHANNEL > 0

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_edma.h
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #ifndef _FSL_EDMA_H_
 #define _FSL_EDMA_H_
@@ -45,7 +45,7 @@
 /*! @name Driver version */
 /*@{*/
 /*! @brief eDMA driver version */
-#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 1)) /*!< Version 2.0.1. */
+#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 1)) /*!< Version 2.1.1. */
 /*@}*/
 
 /*! @brief Compute the offset unit from DCHPRI3 */
@@ -77,28 +77,28 @@ typedef enum _edma_modulo
     kEDMA_Modulo128bytes,       /*!< Circular buffer size is 128 bytes. */
     kEDMA_Modulo256bytes,       /*!< Circular buffer size is 256 bytes. */
     kEDMA_Modulo512bytes,       /*!< Circular buffer size is 512 bytes. */
-    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1K bytes. */
-    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2K bytes. */
-    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4K bytes. */
-    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8K bytes. */
-    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16K bytes. */
-    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32K bytes. */
-    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64K bytes. */
-    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128K bytes. */
-    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256K bytes. */
-    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512K bytes. */
-    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1M bytes. */
-    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2M bytes. */
-    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4M bytes. */
-    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8M bytes. */
-    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16M bytes. */
-    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32M bytes. */
-    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64M bytes. */
-    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128M bytes. */
-    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256M bytes. */
-    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512M bytes. */
-    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1G bytes. */
-    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2G bytes. */
+    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1 K bytes. */
+    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2 K bytes. */
+    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4 K bytes. */
+    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8 K bytes. */
+    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16 K bytes. */
+    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32 K bytes. */
+    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64 K bytes. */
+    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128 K bytes. */
+    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256 K bytes. */
+    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512 K bytes. */
+    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1 M bytes. */
+    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2 M bytes. */
+    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4 M bytes. */
+    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8 M bytes. */
+    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16 M bytes. */
+    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32 M bytes. */
+    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64 M bytes. */
+    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128 M bytes. */
+    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256 M bytes. */
+    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512 M bytes. */
+    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1 G bytes. */
+    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2 G bytes. */
 } edma_modulo_t;
 
 /*! @brief Bandwidth control */
@@ -177,7 +177,7 @@ typedef struct _edma_config
                                            the link channel is itself. */
     bool enableHaltOnError;           /*!< Enable (true) transfer halt on error. Any error causes the HALT bit to set.
                                            Subsequently, all service requests are ignored until the HALT bit is cleared.*/
-    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method, or fixed priority
+    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method or fixed priority
                                            arbitration is used for channel selection */
     bool enableDebugMode; /*!< Enable(true) eDMA debug mode. When in debug mode, the eDMA stalls the start of
                                a new channel. Executing channels are allowed to complete. */
@@ -211,15 +211,15 @@ typedef struct _edma_transfer_config
                                                 form the next-state value as each source read is completed. */
     int16_t destOffset;                    /*!< Sign-extended offset applied to the current destination address to
                                                 form the next-state value as each destination write is completed. */
-    uint16_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
+    uint32_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
     uint32_t majorLoopCounts;              /*!< Major loop iteration count. */
 } edma_transfer_config_t;
 
 /*! @brief eDMA channel priority configuration */
 typedef struct _edma_channel_Preemption_config
 {
-    bool enableChannelPreemption; /*!< If true: channel can be suspended by other channel with higher priority */
-    bool enablePreemptAbility;    /*!< If true: channel can suspend other channel with low priority */
+    bool enableChannelPreemption; /*!< If true: a channel can be suspended by other channel with higher priority */
+    bool enablePreemptAbility;    /*!< If true: a channel can suspend other channel with low priority */
     uint8_t channelPriority;      /*!< Channel priority */
 } edma_channel_Preemption_config_t;
 
@@ -228,7 +228,7 @@ typedef struct _edma_minor_offset_config
 {
     bool enableSrcMinorOffset;  /*!< Enable(true) or Disable(false) source minor loop offset. */
     bool enableDestMinorOffset; /*!< Enable(true) or Disable(false) destination minor loop offset. */
-    uint32_t minorOffset;       /*!< Offset for minor loop mapping. */
+    uint32_t minorOffset;       /*!< Offset for a minor loop mapping. */
 } edma_minor_offset_config_t;
 
 /*!
@@ -255,20 +255,21 @@ typedef struct _edma_tcd
 /*! @brief Callback for eDMA */
 struct _edma_handle;
 
-/*! @brief Define Callback function for eDMA. */
+/*! @brief Define callback function for eDMA. */
 typedef void (*edma_callback)(struct _edma_handle *handle, void *userData, bool transferDone, uint32_t tcds);
 
 /*! @brief eDMA transfer handle structure */
 typedef struct _edma_handle
 {
-    edma_callback callback;  /*!< Callback function for major count exhausted. */
-    void *userData;          /*!< Callback function parameter. */
-    DMA_Type *base;          /*!< eDMA peripheral base address. */
-    edma_tcd_t *tcdPool;     /*!< Pointer to memory stored TCDs. */
-    uint8_t channel;         /*!< eDMA channel number. */
-    volatile int8_t header;  /*!< The first TCD index. */
-    volatile int8_t tail;    /*!< The last TCD index. */
-    volatile int8_t tcdUsed; /*!< The number of used TCD slots. */
+    edma_callback callback; /*!< Callback function for major count exhausted. */
+    void *userData;         /*!< Callback function parameter. */
+    DMA_Type *base;         /*!< eDMA peripheral base address. */
+    edma_tcd_t *tcdPool;    /*!< Pointer to memory stored TCDs. */
+    uint8_t channel;        /*!< eDMA channel number. */
+    volatile int8_t header; /*!< The first TCD index. Should point to the next TCD to be loaded into the eDMA engine. */
+    volatile int8_t tail;   /*!< The last TCD index. Should point to the next TCD to be stored into the memory pool. */
+    volatile int8_t tcdUsed; /*!< The number of used TCD slots. Should reflect the number of TCDs can be used/loaded in
+                                the memory. */
     volatile int8_t tcdSize; /*!< The total number of TCD slots in the queue. */
     uint8_t flags;           /*!< The status of the current channel. */
 } edma_handle_t;
@@ -281,24 +282,24 @@ extern "C" {
 #endif /* __cplusplus */
 
 /*!
- * @name eDMA initialization and De-initialization
+ * @name eDMA initialization and de-initialization
  * @{
  */
 
 /*!
- * @brief Initializes eDMA peripheral.
+ * @brief Initializes the eDMA peripheral.
  *
  * This function ungates the eDMA clock and configures the eDMA peripheral according
  * to the configuration structure.
  *
  * @param base eDMA peripheral base address.
- * @param config Pointer to configuration structure, see "edma_config_t".
- * @note This function enable the minor loop map feature.
+ * @param config A pointer to the configuration structure, see "edma_config_t".
+ * @note This function enables the minor loop map feature.
  */
 void EDMA_Init(DMA_Type *base, const edma_config_t *config);
 
 /*!
- * @brief Deinitializes eDMA peripheral.
+ * @brief Deinitializes the eDMA peripheral.
  *
  * This function gates the eDMA clock.
  *
@@ -309,8 +310,8 @@ void EDMA_Deinit(DMA_Type *base);
 /*!
  * @brief Gets the eDMA default configuration structure.
  *
- * This function sets the configuration structure to a default value.
- * The default configuration is set to the following value:
+ * This function sets the configuration structure to default values.
+ * The default configuration is set to the following values.
  * @code
  *   config.enableContinuousLinkMode = false;
  *   config.enableHaltOnError = true;
@@ -318,7 +319,7 @@ void EDMA_Deinit(DMA_Type *base);
  *   config.enableDebugMode = false;
  * @endcode
  *
- * @param config Pointer to eDMA configuration structure.
+ * @param config A pointer to the eDMA configuration structure.
  */
 void EDMA_GetDefaultConfig(edma_config_t *config);
 
@@ -329,13 +330,13 @@ void EDMA_GetDefaultConfig(edma_config_t *config);
  */
 
 /*!
- * @brief Sets all TCD registers to a default value.
+ * @brief Sets all TCD registers to default values.
  *
- * This function sets TCD registers for this channel to default value.
+ * This function sets TCD registers for this channel to default values.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @note This function must not be called while the channel transfer is on-going,
+ * @note This function must not be called while the channel transfer is ongoing
  *       or it causes unpredictable results.
  * @note This function enables the auto stop request feature.
  */
@@ -364,7 +365,7 @@ void EDMA_ResetChannel(DMA_Type *base, uint32_t channel);
  *                do not want to enable scatter/gather feature.
  * @note If nextTcd is not NULL, it means scatter gather feature is enabled
  *       and DREQ bit is cleared in the previous transfer configuration, which
- *       is set in eDMA_ResetChannel.
+ *       is set in the eDMA_ResetChannel.
  */
 void EDMA_SetTransferConfig(DMA_Type *base,
                             uint32_t channel,
@@ -374,12 +375,12 @@ void EDMA_SetTransferConfig(DMA_Type *base,
 /*!
  * @brief Configures the eDMA minor offset feature.
  *
- * Minor offset means signed-extended value added to source address or destination
+ * The minor offset means that the signed-extended value is added to the source address or destination
  * address after each minor loop.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param config Pointer to Minor offset configuration structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_minor_offset_config_t *config);
 
@@ -390,7 +391,7 @@ void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_mino
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number
- * @param config Pointer to channel preemption configuration structure.
+ * @param config A pointer to the channel preemption configuration structure.
  */
 static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
                                                    uint32_t channel,
@@ -407,13 +408,13 @@ static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
 /*!
  * @brief Sets the channel link for the eDMA transfer.
  *
- * This function configures  minor link or major link mode. The minor link means that the channel link is
+ * This function configures either the minor link or the major link mode. The minor link means that the channel link is
  * triggered every time CITER decreases by 1. The major link means that the channel link is triggered when the CITER is
  * exhausted.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param type Channel link type, it can be one of:
+ * @param type A channel link type, which can be one of the following:
  *   @arg kEDMA_LinkNone
  *   @arg kEDMA_MinorLink
  *   @arg kEDMA_MajorLink
@@ -425,13 +426,13 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 /*!
  * @brief Sets the bandwidth for the eDMA transfer.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
  * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -439,7 +440,7 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWidth);
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA transfer.
+ * @brief Sets the source modulo and the destination modulo for the eDMA transfer.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
@@ -447,8 +448,8 @@ void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWi
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -458,7 +459,7 @@ void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, e
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable(ture) or disable(false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -475,7 +476,7 @@ static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, boo
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable (true) or disable (false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAutoStopRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -499,7 +500,7 @@ void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mas
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param mask The mask of interrupt source to be set. Use
+ * @param mask The mask of the interrupt source to be set. Use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
@@ -523,8 +524,8 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
 /*!
  * @brief Configures the eDMA TCD transfer attribute.
  *
- * TCD is a transfer control descriptor. The content of the TCD is the same as hardware TCD registers.
- * STCD is used in scatter-gather mode.
+ * The TCD is a transfer control descriptor. The content of the TCD is the same as the hardware TCD registers.
+ * The STCD is used in the scatter-gather mode.
  * This function configures the TCD transfer attribute, including source address, destination address,
  * transfer size, address offset, and so on. It also configures the scatter gather feature if the
  * user supplies the next TCD address.
@@ -542,7 +543,7 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
  * @param config Pointer to eDMA transfer configuration structure.
  * @param nextTcd Pointer to the next TCD structure. It can be NULL if users
  *                do not want to enable scatter/gather feature.
- * @note TCD address should be 32 bytes aligned, or it causes an eDMA error.
+ * @note TCD address should be 32 bytes aligned or it causes an eDMA error.
  * @note If the nextTcd is not NULL, the scatter gather feature is enabled
  *       and DREQ bit is cleared in the previous transfer configuration, which
  *       is set in the EDMA_TcdReset.
@@ -552,16 +553,16 @@ void EDMA_TcdSetTransferConfig(edma_tcd_t *tcd, const edma_transfer_config_t *co
 /*!
  * @brief Configures the eDMA TCD minor offset feature.
  *
- * Minor offset is a signed-extended value added to the source address or destination
+ * A minor offset is a signed-extended value added to the source address or a destination
  * address after each minor loop.
  *
- * @param tcd Point to the TCD structure.
- * @param config Pointer to Minor offset configuration structure.
+ * @param tcd A point to the TCD structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_TcdSetMinorOffsetConfig(edma_tcd_t *tcd, const edma_minor_offset_config_t *config);
 
 /*!
- * @brief Sets the channel link for eDMA TCD.
+ * @brief Sets the channel link for the eDMA TCD.
  *
  * This function configures either a minor link or a major link. The minor link means the channel link is
  * triggered every time CITER decreases by 1. The major link means that the channel link  is triggered when the CITER is
@@ -580,11 +581,11 @@ void EDMA_TcdSetChannelLink(edma_tcd_t *tcd, edma_channel_link_type_t type, uint
 /*!
  * @brief Sets the bandwidth for the eDMA TCD.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
- * until the minor count is exhausted. Bandwidth forces the eDMA to stall after the completion of
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
- * @param tcd Point to the TCD structure.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param tcd A pointer to the TCD structure.
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -598,15 +599,15 @@ static inline void EDMA_TcdSetBandWidth(edma_tcd_t *tcd, edma_bandwidth_t bandWi
 }
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA TCD.
+ * @brief Sets the source modulo and the destination modulo for the eDMA TCD.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
  * queue easily.
  *
- * @param tcd Point to the TCD structure.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param tcd A pointer to the TCD structure.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -615,8 +616,8 @@ void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t d
  *
  * If enabling the auto stop request, the eDMA hardware automatically disables the hardware channel request.
  *
- * @param tcd Point to the TCD structure.
- * @param enable The command for enable(ture) or disable(false).
+ * @param tcd A pointer to the TCD structure.
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_TcdEnableAutoStopRequest(edma_tcd_t *tcd, bool enable)
 {
@@ -681,7 +682,7 @@ static inline void EDMA_DisableChannelRequest(DMA_Type *base, uint32_t channel)
 }
 
 /*!
- * @brief Starts the eDMA transfer by software trigger.
+ * @brief Starts the eDMA transfer by using the software trigger.
  *
  * This function starts a minor loop transfer.
  *
@@ -702,25 +703,34 @@ static inline void EDMA_TriggerChannelStart(DMA_Type *base, uint32_t channel)
  */
 
 /*!
- * @brief Gets the Remaining bytes from the eDMA current channel TCD.
+ * @brief Gets the remaining major loop count from the eDMA current channel TCD.
  *
  * This function checks the TCD (Task Control Descriptor) status for a specified
- * eDMA channel and returns the the number of bytes that have not finished.
+ * eDMA channel and returns the the number of major loop count that has not finished.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @return Bytes have not been transferred yet for the current TCD.
- * @note This function can only be used to get unfinished bytes of transfer without
- *       the next TCD, or it might be inaccuracy.
+ * @return Major loop count which has not been transferred yet for the current TCD.
+ * @note 1. This function can only be used to get unfinished major loop count of transfer without
+ *          the next TCD, or it might be inaccuracy.
+ *       2. The unfinished/remaining transfer bytes cannot be obtained directly from registers while
+ *          the channel is running.
+ *          Because to calculate the remaining bytes, the initial NBYTES configured in DMA_TCDn_NBYTES_MLNO
+ *          register is needed while the eDMA IP does not support getting it while a channel is active.
+ *          In another word, the NBYTES value reading is always the actual (decrementing) NBYTES value the dma_engine
+ *          is working with while a channel is running.
+ *          Consequently, to get the remaining transfer bytes, a software-saved initial value of NBYTES (for example
+ *          copied before enabling the channel) is needed. The formula to calculate it is shown below:
+ *          RemainingBytes = RemainingMajorLoopCount * NBYTES(initially configured)
  */
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel);
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel);
 
 /*!
  * @brief Gets the eDMA channel error status flags.
  *
  * @param base eDMA peripheral base address.
  * @return The mask of error status flags. Users need to use the
- *         _edma_error_status_flags type to decode the return variables.
+*         _edma_error_status_flags type to decode the return variables.
  */
 static inline uint32_t EDMA_GetErrorStatusFlags(DMA_Type *base)
 {
@@ -755,8 +765,8 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 /*!
  * @brief Creates the eDMA handle.
  *
- * This function is called if using transaction API for eDMA. This function
- * initializes the internal state of eDMA handle.
+ * This function is called if using the transactional API for eDMA. This function
+ * initializes the internal state of the eDMA handle.
  *
  * @param handle eDMA handle pointer. The eDMA handle stores callback function and
  *               parameters.
@@ -766,12 +776,12 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel);
 
 /*!
- * @brief Installs the TCDs memory pool into eDMA handle.
+ * @brief Installs the TCDs memory pool into the eDMA handle.
  *
  * This function is called after the EDMA_CreateHandle to use scatter/gather feature.
  *
  * @param handle eDMA handle pointer.
- * @param tcdPool Memory pool to store TCDs. It must be 32 bytes aligned.
+ * @param tcdPool A memory pool to store TCDs. It must be 32 bytes aligned.
  * @param tcdSize The number of TCD slots.
  */
 void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t tcdSize);
@@ -779,12 +789,12 @@ void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t 
 /*!
  * @brief Installs a callback function for the eDMA transfer.
  *
- * This callback is called in eDMA IRQ handler. Use the callback to do something after
+ * This callback is called in the eDMA IRQ handler. Use the callback to do something after
  * the current major loop transfer completes.
  *
  * @param handle eDMA handle pointer.
  * @param callback eDMA callback function pointer.
- * @param userData Parameter for callback function.
+ * @param userData A parameter for the callback function.
  */
 void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userData);
 
@@ -802,8 +812,8 @@ void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userD
  * @param transferBytes eDMA transfer bytes to be transferred.
  * @param type eDMA transfer type.
  * @note The data address and the data width must be consistent. For example, if the SRC
- *       is 4 bytes, so the source address must be 4 bytes aligned, or it shall result in
- *       source address error(SAE).
+ *       is 4 bytes, the source address must be 4 bytes aligned, or it results in
+ *       source address error (SAE).
  */
 void EDMA_PrepareTransfer(edma_transfer_config_t *config,
                           void *srcAddr,
@@ -818,7 +828,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
  * @brief Submits the eDMA transfer request.
  *
  * This function submits the eDMA transfer request according to the transfer configuration structure.
- * If the user submits the transfer request repeatedly, this function packs an unprocessed request as
+ * If submitting the transfer request repeatedly, this function packs an unprocessed request as
  * a TCD and enables scatter/gather feature to process it in the next time.
  *
  * @param handle eDMA handle pointer.
@@ -830,7 +840,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
 status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t *config);
 
 /*!
- * @brief eDMA start transfer.
+ * @brief eDMA starts transfer.
  *
  * This function enables the channel request. Users can call this function after submitting the transfer request
  * or before submitting the transfer request.
@@ -840,7 +850,7 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
 void EDMA_StartTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA stop transfer.
+ * @brief eDMA stops transfer.
  *
  * This function disables the channel request to pause the transfer. Users can call EDMA_StartTransfer()
  * again to resume the transfer.
@@ -850,7 +860,7 @@ void EDMA_StartTransfer(edma_handle_t *handle);
 void EDMA_StopTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA abort transfer.
+ * @brief eDMA aborts transfer.
  *
  * This function disables the channel request and clear transfer status bits.
  * Users can submit another transfer after calling this API.
@@ -860,10 +870,30 @@ void EDMA_StopTransfer(edma_handle_t *handle);
 void EDMA_AbortTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA IRQ handler for current major loop transfer complete.
+ * @brief eDMA IRQ handler for the current major loop transfer completion.
  *
- * This function clears the channel major interrupt flag and call
+ * This function clears the channel major interrupt flag and calls
  * the callback function if it is not NULL.
+ *
+ * Note:
+ * For the case using TCD queue, when the major iteration count is exhausted, additional operations are performed.
+ * These include the final address adjustments and reloading of the BITER field into the CITER.
+ * Assertion of an optional interrupt request also occurs at this time, as does a possible fetch of a new TCD from
+ * memory using the scatter/gather address pointer included in the descriptor (if scatter/gather is enabled).
+ *
+ * For instance, when the time interrupt of TCD[0] happens, the TCD[1] has already been loaded into the eDMA engine.
+ * As sga and sga_index are calculated based on the DLAST_SGA bitfield lies in the TCD_CSR register, the sga_index
+ * in this case should be 2 (DLAST_SGA of TCD[1] stores the address of TCD[2]). Thus, the "tcdUsed" updated should be
+ * (tcdUsed - 2U) which indicates the number of TCDs can be loaded in the memory pool (because TCD[0] and TCD[1] have
+ * been loaded into the eDMA engine at this point already.).
+ *
+ * For the last two continuous ISRs in a scatter/gather process, they  both load the last TCD (The last ISR does not
+ * load a new TCD) from the memory pool to the eDMA engine when major loop completes.
+ * Therefore, ensure that the header and tcdUsed updated are identical for them.
+ * tcdUsed are both 0 in this case as no TCD to be loaded.
+ *
+ * See the "eDMA basic data flow" in the eDMA Functional description section of the Reference Manual for
+ * further details.
  *
  * @param handle eDMA handle pointer.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_i2c.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -76,6 +76,19 @@ typedef void (*i2c_isr_t)(I2C_Type *base, void *i2cHandle);
 uint32_t I2C_GetInstance(I2C_Type *base);
 
 /*!
+* @brief Set SCL/SDA hold time, this API receives SCL stop hold time, calculate the
+* closest SCL divider and MULT value for the SDA hold time, SCL start and SCL stop
+* hold time. To reduce the ROM size, SDA/SCL hold value mapping table is not provided,
+* assume SCL divider = SCL stop hold value *2 to get the closest SCL divider value and MULT
+* value, then the related SDA hold time, SCL start and SCL stop hold time is used.
+*
+* @param base I2C peripheral base address.
+* @param sourceClock_Hz I2C functional clock frequency in Hertz.
+* @param sclStopHoldTime_ns SCL stop hold time in ns.
+*/
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz);
+
+/*!
  * @brief Set up master transfer, send slave address and decide the initial
  * transfer state.
  *
@@ -137,8 +150,10 @@ static I2C_Type *const s_i2cBases[] = I2C_BASE_PTRS;
 /*! @brief Pointers to i2c IRQ number for each instance. */
 static const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to i2c clocks for each instance. */
 static const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static i2c_isr_t s_i2cMasterIsr;
@@ -155,7 +170,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_I2C_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -163,16 +178,63 @@ uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_I2C_COUNT);
+    assert(instance < ARRAY_SIZE(s_i2cBases));
 
     return instance;
+}
+
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedSclHoldTime;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult = 0u;
+    uint32_t bestIcr = 0u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    /* SDA hold time = bus period (s) * mul * SDA hold value. */
+    /* SCL start hold time = bus period (s) * mul * SCL start hold value. */
+    /* SCL stop hold time = bus period (s) * mul * SCL stop hold value. */
+
+    for (mult = 0u; (mult <= 2u) && (bestError != 0); ++mult)
+    {
+        multiplier = 1u << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(s_i2cDividerTable[0]); ++i)
+        {
+            /* Assume SCL hold(stop) value = s_i2cDividerTable[i]/2. */
+            computedSclHoldTime = ((multiplier * s_i2cDividerTable[i]) * 500000000U) / sourceClock_Hz;
+            absError = sclStopHoldTime_ns > computedSclHoldTime ? (sclStopHoldTime_ns - computedSclHoldTime) :
+                                                                  (computedSclHoldTime - sclStopHoldTime_ns);
+
+            if (absError < bestError)
+            {
+                bestMult = mult;
+                bestIcr = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
 }
 
 static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
 {
     status_t result = kStatus_Success;
     i2c_direction_t direction = xfer->direction;
-    uint16_t timeout = UINT16_MAX;
 
     /* Initialize the handle transfer information. */
     handle->transfer = *xfer;
@@ -183,27 +245,13 @@ static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t
     /* Initial transfer state. */
     if (handle->transfer.subaddressSize > 0)
     {
-        handle->state = kSendCommandState;
         if (xfer->direction == kI2C_Read)
         {
             direction = kI2C_Write;
         }
     }
-    else
-    {
-        handle->state = kCheckAddressState;
-    }
 
-    /* Wait until the data register is ready for transmit. */
-    while ((!(base->S & kI2C_TransferCompleteFlag)) && (--timeout))
-    {
-    }
-
-    /* Failed to start the transfer. */
-    if (timeout == 0)
-    {
-        return kStatus_I2C_Timeout;
-    }
+    handle->state = kCheckAddressState;
 
     /* Clear all status before transfer. */
     I2C_MasterClearStatusFlags(base, kClearFlags);
@@ -265,32 +313,39 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
         result = kStatus_Success;
     }
 
-    if (result)
-    {
-        return result;
-    }
-
     /* Handle Check address state to check the slave address is Acked in slave
        probe application. */
     if (handle->state == kCheckAddressState)
     {
         if (statusFlags & kI2C_ReceiveNakFlag)
         {
-            return kStatus_I2C_Nak;
+            result = kStatus_I2C_Addr_Nak;
         }
         else
         {
-            if (handle->transfer.direction == kI2C_Write)
+            if (handle->transfer.subaddressSize > 0)
             {
-                /* Next state, send data. */
-                handle->state = kSendDataState;
+                handle->state = kSendCommandState;
             }
             else
             {
-                /* Next state, receive data begin. */
-                handle->state = kReceiveDataBeginState;
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Next state, send data. */
+                    handle->state = kSendDataState;
+                }
+                else
+                {
+                    /* Next state, receive data begin. */
+                    handle->state = kReceiveDataBeginState;
+                }
             }
         }
+    }
+
+    if (result)
+    {
+        return result;
     }
 
     /* Run state machine. */
@@ -375,6 +430,10 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
                     {
                         result = I2C_MasterStop(base);
                     }
+                    else
+                    {
+                        base->C1 |= I2C_C1_TX_MASK;
+                    }
                 }
 
                 /* Send NAK at the last receive byte. */
@@ -407,6 +466,7 @@ static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle)
     {
         s_i2cSlaveIsr(base, handle);
     }
+    __DSB();
 }
 
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz)
@@ -415,14 +475,26 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Temporary register for filter read. */
     uint8_t fltReg;
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    uint8_t c2Reg;
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
     uint8_t s2Reg;
 #endif
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Enable I2C clock. */
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Disable I2C prior to configuring it. */
     base->C1 &= ~(I2C_C1_IICEN_MASK);
@@ -432,14 +504,6 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Configure baud rate. */
     I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
-
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Configure high drive feature. */
-    c2Reg = base->C2;
-    c2Reg &= ~(I2C_C2_HDRS_MASK);
-    c2Reg |= I2C_C2_HDRS(masterConfig->enableHighDrive);
-    base->C2 = c2Reg;
-#endif
 
     /* Read out the FLT register. */
     fltReg = base->FLT;
@@ -472,8 +536,10 @@ void I2C_MasterDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
@@ -482,11 +548,6 @@ void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
 
     /* Default baud rate at 100kbps. */
     masterConfig->baudRate_Bps = 100000U;
-
-/* Default pin high drive is disabled. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    masterConfig->enableHighDrive = false;
-#endif
 
 /* Default stop hold enable is disabled. */
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
@@ -654,7 +715,7 @@ status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_
         base->F = savedMult & (~I2C_F_MULT_MASK);
 
         /* We are already in a transfer, so send a repeated start. */
-        base->C1 |= I2C_C1_RSTA_MASK;
+        base->C1 |= I2C_C1_RSTA_MASK | I2C_C1_TX_MASK;
 
         /* Restore the multiplier factor. */
         base->F = savedMult;
@@ -721,7 +782,7 @@ uint32_t I2C_MasterGetStatusFlags(I2C_Type *base)
     return statusFlags;
 }
 
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     uint8_t statusFlags = 0;
@@ -772,10 +833,19 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
         }
     }
 
+    if (((result == kStatus_Success) && (!(flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
+    {
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Send stop. */
+        result = I2C_MasterStop(base);
+    }
+
     return result;
 }
 
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     volatile uint8_t dummy = 0;
@@ -817,8 +887,16 @@ status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
         /* Single byte use case. */
         if (rxSize == 0)
         {
-            /* Read the final byte. */
-            result = I2C_MasterStop(base);
+            if (!(flags & kI2C_TransferNoStopFlag))
+            {
+                /* Issue STOP command before reading last byte. */
+                result = I2C_MasterStop(base);
+            }
+            else
+            {
+                /* Change direction to Tx to avoid extra clocks. */
+                base->C1 |= I2C_C1_TX_MASK;
+            }
         }
 
         if (rxSize == 1)
@@ -871,72 +949,6 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
         return result;
     }
 
-    /* Send subaddress. */
-    if (xfer->subaddressSize)
-    {
-        do
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear interrupt pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            xfer->subaddressSize--;
-            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
-
-        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
-
-        if (xfer->direction == kI2C_Read)
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            /* Send repeated start and slave address. */
-            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
-
-            /* Return if error. */
-            if (result)
-            {
-                return result;
-            }
-        }
-    }
-
-    /* Wait until address + command transfer complete. */
     while (!(base->S & kI2C_IntPendingFlag))
     {
     }
@@ -949,32 +961,92 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
     {
         if (result == kStatus_I2C_Nak)
         {
+            result = kStatus_I2C_Addr_Nak;
+
             I2C_MasterStop(base);
         }
 
         return result;
     }
 
+    /* Send subaddress. */
+    if (xfer->subaddressSize)
+    {
+        do
+        {
+            /* Clear interrupt pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            xfer->subaddressSize--;
+            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
+
+        if (xfer->direction == kI2C_Read)
+        {
+            /* Clear pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Send repeated start and slave address. */
+            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
+
+            /* Return if error. */
+            if (result)
+            {
+                return result;
+            }
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    result = kStatus_I2C_Addr_Nak;
+
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+        }
+    }
+
     /* Transmit data. */
     if ((xfer->direction == kI2C_Write) && (xfer->dataSize > 0))
     {
         /* Send Data. */
-        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize);
-
-        if (((result == kStatus_Success) && (!(xfer->flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
-        {
-            /* Clear the IICIF flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Send stop. */
-            result = I2C_MasterStop(base);
-        }
+        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     /* Receive Data. */
     if ((xfer->direction == kI2C_Read) && (xfer->dataSize > 0))
     {
-        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize);
+        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     return result;
@@ -1037,11 +1109,37 @@ void I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle)
 {
     assert(handle);
 
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
     /* Disable interrupt. */
     I2C_DisableInterrupts(base, kI2C_GlobalInterruptEnable);
 
     /* Reset the state to idle. */
     handle->state = kIdleState;
+
+    /* Send STOP signal. */
+    if (handle->transfer.direction == kI2C_Read)
+    {
+        base->C1 |= I2C_C1_TXAK_MASK;
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+        dummy = base->D;
+    }
+    else
+    {
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+    }
 }
 
 status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count)
@@ -1075,7 +1173,8 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     if (isDone || result)
     {
         /* Send stop command if transfer done or received Nak. */
-        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak))
+        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak) ||
+            (result == kStatus_I2C_Addr_Nak))
         {
             /* Ensure stop command is a need. */
             if ((base->C1 & I2C_C1_MST_MASK))
@@ -1101,13 +1200,28 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz)
 {
     assert(slaveConfig);
 
     uint8_t tmpReg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Configure addressing mode. */
     switch (slaveConfig->addressingMode)
@@ -1132,14 +1246,10 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg &= ~I2C_C1_WUEN_MASK;
     base->C1 = tmpReg | I2C_C1_WUEN(slaveConfig->enableWakeUp) | I2C_C1_IICEN(slaveConfig->enableSlave);
 
-    /* Configure general call & baud rate control & high drive feature. */
+    /* Configure general call & baud rate control. */
     tmpReg = base->C2;
     tmpReg &= ~(I2C_C2_SBRC_MASK | I2C_C2_GCAEN_MASK);
     tmpReg |= I2C_C2_SBRC(slaveConfig->enableBaudRateCtl) | I2C_C2_GCAEN(slaveConfig->enableGeneralCall);
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    tmpReg &= ~I2C_C2_HDRS_MASK;
-    tmpReg |= I2C_C2_HDRS(slaveConfig->enableHighDrive);
-#endif
     base->C2 = tmpReg;
 
 /* Enable/Disable double buffering. */
@@ -1147,6 +1257,9 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg = base->S2 & (~I2C_S2_DFEN_MASK);
     base->S2 = tmpReg | I2C_S2_DFEN(slaveConfig->enableDoubleBuffering);
 #endif
+
+    /* Set hold time. */
+    I2C_SetHoldTime(base, slaveConfig->sclStopHoldTime_ns, srcClock_Hz);
 }
 
 void I2C_SlaveDeinit(I2C_Type *base)
@@ -1154,8 +1267,10 @@ void I2C_SlaveDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
@@ -1171,11 +1286,6 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
     /* Slave address match waking up MCU from low power mode is disabled. */
     slaveConfig->enableWakeUp = false;
 
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Default pin high drive is disabled. */
-    slaveConfig->enableHighDrive = false;
-#endif
-
     /* Independent slave mode baud rate at maximum frequency is disabled. */
     slaveConfig->enableBaudRateCtl = false;
 
@@ -1183,6 +1293,9 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
     slaveConfig->enableDoubleBuffering = true;
 #endif
+
+    /* Set default SCL stop hold time to 4us which is minimum requirement in I2C spec. */
+    slaveConfig->sclStopHoldTime_ns = 4000;
 
     /* Enable the I2C peripheral. */
     slaveConfig->enableSlave = true;
@@ -1215,7 +1328,7 @@ status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t tx
     /* Read dummy to release bus. */
     dummy = base->D;
 
-    result = I2C_MasterWriteBlocking(base, txBuff, txSize);
+    result = I2C_MasterWriteBlocking(base, txBuff, txSize, kI2C_TransferDefaultFlag);
 
     /* Switch to receive mode. */
     base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
@@ -1323,7 +1436,7 @@ status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle
         handle->isBusy = true;
 
         /* Set up event mask. tx and rx are always enabled. */
-        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent;
+        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent | kI2C_SlaveGenaralcallEvent;
 
         /* Clear all flags. */
         I2C_SlaveClearStatusFlags(base, kClearFlags);
@@ -1412,7 +1525,10 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
             }
         }
 
-        return;
+        if (!(status & kI2C_AddressMatchFlag))
+        {
+            return;
+        }
     }
 #endif /* I2C_HAS_STOP_DETECT */
 
@@ -1482,11 +1598,6 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
         handle->isBusy = true;
         xfer->event = kI2C_SlaveAddressMatchEvent;
 
-        if ((handle->eventMask & xfer->event) && (handle->callback))
-        {
-            handle->callback(base, xfer, handle->userData);
-        }
-
         /* Slave transmit, master reading from slave. */
         if (status & kI2C_TransferDirectionFlag)
         {
@@ -1502,6 +1613,16 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
 
             /* Read dummy to release the bus. */
             dummy = base->D;
+
+            if (dummy == 0)
+            {
+                xfer->event = kI2C_SlaveGenaralcallEvent;
+            }
+        }
+
+        if ((handle->eventMask & xfer->event) && (handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
         }
     }
     /* Check transfer complete flag. */
@@ -1607,27 +1728,30 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
+#if defined(I2C0)
 void I2C0_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C0, s_i2cHandle[0]);
 }
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 1)
+#if defined(I2C1)
 void I2C1_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C1, s_i2cHandle[1]);
 }
-#endif /* I2C COUNT > 1 */
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 2)
+#if defined(I2C2)
 void I2C2_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C2, s_i2cHandle[2]);
 }
-#endif /* I2C COUNT > 2 */
-#if (FSL_FEATURE_SOC_I2C_COUNT > 3)
+#endif
+
+#if defined(I2C3)
 void I2C3_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C3, s_i2cHandle[3]);
 }
-#endif /* I2C COUNT > 3 */
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_i2c.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,15 +37,14 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief I2C driver version 2.0.1. */
-#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*! @brief I2C driver version 2.0.3. */
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 3))
 /*@}*/
 
 #if (defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT || \
@@ -61,6 +60,7 @@ enum _i2c_status
     kStatus_I2C_Nak = MAKE_STATUS(kStatusGroup_I2C, 2),             /*!< NAK received during transfer. */
     kStatus_I2C_ArbitrationLost = MAKE_STATUS(kStatusGroup_I2C, 3), /*!< Arbitration lost during transfer. */
     kStatus_I2C_Timeout = MAKE_STATUS(kStatusGroup_I2C, 4),         /*!< Wait event timeout. */
+    kStatus_I2C_Addr_Nak = MAKE_STATUS(kStatusGroup_I2C, 5),        /*!< NAK received during the address probe. */
 };
 
 /*!
@@ -108,11 +108,11 @@ enum _i2c_interrupt_enable
 #endif                                                       /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
 };
 
-/*! @brief Direction of master and slave transfers. */
+/*! @brief The direction of master and slave transfers. */
 typedef enum _i2c_direction
 {
-    kI2C_Write = 0x0U, /*!< Master transmit to slave. */
-    kI2C_Read = 0x1U,  /*!< Master receive from slave. */
+    kI2C_Write = 0x0U, /*!< Master transmits to the slave. */
+    kI2C_Read = 0x1U,  /*!< Master receives from the slave. */
 } i2c_direction_t;
 
 /*! @brief Addressing mode. */
@@ -125,17 +125,17 @@ typedef enum _i2c_slave_address_mode
 /*! @brief I2C transfer control flag. */
 enum _i2c_master_transfer_flags
 {
-    kI2C_TransferDefaultFlag = 0x0U,       /*!< Transfer starts with a start signal, stops with a stop signal. */
-    kI2C_TransferNoStartFlag = 0x1U,       /*!< Transfer starts without a start signal. */
-    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< Transfer starts with a repeated start signal. */
-    kI2C_TransferNoStopFlag = 0x4U,        /*!< Transfer ends without a stop signal. */
+    kI2C_TransferDefaultFlag = 0x0U,       /*!< A transfer starts with a start signal, stops with a stop signal. */
+    kI2C_TransferNoStartFlag = 0x1U,       /*!< A transfer starts without a start signal. */
+    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< A transfer starts with a repeated start signal. */
+    kI2C_TransferNoStopFlag = 0x4U,        /*!< A transfer ends without a stop signal. */
 };
 
 /*!
  * @brief Set of events sent to the callback for nonblocking slave transfers.
  *
  * These event enumerations are used for two related purposes. First, a bit mask created by OR'ing together
- * events is passed to I2C_SlaveTransferNonBlocking() in order to specify which events to enable.
+ * events is passed to I2C_SlaveTransferNonBlocking() to specify which events to enable.
  * Then, when the slave callback is invoked, it is passed the current event through its @a transfer
  * parameter.
  *
@@ -144,36 +144,34 @@ enum _i2c_master_transfer_flags
 typedef enum _i2c_slave_transfer_event
 {
     kI2C_SlaveAddressMatchEvent = 0x01U, /*!< Received the slave address after a start or repeated start. */
-    kI2C_SlaveTransmitEvent = 0x02U,     /*!< Callback is requested to provide data to transmit
+    kI2C_SlaveTransmitEvent = 0x02U,     /*!< A callback is requested to provide data to transmit
                                                 (slave-transmitter role). */
-    kI2C_SlaveReceiveEvent = 0x04U,      /*!< Callback is requested to provide a buffer in which to place received
+    kI2C_SlaveReceiveEvent = 0x04U,      /*!< A callback is requested to provide a buffer in which to place received
                                                  data (slave-receiver role). */
-    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< Callback needs to either transmit an ACK or NACK. */
+    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< A callback needs to either transmit an ACK or NACK. */
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
     kI2C_SlaveStartEvent = 0x10U, /*!< A start/repeated start was detected. */
 #endif
-    kI2C_SlaveCompletionEvent = 0x20U, /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveCompletionEvent = 0x20U,  /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveGenaralcallEvent = 0x40U, /*!< Received the general call address after a start or repeated start. */
 
-    /*! Bit mask of all available events. */
+    /*! A bit mask of all available events. */
     kI2C_SlaveAllEvents = kI2C_SlaveAddressMatchEvent | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent |
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
                           kI2C_SlaveStartEvent |
 #endif
-                          kI2C_SlaveCompletionEvent,
+                          kI2C_SlaveCompletionEvent | kI2C_SlaveGenaralcallEvent,
 } i2c_slave_transfer_event_t;
 
 /*! @brief I2C master user configuration. */
 typedef struct _i2c_master_config
 {
     bool enableMaster; /*!< Enables the I2C peripheral at initialization time. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
     bool enableStopHold; /*!< Controls the stop hold enable. */
 #endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
-    bool enableDoubleBuffering; /*!< Controls double buffer enable, notice that
+    bool enableDoubleBuffering; /*!< Controls double buffer enable; notice that
                                      enabling the double buffer disables the clock stretch. */
 #endif
     uint32_t baudRate_Bps;     /*!< Baud rate configuration of I2C peripheral. */
@@ -184,19 +182,20 @@ typedef struct _i2c_master_config
 typedef struct _i2c_slave_config
 {
     bool enableSlave;       /*!< Enables the I2C peripheral at initialization time. */
-    bool enableGeneralCall; /*!< Enable general call addressing mode. */
+    bool enableGeneralCall; /*!< Enables the general call addressing mode. */
     bool enableWakeUp;      /*!< Enables/disables waking up MCU from low-power mode. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
-    bool enableDoubleBuffering; /*!< Controls double buffer enable, notice that
+    bool enableDoubleBuffering; /*!< Controls a double buffer enable; notice that
                                      enabling the double buffer disables the clock stretch. */
 #endif
     bool enableBaudRateCtl; /*!< Enables/disables independent slave baud rate on SCL in very fast I2C modes. */
-    uint16_t slaveAddress;  /*!< Slave address configuration. */
-    uint16_t upperAddress;  /*!< Maximum boundary slave address used in range matching mode. */
-    i2c_slave_address_mode_t addressingMode; /*!< Addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint16_t slaveAddress;  /*!< A slave address configuration. */
+    uint16_t upperAddress;  /*!< A maximum boundary slave address used in a range matching mode. */
+    i2c_slave_address_mode_t
+        addressingMode;          /*!< An addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint32_t sclStopHoldTime_ns; /*!< the delay from the rising edge of SCL (I2C clock) to the rising edge of SDA (I2C
+                                    data) while SCL is high (stop condition), SDA hold time and SCL start hold time
+                                    are also configured according to the SCL stop hold time. */
 } i2c_slave_config_t;
 
 /*! @brief I2C master handle typedef. */
@@ -214,13 +213,13 @@ typedef struct _i2c_slave_handle i2c_slave_handle_t;
 /*! @brief I2C master transfer structure. */
 typedef struct _i2c_master_transfer
 {
-    uint32_t flags;            /*!< Transfer flag which controls the transfer. */
+    uint32_t flags;            /*!< A transfer flag which controls the transfer. */
     uint8_t slaveAddress;      /*!< 7-bit slave address. */
-    i2c_direction_t direction; /*!< Transfer direction, read or write. */
-    uint32_t subaddress;       /*!< Sub address. Transferred MSB first. */
-    uint8_t subaddressSize;    /*!< Size of command buffer. */
-    uint8_t *volatile data;    /*!< Transfer buffer. */
-    volatile size_t dataSize;  /*!< Transfer size. */
+    i2c_direction_t direction; /*!< A transfer direction, read or write. */
+    uint32_t subaddress;       /*!< A sub address. Transferred MSB first. */
+    uint8_t subaddressSize;    /*!< A size of the command buffer. */
+    uint8_t *volatile data;    /*!< A transfer buffer. */
+    volatile size_t dataSize;  /*!< A transfer size. */
 } i2c_master_transfer_t;
 
 /*! @brief I2C master handle structure. */
@@ -228,20 +227,21 @@ struct _i2c_master_handle
 {
     i2c_master_transfer_t transfer;                    /*!< I2C master transfer copy. */
     size_t transferSize;                               /*!< Total bytes to be transferred. */
-    uint8_t state;                                     /*!< Transfer state maintained during transfer. */
-    i2c_master_transfer_callback_t completionCallback; /*!< Callback function called when transfer finished. */
-    void *userData;                                    /*!< Callback parameter passed to callback function. */
+    uint8_t state;                                     /*!< A transfer state maintained during transfer. */
+    i2c_master_transfer_callback_t completionCallback; /*!< A callback function called when the transfer is finished. */
+    void *userData;                                    /*!< A callback parameter passed to the callback function. */
 };
 
 /*! @brief I2C slave transfer structure. */
 typedef struct _i2c_slave_transfer
 {
-    i2c_slave_transfer_event_t event; /*!< Reason the callback is being invoked. */
-    uint8_t *volatile data;           /*!< Transfer buffer. */
-    volatile size_t dataSize;         /*!< Transfer size. */
+    i2c_slave_transfer_event_t event; /*!< A reason that the callback is invoked. */
+    uint8_t *volatile data;           /*!< A transfer buffer. */
+    volatile size_t dataSize;         /*!< A transfer size. */
     status_t completionStatus;        /*!< Success or error code describing how the transfer completed. Only applies for
                                          #kI2C_SlaveCompletionEvent. */
-    size_t transferredCount;          /*!< Number of bytes actually transferred since start or last repeated start. */
+    size_t transferredCount; /*!< A number of bytes actually transferred since the start or since the last repeated
+                                start. */
 } i2c_slave_transfer_t;
 
 /*! @brief I2C slave transfer callback typedef. */
@@ -250,11 +250,11 @@ typedef void (*i2c_slave_transfer_callback_t)(I2C_Type *base, i2c_slave_transfer
 /*! @brief I2C slave handle structure. */
 struct _i2c_slave_handle
 {
-    bool isBusy;                            /*!< Whether transfer is busy. */
+    volatile bool isBusy;                   /*!< Indicates whether a transfer is busy. */
     i2c_slave_transfer_t transfer;          /*!< I2C slave transfer copy. */
-    uint32_t eventMask;                     /*!< Mask of enabled events. */
-    i2c_slave_transfer_callback_t callback; /*!< Callback function called at transfer event. */
-    void *userData;                         /*!< Callback parameter passed to callback. */
+    uint32_t eventMask;                     /*!< A mask of enabled events. */
+    i2c_slave_transfer_callback_t callback; /*!< A callback function called at the transfer event. */
+    void *userData;                         /*!< A callback parameter passed to the callback. */
 };
 
 /*******************************************************************************
@@ -274,12 +274,12 @@ extern "C" {
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
  * and configure the I2C with master configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module may cause a hard fault
- * because clock is not enabled. The configuration structure can be filled by user
- * from scratch, or be set with default values by I2C_MasterGetDefaultConfig().
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can be custom filled
+ * or it can be set with default values by using the I2C_MasterGetDefaultConfig().
  * After calling this API, the master is ready to transfer.
- * Example:
+ * This is an example.
  * @code
  * i2c_master_config_t config = {
  * .enableMaster = true,
@@ -292,20 +292,20 @@ extern "C" {
  * @endcode
  *
  * @param base I2C base pointer
- * @param masterConfig pointer to master configuration structure
+ * @param masterConfig A pointer to the master configuration structure
  * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
- * and initializes the I2C with slave configuration.
+ * and initialize the I2C with the slave configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module can cause a hard fault
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
  * because the clock is not enabled. The configuration structure can partly be set
- * with default values by I2C_SlaveGetDefaultConfig(), or can be filled by the user.
- * Example
+ * with default values by I2C_SlaveGetDefaultConfig() or it can be custom filled by the user.
+ * This is an example.
  * @code
  * i2c_slave_config_t config = {
  * .enableSlave = true,
@@ -314,15 +314,17 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
  * .slaveAddress = 0x1DU,
  * .enableWakeUp = false,
  * .enablehighDrive = false,
- * .enableBaudRateCtl = false
+ * .enableBaudRateCtl = false,
+ * .sclStopHoldTime_ns = 4000
  * };
- * I2C_SlaveInit(I2C0, &config);
+ * I2C_SlaveInit(I2C0, &config, 12000000U);
  * @endcode
  *
  * @param base I2C base pointer
- * @param slaveConfig pointer to slave configuration structure
+ * @param slaveConfig A pointer to the slave configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig);
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
@@ -342,28 +344,28 @@ void I2C_SlaveDeinit(I2C_Type *base);
  * @brief  Sets the I2C master configuration structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
- * Use the initialized structure unchanged in I2C_MasterConfigure(), or modify some fields of
- * the structure before calling I2C_MasterConfigure().
- * Example:
+ * Use the initialized structure unchanged in the I2C_MasterConfigure() or modify
+ * the structure before calling the I2C_MasterConfigure().
+ * This is an example.
  * @code
  * i2c_master_config_t config;
  * I2C_MasterGetDefaultConfig(&config);
  * @endcode
- * @param masterConfig Pointer to the master configuration structure.
+ * @param masterConfig A pointer to the master configuration structure.
 */
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig);
 
 /*!
  * @brief  Sets the I2C slave configuration structure to default values.
  *
- * The purpose of this API is to get the configuration structure initialized for use in I2C_SlaveConfigure().
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_SlaveConfigure().
  * Modify fields of the structure before calling the I2C_SlaveConfigure().
- * Example:
+ * This is an example.
  * @code
  * i2c_slave_config_t config;
  * I2C_SlaveGetDefaultConfig(&config);
  * @endcode
- * @param slaveConfig Pointer to the slave configuration structure.
+ * @param slaveConfig A pointer to the slave configuration structure.
  */
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
 
@@ -371,7 +373,7 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
  * @brief Enables or disabless the I2C peripheral operation.
  *
  * @param base I2C base pointer
- * @param enable pass true to enable module, false to disable module
+ * @param enable Pass true to enable and false to disable the module.
  */
 static inline void I2C_Enable(I2C_Type *base, bool enable)
 {
@@ -414,7 +416,7 @@ static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag.
  *
  * @param base I2C base pointer
  * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
@@ -449,7 +451,7 @@ static inline void I2C_MasterClearStatusFlags(I2C_Type *base, uint32_t statusMas
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
  *
   * @param base I2C base pointer
   * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
@@ -581,19 +583,21 @@ status_t I2C_MasterStop(I2C_Type *base);
 status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
 
 /*!
- * @brief Performs a polling send transaction on the I2C bus without a STOP signal.
+ * @brief Performs a polling send transaction on the I2C bus.
  *
  * @param base  The I2C peripheral base pointer.
  * @param txBuff The pointer to the data to be transferred.
  * @param txSize The length in bytes of the data to be transferred.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
  * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags);
 
 /*!
- * @brief Performs a polling receive transaction on the I2C bus with a STOP signal.
+ * @brief Performs a polling receive transaction on the I2C bus.
  *
  * @note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
  * Without stopping the bus prior for the final read, the bus issues another read, resulting
@@ -602,10 +606,12 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
  * @param base I2C peripheral base pointer.
  * @param rxBuff The pointer to the data to store the received data.
  * @param rxSize The length in bytes of the data to be received.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
  */
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags);
 
 /*!
  * @brief Performs a polling send transaction on the I2C bus.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_i2c_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_i2c_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -56,13 +55,14 @@ typedef void (*i2c_master_edma_transfer_callback_t)(I2C_Type *base,
 /*! @brief I2C master eDMA transfer structure. */
 struct _i2c_master_edma_handle
 {
-    i2c_master_transfer_t transfer; /*!< I2C master transfer struct. */
+    i2c_master_transfer_t transfer; /*!< I2C master transfer structure. */
     size_t transferSize;            /*!< Total bytes to be transferred. */
+    uint8_t nbytes;                 /*!< eDMA minor byte transfer count initially configured. */
     uint8_t state;                  /*!< I2C master transfer status. */
     edma_handle_t *dmaHandle;       /*!< The eDMA handler used. */
     i2c_master_edma_transfer_callback_t
-        completionCallback; /*!< Callback function called after eDMA transfer finished. */
-    void *userData;         /*!< Callback parameter passed to callback function. */
+        completionCallback; /*!< A callback function called after the eDMA transfer is finished. */
+    void *userData;         /*!< A callback parameter passed to the callback function. */
 };
 
 /*******************************************************************************
@@ -79,12 +79,12 @@ extern "C" {
  */
 
 /*!
- * @brief Init the I2C handle which is used in transcational functions.
+ * @brief Initializes the I2C handle which is used in transcational functions.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param callback pointer to user callback function.
- * @param userData user param passed to the callback function.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param callback A pointer to the user callback function.
+ * @param userData A user parameter passed to the callback function.
  * @param edmaHandle eDMA handle pointer.
  */
 void I2C_MasterCreateEDMAHandle(I2C_Type *base,
@@ -97,30 +97,30 @@ void I2C_MasterCreateEDMAHandle(I2C_Type *base,
  * @brief Performs a master eDMA non-blocking transfer on the I2C bus.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param xfer pointer to transfer structure of i2c_master_transfer_t.
- * @retval kStatus_Success Sucessully complete the data transmission.
- * @retval kStatus_I2C_Busy Previous transmission still not finished.
- * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param xfer A pointer to the transfer structure of i2c_master_transfer_t.
+ * @retval kStatus_Success Sucessfully completed the data transmission.
+ * @retval kStatus_I2C_Busy A previous transmission is still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, waits for a signal timeout.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
- * @retval kStataus_I2C_Nak Transfer error, receive Nak during transfer.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
 status_t I2C_MasterTransferEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, i2c_master_transfer_t *xfer);
 
 /*!
- * @brief Get master transfer status during a eDMA non-blocking transfer.
+ * @brief Gets a master transfer status during the eDMA non-blocking transfer.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  */
 status_t I2C_MasterTransferGetCountEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, size_t *count);
 
 /*!
- * @brief Abort a master eDMA non-blocking transfer in a early time.
+ * @brief Aborts a master eDMA non-blocking transfer early.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
  */
 void I2C_MasterTransferAbortEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_lpuart.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_lpuart.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,29 +37,27 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief LPUART driver version 2.2.1. */
-#define FSL_LPUART_DRIVER_VERSION (MAKE_VERSION(2, 2, 1))
+/*! @brief LPUART driver version 2.2.3. */
+#define FSL_LPUART_DRIVER_VERSION (MAKE_VERSION(2, 2, 3))
 /*@}*/
 
 /*! @brief Error codes for the LPUART driver. */
 enum _lpuart_status
 {
-    kStatus_LPUART_TxBusy = MAKE_STATUS(kStatusGroup_LPUART, 0),              /*!< TX busy */
-    kStatus_LPUART_RxBusy = MAKE_STATUS(kStatusGroup_LPUART, 1),              /*!< RX busy */
-    kStatus_LPUART_TxIdle = MAKE_STATUS(kStatusGroup_LPUART, 2),              /*!< LPUART transmitter is idle. */
-    kStatus_LPUART_RxIdle = MAKE_STATUS(kStatusGroup_LPUART, 3),              /*!< LPUART receiver is idle. */
-    kStatus_LPUART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 4), /*!< TX FIFO watermark too large  */
-    kStatus_LPUART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 5), /*!< RX FIFO watermark too large  */
-    kStatus_LPUART_FlagCannotClearManually =
-        MAKE_STATUS(kStatusGroup_LPUART, 6),                    /*!< Some flag can't manually clear */
-    kStatus_LPUART_Error = MAKE_STATUS(kStatusGroup_LPUART, 7), /*!< Error happens on LPUART. */
+    kStatus_LPUART_TxBusy = MAKE_STATUS(kStatusGroup_LPUART, 0),                  /*!< TX busy */
+    kStatus_LPUART_RxBusy = MAKE_STATUS(kStatusGroup_LPUART, 1),                  /*!< RX busy */
+    kStatus_LPUART_TxIdle = MAKE_STATUS(kStatusGroup_LPUART, 2),                  /*!< LPUART transmitter is idle. */
+    kStatus_LPUART_RxIdle = MAKE_STATUS(kStatusGroup_LPUART, 3),                  /*!< LPUART receiver is idle. */
+    kStatus_LPUART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 4),     /*!< TX FIFO watermark too large  */
+    kStatus_LPUART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 5),     /*!< RX FIFO watermark too large  */
+    kStatus_LPUART_FlagCannotClearManually = MAKE_STATUS(kStatusGroup_LPUART, 6), /*!< Some flag can't manually clear */
+    kStatus_LPUART_Error = MAKE_STATUS(kStatusGroup_LPUART, 7),                   /*!< Error happens on LPUART. */
     kStatus_LPUART_RxRingBufferOverrun =
         MAKE_STATUS(kStatusGroup_LPUART, 8), /*!< LPUART RX software ring buffer overrun. */
     kStatus_LPUART_RxHardwareOverrun = MAKE_STATUS(kStatusGroup_LPUART, 9), /*!< LPUART RX receiver overrun. */
@@ -67,7 +65,7 @@ enum _lpuart_status
     kStatus_LPUART_FramingError = MAKE_STATUS(kStatusGroup_LPUART, 11),     /*!< LPUART framing error. */
     kStatus_LPUART_ParityError = MAKE_STATUS(kStatusGroup_LPUART, 12),      /*!< LPUART parity error. */
     kStatus_LPUART_BaudrateNotSupport =
-        MAKE_STATUS(kStatusGroup_LPUART, 13),                               /*!< Baudrate is not support in current clock source */
+        MAKE_STATUS(kStatusGroup_LPUART, 13), /*!< Baudrate is not support in current clock source */
 };
 
 /*! @brief LPUART parity mode. */
@@ -81,9 +79,9 @@ typedef enum _lpuart_parity_mode
 /*! @brief LPUART data bits count. */
 typedef enum _lpuart_data_bits
 {
-    kLPUART_EightDataBits = 0x0U,     /*!< Eight data bit */
+    kLPUART_EightDataBits = 0x0U, /*!< Eight data bit */
 #if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
-    kLPUART_SevenDataBits = 0x1U,     /*!< Seven data bit */
+    kLPUART_SevenDataBits = 0x1U, /*!< Seven data bit */
 #endif
 } lpuart_data_bits_t;
 
@@ -168,13 +166,13 @@ enum _lpuart_flags
 #endif
 };
 
-/*! @brief LPUART configure structure. */
+/*! @brief LPUART configuration structure. */
 typedef struct _lpuart_config
 {
-    uint32_t baudRate_Bps;           /*!< LPUART baud rate  */
-    lpuart_parity_mode_t parityMode; /*!< Parity mode, disabled (default), even, odd */
+    uint32_t baudRate_Bps;            /*!< LPUART baud rate  */
+    lpuart_parity_mode_t parityMode;  /*!< Parity mode, disabled (default), even, odd */
     lpuart_data_bits_t dataBitsCount; /*!< Data bits count, eight (default), seven */
-    bool isMsb; /*!< Data bits order, LSB (default), MSB */
+    bool isMsb;                       /*!< Data bits order, LSB (default), MSB */
 #if defined(FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT
     lpuart_stop_bit_count_t stopBitCount; /*!< Number of stop bits, 1 stop bit (default) or 2 stop bits  */
 #endif
@@ -233,35 +231,58 @@ struct _lpuart_handle
 extern "C" {
 #endif /* _cplusplus */
 
+#if defined(FSL_FEATURE_LPUART_HAS_GLOBAL) && FSL_FEATURE_LPUART_HAS_GLOBAL
+
+/*!
+ * @name Software Reset
+ * @{
+ */
+
+/*!
+ * @brief Resets the LPUART using software.
+ *
+ * This function resets all internal logic and registers except the Global Register.
+ * Remains set until cleared by software.
+ *
+ * @param base LPUART peripheral base address.
+ */
+static inline void LPUART_SoftwareReset(LPUART_Type *base)
+{
+    base->GLOBAL |= LPUART_GLOBAL_RST_MASK;
+    base->GLOBAL &= ~LPUART_GLOBAL_RST_MASK;
+}
+/* @} */
+#endif /*FSL_FEATURE_LPUART_HAS_GLOBAL*/
+
 /*!
  * @name Initialization and deinitialization
  * @{
  */
 
 /*!
-* @brief Initializes an LPUART instance with the user configuration structure and the peripheral clock.
-*
-* This function configures the LPUART module with  user-defined settings. Call the LPUART_GetDefaultConfig() function
-* to configure the configuration structure and get the default configuration.
-* The example below shows how to use this API to configure the LPUART.
-* @code
-*  lpuart_config_t lpuartConfig;
-*  lpuartConfig.baudRate_Bps = 115200U;
-*  lpuartConfig.parityMode = kLPUART_ParityDisabled;
-*  lpuartConfig.dataBitsCount = kLPUART_EightDataBits;
-*  lpuartConfig.isMsb = false;
-*  lpuartConfig.stopBitCount = kLPUART_OneStopBit;
-*  lpuartConfig.txFifoWatermark = 0;
-*  lpuartConfig.rxFifoWatermark = 1;
-*  LPUART_Init(LPUART1, &lpuartConfig, 20000000U);
-* @endcode
-*
-* @param base LPUART peripheral base address.
-* @param config Pointer to a user-defined configuration structure.
-* @param srcClock_Hz LPUART clock source frequency in HZ.
-* @retval kStatus_LPUART_BaudrateNotSupport Baudrate is not support in current clock source.
-* @retval kStatus_Success LPUART initialize succeed
-*/
+ * @brief Initializes an LPUART instance with the user configuration structure and the peripheral clock.
+ *
+ * This function configures the LPUART module with user-defined settings. Call the LPUART_GetDefaultConfig() function
+ * to configure the configuration structure and get the default configuration.
+ * The example below shows how to use this API to configure the LPUART.
+ * @code
+ *  lpuart_config_t lpuartConfig;
+ *  lpuartConfig.baudRate_Bps = 115200U;
+ *  lpuartConfig.parityMode = kLPUART_ParityDisabled;
+ *  lpuartConfig.dataBitsCount = kLPUART_EightDataBits;
+ *  lpuartConfig.isMsb = false;
+ *  lpuartConfig.stopBitCount = kLPUART_OneStopBit;
+ *  lpuartConfig.txFifoWatermark = 0;
+ *  lpuartConfig.rxFifoWatermark = 1;
+ *  LPUART_Init(LPUART1, &lpuartConfig, 20000000U);
+ * @endcode
+ *
+ * @param base LPUART peripheral base address.
+ * @param config Pointer to a user-defined configuration structure.
+ * @param srcClock_Hz LPUART clock source frequency in HZ.
+ * @retval kStatus_LPUART_BaudrateNotSupport Baudrate is not support in current clock source.
+ * @retval kStatus_Success LPUART initialize succeed
+ */
 status_t LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcClock_Hz);
 
 /*!
@@ -536,10 +557,10 @@ static inline void LPUART_WriteByte(LPUART_Type *base, uint8_t data)
 }
 
 /*!
- * @brief Reads the RX register.
+ * @brief Reads the receiver register.
  *
  * This function reads data from the receiver register directly. The upper layer must
- * ensure that the RX register is full or that the RX FIFO has data before calling this function.
+ * ensure that the receiver register is full or that the RX FIFO has data before calling this function.
  *
  * @param base LPUART peripheral base address.
  * @return Data read from data register.
@@ -548,8 +569,9 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 {
 #if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
     uint32_t ctrl = base->CTRL;
-    bool isSevenDataBits = ((ctrl & LPUART_CTRL_M7_MASK) ||
-            ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
+    bool isSevenDataBits =
+        ((ctrl & LPUART_CTRL_M7_MASK) ||
+         ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
 
     if (isSevenDataBits)
     {
@@ -565,10 +587,10 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 }
 
 /*!
- * @brief Writes to transmitter register using a blocking method.
+ * @brief Writes to the transmitter register using a blocking method.
  *
  * This function polls the transmitter register, waits for the register to be empty or  for TX FIFO to have
- * room and then writes data to the transmitter buffer.
+ * room, and writes data to the transmitter buffer.
  *
  * @note This function does not check whether all data has been sent out to the bus.
  * Before disabling the transmitter, check the kLPUART_TransmissionCompleteFlag to ensure that the transmit is
@@ -581,10 +603,10 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 void LPUART_WriteBlocking(LPUART_Type *base, const uint8_t *data, size_t length);
 
 /*!
-* @brief Reads the RX data register using a blocking method.
+* @brief Reads the receiver data register using a blocking method.
  *
- * This function polls the RX register, waits for the RX register full or RX FIFO
- * has data then reads data from the TX register.
+ * This function polls the receiver register, waits for the receiver register full or receiver FIFO
+ * has data, and reads data from the TX register.
  *
  * @param base LPUART peripheral base address.
  * @param data Start address of the buffer to store the received data.
@@ -670,7 +692,7 @@ void LPUART_TransferStartRingBuffer(LPUART_Type *base,
                                     size_t ringBufferSize);
 
 /*!
- * @brief Abort the background transfer and uninstall the ring buffer.
+ * @brief Aborts the background transfer and uninstalls the ring buffer.
  *
  * This function aborts the background transfer and uninstalls the ring buffer.
  *
@@ -683,7 +705,7 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle);
  * @brief Aborts the interrupt-driven data transmit.
  *
  * This function aborts the interrupt driven data sending. The user can get the remainBtyes to find out
- * how many bytes are still not sent out.
+ * how many bytes are not sent out.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -691,10 +713,10 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle);
 void LPUART_TransferAbortSend(LPUART_Type *base, lpuart_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to LPUART TX register.
+ * @brief Gets the number of bytes that have been written to the LPUART transmitter register.
  *
  * This function gets the number of bytes that have been written to LPUART TX
- * register by interrupt method.
+ * register by an interrupt method.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -748,7 +770,7 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
 void LPUART_TransferAbortReceive(LPUART_Type *base, lpuart_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of bytes that have been received.
  *
  * This function gets the number of bytes that have been received.
  *

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_lpuart_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_lpuart_edma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -219,6 +219,9 @@ status_t LPUART_SendEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, lpuart
         EDMA_PrepareTransfer(&xferConfig, xfer->data, sizeof(uint8_t), (void *)LPUART_GetDataRegisterAddress(base),
                              sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_MemoryToPeripheral);
 
+        /* Store the initially configured eDMA minor byte transfer count into the LPUART handle */
+        handle->nbytes = sizeof(uint8_t);
+
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->txEdmaHandle, &xferConfig);
         EDMA_StartTransfer(handle->txEdmaHandle);
@@ -256,6 +259,9 @@ status_t LPUART_ReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, lpu
         /* Prepare transfer. */
         EDMA_PrepareTransfer(&xferConfig, (void *)LPUART_GetDataRegisterAddress(base), sizeof(uint8_t), xfer->data,
                              sizeof(uint8_t), sizeof(uint8_t), xfer->dataSize, kEDMA_PeripheralToMemory);
+
+        /* Store the initially configured eDMA minor byte transfer count into the LPUART handle */
+        handle->nbytes = sizeof(uint8_t);
 
         /* Submit transfer. */
         EDMA_SubmitTransfer(handle->rxEdmaHandle, &xferConfig);
@@ -309,7 +315,9 @@ status_t LPUART_TransferGetReceiveCountEDMA(LPUART_Type *base, lpuart_edma_handl
         return kStatus_NoTransferInProgress;
     }
 
-    *count = handle->rxDataSizeAll - EDMA_GetRemainingBytes(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
+    *count = handle->rxDataSizeAll -
+             (uint32_t)handle->nbytes *
+                 EDMA_GetRemainingMajorLoopCount(handle->rxEdmaHandle->base, handle->rxEdmaHandle->channel);
 
     return kStatus_Success;
 }
@@ -325,7 +333,9 @@ status_t LPUART_TransferGetSendCountEDMA(LPUART_Type *base, lpuart_edma_handle_t
         return kStatus_NoTransferInProgress;
     }
 
-    *count = handle->txDataSizeAll - EDMA_GetRemainingBytes(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
+    *count = handle->txDataSizeAll -
+             (uint32_t)handle->nbytes *
+                 EDMA_GetRemainingMajorLoopCount(handle->txEdmaHandle->base, handle->txEdmaHandle->channel);
 
     return kStatus_Success;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_lpuart_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_lpuart_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,7 +39,6 @@
  * @{
  */
 
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -65,6 +64,8 @@ struct _lpuart_edma_handle
 
     edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
     edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
+
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
     volatile uint8_t txState; /*!< TX transfer state. */
     volatile uint8_t rxState; /*!< RX transfer state */
@@ -93,11 +94,11 @@ extern "C" {
  * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
  */
 void LPUART_TransferCreateHandleEDMA(LPUART_Type *base,
-                             lpuart_edma_handle_t *handle,
-                             lpuart_edma_transfer_callback_t callback,
-                             void *userData,
-                             edma_handle_t *txEdmaHandle,
-                             edma_handle_t *rxEdmaHandle);
+                                     lpuart_edma_handle_t *handle,
+                                     lpuart_edma_transfer_callback_t callback,
+                                     void *userData,
+                                     edma_handle_t *txEdmaHandle,
+                                     edma_handle_t *rxEdmaHandle);
 
 /*!
  * @brief Sends data using eDMA.
@@ -150,9 +151,9 @@ void LPUART_TransferAbortSendEDMA(LPUART_Type *base, lpuart_edma_handle_t *handl
 void LPUART_TransferAbortReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to LPUART TX register.
+ * @brief Gets the number of bytes written to the LPUART TX register.
  *
- * This function gets the number of bytes that have been written to LPUART TX
+ * This function gets the number of bytes written to the LPUART TX
  * register by DMA.
  *
  * @param base LPUART peripheral base address.
@@ -165,9 +166,9 @@ void LPUART_TransferAbortReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *ha
 status_t LPUART_TransferGetSendCountEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, uint32_t *count);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of received bytes.
  *
- * This function gets the number of bytes that have been received.
+ * This function gets the number of received bytes.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
@@ -141,13 +141,17 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi.c
@@ -1,38 +1,22 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi.h"
 
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -65,27 +42,27 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
 
 /*!
  * @brief Master fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Master finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
 
 /*!
  * @brief Slave fill up the TX FIFO with data.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
  * @brief Slave finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
- * This is not a public API as it is called from other driver functions.
+ * This is not a public API.
  */
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -100,7 +77,7 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param);
 /*!
  * @brief Master prepare the transfer.
  * Basically it set up dspi_master_handle .
- * This is not a public API as it is called from other driver functions. fsl_dspi_edma.c also call this function.
+ * This is not a public API.
  */
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
 
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -123,11 +100,13 @@ static SPI_Type *const s_dspiBases[] = SPI_BASE_PTRS;
 /*! @brief Pointers to dspi IRQ number for each instance. */
 static IRQn_Type const s_dspiIRQ[] = SPI_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to dspi clocks for each instance. */
 static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to dspi handles for each instance. */
-static void *g_dspiHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
@@ -135,15 +114,22 @@ static dspi_master_isr_t s_dspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_DSPI_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_dspiBases); instance++)
     {
         if (s_dspiBases[instance] == base)
         {
@@ -151,20 +137,80 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_DSPI_COUNT);
+    assert(instance < ARRAY_SIZE(s_dspiBases));
 
     return instance;
 }
 
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+{
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
+}
+
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
+    assert(NULL != masterConfig);
+
     uint32_t temp;
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -173,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -185,48 +229,92 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
-    masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    assert(NULL != masterConfig);
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
+    masterConfig->ctarConfig.bitsPerFrame = 8;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
+
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
+    assert(NULL != slaveConfig);
+
     uint32_t temp = 0;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* enable DSPI clock */
     CLOCK_EnableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
@@ -239,40 +327,66 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
 
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    slaveConfig->whichCtar = kDSPI_Ctar0;
-    slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    assert(NULL != slaveConfig);
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
+    slaveConfig->ctarConfig.bitsPerFrame = 8;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
     DSPI_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* disable DSPI clock */
     CLOCK_DisableClock(s_dspiClock[DSPI_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pcs_polarity_config_t activeLowOrHigh)
@@ -293,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -312,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -378,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -402,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -424,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -455,83 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    assert(NULL != command);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    assert(NULL != command);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    /* First, clear Transmit Complete Flag (TCF) */
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
+
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -540,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -556,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_MASTER_DUMMY_DATA;
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -574,44 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isEndOfQueue = true;
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -620,34 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        if (rxData != NULL)
-                        {
-                            *(rxData) = DSPI_ReadData(base);
-                            rxData++;
-                        }
-                        else
-                        {
-                            DSPI_ReadData(base);
-                        }
-                        remainingReceiveByteCount--;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -659,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -700,54 +1013,39 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *(rxData) = DSPI_ReadData(base);
-                        rxData++;
-                    }
-                    else
-                    {
-                        DSPI_ReadData(base);
-                    }
-                    remainingReceiveByteCount--;
+                        if (rxData != NULL)
+                        {
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
+                            rxData++;
+                        }
+                        else
+                        {
+                            (void)DSPI_ReadData(base);
+                        }
+                        remainingReceiveByteCount--;
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
-                    {
-                        wordReceived = DSPI_ReadData(base);
-
-                        if (rxData != NULL)
-                        {
-                            *rxData = wordReceived;
-                            ++rxData;
-                            *rxData = wordReceived >> 8;
-                            ++rxData;
-                        }
-                        remainingReceiveByteCount -= 2;
-
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
-                    }
-                }
-
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
-                {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -755,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -768,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -821,24 +1120,28 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    wordReceived = DSPI_ReadData(base);
-
-                    if (rxData != NULL)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        *rxData = wordReceived;
-                        ++rxData;
-                        *rxData = wordReceived >> 8;
-                        ++rxData;
-                    }
-                    remainingReceiveByteCount -= 2;
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                    DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        if (rxData != NULL)
+                        {
+                            *rxData = (uint8_t)wordReceived;
+                            ++rxData;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
+                            ++rxData;
+                        }
+                        remainingReceiveByteCount -= 2U;
+
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
+                    }
                 }
             }
         }
@@ -849,27 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    dspi_command_data_config_t commandStruct;
+    assert(NULL != handle);
+    assert(NULL != transfer);
+
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isEndOfQueue = true;
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -877,61 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
-    DSPI_StartTransfer(base);
-
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
-    DSPI_MasterTransferFillUpTxFifo(base, handle);
 
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_StartTransfer(base);
+
+    /* Fill up the Tx FIFO to trigger the transfer. */
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -943,11 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -956,40 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
-
-    /* The transfer is complete.*/
-    handle->state = kDSPI_Idle;
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_MASTER_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -997,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1005,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1021,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1056,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1066,82 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1150,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1178,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1210,85 +1736,107 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (NULL != handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (NULL != handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
+    }
 
     DSPI_StartTransfer(base);
 
     /* Prepare data to transmit */
     DSPI_SlaveTransferFillUpTxFifo(base, handle);
 
-    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
-
-    /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
-
-    if (handle->rxData)
-    {
-        /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
-    }
-    if (handle->txData)
-    {
-        /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
-    }
-
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1300,22 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = DSPI_SLAVE_DUMMY_DATA;
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1333,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1380,24 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1406,65 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    if (handle->callback)
+    handle->state = (uint8_t)kDSPI_Idle;
+
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
-
-    handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    uint8_t dummyPattern = DSPI_SLAVE_DUMMY_DATA;
+    assert(NULL != handle);
+
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1482,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1498,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1571,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1604,12 +2188,17 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 #if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
@@ -1617,7 +2206,7 @@ void SPI0_DriverIRQHandler(void)
 #if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
@@ -1625,7 +2214,7 @@ void SPI1_DriverIRQHandler(void)
 #if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
@@ -1633,7 +2222,7 @@ void SPI2_DriverIRQHandler(void)
 #if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
@@ -1641,7 +2230,7 @@ void SPI3_DriverIRQHandler(void)
 #if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
@@ -1649,7 +2238,7 @@ void SPI4_DriverIRQHandler(void)
 #if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -33,11 +11,9 @@
 #include "fsl_common.h"
 
 /*!
- * @addtogroup dspi
+ * @addtogroup dspi_driver
  * @{
  */
-
-/*! @file */
 
 /**********************************************************************************************************************
  * Definitions
@@ -45,50 +21,49 @@
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.1.0. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
-/*! @name Dummy data */
-/*@{*/
-#define DSPI_MASTER_DUMMY_DATA (0x00U) /*!< Master dummy data used for tx if there is not txData. */
-#define DSPI_SLAVE_DUMMY_DATA (0x00U)  /*!< Slave dummy data used for tx if there is not txData. */
-/*@}*/
+#ifndef DSPI_DUMMY_DATA
+/*! @brief DSPI dummy data if there is no Tx data.*/
+#define DSPI_DUMMY_DATA (0x00U) /*!< Dummy data used for Tx if there is no txData. */
+#endif
 
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out Of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All status above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -105,12 +80,13 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
- * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in Modified Transfer Format. This field is valid
- * only when CPHA bit in CTAR register is 0.
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is
+ * valid
+ * only when the CPHA bit in the CTAR register is 0.
  */
 typedef enum _dspi_master_sample_point
 {
@@ -134,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -169,36 +145,37 @@ typedef enum _dspi_clock_phase
 typedef enum _dspi_shift_direction
 {
     kDSPI_MsbFirst = 0U, /*!< Data transfers start with most significant bit.*/
-    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.*/
+    kDSPI_LsbFirst = 1U  /*!< Data transfers start with least significant bit.
+                              Shifting out of LSB is not supported for slave */
 } dspi_shift_direction_t;
 
 /*! @brief DSPI delay type selection.*/
 typedef enum _dspi_delay_type
 {
     kDSPI_PcsToSck = 1U,  /*!< Pcs-to-SCK delay. */
-    kDSPI_LastSckToPcs,   /*!< Last SCK edge to Pcs delay. */
+    kDSPI_LastSckToPcs,   /*!< The last SCK edge to Pcs delay. */
     kDSPI_BetweenTransfer /*!< Delay between transfers. */
 } dspi_delay_type_t;
 
 /*! @brief DSPI Clock and Transfer Attributes Register (CTAR) selection.*/
 typedef enum _dspi_ctar_selection
 {
-    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode, note that CTAR0 and CTAR0_SLAVE are the
+    kDSPI_Ctar0 = 0U, /*!< CTAR0 selection option for master or slave mode; note that CTAR0 and CTAR0_SLAVE are the
                          same register address. */
     kDSPI_Ctar1 = 1U, /*!< CTAR1 selection option for master mode only. */
-    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only , note that some device do not support CTAR2. */
-    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only , note that some device do not support CTAR3. */
-    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only , note that some device do not support CTAR4. */
-    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only , note that some device do not support CTAR5. */
-    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only , note that some device do not support CTAR6. */
-    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only , note that some device do not support CTAR7. */
+    kDSPI_Ctar2 = 2U, /*!< CTAR2 selection option for master mode only; note that some devices do not support CTAR2. */
+    kDSPI_Ctar3 = 3U, /*!< CTAR3 selection option for master mode only; note that some devices do not support CTAR3. */
+    kDSPI_Ctar4 = 4U, /*!< CTAR4 selection option for master mode only; note that some devices do not support CTAR4. */
+    kDSPI_Ctar5 = 5U, /*!< CTAR5 selection option for master mode only; note that some devices do not support CTAR5. */
+    kDSPI_Ctar6 = 6U, /*!< CTAR6 selection option for master mode only; note that some devices do not support CTAR6. */
+    kDSPI_Ctar7 = 7U  /*!< CTAR7 selection option for master mode only; note that some devices do not support CTAR7. */
 } dspi_ctar_selection_t;
 
-#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro , internal used. */
-#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro , internal used. */
-#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro , internal used. */
-#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro , internal used. */
-/*! @brief Can use this enumeration for DSPI master transfer configFlags. */
+#define DSPI_MASTER_CTAR_SHIFT (0U)   /*!< DSPI master CTAR shift macro; used internally. */
+#define DSPI_MASTER_CTAR_MASK (0x0FU) /*!< DSPI master CTAR mask macro; used internally. */
+#define DSPI_MASTER_PCS_SHIFT (4U)    /*!< DSPI master PCS shift macro; used internally. */
+#define DSPI_MASTER_PCS_MASK (0xF0U)  /*!< DSPI master PCS mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI master transfer configFlags. */
 enum _dspi_transfer_config_flag_for_master
 {
     kDSPI_MasterCtar0 = 0U << DSPI_MASTER_CTAR_SHIFT, /*!< DSPI master transfer use CTAR0 setting. */
@@ -217,20 +194,21 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Is PCS signal continuous. */
-    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Is PCS signal active after last frame transfer.*/
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterActiveAfterTransfer =
+        1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
-#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro , internal used. */
-#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro , internal used. */
-/*! @brief Can use this enum for DSPI slave transfer configFlags. */
+#define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro; used internally. */
+#define DSPI_SLAVE_CTAR_MASK (0x07U) /*!< DSPI slave CTAR mask macro; used internally. */
+/*! @brief Use this enumeration for the DSPI slave transfer configFlags. */
 enum _dspi_transfer_config_flag_for_slave
 {
     kDSPI_SlaveCtar0 = 0U << DSPI_SLAVE_CTAR_SHIFT, /*!< DSPI slave transfer use CTAR0 setting. */
                                                     /*!< DSPI slave can only use PCS0. */
 };
 
-/*! @brief DSPI transfer state, which is used for DSPI transactional APIs' state machine. */
+/*! @brief DSPI transfer state, which is used for DSPI transactional API state machine. */
 enum _dspi_transfer_state
 {
     kDSPI_Idle = 0x0U, /*!< Nothing in the transmitter/receiver. */
@@ -238,15 +216,15 @@ enum _dspi_transfer_state
     kDSPI_Error        /*!< Transfer error. */
 };
 
-/*! @brief DSPI master command date configuration used for SPIx_PUSHR.*/
+/*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
     bool isEndOfQueue;               /*!< Signals that the current transfer is the last in the queue.*/
-    bool clearTransferCount;         /*!< Clears SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
+    bool clearTransferCount;         /*!< Clears the SPI Transfer Counter (SPI_TCNT) before transmission starts.*/
 } dspi_command_data_config_t;
 
 /*! @brief DSPI master ctar configuration structure.*/
@@ -258,33 +236,33 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time with nanosecond , set to 0 sets the minimum
-                                               delay. It sets the boundary value if out of range that can be set.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< Last SCK to PCS delay time with nanosecond , set to 0 sets the
-                                               minimum delay.It sets the boundary value if out of range that can be
-                                               set.*/
-    uint32_t betweenTransferDelayInNanoSec; /*!< After SCK delay time with nanosecond , set to 0 sets the minimum
-                                             delay.It sets the boundary value if out of range that can be set.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
+
+    uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                             delay. It also sets the boundary value if out of range.*/
 } dspi_master_ctar_config_t;
 
 /*! @brief DSPI master configuration structure.*/
 typedef struct _dspi_master_config
 {
-    dspi_ctar_selection_t whichCtar;      /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;      /*!< The desired CTAR to use. */
     dspi_master_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    dspi_which_pcs_t whichPcs;                     /*!< Desired Peripheral Chip Select (pcs). */
-    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< Desired PCS active high or low. */
+    dspi_which_pcs_t whichPcs;                     /*!< The desired Peripheral Chip Select (pcs). */
+    dspi_pcs_polarity_config_t pcsActiveHighOrLow; /*!< The desired PCS active high or low. */
 
-    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable . Note that continuous SCK is only
+    bool enableContinuousSCK;   /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                      supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite; /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                     data is ignored, the data from the transfer that generated the overflow
-                                     is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                     shift to the shift register. */
+    bool enableRxFifoOverWrite; /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                     data is ignored and the data from the transfer that generated the overflow
+                                     is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                     shift register. */
 
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                  Format. It's valid only when CPHA=0. */
 } dspi_master_config_t;
 
@@ -294,34 +272,34 @@ typedef struct _dspi_slave_ctar_config
     uint32_t bitsPerFrame;      /*!< Bits per frame, minimum 4, maximum 16.*/
     dspi_clock_polarity_t cpol; /*!< Clock polarity. */
     dspi_clock_phase_t cpha;    /*!< Clock phase. */
-                                /*!< Slave only supports MSB , does not support LSB.*/
+                                /*!< Slave only supports MSB and does not support LSB.*/
 } dspi_slave_ctar_config_t;
 
 /*! @brief DSPI slave configuration structure.*/
 typedef struct _dspi_slave_config
 {
-    dspi_ctar_selection_t whichCtar;     /*!< Desired CTAR to use. */
+    dspi_ctar_selection_t whichCtar;     /*!< The desired CTAR to use. */
     dspi_slave_ctar_config_t ctarConfig; /*!< Set the ctarConfig to the desired CTAR. */
 
-    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that continuous SCK is only
+    bool enableContinuousSCK;               /*!< CONT_SCKE, continuous SCK enable. Note that the continuous SCK is only
                                                  supported for CPHA = 1.*/
-    bool enableRxFifoOverWrite;             /*!< ROOE, Receive FIFO overflow overwrite enable. ROOE = 0, the incoming
-                                                 data is ignored, the data from the transfer that generated the overflow
-                                                 is either ignored. ROOE = 1, the incoming data is shifted in to the
-                                                 shift to the shift register. */
-    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if it's true.*/
-    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in Modified Transfer
+    bool enableRxFifoOverWrite;             /*!< ROOE, receive FIFO overflow overwrite enable. If ROOE = 0, the incoming
+                                                 data is ignored and the data from the transfer that generated the overflow
+                                                 is also ignored. If ROOE = 1, the incoming data is shifted to the
+                                                 shift register. */
+    bool enableModifiedTimingFormat;        /*!< Enables a modified transfer format to be used if true.*/
+    dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                Format. It's valid only when CPHA=0. */
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -356,47 +334,60 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags , set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
+    volatile uint8_t state; /*!< DSPI transfer state, see _dspi_transfer_state.*/
 
     dspi_master_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                           /*!< Callback user data. */
 };
 
-/*! @brief DSPI slave transfer handle structure used for transactional API. */
+/*! @brief DSPI slave transfer handle structure used for the transactional API. */
 struct _dspi_slave_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame;          /*!< The desired number of bits per frame. */
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     volatile uint8_t state; /*!< DSPI transfer state.*/
 
@@ -421,18 +412,18 @@ extern "C" {
 /*!
  * @brief Initializes the DSPI master.
  *
- * This function initializes the DSPI master configuration. An example use case is as follows:
+ * This function initializes the DSPI master configuration. This is an example use case.
  *  @code
  *   dspi_master_config_t  masterConfig;
  *   masterConfig.whichCtar                                = kDSPI_Ctar0;
- *   masterConfig.ctarConfig.baudRate                      = 500000000;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
  *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
  *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
  *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
  *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
- *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000 / masterConfig.ctarConfig.baudRate ;
- *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000 / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
  *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
  *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
  *   masterConfig.enableContinuousSCK                      = false;
@@ -443,8 +434,8 @@ extern "C" {
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param masterConfig Pointer to structure dspi_master_config_t.
- * @param srcClock_Hz Module source input clock in Hertz
+ * @param masterConfig Pointer to the structure dspi_master_config_t.
+ * @param srcClock_Hz Module source input clock in Hertz.
  */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
@@ -452,8 +443,8 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
  * @brief Sets the dspi_master_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
- * User may use the initialized structure unchanged in DSPI_MasterInit() or modify the structure
- * before calling DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
  * Example:
  * @code
  *  dspi_master_config_t  masterConfig;
@@ -466,7 +457,7 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
 /*!
  * @brief DSPI slave configuration.
  *
- * This function initializes the DSPI slave configuration. An example use case is as follows:
+ * This function initializes the DSPI slave configuration. This is an example use case.
  *  @code
  *   dspi_slave_config_t  slaveConfig;
  *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
@@ -481,22 +472,22 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
  *  @endcode
  *
  * @param base DSPI peripheral address.
- * @param slaveConfig Pointer to structure dspi_master_config_t.
+ * @param slaveConfig Pointer to the structure dspi_master_config_t.
  */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
 
 /*!
- * @brief Sets the dspi_slave_config_t structure to default values.
+ * @brief Sets the dspi_slave_config_t structure to a default value.
  *
  * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
- * User may use the initialized structure unchanged in DSPI_SlaveInit(), or modify the structure
- * before calling DSPI_SlaveInit().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
  * @code
  *  dspi_slave_config_t  slaveConfig;
  *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
  * @endcode
- * @param slaveConfig pointer to dspi_slave_config_t structure.
+ * @param slaveConfig Pointer to the dspi_slave_config_t structure.
  */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig);
 
@@ -510,7 +501,7 @@ void DSPI_Deinit(SPI_Type *base);
  * @brief Enables the DSPI peripheral and sets the MCR MDIS to 0.
  *
  * @param base DSPI peripheral address.
- * @param enable pass true to enable module, false to disable module.
+ * @param enable Pass true to enable module, false to disable module.
  */
 static inline void DSPI_Enable(SPI_Type *base, bool enable)
 {
@@ -526,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -536,7 +527,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 /*!
  * @brief Gets the DSPI status flag state.
  * @param base DSPI peripheral address.
- * @return The DSPI status(in SR register).
+ * @return DSPI status (in SR register).
  */
 static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
 {
@@ -549,13 +540,13 @@ static inline uint32_t DSPI_GetStatusFlags(SPI_Type *base)
  * This function  clears the desired status bit by using a write-1-to-clear. The user passes in the base and the
  * desired status bit to clear.  The list of status bits is defined in the dspi_status_and_interrupt_request_t. The
  * function uses these bit positions in its algorithm to clear the desired flag state.
- * Example usage:
+ * This is an example.
  * @code
  *  DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag|kDSPI_EndOfQueueFlag);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param statusFlags The status flag , used from type dspi_flags.
+ * @param statusFlags The status flag used from the type dspi_flags.
  */
 static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 {
@@ -564,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -574,15 +565,16 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 /*!
  * @brief Enables the DSPI interrupts.
  *
- * This function configures the various interrupt masks of the DSPI.  The parameters are base and an interrupt mask.
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
  * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
  *
  * @code
  *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
 
@@ -594,7 +586,7 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask, can use the enum _dspi_interrupt_enable.
+ * @param mask The interrupt mask; use the enum _dspi_interrupt_enable.
  */
 static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 {
@@ -603,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -613,13 +605,13 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Enables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  DSPI_EnableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -629,13 +621,13 @@ static inline void DSPI_EnableDMA(SPI_Type *base, uint32_t mask)
 /*!
  * @brief Disables the DSPI DMA request.
  *
- * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are base and a DMA mask.
+ * This function configures the Rx and Tx DMA mask of the DSPI.  The parameters are a base and a DMA mask.
  * @code
  *  SPI_DisableDMA(base, kDSPI_TxDmaEnable | kDSPI_RxDmaEnable);
  * @endcode
  *
  * @param base DSPI peripheral address.
- * @param mask The interrupt mask can use the enum dspi_dma_enable.
+ * @param mask The interrupt mask; use the enum dspi_dma_enable.
  */
 static inline void DSPI_DisableDMA(SPI_Type *base, uint32_t mask)
 {
@@ -683,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -709,12 +707,19 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
  *
- * This function sets the module to begin data transfer in either master or slave mode.
+ * This function sets the module to start data transfer in either master or slave mode.
  *
  * @param base DSPI peripheral address.
  */
@@ -723,9 +728,9 @@ static inline void DSPI_StartTransfer(SPI_Type *base)
     base->MCR &= ~SPI_MCR_HALT_MASK;
 }
 /*!
- * @brief Stops (halts) DSPI transfers and sets HALT bit in MCR.
+ * @brief Stops DSPI transfers and sets the HALT bit in MCR.
  *
- * This function stops data transfers in either master or slave mode.
+ * This function stops data transfers in either master or slave modes.
  *
  * @param base DSPI peripheral address.
  */
@@ -735,44 +740,44 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
 }
 
 /*!
- * @brief Enables (or disables) the DSPI FIFOs.
+ * @brief Enables or disables the DSPI FIFOs.
  *
- * This function  allows the caller to disable/enable the Tx and Rx FIFOs (independently).
- * Note that to disable, the caller must pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
- * the caller must pass in a logic 1 (true).
+ * This function  allows the caller to disable/enable the Tx and Rx FIFOs independently.
+ * Note that to disable, pass in a logic 0 (false) for the particular FIFO configuration.  To enable,
+ * pass in a logic 1 (true).
  *
  * @param base DSPI peripheral address.
- * @param enableTxFifo Disables (false) the TX FIFO, else enables (true) the TX FIFO
- * @param enableRxFifo Disables (false) the RX FIFO, else enables (true) the RX FIFO
+ * @param enableTxFifo Disables (false) the TX FIFO; Otherwise, enables (true) the TX FIFO
+ * @param enableRxFifo Disables (false) the RX FIFO; Otherwise, enables (true) the RX FIFO
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Flushes the DSPI FIFOs.
  *
  * @param base DSPI peripheral address.
- * @param flushTxFifo Flushes (true) the Tx FIFO, else do not flush (false) the Tx FIFO
- * @param flushRxFifo Flushes (true) the Rx FIFO, else do not flush (false) the Rx FIFO
+ * @param flushTxFifo Flushes (true) the Tx FIFO; Otherwise, does not flush (false) the Tx FIFO
+ * @param flushRxFifo Flushes (true) the Rx FIFO; Otherwise, does not flush (false) the Rx FIFO
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
  * @brief Configures the DSPI peripheral chip select polarity simultaneously.
- * For example, PCS0 and PCS1 set to active low and other PCS set to active high. Note that the number of
+ * For example, PCS0 and PCS1 are set to active low and other PCS is set to active high. Note that the number of
  * PCSs is specific to the device.
  * @code
  *  DSPI_SetAllPcsPolarity(base, kDSPI_Pcs0ActiveLow | kDSPI_Pcs1ActiveLow);
    @endcode
  * @param base DSPI peripheral address.
- * @param mask The PCS polarity mask ,  can use the enum _dspi_pcs_polarity.
+ * @param mask The PCS polarity mask; use the enum _dspi_pcs_polarity.
  */
 static inline void DSPI_SetAllPcsPolarity(SPI_Type *base, uint32_t mask)
 {
@@ -801,19 +806,19 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
  * @brief Manually configures the delay prescaler and scaler for a particular CTAR.
  *
  * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
- * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT)and scalar (DT).
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes the delay to configure along with the prescaler and scaler value.
- * This allows the user to directly set the prescaler/scaler values if they have pre-calculated them or if they simply
- * wish to manually increment either value.
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
  *
  * @param base DSPI peripheral address.
  * @param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
  * @param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
  * @param scaler The scaler delay value (can be any integer between 0 to 15).
- * @param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * @param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
  */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay);
@@ -821,19 +826,19 @@ void DSPI_MasterSetDelayScaler(
 /*!
  * @brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
  *
- * This function calculates the values for:
+ * This function calculates the values for the following.
  * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
  * After SCK delay pre-scalar (PASC) and scalar (ASC), or
- * Delay after transfer pre-scalar (PDT)and scalar (DT).
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
  *
- * These delay names are available in type dspi_delay_type_t.
+ * These delay names are available in the type dspi_delay_type_t.
  *
- * The user passes which delay they want to configure along with the desired delay value in nanoseconds.  The function
- * calculates the values needed for the prescaler and scaler and returning the actual calculated delay as an exact
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
  * delay match may not be possible. In this case, the closest match is calculated without going below the desired
  * delay value input.
  * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
- * supported delay is returned. The higher level peripheral driver alerts the user of an out of range delay
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
  * input.
  *
  * @param base DSPI peripheral address.
@@ -853,11 +858,11 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
  * @brief Writes data into the data buffer for master mode.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_data_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -869,7 +874,7 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
    @endcode
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
@@ -883,14 +888,14 @@ static inline void DSPI_MasterWriteData(SPI_Type *base, dspi_command_data_config
  * @brief Sets the dspi_command_data_config_t structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
- * User may use the initialized structure unchanged in DSPI_MasterWrite_xx() or modify the structure
- * before calling DSPI_MasterWrite_xx().
- * Example:
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
  * @code
  *  dspi_command_data_config_t  command;
  *  DSPI_GetDefaultDataCommandConfig(&command);
  * @endcode
- * @param command pointer to dspi_command_data_config_t structure.
+ * @param command Pointer to the dspi_command_data_config_t structure.
  */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
 
@@ -898,11 +903,11 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  * @brief Writes data into the data buffer master mode and waits till complete to return.
  *
  * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
- * provides characteristics of the data such as the optional continuous chip select
+ * provides characteristics of the data, such as the optional continuous chip select
  * operation between transfers, the desired Clock and Transfer Attributes register to use for the
  * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
  * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
- * sending the first frame of a data packet). This is an example:
+ * sending the first frame of a data packet). This is an example.
  * @code
  *  dspi_command_config_t commandConfig;
  *  commandConfig.isPcsContinuous = true;
@@ -915,10 +920,10 @@ void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command);
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
- * receive data is available when transmit completes.
+ * the received data is available when the transmit completes.
  *
  * @param base DSPI peripheral address.
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @param data The data word to be sent.
  */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data);
@@ -933,10 +938,10 @@ void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *co
  * improve performance in cases where the command structure is constant. For example, the user calls this function
  * before starting a transfer to generate the command word. When they are ready to transmit the data, they OR
  * this formatted command word with the desired data to transmit. This process increases transmit performance when
- * compared to calling send functions such as DSPI_HAL_WriteDataMastermode which format the command word each time a
+ * compared to calling send functions, such as DSPI_HAL_WriteDataMastermode,  which format the command word each time a
  * data word is to be sent.
  *
- * @param command Pointer to command structure.
+ * @param command Pointer to the command structure.
  * @return The command word formatted to the PUSHR data register bit field.
  */
 static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t *command)
@@ -949,43 +954,44 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
 
 /*!
  * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
- *        buffer, master mode and waits till complete to return.
+ *        buffer master mode and waits till complete to return.
  *
- * In this function, the user must append the 16-bit data to the 16-bit command info then provide the total 32-bit word
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
  * as the data to send.
- * The command portion provides characteristics of the data such as the optional continuous chip select operation
-* between
- * transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
  * @code
  *  dataWord = <16-bit command> | <16-bit data>;
- *  DSPI_HAL_WriteCommandDataMastermodeBlocking(base, dataWord);
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
  * @endcode
  *
  * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
  * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
- * Because the SPI is a synchronous protocol, the receive data is available when transmit completes.
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
- * @param data The data word (command and data combined) to be sent
+ * @param data The data word (command and data combined) to be sent.
  */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data);
 
@@ -1025,8 +1031,16 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 }
 
 /*!
+ * @brief Set up the dummy data.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1037,13 +1051,13 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 /*!
  * @brief Initializes the DSPI master handle.
  *
- * This function initializes the DSPI handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance,  call this API once to get the initialized handle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_handle_t.
- * @param callback dspi callback.
- * @param userData callback function parameter.
+ * @param callback DSPI callback.
+ * @param userData Callback function parameter.
  */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
@@ -1053,12 +1067,11 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using polling.
  *
- * This function transfers data with polling. This is a blocking function, which does not return until all transfers
- * have been
- * completed.
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
  *
  * @param base DSPI peripheral base address.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
@@ -1067,15 +1080,43 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @brief DSPI master transfer data using interrupts.
  *
  * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
- data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1083,19 +1124,19 @@ status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *ha
  * This function gets the master transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count);
 
 /*!
- * @brief DSPI master aborts transfer using an interrupt.
+ * @brief DSPI master aborts a transfer using an interrupt.
  *
  * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1105,7 +1146,7 @@ void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -1115,10 +1156,10 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
  * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * @param handle DSPI handle pointer to dspi_slave_handle_t.
+ * @param handle DSPI handle pointer to the dspi_slave_handle_t.
  * @param base DSPI peripheral base address.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData Callback function parameter.
  */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
@@ -1129,12 +1170,11 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
  * @brief DSPI slave transfers data using an interrupt.
  *
  * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
- * data
- * have been transferred, the callback function is called.
+ * data is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer);
@@ -1145,8 +1185,8 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
  * This function gets the slave transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * @param count The number of bytes transferred by using the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count);
@@ -1154,10 +1194,10 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 /*!
  * @brief DSPI slave aborts a transfer using an interrupt.
  *
- * This function aborts transfer using an interrupt.
+ * This function aborts a transfer using an interrupt.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 
@@ -1167,19 +1207,29 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
  * This function processes the DSPI transmit and receive IRQ.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_handle_t structure which stores the transfer state.
+ * @param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi_edma.c
@@ -1,42 +1,25 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "fsl_dspi_edma.h"
 
 /***********************************************************************************************************************
-* Definitons
-***********************************************************************************************************************/
+ * Definitions
+ ***********************************************************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi_edma"
+#endif
 
 /*!
-* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_master_edma_private_handle
 {
     SPI_Type *base;                    /*!< DSPI peripheral base address. */
@@ -44,8 +27,8 @@ typedef struct _dspi_master_edma_private_handle
 } dspi_master_edma_private_handle_t;
 
 /*!
-* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_slave_edma_private_handle
 {
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
@@ -53,46 +36,58 @@ typedef struct _dspi_slave_edma_private_handle
 } dspi_slave_edma_private_handle_t;
 
 /***********************************************************************************************************************
-* Prototypes
-***********************************************************************************************************************/
+ * Prototypes
+ ***********************************************************************************************************************/
 /*!
-* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
 /*!
-* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
-* This is not a public API as it is called from other driver functions.
-*/
+ * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
-/*!
-* @brief Get instance number for DSPI module.
-*
-* This is not a public API and it's extern from fsl_dspi.c.
-*
-* @param base DSPI peripheral base address
-*/
-extern uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /***********************************************************************************************************************
-* Variables
-***********************************************************************************************************************/
+ * Variables
+ ***********************************************************************************************************************/
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 
 /***********************************************************************************************************************
-* Code
-***********************************************************************************************************************/
+ * Code
+ ***********************************************************************************************************************/
 
+/*!
+ * brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          dspi_master_edma_handle_t *handle,
                                          dspi_master_edma_transfer_callback_t callback,
@@ -101,51 +96,72 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          edma_handle_t *edmaTxDataToIntermediaryHandle,
                                          edma_handle_t *edmaIntermediaryToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+#if (!(defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET))
+    assert(NULL != edmaTxDataToIntermediaryHandle);
+#endif
+    assert(NULL != edmaIntermediaryToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].base   = base;
     s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
     handle->userData = userData;
 
-    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaRxRegToRxDataHandle        = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
-    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+    handle->edmaIntermediaryToTxRegHandle  = edmaIntermediaryToTxRegHandle;
 }
 
+/*!
+ * brief DSPI master transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    uint32_t instance = DSPI_GetInstance(base);
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_MASTER_DUMMY_DATA;
-    uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    uint32_t instance                = DSPI_GetInstance(base);
+    uint16_t wordToSend              = 0;
+    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint8_t dataAlreadyFed           = 0;
+    uint8_t dataFedMax               = 2;
+    uint32_t tmpMCR                  = 0;
+    size_t tmpRemainingSendByteCount = 0;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
@@ -154,32 +170,33 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
 
     edma_transfer_config_t transferConfigA;
     edma_transfer_config_t transferConfigB;
-    edma_transfer_config_t transferConfigC;
 
-    handle->txBuffIfNull = ((uint32_t)DSPI_MASTER_DUMMY_DATA << 8) | DSPI_MASTER_DUMMY_DATA;
-
-    handle->state = kDSPI_Busy;
+    handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
 
     dspi_command_data_config_t commandStruct;
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isEndOfQueue = true;
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -187,98 +204,123 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    /* this limits the amount of data we can transfer due to the linked channel.
-    * The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (handle->bitsPerFrame > 8)
+    /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (transfer->dataSize > 1022)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
     else
     {
-        if (transfer->dataSize > 511)
+        if (transfer->dataSize > limited_size)
         {
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
+    {
+        handle->state = (uint8_t)kDSPI_Idle;
+        return kStatus_InvalidArgument;
+    }
+
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
                      &s_dspiMasterEdmaPrivateHandle[instance]);
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
+    /*
+    (1)For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
+    channel_A minor link to channel_B , channel_B minor link to channel_C.
+
+    Already pushed 1 or 2 data in SPI_PUSHR , then start the DMA tansfer.
+    channel_A:SPI_POPR to rxData,
+    channel_B:next txData to handle->command (low 16 bits),
+    channel_C:handle->command (32 bits) to SPI_PUSHR, and use the scatter/gather to transfer the last data
+    (handle->lastCommand to SPI_PUSHR).
+
+    (2)For DSPI instances with separate RX and TX DMA requests:
+    Rx DMA request -> channel_A
+    Tx DMA request -> channel_C -> channel_B .
+    channel_C major link to channel_B.
+    So need prepare the first data in "intermediary"  before the DMA
+    transfer and then channel_B is used to prepare the next data to "intermediary"
+
+    channel_A:SPI_POPR to rxData,
+    channel_C: handle->command (32 bits) to SPI_PUSHR,
+    channel_B: next txData to handle->command (low 16 bits), and use the scatter/gather to prepare the last data
+    (handle->lastCommand to handle->Command).
+    */
 
     /*If dspi has separate dma request , prepare the first data in "intermediary" .
     else (dspi has shared dma request) , send first 2 data if there is fifo or send first 1 data if there is no fifo*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
-        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
-        */
+         * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+         */
 
         /*Prepare the firt data*/
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
             /* If it's the last word */
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
-                {
-                    if (handle->isThereExtraByte)
-                    {
-                        wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                    }
-                    else
-                    {
-                        wordToSend = *(handle->txData);
-                        ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                    }
-                }
-                else
-                {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                }
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
-            }
-            else /* For all words except the last word , frame > 8bits */
-            {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
+                }
+                else
+                {
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                }
+                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
+            }
+            else /* For all words except the last word , frame > 8bits */
+            {
+                if (NULL != handle->txData)
+                {
+                    wordToSend = *(handle->txData);
+                    ++handle->txData; /* increment to next data byte */
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     ++handle->txData; /* increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData; /* increment to next data word*/
@@ -288,9 +330,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                handle->command     = handle->lastCommand;
             }
             else
             {
@@ -300,66 +343,57 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     }
 
     else /*dspi has shared dma request*/
-
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->remainingSendByteCount <= 2)
+                if (handle->remainingSendByteCount <= 2U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
-                        if (handle->isThereExtraByte)
-                        {
-                            wordToSend = *(handle->txData) | ((uint32_t)dummyData << 8);
-                        }
-                        else
-                        {
-                            wordToSend = *(handle->txData);
-                            ++handle->txData;
-                            wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        }
+                        wordToSend = *(handle->txData);
+                        ++handle->txData;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
                     handle->remainingSendByteCount = 0;
-                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                    base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
                 /* For all words except the last word */
                 else
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                         ++handle->txData;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
-                        ;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
-                    handle->remainingSendByteCount -= 2;
+                    handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -367,9 +401,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData;
@@ -379,7 +414,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     wordToSend = dummyData;
                 }
 
-                if (handle->remainingSendByteCount == 1)
+                if (handle->remainingSendByteCount == 1U)
                 {
                     base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
@@ -389,14 +424,14 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -404,125 +439,66 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
     }
 
-    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
+    /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer(rxData)*/
     EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcAddr   = (uint32_t)rxAddr;
     transferConfigA.srcOffset = 0;
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
         transferConfigA.destOffset = 1;
     }
     else
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
         transferConfigA.destOffset = 0;
     }
 
     transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-    if (handle->bitsPerFrame <= 8)
+    if (handle->bitsPerFrame <= 8U)
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.minorLoopBytes  = 1;
         transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
     }
     else
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-        transferConfigA.minorLoopBytes = 2;
-        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        transferConfigA.minorLoopBytes  = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
     }
+
+    /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+    handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
     EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                           &transferConfigA, NULL);
+                           (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
     EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                 kEDMA_MajorInterruptEnable);
+                                 (uint32_t)kEDMA_MajorInterruptEnable);
 
-    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
-    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
-    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
-    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
-
-    if (handle->remainingSendByteCount > 0)
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*Calculate the last data : handle->lastCommand*/
+    if (((tmpRemainingSendByteCount > 0U) && (1U != (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U))) &&
+         (1U == (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        if (handle->txData)
-        {
-            transferConfigB.srcAddr = (uint32_t)(handle->txData);
-            transferConfigB.srcOffset = 1;
-        }
-        else
-        {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-            transferConfigB.srcOffset = 0;
-        }
-
-        transferConfigB.destAddr = (uint32_t)(&handle->command);
-        transferConfigB.destOffset = 0;
-
-        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-        if (handle->bitsPerFrame <= 8)
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
-
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                majorlink , the majorlink would not trigger the channel_C*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
-            }
-        }
-        else
-        {
-            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
-            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
-            {
-                /*already prepared the first data in "intermediary" , so minus 1 */
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-            }
-            else
-            {
-                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                * majorlink*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
-            }
-        }
-
-        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
-    }
-
-    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
-    handle the last data */
-    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
-
-    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
-        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
-         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
-    {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
             uint32_t bufferIndex = 0;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                if (handle->bitsPerFrame <= 8)
+                if (handle->bitsPerFrame <= 8U)
                 {
-                    bufferIndex = handle->remainingSendByteCount - 1;
+                    bufferIndex = handle->remainingSendByteCount - 1U;
                 }
                 else
                 {
-                    bufferIndex = handle->remainingSendByteCount - 2;
+                    bufferIndex = handle->remainingSendByteCount - 2U;
                 }
             }
             else
@@ -530,85 +506,345 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 bufferIndex = handle->remainingSendByteCount;
             }
 
-            if (handle->bitsPerFrame <= 8)
+            uint32_t tmpLastCommand = handle->lastCommand;
+            uint8_t *tmpTxData      = handle->txData;
+
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | tmpTxData[bufferIndex - 1U];
             }
             else
             {
-                if (handle->isThereExtraByte)
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 2] |
-                                          ((uint32_t)dummyData << 8);
-                }
-                else
-                {
-                    handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
-                                          ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
-                                          handle->txData[bufferIndex - 2];
-                }
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | ((uint32_t)tmpTxData[bufferIndex - 1U] << 8U) |
+                                 tmpTxData[bufferIndex - 2U];
             }
+
+            handle->lastCommand = tmpLastCommand;
         }
         else
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 wordToSend = dummyData;
             }
             else
             {
-                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
             }
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
     }
 
+/* The feature of GASKET is that the SPI supports 8-bit or 16-bit writes to the PUSH TX FIFO,
+ * allowing a single write to the command word followed by multiple writes to the transmit word.
+ * The TX FIFO will save the last command word written, and convert a 8-bit/16-bit write to the
+ * transmit word into a 32-bit write that pushes both the command word and transmit word into
+ * the TX FIFO (PUSH TX FIFO Register In Master Mode)
+ * So, if this feature is supported, we can use use one channel to carry the receive data from
+ * receive regsiter to user data buffer, use the other channel to carry the data from user data buffer
+ * to transmit register,and use the scatter/gather function to prepare the last data.
+ * That is to say, if GASKET feature is supported, we can use only two channels for tansferring data.
+ */
+#if defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET
+    /*  For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to PUSHR register.
+     */
+
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
     if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
-        ((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+        ((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigC.destAddr = (uint32_t)txAddr;
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-        transferConfigC.majorLoopCounts = 1;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t)txAddr;
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
     }
 
-    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)))
+    /*User_Send_Buffer(txData) to PUSHR register. */
+    if (((handle->remainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+        ((handle->remainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U)))
     {
-        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
-        transferConfigC.destAddr = (uint32_t)txAddr;
-
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-
-        if (handle->bitsPerFrame <= 8)
+        if (handle->txData)
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                /* For DSPI with separate RX and TX DMA requests, one frame data has been carry
+                 * to handle->command, so need to reduce the pointer of txData.
+                 */
+                transferConfigB.srcAddr =
+                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8U) ? (1U) : (2U)));
+                transferConfigB.srcOffset = 1;
+            }
+            else
+            {
+                /* For DSPI with shared RX and TX DMA requests, one or two frame data have been carry
+                 * to PUSHR register, so no need to change the pointer of txData.
+                 */
+                transferConfigB.srcAddr   = (uint32_t)((uint8_t *)(handle->txData));
+                transferConfigB.srcOffset = 1;
+            }
         }
         else
         {
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)txAddr;
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1U;
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            transferConfigB.majorLoopCounts  = (handle->remainingSendByteCount / 2U) - 1U;
         }
 
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, softwareTCD);
+    }
+    /* If only one word to transmit, only carry the lastcommand. */
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigB, NULL);
+    }
+
+    /*Start the EDMA channel_A , channel_C. */
+    EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
+    EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
+
+    /* Set the channel link.
+     * For DSPI instances with shared TX and RX DMA requests, setup channel minor link, first receive data from the
+     * receive register, and then carry transmit data to PUSHER register.
+     * For DSPI instance with separate TX and RX DMA requests, there is no need to set up channel link.
+     */
+    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        /*Set channel priority*/
+        uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+        uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
+        uint8_t t                   = 0;
+
+        if (channelPriorityLow > channelPriorityHigh)
+        {
+            t                   = channelPriorityLow;
+            channelPriorityLow  = channelPriorityHigh;
+            channelPriorityHigh = t;
+        }
+
+        edma_channel_Preemption_config_t preemption_config_t;
+        preemption_config_t.enableChannelPreemption = true;
+        preemption_config_t.enablePreemptAbility    = true;
+        preemption_config_t.channelPriority         = channelPriorityLow;
+
+        EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                        &preemption_config_t);
+
+        preemption_config_t.channelPriority = channelPriorityHigh;
+        EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+        /*if there is Rx DMA request , carry the 32bits data (handle->command) to user data first , then link to
+          channelC to carry the next data to PUSHER register.(txData to PUSHER) */
+        if (handle->remainingSendByteCount > 0U)
+        {
+            EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
+                                kEDMA_MinorLink, handle->edmaIntermediaryToTxRegHandle->channel);
+        }
+    }
+
+    DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+
+    /* Setup control info to PUSHER register. */
+    *((uint16_t *)&(base->PUSHR) + 1) = (handle->command >> 16U);
+#else
+
+    /***channel_B *** used for carry the data from User_Send_Buffer to "intermediary" because the SPIx_PUSHR should
+    write the 32bits at once time . Then use channel_C to carry the "intermediary" to SPIx_PUSHR. Note that the
+    SPIx_PUSHR upper 16 bits are the "command" and the low 16bits are data */
+
+    EDMA_ResetChannel(handle->edmaTxDataToIntermediaryHandle->base, handle->edmaTxDataToIntermediaryHandle->channel);
+
+    /*For DSPI instances with separate RX and TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to handle->Command*/
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+    {
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t) & (handle->command);
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*User_Send_Buffer(txData) to intermediary(handle->command)*/
+    if (((((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U))) &&
+         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        if (NULL != handle->txData)
+        {
+            transferConfigB.srcAddr   = (uint32_t)(handle->txData);
+            transferConfigB.srcOffset = 1;
+        }
+        else
+        {
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcOffset = 0;
+        }
+
+        transferConfigB.destAddr   = (uint32_t)(&handle->command);
+        transferConfigB.destOffset = 0;
+
+        transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigB.minorLoopBytes   = 1;
+
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                majorlink , the majorlink would not trigger the channel_C*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1U;
+            }
+        }
+        else
+        {
+            transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigB.minorLoopBytes   = 2;
+            if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+            {
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U - 2U;
+            }
+            else
+            {
+                /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
+                 * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U + 1U;
+            }
+        }
+
+        if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, softwareTCD);
+            EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
+                                       handle->edmaIntermediaryToTxRegHandle->channel, false);
+        }
+        else
+        {
+            EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+        }
+    }
+    else
+    {
+        EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
+                               handle->edmaTxDataToIntermediaryHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
+    }
+
+    /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
+    handle the last data */
+
+    edma_transfer_config_t transferConfigC;
+    EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    /*For DSPI instances with shared RX/TX DMA requests: use the scatter/gather to prepare the last data
+     * (handle->lastCommand) to SPI_PUSHR*/
+    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (tmpRemainingSendByteCount > 0U)))
+    {
+        transferConfigC.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr         = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        transferConfigC.majorLoopCounts  = 1;
+
+        EDMA_TcdReset(softwareTCD);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+    }
+
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    if (((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+        ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U)) ||
+        (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
+    {
+        transferConfigC.srcAddr  = (uint32_t)(&(handle->command));
+        transferConfigC.destAddr = (uint32_t)txAddr;
+
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
+        transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+        {
+            if (handle->bitsPerFrame <= 8U)
+            {
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1U;
+            }
+            else
+            {
+                transferConfigC.majorLoopCounts = (handle->remainingSendByteCount / 2U) - 1U;
+            }
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, softwareTCD);
+        }
+        else
+        {
+            transferConfigC.majorLoopCounts = 1;
+
+            EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+        }
+
         EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
                                    handle->edmaIntermediaryToTxRegHandle->channel, false);
     }
     else
     {
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                               handle->edmaIntermediaryToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
     /*Start the EDMA channel_A , channel_B , channel_C transfer*/
@@ -617,165 +853,233 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
-    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid  = handle->edmaTxDataToIntermediaryHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
     if (channelPriorityLow > channelPriorityMid)
     {
-        t = channelPriorityLow;
+        t                  = channelPriorityLow;
         channelPriorityLow = channelPriorityMid;
         channelPriorityMid = t;
     }
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     if (channelPriorityMid > channelPriorityHigh)
     {
-        t = channelPriorityMid;
-        channelPriorityMid = channelPriorityHigh;
+        t                   = channelPriorityMid;
+        channelPriorityMid  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
-    /*Set the channel link.
-    For DSPI instances with shared RX/TX DMA requests: Rx DMA request -> channel_A -> channel_B-> channel_C.
-    For DSPI instances with separate RX and TX DMA requests:
-    Rx DMA request -> channel_A
-    Tx DMA request -> channel_C -> channel_B . (so need prepare the first data in "intermediary"  before the DMA
-    transfer and then channel_B is used to prepare the next data to "intermediary" ) */
+    /*Set the channel link.*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
-        to prepare the next 32bits data (User_send_buffer to handle->command) */
-        if (handle->remainingSendByteCount > 1)
+        to prepare the next 32bits data (txData to handle->command) */
+        if (handle->remainingSendByteCount > 1U)
         {
             EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
-                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MinorLink,
+                                handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MajorLink,
                                 handle->edmaTxDataToIntermediaryHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
     else
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                    kEDMA_MajorLink, handle->edmaTxDataToIntermediaryHandle->channel);
-            }
 
             EDMA_SetChannelLink(handle->edmaTxDataToIntermediaryHandle->base,
                                 handle->edmaTxDataToIntermediaryHandle->channel, kEDMA_MinorLink,
                                 handle->edmaIntermediaryToTxRegHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
-
+#endif
     DSPI_StartTransfer(base);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI base pointer
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferEDMA(base, handle, &tempXfer);
+
+    return status;
+}
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
     EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the master eDMA transfer count.
+ *
+ * This function gets the master eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -783,13 +1087,33 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         dspi_slave_edma_handle_t *handle,
                                         dspi_slave_edma_transfer_callback_t callback,
@@ -797,14 +1121,16 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle)
 {
-    assert(handle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+    assert(NULL != edmaTxDataToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].base   = base;
     s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
@@ -814,88 +1140,99 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
 
+/*!
+ * brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
+
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle && transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If send/receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    edma_tcd_t *softwareTCD = (edma_tcd_t *)((uint32_t)(&handle->dspiSoftwareTCD[1]) & (~0x1FU));
+    handle->state = (uint8_t)kDSPI_Busy;
 
     uint32_t instance = DSPI_GetInstance(base);
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
-    if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
+    uint32_t limited_size = 0;
+    if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->bitsPerFrame > 8)
+        limited_size = 32767u;
+    }
+    else
+    {
+        limited_size = 511u;
+    }
+
+    if (handle->bitsPerFrame > 8U)
+    {
+        if (transfer->dataSize > (limited_size << 1u))
         {
-            if (transfer->dataSize > 1022)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
-        else
+    }
+    else
+    {
+        if (transfer->dataSize > limited_size)
         {
-            if (transfer->dataSize > 511)
-            {
-                return kStatus_DSPI_OutOfRange;
-            }
+            handle->state = (uint8_t)kDSPI_Idle;
+            return kStatus_DSPI_OutOfRange;
         }
     }
 
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize < 2))
+    /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
 
-    handle->state = kDSPI_Busy;
-
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
-    handle->errorCount = 0;
+    handle->totalByteCount            = transfer->dataSize;
 
-    handle->isThereExtraByte = false;
-    if (handle->bitsPerFrame > 8)
-    {
-        if (handle->remainingSendByteCount % 2 == 1)
-        {
-            handle->remainingSendByteCount++;
-            handle->remainingReceiveByteCount--;
-            handle->isThereExtraByte = true;
-        }
-    }
-
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_SLAVE_DUMMY_DATA;
+    uint32_t wordToSend    = 0;
+    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint8_t dataFedMax     = 2;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
@@ -906,9 +1243,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     DSPI_StartTransfer(base);
 
@@ -918,42 +1255,36 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* Increment to next data byte */
-                    if ((handle->remainingSendByteCount == 2) && (handle->isThereExtraByte))
-                    {
-                        wordToSend |= (unsigned)(dummyData) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
-                    else
-                    {
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
-                        ++handle->txData; /* Increment to next data byte */
-                    }
+
+                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    ++handle->txData; /* Increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -961,9 +1292,10 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     /* Increment to next data word*/
@@ -977,14 +1309,14 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 /* Decrement remainingSendByteCount*/
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -993,179 +1325,132 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     }
 
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
-    if (handle->remainingReceiveByteCount > 0)
+    if (handle->remainingReceiveByteCount > 0U)
     {
         EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcAddr   = (uint32_t)rxAddr;
         transferConfigA.srcOffset = 0;
 
-        if (handle->rxData)
+        if (NULL != handle->rxData)
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
             transferConfigA.destOffset = 1;
         }
         else
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
             transferConfigA.destOffset = 0;
         }
 
         transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.minorLoopBytes  = 1;
             transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
         }
         else
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigA.minorLoopBytes = 2;
-            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+            transferConfigA.minorLoopBytes  = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
         }
+
+        /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
+        handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
+
         EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                               &transferConfigA, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
         EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                     kEDMA_MajorInterruptEnable);
+                                     (uint32_t)kEDMA_MajorInterruptEnable);
     }
 
-    if (handle->remainingSendByteCount > 0)
+    if (handle->remainingSendByteCount > 0U)
     {
         /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
         EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
 
-        /*If there is extra byte , it would use the */
-        if (handle->isThereExtraByte)
-        {
-            if (handle->txData)
-            {
-                handle->txLastData =
-                    handle->txData[handle->remainingSendByteCount - 2] | ((uint32_t)DSPI_SLAVE_DUMMY_DATA << 8);
-            }
-            else
-            {
-                handle->txLastData = DSPI_SLAVE_DUMMY_DATA | ((uint32_t)DSPI_SLAVE_DUMMY_DATA << 8);
-            }
-            transferConfigC.srcAddr = (uint32_t)(&(handle->txLastData));
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-            transferConfigC.srcOffset = 0;
-            transferConfigC.destOffset = 0;
-            transferConfigC.minorLoopBytes = 4;
-            transferConfigC.majorLoopCounts = 1;
+        transferConfigC.destAddr   = (uint32_t)txAddr;
+        transferConfigC.destOffset = 0;
 
-            EDMA_TcdReset(softwareTCD);
-            EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
-        }
-
-        /*Set another  transferConfigC*/
-        if ((handle->isThereExtraByte) && (handle->remainingSendByteCount == 2))
+        if (NULL != handle->txData)
         {
-            EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                   &transferConfigC, NULL);
+            transferConfigC.srcAddr   = (uint32_t)(&(handle->txData[0]));
+            transferConfigC.srcOffset = 1;
         }
         else
         {
-            transferConfigC.destAddr = (uint32_t)txAddr;
-            transferConfigC.destOffset = 0;
-
-            if (handle->txData)
+            transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigC.srcOffset = 0;
+            if (handle->bitsPerFrame <= 8U)
             {
-                transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
-                transferConfigC.srcOffset = 1;
+                handle->txBuffIfNull = dummyData;
             }
             else
             {
-                transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
-                transferConfigC.srcOffset = 0;
-                if (handle->bitsPerFrame <= 8)
-                {
-                    handle->txBuffIfNull = DSPI_SLAVE_DUMMY_DATA;
-                }
-                else
-                {
-                    handle->txBuffIfNull = (DSPI_SLAVE_DUMMY_DATA << 8) | DSPI_SLAVE_DUMMY_DATA;
-                }
+                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
             }
-
-            transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
-
-            if (handle->bitsPerFrame <= 8)
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
-                transferConfigC.minorLoopBytes = 1;
-                transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
-            }
-            else
-            {
-                transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
-                transferConfigC.minorLoopBytes = 2;
-                if (handle->isThereExtraByte)
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
-                }
-                else
-                {
-                    transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
-                }
-            }
-
-            if (handle->isThereExtraByte)
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, softwareTCD);
-                EDMA_EnableAutoStopRequest(handle->edmaTxDataToTxRegHandle->base,
-                                           handle->edmaTxDataToTxRegHandle->channel, false);
-            }
-            else
-            {
-                EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                       &transferConfigC, NULL);
-            }
-
-            EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
         }
+
+        transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
+
+        if (handle->bitsPerFrame <= 8U)
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
+            transferConfigC.minorLoopBytes   = 1;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount;
+        }
+        else
+        {
+            transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
+            transferConfigC.minorLoopBytes   = 2;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount / 2U;
+        }
+
+        EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
+
+        EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
     }
 
     EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.
@@ -1175,16 +1460,16 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     Tx DMA request -> channel_C */
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
         }
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
     else
     {
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
 
     return kStatus_Success;
@@ -1195,58 +1480,67 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    bool transferDone,
                                    uint32_t tcds)
 {
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
+
     dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    uint32_t dataReceived;
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->isThereExtraByte)
-    {
-        while (!((dspiEdmaPrivateHandle->base)->SR & SPI_SR_RFDF_MASK))
-        {
-        }
-        dataReceived = (dspiEdmaPrivateHandle->base)->POPR;
-        if (dspiEdmaPrivateHandle->handle->rxData)
-        {
-            (dspiEdmaPrivateHandle->handle->rxData[dspiEdmaPrivateHandle->handle->totalByteCount - 1]) = dataReceived;
-        }
-    }
-
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
-
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI slave aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
 {
+    assert(NULL != handle);
+
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred so far by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1254,7 +1548,8 @@ status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t
 
     size_t bytes;
 
-    bytes = EDMA_GetRemainingBytes(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
+    bytes = (uint32_t)handle->nbytes * EDMA_GetRemainingMajorLoopCount(handle->edmaRxRegToRxDataHandle->base,
+                                                                       handle->edmaRxRegToRxDataHandle->channel);
 
     *count = handle->totalByteCount - bytes;
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2018 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -37,29 +15,33 @@
  * @{
  */
 
-/*! @file */
-
 /***********************************************************************************************************************
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI master.
+ * @param handle A pointer to the handle for the DSPI master.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
                                                      dspi_master_edma_handle_t *handle,
@@ -69,37 +51,38 @@ typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
  * @brief Completion callback function pointer type.
  *
  * @param base DSPI peripheral base address.
- * @param handle Pointer to the handle for the DSPI slave.
+ * @param handle A pointer to the handle for the DSPI slave.
  * @param status Success or error code describing whether the transfer completed.
- * @param userData Arbitrary pointer-dataSized value passed from the application.
+ * @param userData An arbitrary pointer-dataSized value passed from the application.
  */
 typedef void (*dspi_slave_edma_transfer_callback_t)(SPI_Type *base,
                                                     dspi_slave_edma_handle_t *handle,
                                                     status_t status,
                                                     void *userData);
 
-/*! @brief DSPI master eDMA transfer handle structure used for transactional API. */
+/*! @brief DSPI master eDMA transfer handle structure used for the transactional API. */
 struct _dspi_master_edma_handle
 {
-    uint32_t bitsPerFrame;         /*!< Desired number of bits per frame. */
-    volatile uint32_t command;     /*!< Desired data command. */
-    volatile uint32_t lastCommand; /*!< Desired last data command. */
+    uint32_t bitsPerFrame;         /*!< The desired number of bits per frame. */
+    volatile uint32_t command;     /*!< The desired data command. */
+    volatile uint32_t lastCommand; /*!< The desired last data command. */
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Is PCS signal keep active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Is there extra byte.*/
+    volatile bool
+        isPcsActiveAfterTransfer; /*!< Indicates whether the PCS signal keeps active after the last frame transfer.*/
+
+    uint8_t nbytes;         /*!< eDMA minor byte transfer count initially configured. */
+    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
-
-    volatile uint8_t state; /*!< DSPI transfer state , _dspi_transfer_state.*/
 
     dspi_master_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                                /*!< Callback user data. */
@@ -111,33 +94,30 @@ struct _dspi_master_edma_handle
     edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
-/*! @brief DSPI slave eDMA transfer handle structure used for transactional API.*/
+/*! @brief DSPI slave eDMA transfer handle structure used for the transactional API.*/
 struct _dspi_slave_edma_handle
 {
-    uint32_t bitsPerFrame;          /*!< Desired number of bits per frame. */
-    volatile bool isThereExtraByte; /*!< Is there extra byte.*/
+    uint32_t bitsPerFrame; /*!< The desired number of bits per frame. */
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
-    volatile size_t remainingSendByteCount;    /*!< Number of bytes remaining to send.*/
-    volatile size_t remainingReceiveByteCount; /*!< Number of bytes remaining to receive.*/
-    size_t totalByteCount;                     /*!< Number of transfer bytes*/
+    volatile size_t remainingSendByteCount;    /*!< A number of bytes remaining to send.*/
+    volatile size_t remainingReceiveByteCount; /*!< A number of bytes remaining to receive.*/
+    size_t totalByteCount;                     /*!< A number of transfer bytes*/
 
     uint32_t rxBuffIfNull; /*!< Used if there is not rxData for DMA purpose.*/
     uint32_t txBuffIfNull; /*!< Used if there is not txData for DMA purpose.*/
     uint32_t txLastData;   /*!< Used if there is an extra byte when 16bits per frame for DMA purpose.*/
 
-    volatile uint8_t state; /*!< DSPI transfer state.*/
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
-    uint32_t errorCount; /*!< Error count for slave transfer.*/
+    volatile uint8_t state; /*!< DSPI transfer state.*/
 
     dspi_slave_edma_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                               /*!< Callback user data. */
 
     edma_handle_t *edmaRxRegToRxDataHandle; /*!<edma_handle_t handle point used for RxReg to RxData buff*/
     edma_handle_t *edmaTxDataToTxRegHandle; /*!<edma_handle_t handle point used for TxData to TxReg*/
-
-    edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
 /***********************************************************************************************************************
@@ -153,17 +133,18 @@ extern "C" {
  * @brief Initializes the DSPI master eDMA handle.
  *
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
- * specified DSPI instance, user need only call this API once to get the initialized handle.
+ * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request source.
- * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
- * (2)For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
  *
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_master_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
  * @param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
@@ -179,34 +160,49 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI master transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI master aborts a transfer which using eDMA.
+ * @brief Transfers a block of data using a eDMA method.
  *
- * This function aborts a transfer which using eDMA.
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle);
 
 /*!
  * @brief Gets the master eDMA transfer count.
  *
- * This function get the master eDMA transfer count.
+ * This function gets the master eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_master_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count);
@@ -217,7 +213,8 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
  * specified DSPI instance, call this API once to get the initialized handle.
  *
- * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request source.
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
  * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
  * TX DMAMUX source for edmaTxDataToTxRegHandle.
  * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
@@ -225,7 +222,7 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
  * @param base DSPI peripheral base address.
  * @param handle DSPI handle pointer to dspi_slave_edma_handle_t.
  * @param callback DSPI callback.
- * @param userData callback function parameter.
+ * @param userData A callback function parameter.
  * @param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
  * @param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
  */
@@ -239,25 +236,25 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
 /*!
  * @brief DSPI slave transfer data using eDMA.
  *
- * This function transfer data using eDMA. This is non-blocking function, which returns right away. When all data
- * have been transfer, the callback function is called.
- * Note that slave EDMA transfer cannot support the situation that transfer_size is 1 when the bitsPerFrame is greater
- * than 8 .
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
 
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param transfer pointer to dspi_transfer_t structure.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer);
 
 /*!
- * @brief DSPI slave aborts a transfer which using eDMA.
+ * @brief DSPI slave aborts a transfer which is using eDMA.
  *
- * This function aborts a transfer which using eDMA.
+ * This function aborts a transfer which is using eDMA.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle);
 
@@ -267,8 +264,8 @@ void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handl
  * This function gets the slave eDMA transfer count.
  *
  * @param base DSPI peripheral base address.
- * @param handle pointer to dspi_slave_edma_handle_t structure which stores the transfer state.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * @param count A number of bytes transferred so far by the non-blocking transaction.
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_edma.h
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #ifndef _FSL_EDMA_H_
 #define _FSL_EDMA_H_
@@ -34,11 +34,10 @@
 #include "fsl_common.h"
 
 /*!
- * @addtogroup edma_driver
+ * @addtogroup edma
  * @{
  */
 
-/*! @file */
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -46,7 +45,7 @@
 /*! @name Driver version */
 /*@{*/
 /*! @brief eDMA driver version */
-#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 0, 0)) /*!< Version 2.0.0. */
+#define FSL_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 1)) /*!< Version 2.1.1. */
 /*@}*/
 
 /*! @brief Compute the offset unit from DCHPRI3 */
@@ -78,28 +77,28 @@ typedef enum _edma_modulo
     kEDMA_Modulo128bytes,       /*!< Circular buffer size is 128 bytes. */
     kEDMA_Modulo256bytes,       /*!< Circular buffer size is 256 bytes. */
     kEDMA_Modulo512bytes,       /*!< Circular buffer size is 512 bytes. */
-    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1K bytes. */
-    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2K bytes. */
-    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4K bytes. */
-    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8K bytes. */
-    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16K bytes. */
-    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32K bytes. */
-    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64K bytes. */
-    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128K bytes. */
-    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256K bytes. */
-    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512K bytes. */
-    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1M bytes. */
-    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2M bytes. */
-    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4M bytes. */
-    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8M bytes. */
-    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16M bytes. */
-    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32M bytes. */
-    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64M bytes. */
-    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128M bytes. */
-    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256M bytes. */
-    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512M bytes. */
-    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1G bytes. */
-    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2G bytes. */
+    kEDMA_Modulo1Kbytes,        /*!< Circular buffer size is 1 K bytes. */
+    kEDMA_Modulo2Kbytes,        /*!< Circular buffer size is 2 K bytes. */
+    kEDMA_Modulo4Kbytes,        /*!< Circular buffer size is 4 K bytes. */
+    kEDMA_Modulo8Kbytes,        /*!< Circular buffer size is 8 K bytes. */
+    kEDMA_Modulo16Kbytes,       /*!< Circular buffer size is 16 K bytes. */
+    kEDMA_Modulo32Kbytes,       /*!< Circular buffer size is 32 K bytes. */
+    kEDMA_Modulo64Kbytes,       /*!< Circular buffer size is 64 K bytes. */
+    kEDMA_Modulo128Kbytes,      /*!< Circular buffer size is 128 K bytes. */
+    kEDMA_Modulo256Kbytes,      /*!< Circular buffer size is 256 K bytes. */
+    kEDMA_Modulo512Kbytes,      /*!< Circular buffer size is 512 K bytes. */
+    kEDMA_Modulo1Mbytes,        /*!< Circular buffer size is 1 M bytes. */
+    kEDMA_Modulo2Mbytes,        /*!< Circular buffer size is 2 M bytes. */
+    kEDMA_Modulo4Mbytes,        /*!< Circular buffer size is 4 M bytes. */
+    kEDMA_Modulo8Mbytes,        /*!< Circular buffer size is 8 M bytes. */
+    kEDMA_Modulo16Mbytes,       /*!< Circular buffer size is 16 M bytes. */
+    kEDMA_Modulo32Mbytes,       /*!< Circular buffer size is 32 M bytes. */
+    kEDMA_Modulo64Mbytes,       /*!< Circular buffer size is 64 M bytes. */
+    kEDMA_Modulo128Mbytes,      /*!< Circular buffer size is 128 M bytes. */
+    kEDMA_Modulo256Mbytes,      /*!< Circular buffer size is 256 M bytes. */
+    kEDMA_Modulo512Mbytes,      /*!< Circular buffer size is 512 M bytes. */
+    kEDMA_Modulo1Gbytes,        /*!< Circular buffer size is 1 G bytes. */
+    kEDMA_Modulo2Gbytes,        /*!< Circular buffer size is 2 G bytes. */
 } edma_modulo_t;
 
 /*! @brief Bandwidth control */
@@ -143,7 +142,7 @@ enum _edma_error_status_flags
 #if defined(FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT) && FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT > 1
     kEDMA_GroupPriorityErrorFlag = DMA_ES_GPE_MASK, /*!< Group priority is not unique. */
 #endif
-    kEDMA_ValidFlag = DMA_ES_VLD_MASK, /*!< No error occurred, this bit will be 0, otherwise be 1 */
+    kEDMA_ValidFlag = DMA_ES_VLD_MASK, /*!< No error occurred, this bit is 0. Otherwise, it is 1. */
 };
 
 /*! @brief eDMA interrupt source */
@@ -178,7 +177,7 @@ typedef struct _edma_config
                                            the link channel is itself. */
     bool enableHaltOnError;           /*!< Enable (true) transfer halt on error. Any error causes the HALT bit to set.
                                            Subsequently, all service requests are ignored until the HALT bit is cleared.*/
-    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method, or fixed priority
+    bool enableRoundRobinArbitration; /*!< Enable (true) round robin channel arbitration method or fixed priority
                                            arbitration is used for channel selection */
     bool enableDebugMode; /*!< Enable(true) eDMA debug mode. When in debug mode, the eDMA stalls the start of
                                a new channel. Executing channels are allowed to complete. */
@@ -212,15 +211,15 @@ typedef struct _edma_transfer_config
                                                 form the next-state value as each source read is completed. */
     int16_t destOffset;                    /*!< Sign-extended offset applied to the current destination address to
                                                 form the next-state value as each destination write is completed. */
-    uint16_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
+    uint32_t minorLoopBytes;               /*!< Bytes to transfer in a minor loop*/
     uint32_t majorLoopCounts;              /*!< Major loop iteration count. */
 } edma_transfer_config_t;
 
 /*! @brief eDMA channel priority configuration */
 typedef struct _edma_channel_Preemption_config
 {
-    bool enableChannelPreemption; /*!< If true: channel can be suspended by other channel with higher priority */
-    bool enablePreemptAbility;    /*!< If true: channel can suspend other channel with low priority */
+    bool enableChannelPreemption; /*!< If true: a channel can be suspended by other channel with higher priority */
+    bool enablePreemptAbility;    /*!< If true: a channel can suspend other channel with low priority */
     uint8_t channelPriority;      /*!< Channel priority */
 } edma_channel_Preemption_config_t;
 
@@ -229,14 +228,14 @@ typedef struct _edma_minor_offset_config
 {
     bool enableSrcMinorOffset;  /*!< Enable(true) or Disable(false) source minor loop offset. */
     bool enableDestMinorOffset; /*!< Enable(true) or Disable(false) destination minor loop offset. */
-    uint32_t minorOffset;       /*!< Offset for minor loop mapping. */
+    uint32_t minorOffset;       /*!< Offset for a minor loop mapping. */
 } edma_minor_offset_config_t;
 
 /*!
  * @brief eDMA TCD.
  *
  * This structure is same as TCD register which is described in reference manual,
- * and is used to configure scatter/gather feature as a next hardware TCD.
+ * and is used to configure the scatter/gather feature as a next hardware TCD.
  */
 typedef struct _edma_tcd
 {
@@ -256,20 +255,21 @@ typedef struct _edma_tcd
 /*! @brief Callback for eDMA */
 struct _edma_handle;
 
-/*! @brief Define Callback function for eDMA. */
+/*! @brief Define callback function for eDMA. */
 typedef void (*edma_callback)(struct _edma_handle *handle, void *userData, bool transferDone, uint32_t tcds);
 
 /*! @brief eDMA transfer handle structure */
 typedef struct _edma_handle
 {
-    edma_callback callback;  /*!< Callback function for major count exhausted. */
-    void *userData;          /*!< Callback function parameter. */
-    DMA_Type *base;          /*!< eDMA peripheral base address. */
-    edma_tcd_t *tcdPool;     /*!< Pointer to memory stored TCDs. */
-    uint8_t channel;         /*!< eDMA channel number. */
-    volatile int8_t header;  /*!< The first TCD index. */
-    volatile int8_t tail;    /*!< The last TCD index. */
-    volatile int8_t tcdUsed; /*!< The number of used TCD slots. */
+    edma_callback callback; /*!< Callback function for major count exhausted. */
+    void *userData;         /*!< Callback function parameter. */
+    DMA_Type *base;         /*!< eDMA peripheral base address. */
+    edma_tcd_t *tcdPool;    /*!< Pointer to memory stored TCDs. */
+    uint8_t channel;        /*!< eDMA channel number. */
+    volatile int8_t header; /*!< The first TCD index. Should point to the next TCD to be loaded into the eDMA engine. */
+    volatile int8_t tail;   /*!< The last TCD index. Should point to the next TCD to be stored into the memory pool. */
+    volatile int8_t tcdUsed; /*!< The number of used TCD slots. Should reflect the number of TCDs can be used/loaded in
+                                the memory. */
     volatile int8_t tcdSize; /*!< The total number of TCD slots in the queue. */
     uint8_t flags;           /*!< The status of the current channel. */
 } edma_handle_t;
@@ -282,24 +282,24 @@ extern "C" {
 #endif /* __cplusplus */
 
 /*!
- * @name eDMA initialization and De-initialization
+ * @name eDMA initialization and de-initialization
  * @{
  */
 
 /*!
- * @brief Initializes eDMA peripheral.
+ * @brief Initializes the eDMA peripheral.
  *
- * This function ungates the eDMA clock and configure eDMA peripheral according
+ * This function ungates the eDMA clock and configures the eDMA peripheral according
  * to the configuration structure.
  *
  * @param base eDMA peripheral base address.
- * @param config Pointer to configuration structure, see "edma_config_t".
- * @note This function enable the minor loop map feature.
+ * @param config A pointer to the configuration structure, see "edma_config_t".
+ * @note This function enables the minor loop map feature.
  */
 void EDMA_Init(DMA_Type *base, const edma_config_t *config);
 
 /*!
- * @brief Deinitializes eDMA peripheral.
+ * @brief Deinitializes the eDMA peripheral.
  *
  * This function gates the eDMA clock.
  *
@@ -310,8 +310,8 @@ void EDMA_Deinit(DMA_Type *base);
 /*!
  * @brief Gets the eDMA default configuration structure.
  *
- * This function sets the configuration structure to a default value.
- * The default configuration is set to the following value:
+ * This function sets the configuration structure to default values.
+ * The default configuration is set to the following values.
  * @code
  *   config.enableContinuousLinkMode = false;
  *   config.enableHaltOnError = true;
@@ -319,7 +319,7 @@ void EDMA_Deinit(DMA_Type *base);
  *   config.enableDebugMode = false;
  * @endcode
  *
- * @param config Pointer to eDMA configuration structure.
+ * @param config A pointer to the eDMA configuration structure.
  */
 void EDMA_GetDefaultConfig(edma_config_t *config);
 
@@ -330,22 +330,22 @@ void EDMA_GetDefaultConfig(edma_config_t *config);
  */
 
 /*!
- * @brief Sets all TCD registers to a default value.
+ * @brief Sets all TCD registers to default values.
  *
- * This function sets TCD registers for this channel to default value.
+ * This function sets TCD registers for this channel to default values.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @note This function must not be called while the channel transfer is on-going,
- *       or it will case unpredicated results.
- * @note This function will enable auto stop request feature.
+ * @note This function must not be called while the channel transfer is ongoing
+ *       or it causes unpredictable results.
+ * @note This function enables the auto stop request feature.
  */
 void EDMA_ResetChannel(DMA_Type *base, uint32_t channel);
 
 /*!
  * @brief Configures the eDMA transfer attribute.
  *
- * This function configure the transfer attribute, including source address, destination address,
+ * This function configures the transfer attribute, including source address, destination address,
  * transfer size, address offset, and so on. It also configures the scatter gather feature if the
  * user supplies the TCD address.
  * Example:
@@ -361,11 +361,11 @@ void EDMA_ResetChannel(DMA_Type *base, uint32_t channel);
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
  * @param config Pointer to eDMA transfer configuration structure.
- * @param nextTcd Point to TCD structure. It can be NULL if user
+ * @param nextTcd Point to TCD structure. It can be NULL if users
  *                do not want to enable scatter/gather feature.
- * @note If nextTcd is not NULL, it means scatter gather feature will be enabled.
- *       And DREQ bit will be cleared in the previous transfer configuration which
- *       will be set in eDMA_ResetChannel.
+ * @note If nextTcd is not NULL, it means scatter gather feature is enabled
+ *       and DREQ bit is cleared in the previous transfer configuration, which
+ *       is set in the eDMA_ResetChannel.
  */
 void EDMA_SetTransferConfig(DMA_Type *base,
                             uint32_t channel,
@@ -375,12 +375,12 @@ void EDMA_SetTransferConfig(DMA_Type *base,
 /*!
  * @brief Configures the eDMA minor offset feature.
  *
- * Minor offset means signed-extended value added to source address or destination
+ * The minor offset means that the signed-extended value is added to the source address or destination
  * address after each minor loop.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param config Pointer to Minor offset configuration structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_minor_offset_config_t *config);
 
@@ -391,7 +391,7 @@ void EDMA_SetMinorOffsetConfig(DMA_Type *base, uint32_t channel, const edma_mino
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number
- * @param config Pointer to channel preemption configuration structure.
+ * @param config A pointer to the channel preemption configuration structure.
  */
 static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
                                                    uint32_t channel,
@@ -408,30 +408,31 @@ static inline void EDMA_SetChannelPreemptionConfig(DMA_Type *base,
 /*!
  * @brief Sets the channel link for the eDMA transfer.
  *
- * This function configures  minor link or major link mode. The minor link means that the channel link is
- * triggered every time CITER decreases by 1. The major link means that the channel link is triggered when the CITER is exhausted.
+ * This function configures either the minor link or the major link mode. The minor link means that the channel link is
+ * triggered every time CITER decreases by 1. The major link means that the channel link is triggered when the CITER is
+ * exhausted.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param type Channel link type, it can be one of:
+ * @param type A channel link type, which can be one of the following:
  *   @arg kEDMA_LinkNone
  *   @arg kEDMA_MinorLink
  *   @arg kEDMA_MajorLink
  * @param linkedChannel The linked channel number.
- * @note User should ensure that DONE flag is cleared before call this interface, or the configuration will be invalid.
+ * @note Users should ensure that DONE flag is cleared before calling this interface, or the configuration is invalid.
  */
 void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_type_t type, uint32_t linkedChannel);
 
 /*!
  * @brief Sets the bandwidth for the eDMA transfer.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
  * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -439,7 +440,7 @@ void EDMA_SetChannelLink(DMA_Type *base, uint32_t channel, edma_channel_link_typ
 void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWidth);
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA transfer.
+ * @brief Sets the source modulo and the destination modulo for the eDMA transfer.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
@@ -447,8 +448,8 @@ void EDMA_SetBandWidth(DMA_Type *base, uint32_t channel, edma_bandwidth_t bandWi
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -458,7 +459,7 @@ void EDMA_SetModulo(DMA_Type *base, uint32_t channel, edma_modulo_t srcModulo, e
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable(ture) or disable(false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -475,7 +476,7 @@ static inline void EDMA_EnableAsyncRequest(DMA_Type *base, uint32_t channel, boo
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param enable The command for enable (true) or disable (false).
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_EnableAutoStopRequest(DMA_Type *base, uint32_t channel, bool enable)
 {
@@ -489,7 +490,7 @@ static inline void EDMA_EnableAutoStopRequest(DMA_Type *base, uint32_t channel, 
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param mask The mask of interrupt source to be set. User need to use
+ * @param mask The mask of interrupt source to be set. Users need to use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
@@ -499,7 +500,7 @@ void EDMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mas
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param mask The mask of interrupt source to be set. Use
+ * @param mask The mask of the interrupt source to be set. Use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t mask);
@@ -516,15 +517,15 @@ void EDMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel, uint32_t ma
  * This function sets all fields for this TCD structure to default value.
  *
  * @param tcd Pointer to the TCD structure.
- * @note This function will enable auto stop request feature.
+ * @note This function enables the auto stop request feature.
  */
 void EDMA_TcdReset(edma_tcd_t *tcd);
 
 /*!
  * @brief Configures the eDMA TCD transfer attribute.
  *
- * TCD is a transfer control descriptor. The content of the TCD is the same as hardware TCD registers.
- * STCD is used in scatter-gather mode.
+ * The TCD is a transfer control descriptor. The content of the TCD is the same as the hardware TCD registers.
+ * The STCD is used in the scatter-gather mode.
  * This function configures the TCD transfer attribute, including source address, destination address,
  * transfer size, address offset, and so on. It also configures the scatter gather feature if the
  * user supplies the next TCD address.
@@ -540,33 +541,34 @@ void EDMA_TcdReset(edma_tcd_t *tcd);
  *
  * @param tcd Pointer to the TCD structure.
  * @param config Pointer to eDMA transfer configuration structure.
- * @param nextTcd Pointer to the next TCD structure. It can be NULL if user
+ * @param nextTcd Pointer to the next TCD structure. It can be NULL if users
  *                do not want to enable scatter/gather feature.
- * @note TCD address should be 32 bytes aligned, or it will cause eDMA error.
- * @note If nextTcd is not NULL, it means scatter gather feature will be enabled.
- *       And DREQ bit will be cleared in the previous transfer configuration which
- *       will be set in EDMA_TcdReset.
+ * @note TCD address should be 32 bytes aligned or it causes an eDMA error.
+ * @note If the nextTcd is not NULL, the scatter gather feature is enabled
+ *       and DREQ bit is cleared in the previous transfer configuration, which
+ *       is set in the EDMA_TcdReset.
  */
 void EDMA_TcdSetTransferConfig(edma_tcd_t *tcd, const edma_transfer_config_t *config, edma_tcd_t *nextTcd);
 
 /*!
  * @brief Configures the eDMA TCD minor offset feature.
  *
- * Minor offset is a signed-extended value added to the source address or destination
+ * A minor offset is a signed-extended value added to the source address or a destination
  * address after each minor loop.
  *
- * @param tcd Point to the TCD structure.
- * @param config Pointer to Minor offset configuration structure.
+ * @param tcd A point to the TCD structure.
+ * @param config A pointer to the minor offset configuration structure.
  */
 void EDMA_TcdSetMinorOffsetConfig(edma_tcd_t *tcd, const edma_minor_offset_config_t *config);
 
 /*!
- * @brief Sets the channel link for eDMA TCD.
+ * @brief Sets the channel link for the eDMA TCD.
  *
  * This function configures either a minor link or a major link. The minor link means the channel link is
- * triggered every time CITER decreases by 1. The major link means that the channel link  is triggered when the CITER is exhausted.
+ * triggered every time CITER decreases by 1. The major link means that the channel link  is triggered when the CITER is
+ * exhausted.
  *
- * @note User should ensure that DONE flag is cleared before call this interface, or the configuration will be invalid.
+ * @note Users should ensure that DONE flag is cleared before calling this interface, or the configuration is invalid.
  * @param tcd Point to the TCD structure.
  * @param type Channel link type, it can be one of:
  *   @arg kEDMA_LinkNone
@@ -579,11 +581,11 @@ void EDMA_TcdSetChannelLink(edma_tcd_t *tcd, edma_channel_link_type_t type, uint
 /*!
  * @brief Sets the bandwidth for the eDMA TCD.
  *
- * In general, because the eDMA processes the minor loop, it continuously generates read/write sequences
- * until the minor count is exhausted. Bandwidth forces the eDMA to stall after the completion of
+ * Because the eDMA processes the minor loop, it continuously generates read/write sequences
+ * until the minor count is exhausted. The bandwidth forces the eDMA to stall after the completion of
  * each read/write access to control the bus request bandwidth seen by the crossbar switch.
- * @param tcd Point to the TCD structure.
- * @param bandWidth Bandwidth setting, it can be one of:
+ * @param tcd A pointer to the TCD structure.
+ * @param bandWidth A bandwidth setting, which can be one of the following:
  *     @arg kEDMABandwidthStallNone
  *     @arg kEDMABandwidthStall4Cycle
  *     @arg kEDMABandwidthStall8Cycle
@@ -597,15 +599,15 @@ static inline void EDMA_TcdSetBandWidth(edma_tcd_t *tcd, edma_bandwidth_t bandWi
 }
 
 /*!
- * @brief Sets the source modulo and destination modulo for eDMA TCD.
+ * @brief Sets the source modulo and the destination modulo for the eDMA TCD.
  *
  * This function defines a specific address range specified to be the value after (SADDR + SOFF)/(DADDR + DOFF)
  * calculation is performed or the original register value. It provides the ability to implement a circular data
  * queue easily.
  *
- * @param tcd Point to the TCD structure.
- * @param srcModulo Source modulo value.
- * @param destModulo Destination modulo value.
+ * @param tcd A pointer to the TCD structure.
+ * @param srcModulo A source modulo value.
+ * @param destModulo A destination modulo value.
  */
 void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t destModulo);
 
@@ -614,8 +616,8 @@ void EDMA_TcdSetModulo(edma_tcd_t *tcd, edma_modulo_t srcModulo, edma_modulo_t d
  *
  * If enabling the auto stop request, the eDMA hardware automatically disables the hardware channel request.
  *
- * @param tcd Point to the TCD structure.
- * @param enable The command for enable(ture) or disable(false).
+ * @param tcd A pointer to the TCD structure.
+ * @param enable The command to enable (true) or disable (false).
  */
 static inline void EDMA_TcdEnableAutoStopRequest(edma_tcd_t *tcd, bool enable)
 {
@@ -629,7 +631,7 @@ static inline void EDMA_TcdEnableAutoStopRequest(edma_tcd_t *tcd, bool enable)
  * @brief Enables the interrupt source for the eDMA TCD.
  *
  * @param tcd Point to the TCD structure.
- * @param mask The mask of interrupt source to be set. User need to use
+ * @param mask The mask of interrupt source to be set. Users need to use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_TcdEnableInterrupts(edma_tcd_t *tcd, uint32_t mask);
@@ -638,7 +640,7 @@ void EDMA_TcdEnableInterrupts(edma_tcd_t *tcd, uint32_t mask);
  * @brief Disables the interrupt source for the eDMA TCD.
  *
  * @param tcd Point to the TCD structure.
- * @param mask The mask of interrupt source to be set. User need to use
+ * @param mask The mask of interrupt source to be set. Users need to use
  *             the defined edma_interrupt_enable_t type.
  */
 void EDMA_TcdDisableInterrupts(edma_tcd_t *tcd, uint32_t mask);
@@ -680,7 +682,7 @@ static inline void EDMA_DisableChannelRequest(DMA_Type *base, uint32_t channel)
 }
 
 /*!
- * @brief Starts the eDMA transfer by software trigger.
+ * @brief Starts the eDMA transfer by using the software trigger.
  *
  * This function starts a minor loop transfer.
  *
@@ -701,25 +703,34 @@ static inline void EDMA_TriggerChannelStart(DMA_Type *base, uint32_t channel)
  */
 
 /*!
- * @brief Gets the Remaining bytes from the eDMA current channel TCD.
+ * @brief Gets the remaining major loop count from the eDMA current channel TCD.
  *
  * This function checks the TCD (Task Control Descriptor) status for a specified
- * eDMA channel and returns the the number of bytes that have not finished.
+ * eDMA channel and returns the the number of major loop count that has not finished.
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @return Bytes have not been transferred yet for the current TCD.
- * @note This function can only be used to get unfinished bytes of transfer without
- *       the next TCD, or it might be inaccuracy.
+ * @return Major loop count which has not been transferred yet for the current TCD.
+ * @note 1. This function can only be used to get unfinished major loop count of transfer without
+ *          the next TCD, or it might be inaccuracy.
+ *       2. The unfinished/remaining transfer bytes cannot be obtained directly from registers while
+ *          the channel is running.
+ *          Because to calculate the remaining bytes, the initial NBYTES configured in DMA_TCDn_NBYTES_MLNO
+ *          register is needed while the eDMA IP does not support getting it while a channel is active.
+ *          In another word, the NBYTES value reading is always the actual (decrementing) NBYTES value the dma_engine
+ *          is working with while a channel is running.
+ *          Consequently, to get the remaining transfer bytes, a software-saved initial value of NBYTES (for example
+ *          copied before enabling the channel) is needed. The formula to calculate it is shown below:
+ *          RemainingBytes = RemainingMajorLoopCount * NBYTES(initially configured)
  */
-uint32_t EDMA_GetRemainingBytes(DMA_Type *base, uint32_t channel);
+uint32_t EDMA_GetRemainingMajorLoopCount(DMA_Type *base, uint32_t channel);
 
 /*!
  * @brief Gets the eDMA channel error status flags.
  *
  * @param base eDMA peripheral base address.
- * @return The mask of error status flags. User need to use the
- *         _edma_error_status_flags type to decode the return variables.
+ * @return The mask of error status flags. Users need to use the
+*         _edma_error_status_flags type to decode the return variables.
  */
 static inline uint32_t EDMA_GetErrorStatusFlags(DMA_Type *base)
 {
@@ -731,7 +742,7 @@ static inline uint32_t EDMA_GetErrorStatusFlags(DMA_Type *base)
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @return The mask of channel status flags. User need to use the
+ * @return The mask of channel status flags. Users need to use the
  *         _edma_channel_status_flags type to decode the return variables.
  */
 uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel);
@@ -741,7 +752,7 @@ uint32_t EDMA_GetChannelStatusFlags(DMA_Type *base, uint32_t channel);
  *
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
- * @param mask The mask of channel status to be cleared. User need to use
+ * @param mask The mask of channel status to be cleared. Users need to use
  *             the defined _edma_channel_status_flags type.
  */
 void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mask);
@@ -754,8 +765,8 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 /*!
  * @brief Creates the eDMA handle.
  *
- * This function is called if using transaction API for eDMA. This function
- * initializes the internal state of eDMA handle.
+ * This function is called if using the transactional API for eDMA. This function
+ * initializes the internal state of the eDMA handle.
  *
  * @param handle eDMA handle pointer. The eDMA handle stores callback function and
  *               parameters.
@@ -765,12 +776,12 @@ void EDMA_ClearChannelStatusFlags(DMA_Type *base, uint32_t channel, uint32_t mas
 void EDMA_CreateHandle(edma_handle_t *handle, DMA_Type *base, uint32_t channel);
 
 /*!
- * @brief Installs the TCDs memory pool into eDMA handle.
+ * @brief Installs the TCDs memory pool into the eDMA handle.
  *
  * This function is called after the EDMA_CreateHandle to use scatter/gather feature.
  *
  * @param handle eDMA handle pointer.
- * @param tcdPool Memory pool to store TCDs. It must be 32 bytes aligned.
+ * @param tcdPool A memory pool to store TCDs. It must be 32 bytes aligned.
  * @param tcdSize The number of TCD slots.
  */
 void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t tcdSize);
@@ -778,12 +789,12 @@ void EDMA_InstallTCDMemory(edma_handle_t *handle, edma_tcd_t *tcdPool, uint32_t 
 /*!
  * @brief Installs a callback function for the eDMA transfer.
  *
- * This callback is called in eDMA IRQ handler. Use the callback to do something after
+ * This callback is called in the eDMA IRQ handler. Use the callback to do something after
  * the current major loop transfer completes.
  *
  * @param handle eDMA handle pointer.
  * @param callback eDMA callback function pointer.
- * @param userData Parameter for callback function.
+ * @param userData A parameter for the callback function.
  */
 void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userData);
 
@@ -801,8 +812,8 @@ void EDMA_SetCallback(edma_handle_t *handle, edma_callback callback, void *userD
  * @param transferBytes eDMA transfer bytes to be transferred.
  * @param type eDMA transfer type.
  * @note The data address and the data width must be consistent. For example, if the SRC
- *       is 4 bytes, so the source address must be 4 bytes aligned, or it shall result in
- *       source address error(SAE).
+ *       is 4 bytes, the source address must be 4 bytes aligned, or it results in
+ *       source address error (SAE).
  */
 void EDMA_PrepareTransfer(edma_transfer_config_t *config,
                           void *srcAddr,
@@ -817,7 +828,7 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
  * @brief Submits the eDMA transfer request.
  *
  * This function submits the eDMA transfer request according to the transfer configuration structure.
- * If the user submits the transfer request repeatedly, this function packs an unprocessed request as
+ * If submitting the transfer request repeatedly, this function packs an unprocessed request as
  * a TCD and enables scatter/gather feature to process it in the next time.
  *
  * @param handle eDMA handle pointer.
@@ -829,9 +840,9 @@ void EDMA_PrepareTransfer(edma_transfer_config_t *config,
 status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t *config);
 
 /*!
- * @brief eDMA start transfer.
+ * @brief eDMA starts transfer.
  *
- * This function enables the channel request. User can call this function after submitting the transfer request
+ * This function enables the channel request. Users can call this function after submitting the transfer request
  * or before submitting the transfer request.
  *
  * @param handle eDMA handle pointer.
@@ -839,9 +850,9 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
 void EDMA_StartTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA stop transfer.
+ * @brief eDMA stops transfer.
  *
- * This function disables the channel request to pause the transfer. User can call EDMA_StartTransfer()
+ * This function disables the channel request to pause the transfer. Users can call EDMA_StartTransfer()
  * again to resume the transfer.
  *
  * @param handle eDMA handle pointer.
@@ -849,20 +860,40 @@ void EDMA_StartTransfer(edma_handle_t *handle);
 void EDMA_StopTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA abort transfer.
+ * @brief eDMA aborts transfer.
  *
  * This function disables the channel request and clear transfer status bits.
- * User can submit another transfer after calling this API.
+ * Users can submit another transfer after calling this API.
  *
  * @param handle DMA handle pointer.
  */
 void EDMA_AbortTransfer(edma_handle_t *handle);
 
 /*!
- * @brief eDMA IRQ handler for current major loop transfer complete.
+ * @brief eDMA IRQ handler for the current major loop transfer completion.
  *
- * This function clears the channel major interrupt flag and call
+ * This function clears the channel major interrupt flag and calls
  * the callback function if it is not NULL.
+ *
+ * Note:
+ * For the case using TCD queue, when the major iteration count is exhausted, additional operations are performed.
+ * These include the final address adjustments and reloading of the BITER field into the CITER.
+ * Assertion of an optional interrupt request also occurs at this time, as does a possible fetch of a new TCD from
+ * memory using the scatter/gather address pointer included in the descriptor (if scatter/gather is enabled).
+ *
+ * For instance, when the time interrupt of TCD[0] happens, the TCD[1] has already been loaded into the eDMA engine.
+ * As sga and sga_index are calculated based on the DLAST_SGA bitfield lies in the TCD_CSR register, the sga_index
+ * in this case should be 2 (DLAST_SGA of TCD[1] stores the address of TCD[2]). Thus, the "tcdUsed" updated should be
+ * (tcdUsed - 2U) which indicates the number of TCDs can be loaded in the memory pool (because TCD[0] and TCD[1] have
+ * been loaded into the eDMA engine at this point already.).
+ *
+ * For the last two continuous ISRs in a scatter/gather process, they  both load the last TCD (The last ISR does not
+ * load a new TCD) from the memory pool to the eDMA engine when major loop completes.
+ * Therefore, ensure that the header and tcdUsed updated are identical for them.
+ * tcdUsed are both 0 in this case as no TCD to be loaded.
+ *
+ * See the "eDMA basic data flow" in the eDMA Functional description section of the Reference Manual for
+ * further details.
  *
  * @param handle eDMA handle pointer.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_i2c.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -76,6 +76,19 @@ typedef void (*i2c_isr_t)(I2C_Type *base, void *i2cHandle);
 uint32_t I2C_GetInstance(I2C_Type *base);
 
 /*!
+* @brief Set SCL/SDA hold time, this API receives SCL stop hold time, calculate the
+* closest SCL divider and MULT value for the SDA hold time, SCL start and SCL stop
+* hold time. To reduce the ROM size, SDA/SCL hold value mapping table is not provided,
+* assume SCL divider = SCL stop hold value *2 to get the closest SCL divider value and MULT
+* value, then the related SDA hold time, SCL start and SCL stop hold time is used.
+*
+* @param base I2C peripheral base address.
+* @param sourceClock_Hz I2C functional clock frequency in Hertz.
+* @param sclStopHoldTime_ns SCL stop hold time in ns.
+*/
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz);
+
+/*!
  * @brief Set up master transfer, send slave address and decide the initial
  * transfer state.
  *
@@ -125,20 +138,22 @@ static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle);
 static void *s_i2cHandle[FSL_FEATURE_SOC_I2C_COUNT] = {NULL};
 
 /*! @brief SCL clock divider used to calculate baudrate. */
-const uint16_t s_i2cDividerTable[] = {20,   22,   24,   26,   28,   30,   34,   40,   28,   32,   36,   40,  44,
-                                      48,   56,   68,   48,   56,   64,   72,   80,   88,   104,  128,  80,  96,
-                                      112,  128,  144,  160,  192,  240,  160,  192,  224,  256,  288,  320, 384,
-                                      480,  320,  384,  448,  512,  576,  640,  768,  960,  640,  768,  896, 1024,
-                                      1152, 1280, 1536, 1920, 1280, 1536, 1792, 2048, 2304, 2560, 3072, 3840};
+static const uint16_t s_i2cDividerTable[] = {
+    20,  22,  24,  26,   28,   30,   34,   40,   28,   32,   36,   40,   44,   48,   56,   68,
+    48,  56,  64,  72,   80,   88,   104,  128,  80,   96,   112,  128,  144,  160,  192,  240,
+    160, 192, 224, 256,  288,  320,  384,  480,  320,  384,  448,  512,  576,  640,  768,  960,
+    640, 768, 896, 1024, 1152, 1280, 1536, 1920, 1280, 1536, 1792, 2048, 2304, 2560, 3072, 3840};
 
 /*! @brief Pointers to i2c bases for each instance. */
 static I2C_Type *const s_i2cBases[] = I2C_BASE_PTRS;
 
 /*! @brief Pointers to i2c IRQ number for each instance. */
-const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
+static const IRQn_Type s_i2cIrqs[] = I2C_IRQS;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to i2c clocks for each instance. */
-const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+static const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static i2c_isr_t s_i2cMasterIsr;
@@ -155,7 +170,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_I2C_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -163,16 +178,63 @@ uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_I2C_COUNT);
+    assert(instance < ARRAY_SIZE(s_i2cBases));
 
     return instance;
+}
+
+static void I2C_SetHoldTime(I2C_Type *base, uint32_t sclStopHoldTime_ns, uint32_t sourceClock_Hz)
+{
+    uint32_t multiplier;
+    uint32_t computedSclHoldTime;
+    uint32_t absError;
+    uint32_t bestError = UINT32_MAX;
+    uint32_t bestMult = 0u;
+    uint32_t bestIcr = 0u;
+    uint8_t mult;
+    uint8_t i;
+
+    /* Search for the settings with the lowest error. Mult is the MULT field of the I2C_F register,
+     * and ranges from 0-2. It selects the multiplier factor for the divider. */
+    /* SDA hold time = bus period (s) * mul * SDA hold value. */
+    /* SCL start hold time = bus period (s) * mul * SCL start hold value. */
+    /* SCL stop hold time = bus period (s) * mul * SCL stop hold value. */
+
+    for (mult = 0u; (mult <= 2u) && (bestError != 0); ++mult)
+    {
+        multiplier = 1u << mult;
+
+        /* Scan table to find best match. */
+        for (i = 0u; i < sizeof(s_i2cDividerTable) / sizeof(s_i2cDividerTable[0]); ++i)
+        {
+            /* Assume SCL hold(stop) value = s_i2cDividerTable[i]/2. */
+            computedSclHoldTime = ((multiplier * s_i2cDividerTable[i]) * 500000000U) / sourceClock_Hz;
+            absError = sclStopHoldTime_ns > computedSclHoldTime ? (sclStopHoldTime_ns - computedSclHoldTime) :
+                                                                  (computedSclHoldTime - sclStopHoldTime_ns);
+
+            if (absError < bestError)
+            {
+                bestMult = mult;
+                bestIcr = i;
+                bestError = absError;
+
+                /* If the error is 0, then we can stop searching because we won't find a better match. */
+                if (absError == 0)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Set frequency register based on best settings. */
+    base->F = I2C_F_MULT(bestMult) | I2C_F_ICR(bestIcr);
 }
 
 static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t *handle, i2c_master_transfer_t *xfer)
 {
     status_t result = kStatus_Success;
     i2c_direction_t direction = xfer->direction;
-    uint16_t timeout = UINT16_MAX;
 
     /* Initialize the handle transfer information. */
     handle->transfer = *xfer;
@@ -183,27 +245,13 @@ static status_t I2C_InitTransferStateMachine(I2C_Type *base, i2c_master_handle_t
     /* Initial transfer state. */
     if (handle->transfer.subaddressSize > 0)
     {
-        handle->state = kSendCommandState;
         if (xfer->direction == kI2C_Read)
         {
             direction = kI2C_Write;
         }
     }
-    else
-    {
-        handle->state = kCheckAddressState;
-    }
 
-    /* Wait until the data register is ready for transmit. */
-    while ((!(base->S & kI2C_TransferCompleteFlag)) && (--timeout))
-    {
-    }
-
-    /* Failed to start the transfer. */
-    if (timeout == 0)
-    {
-        return kStatus_I2C_Timeout;
-    }
+    handle->state = kCheckAddressState;
 
     /* Clear all status before transfer. */
     I2C_MasterClearStatusFlags(base, kClearFlags);
@@ -265,32 +313,39 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
         result = kStatus_Success;
     }
 
-    if (result)
-    {
-        return result;
-    }
-
     /* Handle Check address state to check the slave address is Acked in slave
        probe application. */
     if (handle->state == kCheckAddressState)
     {
         if (statusFlags & kI2C_ReceiveNakFlag)
         {
-            return kStatus_I2C_Nak;
+            result = kStatus_I2C_Addr_Nak;
         }
         else
         {
-            if (handle->transfer.direction == kI2C_Write)
+            if (handle->transfer.subaddressSize > 0)
             {
-                /* Next state, send data. */
-                handle->state = kSendDataState;
+                handle->state = kSendCommandState;
             }
             else
             {
-                /* Next state, receive data begin. */
-                handle->state = kReceiveDataBeginState;
+                if (handle->transfer.direction == kI2C_Write)
+                {
+                    /* Next state, send data. */
+                    handle->state = kSendDataState;
+                }
+                else
+                {
+                    /* Next state, receive data begin. */
+                    handle->state = kReceiveDataBeginState;
+                }
             }
         }
+    }
+
+    if (result)
+    {
+        return result;
     }
 
     /* Run state machine. */
@@ -375,6 +430,10 @@ static status_t I2C_MasterTransferRunStateMachine(I2C_Type *base, i2c_master_han
                     {
                         result = I2C_MasterStop(base);
                     }
+                    else
+                    {
+                        base->C1 |= I2C_C1_TX_MASK;
+                    }
                 }
 
                 /* Send NAK at the last receive byte. */
@@ -407,6 +466,7 @@ static void I2C_TransferCommonIRQHandler(I2C_Type *base, void *handle)
     {
         s_i2cSlaveIsr(base, handle);
     }
+    __DSB();
 }
 
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz)
@@ -415,12 +475,26 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Temporary register for filter read. */
     uint8_t fltReg;
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    uint8_t c2Reg;
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    uint8_t s2Reg;
 #endif
-
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Enable I2C clock. */
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Disable I2C prior to configuring it. */
     base->C1 &= ~(I2C_C1_IICEN_MASK);
@@ -430,14 +504,6 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
 
     /* Configure baud rate. */
     I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
-
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Configure high drive feature. */
-    c2Reg = base->C2;
-    c2Reg &= ~(I2C_C2_HDRS_MASK);
-    c2Reg |= I2C_C2_HDRS(masterConfig->enableHighDrive);
-    base->C2 = c2Reg;
-#endif
 
     /* Read out the FLT register. */
     fltReg = base->FLT;
@@ -455,6 +521,12 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
     /* Write the register value back to the filter register. */
     base->FLT = fltReg;
 
+/* Enable/Disable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    s2Reg = base->S2 & (~I2C_S2_DFEN_MASK);
+    base->S2 = s2Reg | I2C_S2_DFEN(masterConfig->enableDoubleBuffering);
+#endif
+
     /* Enable the I2C peripheral based on the configuration. */
     base->C1 = I2C_C1_IICEN(masterConfig->enableMaster);
 }
@@ -464,8 +536,10 @@ void I2C_MasterDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
@@ -475,11 +549,6 @@ void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
     /* Default baud rate at 100kbps. */
     masterConfig->baudRate_Bps = 100000U;
 
-/* Default pin high drive is disabled. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    masterConfig->enableHighDrive = false;
-#endif
-
 /* Default stop hold enable is disabled. */
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
     masterConfig->enableStopHold = false;
@@ -488,12 +557,21 @@ void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig)
     /* Default glitch filter value is no filter. */
     masterConfig->glitchFilterWidth = 0U;
 
+/* Default enable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    masterConfig->enableDoubleBuffering = true;
+#endif
+
     /* Enable the I2C peripheral. */
     masterConfig->enableMaster = true;
 }
 
 void I2C_EnableInterrupts(I2C_Type *base, uint32_t mask)
 {
+#ifdef I2C_HAS_STOP_DETECT
+    uint8_t fltReg;
+#endif
+
     if (mask & kI2C_GlobalInterruptEnable)
     {
         base->C1 |= I2C_C1_IICIE_MASK;
@@ -502,14 +580,28 @@ void I2C_EnableInterrupts(I2C_Type *base, uint32_t mask)
 #if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
     if (mask & kI2C_StopDetectInterruptEnable)
     {
-        base->FLT |= I2C_FLT_STOPIE_MASK;
+        fltReg = base->FLT;
+
+        /* Keep STOPF flag. */
+        fltReg &= ~I2C_FLT_STOPF_MASK;
+
+        /* Stop detect enable. */
+        fltReg |= I2C_FLT_STOPIE_MASK;
+        base->FLT = fltReg;
     }
 #endif /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
 
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
     if (mask & kI2C_StartStopDetectInterruptEnable)
     {
-        base->FLT |= I2C_FLT_SSIE_MASK;
+        fltReg = base->FLT;
+
+        /* Keep STARTF and STOPF flags. */
+        fltReg &= ~(I2C_FLT_STOPF_MASK | I2C_FLT_STARTF_MASK);
+
+        /* Start and stop detect enable. */
+        fltReg |= I2C_FLT_SSIE_MASK;
+        base->FLT = fltReg;
     }
 #endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
 }
@@ -524,14 +616,14 @@ void I2C_DisableInterrupts(I2C_Type *base, uint32_t mask)
 #if defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
     if (mask & kI2C_StopDetectInterruptEnable)
     {
-        base->FLT &= ~I2C_FLT_STOPIE_MASK;
+        base->FLT &= ~(I2C_FLT_STOPIE_MASK | I2C_FLT_STOPF_MASK);
     }
 #endif /* FSL_FEATURE_I2C_HAS_STOP_DETECT */
 
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
     if (mask & kI2C_StartStopDetectInterruptEnable)
     {
-        base->FLT &= ~I2C_FLT_SSIE_MASK;
+        base->FLT &= ~(I2C_FLT_SSIE_MASK | I2C_FLT_STOPF_MASK | I2C_FLT_STARTF_MASK);
     }
 #endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
 }
@@ -623,7 +715,7 @@ status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_
         base->F = savedMult & (~I2C_F_MULT_MASK);
 
         /* We are already in a transfer, so send a repeated start. */
-        base->C1 |= I2C_C1_RSTA_MASK;
+        base->C1 |= I2C_C1_RSTA_MASK | I2C_C1_TX_MASK;
 
         /* Restore the multiplier factor. */
         base->F = savedMult;
@@ -690,7 +782,7 @@ uint32_t I2C_MasterGetStatusFlags(I2C_Type *base)
     return statusFlags;
 }
 
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     uint8_t statusFlags = 0;
@@ -728,7 +820,7 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
             result = kStatus_I2C_ArbitrationLost;
         }
 
-        if (statusFlags & kI2C_ReceiveNakFlag)
+        if ((statusFlags & kI2C_ReceiveNakFlag) && txSize)
         {
             base->S = kI2C_ReceiveNakFlag;
             result = kStatus_I2C_Nak;
@@ -741,10 +833,19 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
         }
     }
 
+    if (((result == kStatus_Success) && (!(flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
+    {
+        /* Clear the IICIF flag. */
+        base->S = kI2C_IntPendingFlag;
+
+        /* Send stop. */
+        result = I2C_MasterStop(base);
+    }
+
     return result;
 }
 
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags)
 {
     status_t result = kStatus_Success;
     volatile uint8_t dummy = 0;
@@ -786,8 +887,16 @@ status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
         /* Single byte use case. */
         if (rxSize == 0)
         {
-            /* Read the final byte. */
-            result = I2C_MasterStop(base);
+            if (!(flags & kI2C_TransferNoStopFlag))
+            {
+                /* Issue STOP command before reading last byte. */
+                result = I2C_MasterStop(base);
+            }
+            else
+            {
+                /* Change direction to Tx to avoid extra clocks. */
+                base->C1 |= I2C_C1_TX_MASK;
+            }
         }
 
         if (rxSize == 1)
@@ -840,72 +949,6 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
         return result;
     }
 
-    /* Send subaddress. */
-    if (xfer->subaddressSize)
-    {
-        do
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear interrupt pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            xfer->subaddressSize--;
-            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
-
-        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
-
-        if (xfer->direction == kI2C_Read)
-        {
-            /* Wait until data transfer complete. */
-            while (!(base->S & kI2C_IntPendingFlag))
-            {
-            }
-
-            /* Clear pending flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Check if there's transfer error. */
-            result = I2C_CheckAndClearError(base, base->S);
-
-            if (result)
-            {
-                if (result == kStatus_I2C_Nak)
-                {
-                    I2C_MasterStop(base);
-                }
-
-                return result;
-            }
-
-            /* Send repeated start and slave address. */
-            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
-
-            /* Return if error. */
-            if (result)
-            {
-                return result;
-            }
-        }
-    }
-
-    /* Wait until address + command transfer complete. */
     while (!(base->S & kI2C_IntPendingFlag))
     {
     }
@@ -918,32 +961,92 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
     {
         if (result == kStatus_I2C_Nak)
         {
+            result = kStatus_I2C_Addr_Nak;
+
             I2C_MasterStop(base);
         }
 
         return result;
     }
 
+    /* Send subaddress. */
+    if (xfer->subaddressSize)
+    {
+        do
+        {
+            /* Clear interrupt pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            xfer->subaddressSize--;
+            base->D = ((xfer->subaddress) >> (8 * xfer->subaddressSize));
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+
+        } while ((xfer->subaddressSize > 0) && (result == kStatus_Success));
+
+        if (xfer->direction == kI2C_Read)
+        {
+            /* Clear pending flag. */
+            base->S = kI2C_IntPendingFlag;
+
+            /* Send repeated start and slave address. */
+            result = I2C_MasterRepeatedStart(base, xfer->slaveAddress, kI2C_Read);
+
+            /* Return if error. */
+            if (result)
+            {
+                return result;
+            }
+
+            /* Wait until data transfer complete. */
+            while (!(base->S & kI2C_IntPendingFlag))
+            {
+            }
+
+            /* Check if there's transfer error. */
+            result = I2C_CheckAndClearError(base, base->S);
+
+            if (result)
+            {
+                if (result == kStatus_I2C_Nak)
+                {
+                    result = kStatus_I2C_Addr_Nak;
+
+                    I2C_MasterStop(base);
+                }
+
+                return result;
+            }
+        }
+    }
+
     /* Transmit data. */
     if ((xfer->direction == kI2C_Write) && (xfer->dataSize > 0))
     {
         /* Send Data. */
-        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize);
-
-        if (((result == kStatus_Success) && (!(xfer->flags & kI2C_TransferNoStopFlag))) || (result == kStatus_I2C_Nak))
-        {
-            /* Clear the IICIF flag. */
-            base->S = kI2C_IntPendingFlag;
-
-            /* Send stop. */
-            result = I2C_MasterStop(base);
-        }
+        result = I2C_MasterWriteBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     /* Receive Data. */
     if ((xfer->direction == kI2C_Read) && (xfer->dataSize > 0))
     {
-        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize);
+        result = I2C_MasterReadBlocking(base, xfer->data, xfer->dataSize, xfer->flags);
     }
 
     return result;
@@ -1006,11 +1109,37 @@ void I2C_MasterTransferAbort(I2C_Type *base, i2c_master_handle_t *handle)
 {
     assert(handle);
 
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
     /* Disable interrupt. */
     I2C_DisableInterrupts(base, kI2C_GlobalInterruptEnable);
 
     /* Reset the state to idle. */
     handle->state = kIdleState;
+
+    /* Send STOP signal. */
+    if (handle->transfer.direction == kI2C_Read)
+    {
+        base->C1 |= I2C_C1_TXAK_MASK;
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+        dummy = base->D;
+    }
+    else
+    {
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
+        base->S = kI2C_IntPendingFlag;
+        base->C1 &= ~(I2C_C1_MST_MASK | I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+    }
 }
 
 status_t I2C_MasterTransferGetCount(I2C_Type *base, i2c_master_handle_t *handle, size_t *count)
@@ -1044,7 +1173,8 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     if (isDone || result)
     {
         /* Send stop command if transfer done or received Nak. */
-        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak))
+        if ((!(handle->transfer.flags & kI2C_TransferNoStopFlag)) || (result == kStatus_I2C_Nak) ||
+            (result == kStatus_I2C_Addr_Nak))
         {
             /* Ensure stop command is a need. */
             if ((base->C1 & I2C_C1_MST_MASK))
@@ -1070,13 +1200,28 @@ void I2C_MasterTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz)
 {
     assert(slaveConfig);
 
     uint8_t tmpReg;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     CLOCK_EnableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    /* Reset the module. */
+    base->A1 = 0;
+    base->F = 0;
+    base->C1 = 0;
+    base->S = 0xFFU;
+    base->C2 = 0;
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    base->FLT = 0x50U;
+#elif defined(FSL_FEATURE_I2C_HAS_STOP_DETECT) && FSL_FEATURE_I2C_HAS_STOP_DETECT
+    base->FLT = 0x40U;
+#endif
+    base->RA = 0;
 
     /* Configure addressing mode. */
     switch (slaveConfig->addressingMode)
@@ -1101,15 +1246,20 @@ void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig)
     tmpReg &= ~I2C_C1_WUEN_MASK;
     base->C1 = tmpReg | I2C_C1_WUEN(slaveConfig->enableWakeUp) | I2C_C1_IICEN(slaveConfig->enableSlave);
 
-    /* Configure general call & baud rate control & high drive feature. */
+    /* Configure general call & baud rate control. */
     tmpReg = base->C2;
     tmpReg &= ~(I2C_C2_SBRC_MASK | I2C_C2_GCAEN_MASK);
     tmpReg |= I2C_C2_SBRC(slaveConfig->enableBaudRateCtl) | I2C_C2_GCAEN(slaveConfig->enableGeneralCall);
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    tmpReg &= ~I2C_C2_HDRS_MASK;
-    tmpReg |= I2C_C2_HDRS(slaveConfig->enableHighDrive);
-#endif
     base->C2 = tmpReg;
+
+/* Enable/Disable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    tmpReg = base->S2 & (~I2C_S2_DFEN_MASK);
+    base->S2 = tmpReg | I2C_S2_DFEN(slaveConfig->enableDoubleBuffering);
+#endif
+
+    /* Set hold time. */
+    I2C_SetHoldTime(base, slaveConfig->sclStopHoldTime_ns, srcClock_Hz);
 }
 
 void I2C_SlaveDeinit(I2C_Type *base)
@@ -1117,8 +1267,10 @@ void I2C_SlaveDeinit(I2C_Type *base)
     /* Disable I2C module. */
     I2C_Enable(base, false);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Disable I2C clock. */
     CLOCK_DisableClock(s_i2cClocks[I2C_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
@@ -1134,13 +1286,16 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
     /* Slave address match waking up MCU from low power mode is disabled. */
     slaveConfig->enableWakeUp = false;
 
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    /* Default pin high drive is disabled. */
-    slaveConfig->enableHighDrive = false;
-#endif
-
     /* Independent slave mode baud rate at maximum frequency is disabled. */
     slaveConfig->enableBaudRateCtl = false;
+
+/* Default enable double buffering. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    slaveConfig->enableDoubleBuffering = true;
+#endif
+
+    /* Set default SCL stop hold time to 4us which is minimum requirement in I2C spec. */
+    slaveConfig->sclStopHoldTime_ns = 4000;
 
     /* Enable the I2C peripheral. */
     slaveConfig->enableSlave = true;
@@ -1148,34 +1303,89 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig)
 
 status_t I2C_SlaveWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize)
 {
-    return I2C_MasterWriteBlocking(base, txBuff, txSize);
+    status_t result = kStatus_Success;
+    volatile uint8_t dummy = 0;
+
+    /* Add this to avoid build warning. */
+    dummy++;
+
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Check start flag. */
+    while (!(base->FLT & I2C_FLT_STARTF_MASK))
+    {
+    }
+    /* Clear STARTF flag. */
+    base->FLT |= I2C_FLT_STARTF_MASK;
+    /* Clear the IICIF flag. */
+    base->S = kI2C_IntPendingFlag;
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+    /* Wait for address match flag. */
+    while (!(base->S & kI2C_AddressMatchFlag))
+    {
+    }
+
+    /* Read dummy to release bus. */
+    dummy = base->D;
+
+    result = I2C_MasterWriteBlocking(base, txBuff, txSize, kI2C_TransferDefaultFlag);
+
+    /* Switch to receive mode. */
+    base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
+
+    /* Read dummy to release bus. */
+    dummy = base->D;
+
+    return result;
 }
 
 void I2C_SlaveReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize)
 {
-    /* Clear the IICIF flag. */
-    base->S = kI2C_IntPendingFlag;
+    volatile uint8_t dummy = 0;
 
-    /* Wait until the data register is ready for receive. */
-    while (!(base->S & kI2C_TransferCompleteFlag))
+    /* Add this to avoid build warning. */
+    dummy++;
+
+/* Wait until address match. */
+#if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
+    /* Check start flag. */
+    while (!(base->FLT & I2C_FLT_STARTF_MASK))
     {
     }
+    /* Clear STARTF flag. */
+    base->FLT |= I2C_FLT_STARTF_MASK;
+    /* Clear the IICIF flag. */
+    base->S = kI2C_IntPendingFlag;
+#endif /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
+
+    /* Wait for address match and int pending flag. */
+    while (!(base->S & kI2C_AddressMatchFlag))
+    {
+    }
+    while (!(base->S & kI2C_IntPendingFlag))
+    {
+    }
+
+    /* Read dummy to release bus. */
+    dummy = base->D;
+
+    /* Clear the IICIF flag. */
+    base->S = kI2C_IntPendingFlag;
 
     /* Setup the I2C peripheral to receive data. */
     base->C1 &= ~(I2C_C1_TX_MASK);
 
     while (rxSize--)
     {
+        /* Wait until data transfer complete. */
+        while (!(base->S & kI2C_IntPendingFlag))
+        {
+        }
         /* Clear the IICIF flag. */
         base->S = kI2C_IntPendingFlag;
 
         /* Read from the data register. */
         *rxBuff++ = base->D;
-
-        /* Wait until data transfer complete. */
-        while (!(base->S & kI2C_IntPendingFlag))
-        {
-        }
     }
 }
 
@@ -1226,7 +1436,7 @@ status_t I2C_SlaveTransferNonBlocking(I2C_Type *base, i2c_slave_handle_t *handle
         handle->isBusy = true;
 
         /* Set up event mask. tx and rx are always enabled. */
-        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent;
+        handle->eventMask = eventMask | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent | kI2C_SlaveGenaralcallEvent;
 
         /* Clear all flags. */
         I2C_SlaveClearStatusFlags(base, kClearFlags);
@@ -1315,7 +1525,10 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
             }
         }
 
-        return;
+        if (!(status & kI2C_AddressMatchFlag))
+        {
+            return;
+        }
     }
 #endif /* I2C_HAS_STOP_DETECT */
 
@@ -1328,7 +1541,7 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
         /* Clear the interrupt flag. */
         base->S = kI2C_IntPendingFlag;
 
-        xfer->event = kI2C_SlaveRepeatedStartEvent;
+        xfer->event = kI2C_SlaveStartEvent;
 
         if ((handle->eventMask & xfer->event) && (handle->callback))
         {
@@ -1385,30 +1598,11 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
         handle->isBusy = true;
         xfer->event = kI2C_SlaveAddressMatchEvent;
 
-        if ((handle->eventMask & xfer->event) && (handle->callback))
-        {
-            handle->callback(base, xfer, handle->userData);
-        }
-
         /* Slave transmit, master reading from slave. */
         if (status & kI2C_TransferDirectionFlag)
         {
             /* Change direction to send data. */
             base->C1 |= I2C_C1_TX_MASK;
-
-            /* If we're out of data, invoke callback to get more. */
-            if ((!xfer->data) || (!xfer->dataSize))
-            {
-                xfer->event = kI2C_SlaveTransmitEvent;
-
-                if (handle->callback)
-                {
-                    handle->callback(base, xfer, handle->userData);
-                }
-
-                /* Clear the transferred count now that we have a new buffer. */
-                xfer->transferredCount = 0;
-            }
 
             doTransmit = true;
         }
@@ -1417,6 +1611,30 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
             /* Slave receive, master writing to slave. */
             base->C1 &= ~(I2C_C1_TX_MASK | I2C_C1_TXAK_MASK);
 
+            /* Read dummy to release the bus. */
+            dummy = base->D;
+
+            if (dummy == 0)
+            {
+                xfer->event = kI2C_SlaveGenaralcallEvent;
+            }
+        }
+
+        if ((handle->eventMask & xfer->event) && (handle->callback))
+        {
+            handle->callback(base, xfer, handle->userData);
+        }
+    }
+    /* Check transfer complete flag. */
+    else if (status & kI2C_TransferCompleteFlag)
+    {
+        /* Slave transmit, master reading from slave. */
+        if (status & kI2C_TransferDirectionFlag)
+        {
+            doTransmit = true;
+        }
+        else
+        {
             /* If we're out of data, invoke callback to get more. */
             if ((!xfer->data) || (!xfer->dataSize))
             {
@@ -1431,20 +1649,6 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
                 xfer->transferredCount = 0;
             }
 
-            /* Read dummy to release the bus. */
-            dummy = base->D;
-        }
-    }
-    /* Check transfer complete flag. */
-    else if (status & kI2C_TransferCompleteFlag)
-    {
-        /* Slave transmit, master reading from slave. */
-        if (status & kI2C_TransferDirectionFlag)
-        {
-            doTransmit = true;
-        }
-        else
-        {
             /* Slave receive, master writing to slave. */
             uint8_t data = base->D;
 
@@ -1480,6 +1684,20 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     /* Send data if there is the need. */
     if (doTransmit)
     {
+        /* If we're out of data, invoke callback to get more. */
+        if ((!xfer->data) || (!xfer->dataSize))
+        {
+            xfer->event = kI2C_SlaveTransmitEvent;
+
+            if (handle->callback)
+            {
+                handle->callback(base, xfer, handle->userData);
+            }
+
+            /* Clear the transferred count now that we have a new buffer. */
+            xfer->transferredCount = 0;
+        }
+
         if (handle->transfer.dataSize)
         {
             /* Send data. */
@@ -1510,27 +1728,30 @@ void I2C_SlaveTransferHandleIRQ(I2C_Type *base, void *i2cHandle)
     }
 }
 
+#if defined(I2C0)
 void I2C0_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C0, s_i2cHandle[0]);
 }
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 1)
+#if defined(I2C1)
 void I2C1_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C1, s_i2cHandle[1]);
 }
-#endif /* I2C COUNT > 1 */
+#endif
 
-#if (FSL_FEATURE_SOC_I2C_COUNT > 2)
+#if defined(I2C2)
 void I2C2_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C2, s_i2cHandle[2]);
 }
-#endif /* I2C COUNT > 2 */
-#if (FSL_FEATURE_SOC_I2C_COUNT > 3)
+#endif
+
+#if defined(I2C3)
 void I2C3_DriverIRQHandler(void)
 {
     I2C_TransferCommonIRQHandler(I2C3, s_i2cHandle[3]);
 }
-#endif /* I2C COUNT > 3 */
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_i2c.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,16 +37,14 @@
  * @{
  */
 
-/*! @file */
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief I2C driver version 2.0.0. */
-#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*! @brief I2C driver version 2.0.3. */
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 0, 3))
 /*@}*/
 
 #if (defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT || \
@@ -62,6 +60,7 @@ enum _i2c_status
     kStatus_I2C_Nak = MAKE_STATUS(kStatusGroup_I2C, 2),             /*!< NAK received during transfer. */
     kStatus_I2C_ArbitrationLost = MAKE_STATUS(kStatusGroup_I2C, 3), /*!< Arbitration lost during transfer. */
     kStatus_I2C_Timeout = MAKE_STATUS(kStatusGroup_I2C, 4),         /*!< Wait event timeout. */
+    kStatus_I2C_Addr_Nak = MAKE_STATUS(kStatusGroup_I2C, 5),        /*!< NAK received during the address probe. */
 };
 
 /*!
@@ -109,11 +108,11 @@ enum _i2c_interrupt_enable
 #endif                                                       /* FSL_FEATURE_I2C_HAS_START_STOP_DETECT */
 };
 
-/*! @brief Direction of master and slave transfers. */
+/*! @brief The direction of master and slave transfers. */
 typedef enum _i2c_direction
 {
-    kI2C_Write = 0x0U, /*!< Master transmit to slave. */
-    kI2C_Read = 0x1U,  /*!< Master receive from slave. */
+    kI2C_Write = 0x0U, /*!< Master transmits to the slave. */
+    kI2C_Read = 0x1U,  /*!< Master receives from the slave. */
 } i2c_direction_t;
 
 /*! @brief Addressing mode. */
@@ -126,17 +125,17 @@ typedef enum _i2c_slave_address_mode
 /*! @brief I2C transfer control flag. */
 enum _i2c_master_transfer_flags
 {
-    kI2C_TransferDefaultFlag = 0x0U,       /*!< Transfer starts with a start signal, stops with a stop signal. */
-    kI2C_TransferNoStartFlag = 0x1U,       /*!< Transfer starts without a start signal. */
-    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< Transfer starts with a repeated start signal. */
-    kI2C_TransferNoStopFlag = 0x4U,        /*!< Transfer ends without a stop signal. */
+    kI2C_TransferDefaultFlag = 0x0U,       /*!< A transfer starts with a start signal, stops with a stop signal. */
+    kI2C_TransferNoStartFlag = 0x1U,       /*!< A transfer starts without a start signal. */
+    kI2C_TransferRepeatedStartFlag = 0x2U, /*!< A transfer starts with a repeated start signal. */
+    kI2C_TransferNoStopFlag = 0x4U,        /*!< A transfer ends without a stop signal. */
 };
 
 /*!
  * @brief Set of events sent to the callback for nonblocking slave transfers.
  *
  * These event enumerations are used for two related purposes. First, a bit mask created by OR'ing together
- * events is passed to I2C_SlaveTransferNonBlocking() in order to specify which events to enable.
+ * events is passed to I2C_SlaveTransferNonBlocking() to specify which events to enable.
  * Then, when the slave callback is invoked, it is passed the current event through its @a transfer
  * parameter.
  *
@@ -145,33 +144,35 @@ enum _i2c_master_transfer_flags
 typedef enum _i2c_slave_transfer_event
 {
     kI2C_SlaveAddressMatchEvent = 0x01U, /*!< Received the slave address after a start or repeated start. */
-    kI2C_SlaveTransmitEvent = 0x02U,     /*!< Callback is requested to provide data to transmit
+    kI2C_SlaveTransmitEvent = 0x02U,     /*!< A callback is requested to provide data to transmit
                                                 (slave-transmitter role). */
-    kI2C_SlaveReceiveEvent = 0x04U,      /*!< Callback is requested to provide a buffer in which to place received
+    kI2C_SlaveReceiveEvent = 0x04U,      /*!< A callback is requested to provide a buffer in which to place received
                                                  data (slave-receiver role). */
-    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< Callback needs to either transmit an ACK or NACK. */
+    kI2C_SlaveTransmitAckEvent = 0x08U,  /*!< A callback needs to either transmit an ACK or NACK. */
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
-    kI2C_SlaveRepeatedStartEvent = 0x10U, /*!< A repeated start was detected. */
+    kI2C_SlaveStartEvent = 0x10U, /*!< A start/repeated start was detected. */
 #endif
-    kI2C_SlaveCompletionEvent = 0x20U, /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveCompletionEvent = 0x20U,  /*!< A stop was detected or finished transfer, completing the transfer. */
+    kI2C_SlaveGenaralcallEvent = 0x40U, /*!< Received the general call address after a start or repeated start. */
 
-    /*! Bit mask of all available events. */
+    /*! A bit mask of all available events. */
     kI2C_SlaveAllEvents = kI2C_SlaveAddressMatchEvent | kI2C_SlaveTransmitEvent | kI2C_SlaveReceiveEvent |
 #if defined(FSL_FEATURE_I2C_HAS_START_STOP_DETECT) && FSL_FEATURE_I2C_HAS_START_STOP_DETECT
-                          kI2C_SlaveRepeatedStartEvent |
+                          kI2C_SlaveStartEvent |
 #endif
-                          kI2C_SlaveCompletionEvent,
+                          kI2C_SlaveCompletionEvent | kI2C_SlaveGenaralcallEvent,
 } i2c_slave_transfer_event_t;
 
 /*! @brief I2C master user configuration. */
 typedef struct _i2c_master_config
 {
     bool enableMaster; /*!< Enables the I2C peripheral at initialization time. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
-#endif
 #if defined(FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF) && FSL_FEATURE_I2C_HAS_STOP_HOLD_OFF
     bool enableStopHold; /*!< Controls the stop hold enable. */
+#endif
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    bool enableDoubleBuffering; /*!< Controls double buffer enable; notice that
+                                     enabling the double buffer disables the clock stretch. */
 #endif
     uint32_t baudRate_Bps;     /*!< Baud rate configuration of I2C peripheral. */
     uint8_t glitchFilterWidth; /*!< Controls the width of the glitch. */
@@ -181,15 +182,20 @@ typedef struct _i2c_master_config
 typedef struct _i2c_slave_config
 {
     bool enableSlave;       /*!< Enables the I2C peripheral at initialization time. */
-    bool enableGeneralCall; /*!< Enable general call addressing mode. */
-    bool enableWakeUp;      /*!< Enables/disables waking up MCU from low power mode. */
-#if defined(FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION) && FSL_FEATURE_I2C_HAS_HIGH_DRIVE_SELECTION
-    bool enableHighDrive; /*!< Controls the drive capability of the I2C pads. */
+    bool enableGeneralCall; /*!< Enables the general call addressing mode. */
+    bool enableWakeUp;      /*!< Enables/disables waking up MCU from low-power mode. */
+#if defined(FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE) && FSL_FEATURE_I2C_HAS_DOUBLE_BUFFER_ENABLE
+    bool enableDoubleBuffering; /*!< Controls a double buffer enable; notice that
+                                     enabling the double buffer disables the clock stretch. */
 #endif
     bool enableBaudRateCtl; /*!< Enables/disables independent slave baud rate on SCL in very fast I2C modes. */
-    uint16_t slaveAddress;  /*!< Slave address configuration. */
-    uint16_t upperAddress;  /*!< Maximum boundary slave address used in range matching mode. */
-    i2c_slave_address_mode_t addressingMode; /*!< Addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint16_t slaveAddress;  /*!< A slave address configuration. */
+    uint16_t upperAddress;  /*!< A maximum boundary slave address used in a range matching mode. */
+    i2c_slave_address_mode_t
+        addressingMode;          /*!< An addressing mode configuration of i2c_slave_address_mode_config_t. */
+    uint32_t sclStopHoldTime_ns; /*!< the delay from the rising edge of SCL (I2C clock) to the rising edge of SDA (I2C
+                                    data) while SCL is high (stop condition), SDA hold time and SCL start hold time
+                                    are also configured according to the SCL stop hold time. */
 } i2c_slave_config_t;
 
 /*! @brief I2C master handle typedef. */
@@ -207,13 +213,13 @@ typedef struct _i2c_slave_handle i2c_slave_handle_t;
 /*! @brief I2C master transfer structure. */
 typedef struct _i2c_master_transfer
 {
-    uint32_t flags;            /*!< Transfer flag which controls the transfer. */
+    uint32_t flags;            /*!< A transfer flag which controls the transfer. */
     uint8_t slaveAddress;      /*!< 7-bit slave address. */
-    i2c_direction_t direction; /*!< Transfer direction, read or write. */
-    uint32_t subaddress;       /*!< Sub address. Transferred MSB first. */
-    uint8_t subaddressSize;    /*!< Size of command buffer. */
-    uint8_t *volatile data;    /*!< Transfer buffer. */
-    volatile size_t dataSize;  /*!< Transfer size. */
+    i2c_direction_t direction; /*!< A transfer direction, read or write. */
+    uint32_t subaddress;       /*!< A sub address. Transferred MSB first. */
+    uint8_t subaddressSize;    /*!< A size of the command buffer. */
+    uint8_t *volatile data;    /*!< A transfer buffer. */
+    volatile size_t dataSize;  /*!< A transfer size. */
 } i2c_master_transfer_t;
 
 /*! @brief I2C master handle structure. */
@@ -221,20 +227,21 @@ struct _i2c_master_handle
 {
     i2c_master_transfer_t transfer;                    /*!< I2C master transfer copy. */
     size_t transferSize;                               /*!< Total bytes to be transferred. */
-    uint8_t state;                                     /*!< Transfer state maintained during transfer. */
-    i2c_master_transfer_callback_t completionCallback; /*!< Callback function called when transfer finished. */
-    void *userData;                                    /*!< Callback parameter passed to callback function. */
+    uint8_t state;                                     /*!< A transfer state maintained during transfer. */
+    i2c_master_transfer_callback_t completionCallback; /*!< A callback function called when the transfer is finished. */
+    void *userData;                                    /*!< A callback parameter passed to the callback function. */
 };
 
 /*! @brief I2C slave transfer structure. */
 typedef struct _i2c_slave_transfer
 {
-    i2c_slave_transfer_event_t event; /*!< Reason the callback is being invoked. */
-    uint8_t *volatile data;           /*!< Transfer buffer. */
-    volatile size_t dataSize;         /*!< Transfer size. */
+    i2c_slave_transfer_event_t event; /*!< A reason that the callback is invoked. */
+    uint8_t *volatile data;           /*!< A transfer buffer. */
+    volatile size_t dataSize;         /*!< A transfer size. */
     status_t completionStatus;        /*!< Success or error code describing how the transfer completed. Only applies for
                                          #kI2C_SlaveCompletionEvent. */
-    size_t transferredCount;          /*!< Number of bytes actually transferred since start or last repeated start. */
+    size_t transferredCount; /*!< A number of bytes actually transferred since the start or since the last repeated
+                                start. */
 } i2c_slave_transfer_t;
 
 /*! @brief I2C slave transfer callback typedef. */
@@ -243,11 +250,11 @@ typedef void (*i2c_slave_transfer_callback_t)(I2C_Type *base, i2c_slave_transfer
 /*! @brief I2C slave handle structure. */
 struct _i2c_slave_handle
 {
-    bool isBusy;                            /*!< Whether transfer is busy. */
+    volatile bool isBusy;                   /*!< Indicates whether a transfer is busy. */
     i2c_slave_transfer_t transfer;          /*!< I2C slave transfer copy. */
-    uint32_t eventMask;                     /*!< Mask of enabled events. */
-    i2c_slave_transfer_callback_t callback; /*!< Callback function called at transfer event. */
-    void *userData;                         /*!< Callback parameter passed to callback. */
+    uint32_t eventMask;                     /*!< A mask of enabled events. */
+    i2c_slave_transfer_callback_t callback; /*!< A callback function called at the transfer event. */
+    void *userData;                         /*!< A callback parameter passed to the callback. */
 };
 
 /*******************************************************************************
@@ -267,12 +274,12 @@ extern "C" {
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
  * and configure the I2C with master configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module could cause hard fault
- * because clock is not enabled. The configuration structure can be filled by user
- * from scratch, or be set with default values by I2C_MasterGetDefaultConfig().
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
+ * because the clock is not enabled. The configuration structure can be custom filled
+ * or it can be set with default values by using the I2C_MasterGetDefaultConfig().
  * After calling this API, the master is ready to transfer.
- * Example:
+ * This is an example.
  * @code
  * i2c_master_config_t config = {
  * .enableMaster = true,
@@ -285,20 +292,20 @@ extern "C" {
  * @endcode
  *
  * @param base I2C base pointer
- * @param masterConfig pointer to master configuration structure
+ * @param masterConfig A pointer to the master configuration structure
  * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
 void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief Initializes the I2C peripheral. Call this API to ungate the I2C clock
- * and initializes the I2C with slave configuration.
+ * and initialize the I2C with the slave configuration.
  *
- * @note This API should be called at the beginning of the application to use
- * the I2C driver, or any operation to the I2C module can cause a hard fault
+ * @note This API should be called at the beginning of the application.
+ * Otherwise, any operation to the I2C module can cause a hard fault
  * because the clock is not enabled. The configuration structure can partly be set
- * with default values by I2C_SlaveGetDefaultConfig(), or can be filled by the user.
- * Example
+ * with default values by I2C_SlaveGetDefaultConfig() or it can be custom filled by the user.
+ * This is an example.
  * @code
  * i2c_slave_config_t config = {
  * .enableSlave = true,
@@ -307,15 +314,17 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
  * .slaveAddress = 0x1DU,
  * .enableWakeUp = false,
  * .enablehighDrive = false,
- * .enableBaudRateCtl = false
+ * .enableBaudRateCtl = false,
+ * .sclStopHoldTime_ns = 4000
  * };
- * I2C_SlaveInit(I2C0, &config);
+ * I2C_SlaveInit(I2C0, &config, 12000000U);
  * @endcode
  *
  * @param base I2C base pointer
- * @param slaveConfig pointer to slave configuration structure
+ * @param slaveConfig A pointer to the slave configuration structure
+ * @param srcClock_Hz I2C peripheral clock frequency in Hz
  */
-void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig);
+void I2C_SlaveInit(I2C_Type *base, const i2c_slave_config_t *slaveConfig, uint32_t srcClock_Hz);
 
 /*!
  * @brief De-initializes the I2C master peripheral. Call this API to gate the I2C clock.
@@ -335,28 +344,28 @@ void I2C_SlaveDeinit(I2C_Type *base);
  * @brief  Sets the I2C master configuration structure to default values.
  *
  * The purpose of this API is to get the configuration structure initialized for use in the I2C_MasterConfigure().
- * Use the initialized structure unchanged in I2C_MasterConfigure(), or modify some fields of
- * the structure before calling I2C_MasterConfigure().
- * Example:
+ * Use the initialized structure unchanged in the I2C_MasterConfigure() or modify
+ * the structure before calling the I2C_MasterConfigure().
+ * This is an example.
  * @code
  * i2c_master_config_t config;
  * I2C_MasterGetDefaultConfig(&config);
  * @endcode
- * @param masterConfig Pointer to the master configuration structure.
+ * @param masterConfig A pointer to the master configuration structure.
 */
 void I2C_MasterGetDefaultConfig(i2c_master_config_t *masterConfig);
 
 /*!
  * @brief  Sets the I2C slave configuration structure to default values.
  *
- * The purpose of this API is to get the configuration structure initialized for use in I2C_SlaveConfigure().
+ * The purpose of this API is to get the configuration structure initialized for use in the I2C_SlaveConfigure().
  * Modify fields of the structure before calling the I2C_SlaveConfigure().
- * Example:
+ * This is an example.
  * @code
  * i2c_slave_config_t config;
  * I2C_SlaveGetDefaultConfig(&config);
  * @endcode
- * @param slaveConfig Pointer to the slave configuration structure.
+ * @param slaveConfig A pointer to the slave configuration structure.
  */
 void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
 
@@ -364,7 +373,7 @@ void I2C_SlaveGetDefaultConfig(i2c_slave_config_t *slaveConfig);
  * @brief Enables or disabless the I2C peripheral operation.
  *
  * @param base I2C base pointer
- * @param enable pass true to enable module, false to disable module
+ * @param enable Pass true to enable and false to disable the module.
  */
 static inline void I2C_Enable(I2C_Type *base, bool enable)
 {
@@ -389,7 +398,7 @@ static inline void I2C_Enable(I2C_Type *base, bool enable)
  * @brief Gets the I2C status flags.
  *
  * @param base I2C base pointer
- * @return status flag, use status flag to AND #_i2c_flags could get the related status.
+ * @return status flag, use status flag to AND #_i2c_flags to get the related status.
  */
 uint32_t I2C_MasterGetStatusFlags(I2C_Type *base);
 
@@ -397,7 +406,7 @@ uint32_t I2C_MasterGetStatusFlags(I2C_Type *base);
  * @brief Gets the I2C status flags.
  *
  * @param base I2C base pointer
- * @return status flag, use status flag to AND #_i2c_flags could get the related status.
+ * @return status flag, use status flag to AND #_i2c_flags to get the related status.
  */
 static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
 {
@@ -407,11 +416,11 @@ static inline uint32_t I2C_SlaveGetStatusFlags(I2C_Type *base)
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag.
  *
  * @param base I2C base pointer
  * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
- *      The parameter could be any combination of the following values:
+ *      The parameter can be any combination of the following values:
  *          @arg kI2C_StartDetectFlag (if available)
  *          @arg kI2C_StopDetectFlag (if available)
  *          @arg kI2C_ArbitrationLostFlag
@@ -442,11 +451,11 @@ static inline void I2C_MasterClearStatusFlags(I2C_Type *base, uint32_t statusMas
 /*!
  * @brief Clears the I2C status flag state.
  *
- * The following status register flags can be cleared: kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
+ * The following status register flags can be cleared kI2C_ArbitrationLostFlag and kI2C_IntPendingFlag
  *
   * @param base I2C base pointer
   * @param statusMask The status flag mask, defined in type i2c_status_flag_t.
- *      The parameter could be any combination of the following values:
+ *      The parameter can be any combination of the following values:
  *          @arg kI2C_StartDetectFlag (if available)
  *          @arg kI2C_StopDetectFlag (if available)
  *          @arg kI2C_ArbitrationLostFlag
@@ -574,19 +583,21 @@ status_t I2C_MasterStop(I2C_Type *base);
 status_t I2C_MasterRepeatedStart(I2C_Type *base, uint8_t address, i2c_direction_t direction);
 
 /*!
- * @brief Performs a polling send transaction on the I2C bus without a STOP signal.
+ * @brief Performs a polling send transaction on the I2C bus.
  *
  * @param base  The I2C peripheral base pointer.
  * @param txBuff The pointer to the data to be transferred.
  * @param txSize The length in bytes of the data to be transferred.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
  * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
-status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize);
+status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t txSize, uint32_t flags);
 
 /*!
- * @brief Performs a polling receive transaction on the I2C bus with a STOP signal.
+ * @brief Performs a polling receive transaction on the I2C bus.
  *
  * @note The I2C_MasterReadBlocking function stops the bus before reading the final byte.
  * Without stopping the bus prior for the final read, the bus issues another read, resulting
@@ -595,10 +606,12 @@ status_t I2C_MasterWriteBlocking(I2C_Type *base, const uint8_t *txBuff, size_t t
  * @param base I2C peripheral base pointer.
  * @param rxBuff The pointer to the data to store the received data.
  * @param rxSize The length in bytes of the data to be received.
+ * @param flags Transfer control flag to decide whether need to send a stop, use kI2C_TransferDefaultFlag
+*  to issue a stop and kI2C_TransferNoStop to not send a stop.
  * @retval kStatus_Success Successfully complete the data transmission.
  * @retval kStatus_I2C_Timeout Send stop signal failed, timeout.
  */
-status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize);
+status_t I2C_MasterReadBlocking(I2C_Type *base, uint8_t *rxBuff, size_t rxSize, uint32_t flags);
 
 /*!
  * @brief Performs a polling send transaction on the I2C bus.
@@ -650,7 +663,7 @@ status_t I2C_MasterTransferBlocking(I2C_Type *base, i2c_master_transfer_t *xfer)
  * @param base I2C base pointer.
  * @param handle pointer to i2c_master_handle_t structure to store the transfer state.
  * @param callback pointer to user callback function.
- * @param userData user paramater passed to the callback function.
+ * @param userData user parameter passed to the callback function.
  */
 void I2C_MasterTransferCreateHandle(I2C_Type *base,
                                     i2c_master_handle_t *handle,
@@ -660,15 +673,15 @@ void I2C_MasterTransferCreateHandle(I2C_Type *base,
 /*!
  * @brief Performs a master interrupt non-blocking transfer on the I2C bus.
  *
- * @note Calling the API will return immediately after transfer initiates, user needs
+ * @note Calling the API returns immediately after transfer initiates. The user needs
  * to call I2C_MasterGetTransferCount to poll the transfer status to check whether
- * the transfer is finished, if the return status is not kStatus_I2C_Busy, the transfer
+ * the transfer is finished. If the return status is not kStatus_I2C_Busy, the transfer
  * is finished.
  *
  * @param base I2C base pointer.
  * @param handle pointer to i2c_master_handle_t structure which stores the transfer state.
  * @param xfer pointer to i2c_master_transfer_t structure.
- * @retval kStatus_Success Sucessully start the data transmission.
+ * @retval kStatus_Success Successfully start the data transmission.
  * @retval kStatus_I2C_Busy Previous transmission still not finished.
  * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
  */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_i2c_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_i2c_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,31 +39,30 @@
  * @{
  */
 
-/*! @file */
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
-/*! @brief I2C master edma handle typedef. */
+/*! @brief I2C master eDMA handle typedef. */
 typedef struct _i2c_master_edma_handle i2c_master_edma_handle_t;
 
-/*! @brief I2C master edma transfer callback typedef. */
+/*! @brief I2C master eDMA transfer callback typedef. */
 typedef void (*i2c_master_edma_transfer_callback_t)(I2C_Type *base,
                                                     i2c_master_edma_handle_t *handle,
                                                     status_t status,
                                                     void *userData);
 
-/*! @brief I2C master edma transfer structure. */
+/*! @brief I2C master eDMA transfer structure. */
 struct _i2c_master_edma_handle
 {
-    i2c_master_transfer_t transfer; /*!< I2C master transfer struct. */
+    i2c_master_transfer_t transfer; /*!< I2C master transfer structure. */
     size_t transferSize;            /*!< Total bytes to be transferred. */
+    uint8_t nbytes;                 /*!< eDMA minor byte transfer count initially configured. */
     uint8_t state;                  /*!< I2C master transfer status. */
     edma_handle_t *dmaHandle;       /*!< The eDMA handler used. */
     i2c_master_edma_transfer_callback_t
-        completionCallback; /*!< Callback function called after edma transfer finished. */
-    void *userData;         /*!< Callback parameter passed to callback function. */
+        completionCallback; /*!< A callback function called after the eDMA transfer is finished. */
+    void *userData;         /*!< A callback parameter passed to the callback function. */
 };
 
 /*******************************************************************************
@@ -75,18 +74,18 @@ extern "C" {
 #endif /*_cplusplus. */
 
 /*!
- * @name I2C Block EDMA Transfer Operation
+ * @name I2C Block eDMA Transfer Operation
  * @{
  */
 
 /*!
- * @brief Init the I2C handle which is used in transcational functions.
+ * @brief Initializes the I2C handle which is used in transcational functions.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param callback pointer to user callback function.
- * @param userData user param passed to the callback function.
- * @param edmaHandle EDMA handle pointer.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param callback A pointer to the user callback function.
+ * @param userData A user parameter passed to the callback function.
+ * @param edmaHandle eDMA handle pointer.
  */
 void I2C_MasterCreateEDMAHandle(I2C_Type *base,
                                 i2c_master_edma_handle_t *handle,
@@ -95,33 +94,33 @@ void I2C_MasterCreateEDMAHandle(I2C_Type *base,
                                 edma_handle_t *edmaHandle);
 
 /*!
- * @brief Performs a master edma non-blocking transfer on the I2C bus.
+ * @brief Performs a master eDMA non-blocking transfer on the I2C bus.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param xfer pointer to transfer structure of i2c_master_transfer_t.
- * @retval kStatus_Success Sucessully complete the data transmission.
- * @retval kStatus_I2C_Busy Previous transmission still not finished.
- * @retval kStatus_I2C_Timeout Transfer error, wait signal timeout.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param xfer A pointer to the transfer structure of i2c_master_transfer_t.
+ * @retval kStatus_Success Sucessfully completed the data transmission.
+ * @retval kStatus_I2C_Busy A previous transmission is still not finished.
+ * @retval kStatus_I2C_Timeout Transfer error, waits for a signal timeout.
  * @retval kStatus_I2C_ArbitrationLost Transfer error, arbitration lost.
- * @retval kStataus_I2C_Nak Transfer error, receive Nak during transfer.
+ * @retval kStataus_I2C_Nak Transfer error, receive NAK during transfer.
  */
 status_t I2C_MasterTransferEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, i2c_master_transfer_t *xfer);
 
 /*!
- * @brief Get master transfer status during a edma non-blocking transfer.
+ * @brief Gets a master transfer status during the eDMA non-blocking transfer.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
- * @param count Number of bytes transferred so far by the non-blocking transaction.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
+ * @param count A number of bytes transferred by the non-blocking transaction.
  */
 status_t I2C_MasterTransferGetCountEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle, size_t *count);
 
 /*!
- * @brief Abort a master edma non-blocking transfer in a early time.
+ * @brief Aborts a master eDMA non-blocking transfer early.
  *
  * @param base I2C peripheral base address.
- * @param handle pointer to i2c_master_edma_handle_t structure.
+ * @param handle A pointer to the i2c_master_edma_handle_t structure.
  */
 void I2C_MasterTransferAbortEDMA(I2C_Type *base, i2c_master_edma_handle_t *handle);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_lpuart.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_lpuart.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -109,9 +109,23 @@ static lpuart_handle_t *s_lpuartHandle[FSL_FEATURE_SOC_LPUART_COUNT];
 /* Array of LPUART peripheral base address. */
 static LPUART_Type *const s_lpuartBases[] = LPUART_BASE_PTRS;
 /* Array of LPUART IRQ number. */
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+static const IRQn_Type s_lpuartRxIRQ[] = LPUART_RX_IRQS;
+static const IRQn_Type s_lpuartTxIRQ[] = LPUART_TX_IRQS;
+#else
 static const IRQn_Type s_lpuartIRQ[] = LPUART_RX_TX_IRQS;
+#endif
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /* Array of LPUART clock name. */
 static const clock_ip_name_t s_lpuartClock[] = LPUART_CLOCKS;
+
+#if defined(LPUART_PERIPH_CLOCKS)
+/* Array of LPUART functional clock name. */
+static const clock_ip_name_t s_lpuartPeriphClocks[] = LPUART_PERIPH_CLOCKS;
+#endif
+
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
 /* LPUART ISR for transactional APIs. */
 static lpuart_isr_t s_lpuartIsr;
 
@@ -123,7 +137,7 @@ uint32_t LPUART_GetInstance(LPUART_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < FSL_FEATURE_SOC_LPUART_COUNT; instance++)
+    for (instance = 0; instance < ARRAY_SIZE(s_lpuartBases); instance++)
     {
         if (s_lpuartBases[instance] == base)
         {
@@ -131,13 +145,15 @@ uint32_t LPUART_GetInstance(LPUART_Type *base)
         }
     }
 
-    assert(instance < FSL_FEATURE_SOC_LPUART_COUNT);
+    assert(instance < ARRAY_SIZE(s_lpuartBases));
 
     return instance;
 }
 
 static size_t LPUART_TransferGetRxRingBufferLength(LPUART_Type *base, lpuart_handle_t *handle)
 {
+    assert(handle);
+
     size_t size;
 
     if (handle->rxRingBufferTail > handle->rxRingBufferHead)
@@ -154,6 +170,8 @@ static size_t LPUART_TransferGetRxRingBufferLength(LPUART_Type *base, lpuart_han
 
 static bool LPUART_TransferIsRxRingBufferFull(LPUART_Type *base, lpuart_handle_t *handle)
 {
+    assert(handle);
+
     bool full;
 
     if (LPUART_TransferGetRxRingBufferLength(base, handle) == (handle->rxRingBufferSize - 1U))
@@ -169,6 +187,8 @@ static bool LPUART_TransferIsRxRingBufferFull(LPUART_Type *base, lpuart_handle_t
 
 static void LPUART_WriteNonBlocking(LPUART_Type *base, const uint8_t *data, size_t length)
 {
+    assert(data);
+
     size_t i;
 
     /* The Non Blocking write data API assume user have ensured there is enough space in
@@ -181,32 +201,47 @@ static void LPUART_WriteNonBlocking(LPUART_Type *base, const uint8_t *data, size
 
 static void LPUART_ReadNonBlocking(LPUART_Type *base, uint8_t *data, size_t length)
 {
+    assert(data);
+
     size_t i;
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    uint32_t ctrl = base->CTRL;
+    bool isSevenDataBits =
+        ((ctrl & LPUART_CTRL_M7_MASK) ||
+         ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
+#endif
 
     /* The Non Blocking read data API assume user have ensured there is enough space in
     peripheral to write. */
     for (i = 0; i < length; i++)
     {
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+        if (isSevenDataBits)
+        {
+            data[i] = (base->DATA & 0x7F);
+        }
+        else
+        {
+            data[i] = base->DATA;
+        }
+#else
         data[i] = base->DATA;
+#endif
     }
 }
 
-void LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcClock_Hz)
+status_t LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcClock_Hz)
 {
     assert(config);
+    assert(config->baudRate_Bps);
 #if defined(FSL_FEATURE_LPUART_HAS_FIFO) && FSL_FEATURE_LPUART_HAS_FIFO
     assert(FSL_FEATURE_LPUART_FIFO_SIZEn(base) >= config->txFifoWatermark);
     assert(FSL_FEATURE_LPUART_FIFO_SIZEn(base) >= config->rxFifoWatermark);
 #endif
+
     uint32_t temp;
     uint16_t sbr, sbrTemp;
     uint32_t osr, osrTemp, tempDiff, calculatedBaud, baudDiff;
-
-    /* Enable lpuart clock */
-    CLOCK_EnableClock(s_lpuartClock[LPUART_GetInstance(base)]);
-
-    /* Disable LPUART TX RX before setting. */
-    base->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
 
     /* This LPUART instantiation uses a slightly different baud rate calculation
      * The idea is to use the best OSR (over-sampling rate) possible
@@ -248,34 +283,75 @@ void LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcC
 
     /* Check to see if actual baud rate is within 3% of desired baud rate
      * based on the best calculate OSR value */
-    if (baudDiff < ((config->baudRate_Bps / 100) * 3))
+    if (baudDiff > ((config->baudRate_Bps / 100) * 3))
     {
-        temp = base->BAUD;
-
-        /* Acceptable baud rate, check if OSR is between 4x and 7x oversampling.
-         * If so, then "BOTHEDGE" sampling must be turned on */
-        if ((osr > 3) && (osr < 8))
-        {
-            temp |= LPUART_BAUD_BOTHEDGE_MASK;
-        }
-
-        /* program the osr value (bit value is one less than actual value) */
-        temp &= ~LPUART_BAUD_OSR_MASK;
-        temp |= LPUART_BAUD_OSR(osr - 1);
-
-        /* write the sbr value to the BAUD registers */
-        temp &= ~LPUART_BAUD_SBR_MASK;
-        base->BAUD = temp | LPUART_BAUD_SBR(sbr);
+        /* Unacceptable baud rate difference of more than 3%*/
+        return kStatus_LPUART_BaudrateNotSupport;
     }
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    
+    uint32_t instance = LPUART_GetInstance(base);
+
+    /* Enable lpuart clock */
+    CLOCK_EnableClock(s_lpuartClock[instance]);
+#if defined(LPUART_PERIPH_CLOCKS)
+    CLOCK_EnableClock(s_lpuartPeriphClocks[instance]);
+#endif
+
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+#if defined(FSL_FEATURE_LPUART_HAS_GLOBAL) && FSL_FEATURE_LPUART_HAS_GLOBAL
+    /*Reset all internal logic and registers, except the Global Register */
+    LPUART_SoftwareReset(base);
+#else
+    /* Disable LPUART TX RX before setting. */
+    base->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
+#endif
+
+    temp = base->BAUD;
+
+    /* Acceptable baud rate, check if OSR is between 4x and 7x oversampling.
+     * If so, then "BOTHEDGE" sampling must be turned on */
+    if ((osr > 3) && (osr < 8))
+    {
+        temp |= LPUART_BAUD_BOTHEDGE_MASK;
+    }
+
+    /* program the osr value (bit value is one less than actual value) */
+    temp &= ~LPUART_BAUD_OSR_MASK;
+    temp |= LPUART_BAUD_OSR(osr - 1);
+
+    /* write the sbr value to the BAUD registers */
+    temp &= ~LPUART_BAUD_SBR_MASK;
+    base->BAUD = temp | LPUART_BAUD_SBR(sbr);
 
     /* Set bit count and parity mode. */
     base->BAUD &= ~LPUART_BAUD_M10_MASK;
 
     temp = base->CTRL & ~(LPUART_CTRL_PE_MASK | LPUART_CTRL_PT_MASK | LPUART_CTRL_M_MASK);
 
-    if (kLPUART_ParityDisabled != config->parityMode)
+    temp |= (uint8_t)config->parityMode;
+
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    if (kLPUART_SevenDataBits == config->dataBitsCount)
     {
-        temp |= (LPUART_CTRL_M_MASK | (uint8_t)config->parityMode);
+        if (kLPUART_ParityDisabled != config->parityMode)
+        {
+            temp &= ~LPUART_CTRL_M7_MASK; /* Seven data bits and one parity bit */
+        }
+        else
+        {
+            temp |= LPUART_CTRL_M7_MASK;
+        }
+    }
+    else
+#endif
+    {
+        if (kLPUART_ParityDisabled != config->parityMode)
+        {
+            temp |= LPUART_CTRL_M_MASK; /* Eight data bits and one parity bit */
+        }
     }
 
     base->CTRL = temp;
@@ -298,16 +374,26 @@ void LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcC
 #endif
 
     /* Clear all status flags */
-    temp = (LPUART_STAT_LBKDIF_MASK | LPUART_STAT_RXEDGIF_MASK | LPUART_STAT_OR_MASK | LPUART_STAT_NF_MASK |
+    temp = (LPUART_STAT_RXEDGIF_MASK | LPUART_STAT_IDLE_MASK | LPUART_STAT_OR_MASK | LPUART_STAT_NF_MASK |
             LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK);
 
 #if defined(FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT) && FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT
-    temp |= LPUART_STAT_IDLE_MASK;
+    temp |= LPUART_STAT_LBKDIF_MASK;
 #endif
 
 #if defined(FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING) && FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING
     temp |= (LPUART_STAT_MA1F_MASK | LPUART_STAT_MA2F_MASK);
 #endif
+
+    /* Set data bits order. */
+    if (config->isMsb)
+    {
+        temp |= LPUART_STAT_MSBF_MASK;
+    }
+    else
+    {
+        temp &= ~LPUART_STAT_MSBF_MASK;
+    }
 
     base->STAT |= temp;
 
@@ -324,6 +410,8 @@ void LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcC
     }
 
     base->CTRL = temp;
+
+    return kStatus_Success;
 }
 void LPUART_Deinit(LPUART_Type *base)
 {
@@ -341,11 +429,11 @@ void LPUART_Deinit(LPUART_Type *base)
     }
 
     /* Clear all status flags */
-    temp = (LPUART_STAT_LBKDIF_MASK | LPUART_STAT_RXEDGIF_MASK | LPUART_STAT_OR_MASK | LPUART_STAT_NF_MASK |
+    temp = (LPUART_STAT_RXEDGIF_MASK | LPUART_STAT_IDLE_MASK | LPUART_STAT_OR_MASK | LPUART_STAT_NF_MASK |
             LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK);
 
 #if defined(FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT) && FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT
-    temp |= LPUART_STAT_IDLE_MASK;
+    temp |= LPUART_STAT_LBKDIF_MASK;
 #endif
 
 #if defined(FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING) && FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING
@@ -357,15 +445,27 @@ void LPUART_Deinit(LPUART_Type *base)
     /* Disable the module. */
     base->CTRL = 0;
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    uint32_t instance = LPUART_GetInstance(base);
+
     /* Disable lpuart clock */
-    CLOCK_DisableClock(s_lpuartClock[LPUART_GetInstance(base)]);
+    CLOCK_DisableClock(s_lpuartClock[instance]);
+
+#if defined(LPUART_PERIPH_CLOCKS)
+    CLOCK_DisableClock(s_lpuartPeriphClocks[instance]);
+#endif
+
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 void LPUART_GetDefaultConfig(lpuart_config_t *config)
 {
     assert(config);
+
     config->baudRate_Bps = 115200U;
     config->parityMode = kLPUART_ParityDisabled;
+    config->dataBitsCount = kLPUART_EightDataBits;
+    config->isMsb = false;
 #if defined(FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT
     config->stopBitCount = kLPUART_OneStopBit;
 #endif
@@ -377,17 +477,13 @@ void LPUART_GetDefaultConfig(lpuart_config_t *config)
     config->enableRx = false;
 }
 
-void LPUART_SetBaudRate(LPUART_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
+status_t LPUART_SetBaudRate(LPUART_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz)
 {
+    assert(baudRate_Bps);
+
     uint32_t temp, oldCtrl;
     uint16_t sbr, sbrTemp;
     uint32_t osr, osrTemp, tempDiff, calculatedBaud, baudDiff;
-
-    /* Store CTRL before disable Tx and Rx */
-    oldCtrl = base->CTRL;
-
-    /* Disable LPUART TX RX before setting. */
-    base->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
 
     /* This LPUART instantiation uses a slightly different baud rate calculation
      * The idea is to use the best OSR (over-sampling rate) possible
@@ -431,6 +527,12 @@ void LPUART_SetBaudRate(LPUART_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
      * based on the best calculate OSR value */
     if (baudDiff < ((baudRate_Bps / 100) * 3))
     {
+        /* Store CTRL before disable Tx and Rx */
+        oldCtrl = base->CTRL;
+
+        /* Disable LPUART TX RX before setting. */
+        base->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
+
         temp = base->BAUD;
 
         /* Acceptable baud rate, check if OSR is between 4x and 7x oversampling.
@@ -447,17 +549,25 @@ void LPUART_SetBaudRate(LPUART_Type *base, uint32_t baudRate_Bps, uint32_t srcCl
         /* write the sbr value to the BAUD registers */
         temp &= ~LPUART_BAUD_SBR_MASK;
         base->BAUD = temp | LPUART_BAUD_SBR(sbr);
-    }
 
-    /* Restore CTRL. */
-    base->CTRL = oldCtrl;
+        /* Restore CTRL. */
+        base->CTRL = oldCtrl;
+
+        return kStatus_Success;
+    }
+    else
+    {
+        /* Unacceptable baud rate difference of more than 3%*/
+        return kStatus_LPUART_BaudrateNotSupport;
+    }
 }
 
 void LPUART_EnableInterrupts(LPUART_Type *base, uint32_t mask)
 {
     base->BAUD |= ((mask << 8) & (LPUART_BAUD_LBKDIE_MASK | LPUART_BAUD_RXEDGIE_MASK));
 #if defined(FSL_FEATURE_LPUART_HAS_FIFO) && FSL_FEATURE_LPUART_HAS_FIFO
-    base->FIFO |= ((mask << 8) & (LPUART_FIFO_TXOFE_MASK | LPUART_FIFO_RXUFE_MASK));
+    base->FIFO = (base->FIFO & ~(LPUART_FIFO_TXOF_MASK | LPUART_FIFO_RXUF_MASK)) |
+                 ((mask << 8) & (LPUART_FIFO_TXOFE_MASK | LPUART_FIFO_RXUFE_MASK));
 #endif
     mask &= 0xFFFFFF00U;
     base->CTRL |= mask;
@@ -467,7 +577,8 @@ void LPUART_DisableInterrupts(LPUART_Type *base, uint32_t mask)
 {
     base->BAUD &= ~((mask << 8) & (LPUART_BAUD_LBKDIE_MASK | LPUART_BAUD_RXEDGIE_MASK));
 #if defined(FSL_FEATURE_LPUART_HAS_FIFO) && FSL_FEATURE_LPUART_HAS_FIFO
-    base->FIFO &= ~((mask << 8) & (LPUART_FIFO_TXOFE_MASK | LPUART_FIFO_RXUFE_MASK));
+    base->FIFO = (base->FIFO & ~(LPUART_FIFO_TXOF_MASK | LPUART_FIFO_RXUF_MASK)) &
+                 ~((mask << 8) & (LPUART_FIFO_TXOFE_MASK | LPUART_FIFO_RXUFE_MASK));
 #endif
     mask &= 0xFFFFFF00U;
     base->CTRL &= ~mask;
@@ -503,24 +614,24 @@ status_t LPUART_ClearStatusFlags(LPUART_Type *base, uint32_t mask)
     status_t status;
 #if defined(FSL_FEATURE_LPUART_HAS_FIFO) && FSL_FEATURE_LPUART_HAS_FIFO
     temp = (uint32_t)base->FIFO;
-    temp &= (uint32_t)(~(kLPUART_TxFifoOverflowFlag | kLPUART_RxFifoUnderflowFlag));
-    temp |= mask & (kLPUART_TxFifoOverflowFlag | kLPUART_RxFifoUnderflowFlag);
+    temp &= (uint32_t)(~(LPUART_FIFO_TXOF_MASK | LPUART_FIFO_RXUF_MASK));
+    temp |= (mask << 16) & (LPUART_FIFO_TXOF_MASK | LPUART_FIFO_RXUF_MASK);
     base->FIFO = temp;
 #endif
     temp = (uint32_t)base->STAT;
 #if defined(FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT) && FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT
-    temp &= (uint32_t)(~(kLPUART_LinBreakFlag));
-    temp |= mask & kLPUART_LinBreakFlag;
+    temp &= (uint32_t)(~(LPUART_STAT_LBKDIF_MASK));
+    temp |= mask & LPUART_STAT_LBKDIF_MASK;
 #endif
-    temp &= (uint32_t)(~(kLPUART_RxActiveEdgeFlag | kLPUART_IdleLineFlag | kLPUART_RxOverrunFlag |
-                         kLPUART_NoiseErrorFlag | kLPUART_FramingErrorFlag | kLPUART_ParityErrorFlag));
-    temp |= mask & (kLPUART_RxActiveEdgeFlag | kLPUART_IdleLineFlag | kLPUART_RxOverrunFlag | kLPUART_NoiseErrorFlag |
-                    kLPUART_FramingErrorFlag | kLPUART_ParityErrorFlag);
+    temp &= (uint32_t)(~(LPUART_STAT_RXEDGIF_MASK | LPUART_STAT_IDLE_MASK | LPUART_STAT_OR_MASK | LPUART_STAT_NF_MASK |
+                         LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK));
+    temp |= mask & (LPUART_STAT_RXEDGIF_MASK | LPUART_STAT_IDLE_MASK | LPUART_STAT_OR_MASK | LPUART_STAT_NF_MASK |
+                    LPUART_STAT_FE_MASK | LPUART_STAT_PF_MASK);
 #if defined(FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING) && FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING
-    temp &= (uint32_t)(~(kLPUART_DataMatch2Flag | kLPUART_DataMatch2Flag));
-    temp |= mask & (kLPUART_DataMatch2Flag | kLPUART_DataMatch2Flag);
+    temp &= (uint32_t)(~(LPUART_STAT_MA2F_MASK | LPUART_STAT_MA1F_MASK));
+    temp |= mask & (LPUART_STAT_MA2F_MASK | LPUART_STAT_MA1F_MASK);
 #endif
-    base->STAT |= temp;
+    base->STAT = temp;
     /* If some flags still pending. */
     if (mask & LPUART_GetStatusFlags(base))
     {
@@ -540,6 +651,8 @@ status_t LPUART_ClearStatusFlags(LPUART_Type *base, uint32_t mask)
 
 void LPUART_WriteBlocking(LPUART_Type *base, const uint8_t *data, size_t length)
 {
+    assert(data);
+
     /* This API can only ensure that the data is written into the data buffer but can't
     ensure all data in the data buffer are sent into the transmit shift buffer. */
     while (length--)
@@ -553,7 +666,15 @@ void LPUART_WriteBlocking(LPUART_Type *base, const uint8_t *data, size_t length)
 
 status_t LPUART_ReadBlocking(LPUART_Type *base, uint8_t *data, size_t length)
 {
+    assert(data);
+
     uint32_t statusFlag;
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    uint32_t ctrl = base->CTRL;
+    bool isSevenDataBits =
+        ((ctrl & LPUART_CTRL_M7_MASK) ||
+         ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
+#endif
 
     while (length--)
     {
@@ -589,7 +710,18 @@ status_t LPUART_ReadBlocking(LPUART_Type *base, uint8_t *data, size_t length)
                 return kStatus_LPUART_ParityError;
             }
         }
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+        if (isSevenDataBits)
+        {
+            *(data++) = (base->DATA & 0x7F);
+        }
+        else
+        {
+            *(data++) = base->DATA;
+        }
+#else
         *(data++) = base->DATA;
+#endif
     }
 
     return kStatus_Success;
@@ -603,6 +735,12 @@ void LPUART_TransferCreateHandle(LPUART_Type *base,
     assert(handle);
 
     uint32_t instance;
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    uint32_t ctrl = base->CTRL;
+    bool isSevenDataBits =
+        ((ctrl & LPUART_CTRL_M7_MASK) ||
+         ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
+#endif
 
     /* Zero the handle. */
     memset(handle, 0, sizeof(lpuart_handle_t));
@@ -615,6 +753,11 @@ void LPUART_TransferCreateHandle(LPUART_Type *base,
     handle->callback = callback;
     handle->userData = userData;
 
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    /* Initial seven data bits flag */
+    handle->isSevenDataBits = isSevenDataBits;
+#endif
+
 #if defined(FSL_FEATURE_LPUART_HAS_FIFO) && FSL_FEATURE_LPUART_HAS_FIFO
     /* Note:
        Take care of the RX FIFO, RX interrupt request only assert when received bytes
@@ -624,7 +767,7 @@ void LPUART_TransferCreateHandle(LPUART_Type *base,
        5 bytes are received. the last byte will be saved in FIFO but not trigger
        RX interrupt because the water mark is 2.
      */
-    base->WATER &= (~LPUART_WATER_RXWATER_SHIFT);
+    base->WATER &= (~LPUART_WATER_RXWATER_MASK);
 #endif
 
     /* Get instance from peripheral base address. */
@@ -635,8 +778,13 @@ void LPUART_TransferCreateHandle(LPUART_Type *base,
 
     s_lpuartIsr = LPUART_TransferHandleIRQ;
 
-    /* Enable interrupt in NVIC. */
+/* Enable interrupt in NVIC. */
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+    EnableIRQ(s_lpuartRxIRQ[instance]);
+    EnableIRQ(s_lpuartTxIRQ[instance]);
+#else
     EnableIRQ(s_lpuartIRQ[instance]);
+#endif
 }
 
 void LPUART_TransferStartRingBuffer(LPUART_Type *base,
@@ -645,18 +793,16 @@ void LPUART_TransferStartRingBuffer(LPUART_Type *base,
                                     size_t ringBufferSize)
 {
     assert(handle);
+    assert(ringBuffer);
 
     /* Setup the ring buffer address */
-    if (ringBuffer)
-    {
-        handle->rxRingBuffer = ringBuffer;
-        handle->rxRingBufferSize = ringBufferSize;
-        handle->rxRingBufferHead = 0U;
-        handle->rxRingBufferTail = 0U;
+    handle->rxRingBuffer = ringBuffer;
+    handle->rxRingBufferSize = ringBufferSize;
+    handle->rxRingBufferHead = 0U;
+    handle->rxRingBufferTail = 0U;
 
-        /* Enable the interrupt to accept the data when user need the ring buffer. */
-        LPUART_EnableInterrupts(base, kLPUART_RxDataRegFullInterruptEnable | kLPUART_RxOverrunInterruptEnable);
-    }
+    /* Enable the interrupt to accept the data when user need the ring buffer. */
+    LPUART_EnableInterrupts(base, kLPUART_RxDataRegFullInterruptEnable | kLPUART_RxOverrunInterruptEnable);
 }
 
 void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle)
@@ -676,13 +822,12 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle)
 
 status_t LPUART_TransferSendNonBlocking(LPUART_Type *base, lpuart_handle_t *handle, lpuart_transfer_t *xfer)
 {
-    status_t status;
+    assert(handle);
+    assert(xfer);
+    assert(xfer->data);
+    assert(xfer->dataSize);
 
-    /* Return error if xfer invalid. */
-    if ((0U == xfer->dataSize) || (NULL == xfer->data))
-    {
-        return kStatus_InvalidArgument;
-    }
+    status_t status;
 
     /* Return error if current TX busy. */
     if (kLPUART_TxBusy == handle->txState)
@@ -707,6 +852,8 @@ status_t LPUART_TransferSendNonBlocking(LPUART_Type *base, lpuart_handle_t *hand
 
 void LPUART_TransferAbortSend(LPUART_Type *base, lpuart_handle_t *handle)
 {
+    assert(handle);
+
     LPUART_DisableInterrupts(base, kLPUART_TxDataRegEmptyInterruptEnable | kLPUART_TransmissionCompleteInterruptEnable);
 
     handle->txDataSize = 0;
@@ -715,14 +862,12 @@ void LPUART_TransferAbortSend(LPUART_Type *base, lpuart_handle_t *handle)
 
 status_t LPUART_TransferGetSendCount(LPUART_Type *base, lpuart_handle_t *handle, uint32_t *count)
 {
+    assert(handle);
+    assert(count);
+
     if (kLPUART_TxIdle == handle->txState)
     {
         return kStatus_NoTransferInProgress;
-    }
-
-    if (!count)
-    {
-        return kStatus_InvalidArgument;
     }
 
     *count = handle->txDataSizeAll - handle->txDataSize;
@@ -735,6 +880,11 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
                                            lpuart_transfer_t *xfer,
                                            size_t *receivedBytes)
 {
+    assert(handle);
+    assert(xfer);
+    assert(xfer->data);
+    assert(xfer->dataSize);
+
     uint32_t i;
     status_t status;
     /* How many bytes to copy from ring buffer to user memory. */
@@ -743,13 +893,6 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
     size_t bytesToReceive;
     /* How many bytes currently have received. */
     size_t bytesCurrentReceived;
-    uint32_t regPrimask = 0U;
-
-    /* Return error if xfer invalid. */
-    if ((0U == xfer->dataSize) || (NULL == xfer->data))
-    {
-        return kStatus_InvalidArgument;
-    }
 
     /* How to get data:
        1. If RX ring buffer is not enabled, then save xfer->data and xfer->dataSize
@@ -773,8 +916,8 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
         /* If RX ring buffer is used. */
         if (handle->rxRingBuffer)
         {
-            /* Disable IRQ, protect ring buffer. */
-            regPrimask = DisableGlobalIRQ();
+            /* Disable LPUART RX IRQ, protect ring buffer. */
+            LPUART_DisableInterrupts(base, kLPUART_RxDataRegFullInterruptEnable);
 
             /* How many bytes in RX ring buffer currently. */
             bytesToCopy = LPUART_TransferGetRxRingBufferLength(base, handle);
@@ -811,8 +954,8 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
                 handle->rxDataSizeAll = bytesToReceive;
                 handle->rxState = kLPUART_RxBusy;
             }
-            /* Enable IRQ if previously enabled. */
-            EnableGlobalIRQ(regPrimask);
+            /* Enable LPUART RX IRQ if previously enabled. */
+            LPUART_EnableInterrupts(base, kLPUART_RxDataRegFullInterruptEnable);
 
             /* Call user callback since all data are received. */
             if (0 == bytesToReceive)
@@ -849,6 +992,8 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
 
 void LPUART_TransferAbortReceive(LPUART_Type *base, lpuart_handle_t *handle)
 {
+    assert(handle);
+
     /* Only abort the receive to handle->rxData, the RX ring buffer is still working. */
     if (!handle->rxRingBuffer)
     {
@@ -862,14 +1007,12 @@ void LPUART_TransferAbortReceive(LPUART_Type *base, lpuart_handle_t *handle)
 
 status_t LPUART_TransferGetReceiveCount(LPUART_Type *base, lpuart_handle_t *handle, uint32_t *count)
 {
+    assert(handle);
+    assert(count);
+
     if (kLPUART_RxIdle == handle->rxState)
     {
         return kStatus_NoTransferInProgress;
-    }
-
-    if (!count)
-    {
-        return kStatus_InvalidArgument;
     }
 
     *count = handle->rxDataSizeAll - handle->rxDataSize;
@@ -879,19 +1022,17 @@ status_t LPUART_TransferGetReceiveCount(LPUART_Type *base, lpuart_handle_t *hand
 
 void LPUART_TransferHandleIRQ(LPUART_Type *base, lpuart_handle_t *handle)
 {
+    assert(handle);
+
     uint8_t count;
     uint8_t tempCount;
-    volatile uint8_t dummy;
-
-    assert(handle);
 
     /* If RX overrun. */
     if (LPUART_STAT_OR_MASK & base->STAT)
     {
-        /* Read base->DATA, otherwise the RX does not work. */
-        dummy = base->DATA;
-        /* Avoid optimization */
-        dummy++;
+        /* Clear overrun flag, otherwise the RX does not work. */
+        base->STAT = ((base->STAT & 0x3FE00000U) | LPUART_STAT_OR_MASK);
+
         /* Trigger callback. */
         if (handle->callback)
         {
@@ -964,8 +1105,19 @@ void LPUART_TransferHandleIRQ(LPUART_Type *base, lpuart_handle_t *handle)
                     }
                 }
 
-                /* Read data. */
+/* Read data. */
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+                if (handle->isSevenDataBits)
+                {
+                    handle->rxRingBuffer[handle->rxRingBufferHead] = (base->DATA & 0x7F);
+                }
+                else
+                {
+                    handle->rxRingBuffer[handle->rxRingBufferHead] = base->DATA;
+                }
+#else
                 handle->rxRingBuffer[handle->rxRingBufferHead] = base->DATA;
+#endif
 
                 /* Increase handle->rxRingBufferHead. */
                 if (handle->rxRingBufferHead + 1U == handle->rxRingBufferSize)
@@ -1033,71 +1185,113 @@ void LPUART_TransferHandleIRQ(LPUART_Type *base, lpuart_handle_t *handle)
 
 void LPUART_TransferHandleErrorIRQ(LPUART_Type *base, lpuart_handle_t *handle)
 {
-    /* TODO: To be implemented. */
+    /* To be implemented by User. */
 }
 
 #if defined(LPUART0)
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+void LPUART0_TX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART0, s_lpuartHandle[0]);
+}
+void LPUART0_RX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART0, s_lpuartHandle[0]);
+}
+#else
 void LPUART0_DriverIRQHandler(void)
 {
     s_lpuartIsr(LPUART0, s_lpuartHandle[0]);
 }
-void LPUART0_RX_TX_DriverIRQHandler(void)
-{
-    LPUART0_DriverIRQHandler();
-}
+#endif
 #endif
 
 #if defined(LPUART1)
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+void LPUART1_TX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART1, s_lpuartHandle[1]);
+}
+void LPUART1_RX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART1, s_lpuartHandle[1]);
+}
+#else
 void LPUART1_DriverIRQHandler(void)
 {
     s_lpuartIsr(LPUART1, s_lpuartHandle[1]);
 }
-void LPUART1_RX_TX_DriverIRQHandler(void)
-{
-    LPUART1_DriverIRQHandler();
-}
+#endif
 #endif
 
 #if defined(LPUART2)
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+void LPUART2_TX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART2, s_lpuartHandle[2]);
+}
+void LPUART2_RX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART2, s_lpuartHandle[2]);
+}
+#else
 void LPUART2_DriverIRQHandler(void)
 {
     s_lpuartIsr(LPUART2, s_lpuartHandle[2]);
 }
-void LPUART2_RX_TX_DriverIRQHandler(void)
-{
-    LPUART2_DriverIRQHandler();
-}
+#endif
 #endif
 
 #if defined(LPUART3)
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+void LPUART3_TX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART3, s_lpuartHandle[3]);
+}
+void LPUART3_RX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART3, s_lpuartHandle[3]);
+}
+#else
 void LPUART3_DriverIRQHandler(void)
 {
     s_lpuartIsr(LPUART3, s_lpuartHandle[3]);
 }
-void LPUART3_RX_TX_DriverIRQHandler(void)
-{
-    LPUART3_DriverIRQHandler();
-}
+#endif
 #endif
 
 #if defined(LPUART4)
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+void LPUART4_TX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART4, s_lpuartHandle[4]);
+}
+void LPUART4_RX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART4, s_lpuartHandle[4]);
+}
+#else
 void LPUART4_DriverIRQHandler(void)
 {
     s_lpuartIsr(LPUART4, s_lpuartHandle[4]);
 }
-void LPUART4_RX_TX_DriverIRQHandler(void)
-{
-    LPUART4_DriverIRQHandler();
-}
+#endif
 #endif
 
 #if defined(LPUART5)
+#if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
+void LPUART5_TX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART5, s_lpuartHandle[5]);
+}
+void LPUART5_RX_DriverIRQHandler(void)
+{
+    s_lpuartIsr(LPUART5, s_lpuartHandle[5]);
+}
+#else
 void LPUART5_DriverIRQHandler(void)
 {
     s_lpuartIsr(LPUART5, s_lpuartHandle[5]);
 }
-void LPUART5_RX_TX_DriverIRQHandler(void)
-{
-    LPUART5_DriverIRQHandler();
-}
+#endif
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_lpuart.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_lpuart.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -37,36 +37,35 @@
  * @{
  */
 
-/*! @file*/
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief LPUART driver version 2.1.0. */
-#define FSL_LPUART_DRIVER_VERSION (MAKE_VERSION(2, 1, 0))
+/*! @brief LPUART driver version 2.2.3. */
+#define FSL_LPUART_DRIVER_VERSION (MAKE_VERSION(2, 2, 3))
 /*@}*/
 
 /*! @brief Error codes for the LPUART driver. */
 enum _lpuart_status
 {
-    kStatus_LPUART_TxBusy = MAKE_STATUS(kStatusGroup_LPUART, 0),              /*!< TX busy */
-    kStatus_LPUART_RxBusy = MAKE_STATUS(kStatusGroup_LPUART, 1),              /*!< RX busy */
-    kStatus_LPUART_TxIdle = MAKE_STATUS(kStatusGroup_LPUART, 2),              /*!< LPUART transmitter is idle. */
-    kStatus_LPUART_RxIdle = MAKE_STATUS(kStatusGroup_LPUART, 3),              /*!< LPUART receiver is idle. */
-    kStatus_LPUART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 4), /*!< TX FIFO watermark too large  */
-    kStatus_LPUART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 5), /*!< RX FIFO watermark too large  */
-    kStatus_LPUART_FlagCannotClearManually =
-        MAKE_STATUS(kStatusGroup_LPUART, 6),                    /*!< Some flag can't manually clear */
-    kStatus_LPUART_Error = MAKE_STATUS(kStatusGroup_LPUART, 7), /*!< Error happens on LPUART. */
+    kStatus_LPUART_TxBusy = MAKE_STATUS(kStatusGroup_LPUART, 0),                  /*!< TX busy */
+    kStatus_LPUART_RxBusy = MAKE_STATUS(kStatusGroup_LPUART, 1),                  /*!< RX busy */
+    kStatus_LPUART_TxIdle = MAKE_STATUS(kStatusGroup_LPUART, 2),                  /*!< LPUART transmitter is idle. */
+    kStatus_LPUART_RxIdle = MAKE_STATUS(kStatusGroup_LPUART, 3),                  /*!< LPUART receiver is idle. */
+    kStatus_LPUART_TxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 4),     /*!< TX FIFO watermark too large  */
+    kStatus_LPUART_RxWatermarkTooLarge = MAKE_STATUS(kStatusGroup_LPUART, 5),     /*!< RX FIFO watermark too large  */
+    kStatus_LPUART_FlagCannotClearManually = MAKE_STATUS(kStatusGroup_LPUART, 6), /*!< Some flag can't manually clear */
+    kStatus_LPUART_Error = MAKE_STATUS(kStatusGroup_LPUART, 7),                   /*!< Error happens on LPUART. */
     kStatus_LPUART_RxRingBufferOverrun =
         MAKE_STATUS(kStatusGroup_LPUART, 8), /*!< LPUART RX software ring buffer overrun. */
     kStatus_LPUART_RxHardwareOverrun = MAKE_STATUS(kStatusGroup_LPUART, 9), /*!< LPUART RX receiver overrun. */
     kStatus_LPUART_NoiseError = MAKE_STATUS(kStatusGroup_LPUART, 10),       /*!< LPUART noise error. */
     kStatus_LPUART_FramingError = MAKE_STATUS(kStatusGroup_LPUART, 11),     /*!< LPUART framing error. */
     kStatus_LPUART_ParityError = MAKE_STATUS(kStatusGroup_LPUART, 12),      /*!< LPUART parity error. */
+    kStatus_LPUART_BaudrateNotSupport =
+        MAKE_STATUS(kStatusGroup_LPUART, 13), /*!< Baudrate is not support in current clock source */
 };
 
 /*! @brief LPUART parity mode. */
@@ -76,6 +75,15 @@ typedef enum _lpuart_parity_mode
     kLPUART_ParityEven = 0x2U,     /*!< Parity enabled, type even, bit setting: PE|PT = 10 */
     kLPUART_ParityOdd = 0x3U,      /*!< Parity enabled, type odd,  bit setting: PE|PT = 11 */
 } lpuart_parity_mode_t;
+
+/*! @brief LPUART data bits count. */
+typedef enum _lpuart_data_bits
+{
+    kLPUART_EightDataBits = 0x0U, /*!< Eight data bit */
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    kLPUART_SevenDataBits = 0x1U, /*!< Seven data bit */
+#endif
+} lpuart_data_bits_t;
 
 /*! @brief LPUART stop bit count. */
 typedef enum _lpuart_stop_bit_count
@@ -158,11 +166,13 @@ enum _lpuart_flags
 #endif
 };
 
-/*! @brief LPUART configure structure. */
+/*! @brief LPUART configuration structure. */
 typedef struct _lpuart_config
 {
-    uint32_t baudRate_Bps;           /*!< LPUART baud rate  */
-    lpuart_parity_mode_t parityMode; /*!< Parity mode, disabled (default), even, odd */
+    uint32_t baudRate_Bps;            /*!< LPUART baud rate  */
+    lpuart_parity_mode_t parityMode;  /*!< Parity mode, disabled (default), even, odd */
+    lpuart_data_bits_t dataBitsCount; /*!< Data bits count, eight (default), seven */
+    bool isMsb;                       /*!< Data bits order, LSB (default), MSB */
 #if defined(FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT) && FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT
     lpuart_stop_bit_count_t stopBitCount; /*!< Number of stop bits, 1 stop bit (default) or 2 stop bits  */
 #endif
@@ -206,7 +216,11 @@ struct _lpuart_handle
     void *userData;                      /*!< LPUART callback function parameter.*/
 
     volatile uint8_t txState; /*!< TX transfer state. */
-    volatile uint8_t rxState; /*!< RX transfer state */
+    volatile uint8_t rxState; /*!< RX transfer state. */
+
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    bool isSevenDataBits; /*!< Seven data bits flag. */
+#endif
 };
 
 /*******************************************************************************
@@ -217,32 +231,59 @@ struct _lpuart_handle
 extern "C" {
 #endif /* _cplusplus */
 
+#if defined(FSL_FEATURE_LPUART_HAS_GLOBAL) && FSL_FEATURE_LPUART_HAS_GLOBAL
+
+/*!
+ * @name Software Reset
+ * @{
+ */
+
+/*!
+ * @brief Resets the LPUART using software.
+ *
+ * This function resets all internal logic and registers except the Global Register.
+ * Remains set until cleared by software.
+ *
+ * @param base LPUART peripheral base address.
+ */
+static inline void LPUART_SoftwareReset(LPUART_Type *base)
+{
+    base->GLOBAL |= LPUART_GLOBAL_RST_MASK;
+    base->GLOBAL &= ~LPUART_GLOBAL_RST_MASK;
+}
+/* @} */
+#endif /*FSL_FEATURE_LPUART_HAS_GLOBAL*/
+
 /*!
  * @name Initialization and deinitialization
  * @{
  */
 
 /*!
-* @brief Initializes an LPUART instance with the user configuration structure and the peripheral clock.
-*
-* This function configures the LPUART module with  user-defined settings. Call the LPUART_GetDefaultConfig() function
-* to configure the configuration structure and get the default configuration.
-* The example below shows how to use this API to configure the LPUART.
-* @code
-*  lpuart_config_t lpuartConfig;
-*  lpuartConfig.baudRate_Bps = 115200U;
-*  lpuartConfig.parityMode = kLPUART_ParityDisabled;
-*  lpuartConfig.stopBitCount = kLPUART_OneStopBit;
-*  lpuartConfig.txFifoWatermark = 0;
-*  lpuartConfig.rxFifoWatermark = 1;
-*  LPUART_Init(LPUART1, &lpuartConfig, 20000000U);
-* @endcode
-*
-* @param base LPUART peripheral base address.
-* @param config Pointer to a user-defined configuration structure.
-* @param srcClock_Hz LPUART clock source frequency in HZ.
-*/
-void LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcClock_Hz);
+ * @brief Initializes an LPUART instance with the user configuration structure and the peripheral clock.
+ *
+ * This function configures the LPUART module with user-defined settings. Call the LPUART_GetDefaultConfig() function
+ * to configure the configuration structure and get the default configuration.
+ * The example below shows how to use this API to configure the LPUART.
+ * @code
+ *  lpuart_config_t lpuartConfig;
+ *  lpuartConfig.baudRate_Bps = 115200U;
+ *  lpuartConfig.parityMode = kLPUART_ParityDisabled;
+ *  lpuartConfig.dataBitsCount = kLPUART_EightDataBits;
+ *  lpuartConfig.isMsb = false;
+ *  lpuartConfig.stopBitCount = kLPUART_OneStopBit;
+ *  lpuartConfig.txFifoWatermark = 0;
+ *  lpuartConfig.rxFifoWatermark = 1;
+ *  LPUART_Init(LPUART1, &lpuartConfig, 20000000U);
+ * @endcode
+ *
+ * @param base LPUART peripheral base address.
+ * @param config Pointer to a user-defined configuration structure.
+ * @param srcClock_Hz LPUART clock source frequency in HZ.
+ * @retval kStatus_LPUART_BaudrateNotSupport Baudrate is not support in current clock source.
+ * @retval kStatus_Success LPUART initialize succeed
+ */
+status_t LPUART_Init(LPUART_Type *base, const lpuart_config_t *config, uint32_t srcClock_Hz);
 
 /*!
  * @brief Deinitializes a LPUART instance.
@@ -260,6 +301,8 @@ void LPUART_Deinit(LPUART_Type *base);
  * values are:
  *   lpuartConfig->baudRate_Bps = 115200U;
  *   lpuartConfig->parityMode = kLPUART_ParityDisabled;
+ *   lpuartConfig->dataBitsCount = kLPUART_EightDataBits;
+ *   lpuartConfig->isMsb = false;
  *   lpuartConfig->stopBitCount = kLPUART_OneStopBit;
  *   lpuartConfig->txFifoWatermark = 0;
  *   lpuartConfig->rxFifoWatermark = 1;
@@ -282,8 +325,10 @@ void LPUART_GetDefaultConfig(lpuart_config_t *config);
  * @param base LPUART peripheral base address.
  * @param baudRate_Bps LPUART baudrate to be set.
  * @param srcClock_Hz LPUART clock source frequency in HZ.
+ * @retval kStatus_LPUART_BaudrateNotSupport Baudrate is not supported in the current clock source.
+ * @retval kStatus_Success Set baudrate succeeded.
  */
-void LPUART_SetBaudRate(LPUART_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz);
+status_t LPUART_SetBaudRate(LPUART_Type *base, uint32_t baudRate_Bps, uint32_t srcClock_Hz);
 
 /* @} */
 
@@ -512,24 +557,40 @@ static inline void LPUART_WriteByte(LPUART_Type *base, uint8_t data)
 }
 
 /*!
- * @brief Reads the RX register.
+ * @brief Reads the receiver register.
  *
- * This function reads data from the TX register directly. The upper layer must
- * ensure that the RX register is full or that the TX FIFO has data before calling this function.
+ * This function reads data from the receiver register directly. The upper layer must
+ * ensure that the receiver register is full or that the RX FIFO has data before calling this function.
  *
  * @param base LPUART peripheral base address.
  * @return Data read from data register.
  */
 static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 {
+#if defined(FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT) && FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT
+    uint32_t ctrl = base->CTRL;
+    bool isSevenDataBits =
+        ((ctrl & LPUART_CTRL_M7_MASK) ||
+         ((!(ctrl & LPUART_CTRL_M7_MASK)) && (!(ctrl & LPUART_CTRL_M_MASK)) && (ctrl & LPUART_CTRL_PE_MASK)));
+
+    if (isSevenDataBits)
+    {
+        return (base->DATA & 0x7F);
+    }
+    else
+    {
+        return base->DATA;
+    }
+#else
     return base->DATA;
+#endif
 }
 
 /*!
- * @brief Writes to transmitter register using a blocking method.
+ * @brief Writes to the transmitter register using a blocking method.
  *
  * This function polls the transmitter register, waits for the register to be empty or  for TX FIFO to have
- * room and then writes data to the transmitter buffer.
+ * room, and writes data to the transmitter buffer.
  *
  * @note This function does not check whether all data has been sent out to the bus.
  * Before disabling the transmitter, check the kLPUART_TransmissionCompleteFlag to ensure that the transmit is
@@ -542,10 +603,10 @@ static inline uint8_t LPUART_ReadByte(LPUART_Type *base)
 void LPUART_WriteBlocking(LPUART_Type *base, const uint8_t *data, size_t length);
 
 /*!
-* @brief Reads the RX data register using a blocking method.
+* @brief Reads the receiver data register using a blocking method.
  *
- * This function polls the RX register, waits for the RX register full or RX FIFO
- * has data then reads data from the TX register.
+ * This function polls the receiver register, waits for the receiver register full or receiver FIFO
+ * has data, and reads data from the TX register.
  *
  * @param base LPUART peripheral base address.
  * @param data Start address of the buffer to store the received data.
@@ -601,7 +662,7 @@ void LPUART_TransferCreateHandle(LPUART_Type *base,
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
- * @param xfer LPUART transfer structure, refer to #lpuart_transfer_t.
+ * @param xfer LPUART transfer structure, see #lpuart_transfer_t.
  * @retval kStatus_Success Successfully start the data transmission.
  * @retval kStatus_LPUART_TxBusy Previous transmission still not finished, data not all written to the TX register.
  * @retval kStatus_InvalidArgument Invalid argument.
@@ -631,7 +692,7 @@ void LPUART_TransferStartRingBuffer(LPUART_Type *base,
                                     size_t ringBufferSize);
 
 /*!
- * @brief Abort the background transfer and uninstall the ring buffer.
+ * @brief Aborts the background transfer and uninstalls the ring buffer.
  *
  * This function aborts the background transfer and uninstalls the ring buffer.
  *
@@ -644,7 +705,7 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle);
  * @brief Aborts the interrupt-driven data transmit.
  *
  * This function aborts the interrupt driven data sending. The user can get the remainBtyes to find out
- * how many bytes are still not sent out.
+ * how many bytes are not sent out.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -652,10 +713,10 @@ void LPUART_TransferStopRingBuffer(LPUART_Type *base, lpuart_handle_t *handle);
 void LPUART_TransferAbortSend(LPUART_Type *base, lpuart_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to LPUART TX register.
+ * @brief Gets the number of bytes that have been written to the LPUART transmitter register.
  *
  * This function gets the number of bytes that have been written to LPUART TX
- * register by interrupt method.
+ * register by an interrupt method.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -686,7 +747,7 @@ status_t LPUART_TransferGetSendCount(LPUART_Type *base, lpuart_handle_t *handle,
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
- * @param xfer LPUART transfer structure, refer to #uart_transfer_t.
+ * @param xfer LPUART transfer structure, see #uart_transfer_t.
  * @param receivedBytes Bytes received from the ring buffer directly.
  * @retval kStatus_Success Successfully queue the transfer into the transmit queue.
  * @retval kStatus_LPUART_RxBusy Previous receive request is not finished.
@@ -709,7 +770,7 @@ status_t LPUART_TransferReceiveNonBlocking(LPUART_Type *base,
 void LPUART_TransferAbortReceive(LPUART_Type *base, lpuart_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of bytes that have been received.
  *
  * This function gets the number of bytes that have been received.
  *

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_lpuart_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_lpuart_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -39,8 +39,6 @@
  * @{
  */
 
-/*! @file*/
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -66,6 +64,8 @@ struct _lpuart_edma_handle
 
     edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
     edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
+
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
 
     volatile uint8_t txState; /*!< TX transfer state. */
     volatile uint8_t rxState; /*!< RX transfer state */
@@ -94,11 +94,11 @@ extern "C" {
  * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
  */
 void LPUART_TransferCreateHandleEDMA(LPUART_Type *base,
-                             lpuart_edma_handle_t *handle,
-                             lpuart_edma_transfer_callback_t callback,
-                             void *userData,
-                             edma_handle_t *txEdmaHandle,
-                             edma_handle_t *rxEdmaHandle);
+                                     lpuart_edma_handle_t *handle,
+                                     lpuart_edma_transfer_callback_t callback,
+                                     void *userData,
+                                     edma_handle_t *txEdmaHandle,
+                                     edma_handle_t *rxEdmaHandle);
 
 /*!
  * @brief Sends data using eDMA.
@@ -123,7 +123,7 @@ status_t LPUART_SendEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, lpuart
  *
  * @param base LPUART peripheral base address.
  * @param handle Pointer to lpuart_edma_handle_t structure.
- * @param xfer LPUART eDMA transfer structure, refer to #lpuart_transfer_t.
+ * @param xfer LPUART eDMA transfer structure, see #lpuart_transfer_t.
  * @retval kStatus_Success if succeed, others fail.
  * @retval kStatus_LPUART_RxBusy Previous transfer ongoing.
  * @retval kStatus_InvalidArgument Invalid argument.
@@ -151,9 +151,9 @@ void LPUART_TransferAbortSendEDMA(LPUART_Type *base, lpuart_edma_handle_t *handl
 void LPUART_TransferAbortReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to LPUART TX register.
+ * @brief Gets the number of bytes written to the LPUART TX register.
  *
- * This function gets the number of bytes that have been written to LPUART TX
+ * This function gets the number of bytes written to the LPUART TX
  * register by DMA.
  *
  * @param base LPUART peripheral base address.
@@ -166,9 +166,9 @@ void LPUART_TransferAbortReceiveEDMA(LPUART_Type *base, lpuart_edma_handle_t *ha
 status_t LPUART_TransferGetSendCountEDMA(LPUART_Type *base, lpuart_edma_handle_t *handle, uint32_t *count);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of received bytes.
  *
- * This function gets the number of bytes that have been received.
+ * This function gets the number of received bytes.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_sai_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_sai_edma.c
@@ -1,40 +1,25 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_sai_edma.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.sai_edma"
+#endif
 
 /*******************************************************************************
  * Definitations
  ******************************************************************************/
 /* Used for 32byte aligned */
-#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)address + 32) & ~0x1FU)
+#define STCD_ADDR(address) (edma_tcd_t *)(((uint32_t)(address) + 32) & ~0x1FU)
+
+static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
 
 /*<! Structure definition for uart_edma_private_handle_t. The structure is private. */
 typedef struct _sai_edma_private_handle
@@ -50,7 +35,7 @@ enum _sai_edma_transfer_state
 };
 
 /*<! Private handle only used for internally. */
-static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][2];
+static sai_edma_private_handle_t s_edmaPrivateHandle[ARRAY_SIZE(s_saiBases)][2];
 
 /*******************************************************************************
  * Prototypes
@@ -60,7 +45,7 @@ static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_FEATURE_SOC_I2S_COUNT][
  *
  * @param base SAI base pointer.
  */
-extern uint32_t SAI_GetInstance(I2S_Type *base);
+static uint32_t SAI_GetInstance(I2S_Type *base);
 
 /*!
  * @brief SAI EDMA callback for send.
@@ -85,6 +70,24 @@ static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done,
 /*******************************************************************************
 * Code
 ******************************************************************************/
+static uint32_t SAI_GetInstance(I2S_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    for (instance = 0; instance < ARRAY_SIZE(s_saiBases); instance++)
+    {
+        if (s_saiBases[instance] == base)
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_saiBases));
+
+    return instance;
+}
+
 static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done, uint32_t tcds)
 {
     sai_edma_private_handle_t *privHandle = (sai_edma_private_handle_t *)userData;
@@ -101,7 +104,9 @@ static void SAI_TxEDMACallback(edma_handle_t *handle, void *userData, bool done,
     /* If all data finished, just stop the transfer */
     if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
     {
-        SAI_TransferAbortSendEDMA(privHandle->base, saiHandle);
+        /* Disable DMA enable bit */
+        SAI_TxEnableDMA(privHandle->base, kSAI_FIFORequestDMAEnable, false);
+        EDMA_AbortTransfer(handle);
     }
 }
 
@@ -121,16 +126,34 @@ static void SAI_RxEDMACallback(edma_handle_t *handle, void *userData, bool done,
     /* If all data finished, just stop the transfer */
     if (saiHandle->saiQueue[saiHandle->queueDriver].data == NULL)
     {
-        SAI_TransferAbortReceiveEDMA(privHandle->base, saiHandle);
+        /* Disable DMA enable bit */
+        SAI_RxEnableDMA(privHandle->base, kSAI_FIFORequestDMAEnable, false);
+        EDMA_AbortTransfer(handle);
     }
 }
 
+/*!
+ * brief Initializes the SAI eDMA handle.
+ *
+ * This function initializes the SAI master DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param base SAI peripheral base address.
+ * param callback Pointer to user callback function.
+ * param userData User parameter passed to the callback function.
+ * param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
 void SAI_TransferTxCreateHandleEDMA(
     I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
 {
     assert(handle && dmaHandle);
 
     uint32_t instance = SAI_GetInstance(base);
+
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
 
     /* Set sai base to handle */
     handle->dmaHandle = dmaHandle;
@@ -144,18 +167,34 @@ void SAI_TransferTxCreateHandleEDMA(
     s_edmaPrivateHandle[instance][0].handle = handle;
 
     /* Need to use scatter gather */
-    EDMA_InstallTCDMemory(dmaHandle, STCD_ADDR(handle->tcd), SAI_XFER_QUEUE_SIZE);
+    EDMA_InstallTCDMemory(dmaHandle, (edma_tcd_t *)(STCD_ADDR(handle->tcd)), SAI_XFER_QUEUE_SIZE);
 
     /* Install callback for Tx dma channel */
     EDMA_SetCallback(dmaHandle, SAI_TxEDMACallback, &s_edmaPrivateHandle[instance][0]);
 }
 
+/*!
+ * brief Initializes the SAI Rx eDMA handle.
+ *
+ * This function initializes the SAI slave DMA handle, which can be used for other SAI master transactional APIs.
+ * Usually, for a specified SAI instance, call this API once to get the initialized handle.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param base SAI peripheral base address.
+ * param callback Pointer to user callback function.
+ * param userData User parameter passed to the callback function.
+ * param dmaHandle eDMA handle pointer, this handle shall be static allocated by users.
+ */
 void SAI_TransferRxCreateHandleEDMA(
     I2S_Type *base, sai_edma_handle_t *handle, sai_edma_callback_t callback, void *userData, edma_handle_t *dmaHandle)
 {
     assert(handle && dmaHandle);
 
     uint32_t instance = SAI_GetInstance(base);
+
+    /* Zero the handle */
+    memset(handle, 0, sizeof(*handle));
 
     /* Set sai base to handle */
     handle->dmaHandle = dmaHandle;
@@ -175,6 +214,21 @@ void SAI_TransferRxCreateHandleEDMA(
     EDMA_SetCallback(dmaHandle, SAI_RxEDMACallback, &s_edmaPrivateHandle[instance][1]);
 }
 
+/*!
+ * brief Configures the SAI Tx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param format Pointer to SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If bit clock source is master
+ * clock, this value should equals to masterClockHz in format.
+ * retval kStatus_Success Audio format set successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+*/
 void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
                                  sai_edma_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -187,10 +241,20 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
     SAI_TxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
 
     /* Get the tranfer size from format, this should be used in EDMA configuration */
-    handle->bytesPerFrame = format->bitWidth / 8U;
+    if (format->bitWidth == 24U)
+    {
+        handle->bytesPerFrame = 4U;
+    }
+    else
+    {
+        handle->bytesPerFrame = format->bitWidth / 8U;
+    }
 
     /* Update the data channel SAI used */
     handle->channel = format->channel;
+
+    /* Clear the channel enable bits unitl do a send/receive */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->count = FSL_FEATURE_SAI_FIFO_COUNT - format->watermark;
 #else
@@ -198,6 +262,21 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT */
 }
 
+/*!
+ * brief Configures the SAI Rx audio format.
+ *
+ * The audio format can be changed at run-time. This function configures the sample rate and audio data
+ * format to be transferred. This function also sets the eDMA parameter according to formatting requirements.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param format Pointer to SAI audio data format structure.
+ * param mclkSourceClockHz SAI master clock source frequency in Hz.
+ * param bclkSourceClockHz SAI bit clock source frequency in Hz. If a bit clock source is the master
+ * clock, this value should equal to masterClockHz in format.
+ * retval kStatus_Success Audio format set successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+*/
 void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
                                  sai_edma_handle_t *handle,
                                  sai_transfer_format_t *format,
@@ -210,11 +289,20 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
     SAI_RxSetFormat(base, format, mclkSourceClockHz, bclkSourceClockHz);
 
     /* Get the tranfer size from format, this should be used in EDMA configuration */
-    handle->bytesPerFrame = format->bitWidth / 8U;
+    if (format->bitWidth == 24U)
+    {
+        handle->bytesPerFrame = 4U;
+    }
+    else
+    {
+        handle->bytesPerFrame = format->bitWidth / 8U;
+    }
 
     /* Update the data channel SAI used */
     handle->channel = format->channel;
 
+    /* Clear the channel enable bits unitl do a send/receive */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
 #if defined(FSL_FEATURE_SAI_FIFO_COUNT) && (FSL_FEATURE_SAI_FIFO_COUNT > 1)
     handle->count = format->watermark;
 #else
@@ -222,6 +310,19 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
 #endif /* FSL_FEATURE_SAI_FIFO_COUNT */
 }
 
+/*!
+ * brief Performs a non-blocking SAI transfer using DMA.
+ *
+ * note This interface returns immediately after the transfer initiates. Call
+ * SAI_GetTransferStatus to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param xfer Pointer to the DMA transfer structure.
+ * retval kStatus_Success Start a SAI eDMA send successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+ * retval kStatus_TxBusy SAI is busy sending data.
+ */
 status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -253,6 +354,9 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
     EDMA_PrepareTransfer(&config, xfer->data, handle->bytesPerFrame, (void *)destAddr, handle->bytesPerFrame,
                          handle->count * handle->bytesPerFrame, xfer->dataSize, kEDMA_MemoryToPeripheral);
 
+    /* Store the initially configured eDMA minor byte transfer count into the SAI handle */
+    handle->nbytes = handle->count * handle->bytesPerFrame;
+
     EDMA_SubmitTransfer(handle->dmaHandle, &config);
 
     /* Start DMA transfer */
@@ -264,9 +368,25 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
     /* Enable SAI Tx clock */
     SAI_TxEnable(base, true);
 
+    /* Enable the channel FIFO */
+    base->TCR3 |= I2S_TCR3_TCE(1U << handle->channel);
+
     return kStatus_Success;
 }
 
+/*!
+ * brief Performs a non-blocking SAI receive using eDMA.
+ *
+ * note This interface returns immediately after the transfer initiates. Call
+ * the SAI_GetReceiveRemainingBytes to poll the transfer status and check whether the SAI transfer is finished.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ * param xfer Pointer to DMA transfer structure.
+ * retval kStatus_Success Start a SAI eDMA receive successfully.
+ * retval kStatus_InvalidArgument The input argument is invalid.
+ * retval kStatus_RxBusy SAI is busy receiving data.
+ */
 status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer)
 {
     assert(handle && xfer);
@@ -298,6 +418,9 @@ status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     EDMA_PrepareTransfer(&config, (void *)srcAddr, handle->bytesPerFrame, xfer->data, handle->bytesPerFrame,
                          handle->count * handle->bytesPerFrame, xfer->dataSize, kEDMA_PeripheralToMemory);
 
+    /* Store the initially configured eDMA minor byte transfer count into the SAI handle */
+    handle->nbytes = handle->count * handle->bytesPerFrame;
+
     EDMA_SubmitTransfer(handle->dmaHandle, &config);
 
     /* Start DMA transfer */
@@ -306,12 +429,24 @@ status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     /* Enable DMA enable bit */
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
 
+    /* Enable the channel FIFO */
+    base->RCR3 |= I2S_RCR3_RCE(1U << handle->channel);
+
     /* Enable SAI Rx clock */
     SAI_RxEnable(base, true);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Aborts a SAI transfer using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateSendEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
 void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
 {
     assert(handle);
@@ -319,13 +454,36 @@ void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
     /* Disable dma */
     EDMA_AbortTransfer(handle->dmaHandle);
 
+    /* Disable the channel FIFO */
+    base->TCR3 &= ~I2S_TCR3_TCE_MASK;
+
     /* Disable DMA enable bit */
     SAI_TxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
+
+    /* Disable Tx */
+    SAI_TxEnable(base, false);
+
+    /* Reset the FIFO pointer, at the same time clear all error flags if set */
+    base->TCSR |= (I2S_TCSR_FR_MASK | I2S_TCSR_SR_MASK);
+    base->TCSR &= ~I2S_TCSR_SR_MASK;
+
+    /* Handle the queue index */
+    memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+    handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
 
     /* Set the handle state */
     handle->state = kSAI_Idle;
 }
 
+/*!
+ * brief Aborts a SAI receive using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateReceiveEDMA.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ */
 void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
 {
     assert(handle);
@@ -333,13 +491,84 @@ void SAI_TransferAbortReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
     /* Disable dma */
     EDMA_AbortTransfer(handle->dmaHandle);
 
+    /* Disable the channel FIFO */
+    base->RCR3 &= ~I2S_RCR3_RCE_MASK;
+
     /* Disable DMA enable bit */
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, false);
+
+    /* Disable Rx */
+    SAI_RxEnable(base, false);
+
+    /* Reset the FIFO pointer, at the same time clear all error flags if set */
+    base->RCSR |= (I2S_RCSR_FR_MASK | I2S_RCSR_SR_MASK);
+    base->RCSR &= ~I2S_RCSR_SR_MASK;
+
+    /* Handle the queue index */
+    memset(&handle->saiQueue[handle->queueDriver], 0, sizeof(sai_transfer_t));
+    handle->queueDriver = (handle->queueDriver + 1) % SAI_XFER_QUEUE_SIZE;
 
     /* Set the handle state */
     handle->state = kSAI_Idle;
 }
 
+/*!
+ * brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSendEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSendEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortSendEDMA(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->tcd, 0U, sizeof(handle->tcd));
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceiveEDMA.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle)
+{
+    assert(handle);
+
+    /* Abort the current transfer */
+    SAI_TransferAbortReceiveEDMA(base, handle);
+
+    /* Clear all the internal information */
+    memset(handle->tcd, 0U, sizeof(handle->tcd));
+    memset(handle->saiQueue, 0U, sizeof(handle->saiQueue));
+    memset(handle->transferSize, 0U, sizeof(handle->transferSize));
+    handle->queueUser = 0U;
+    handle->queueDriver = 0U;
+}
+
+/*!
+ * brief Gets byte count sent by SAI.
+ *
+ * param base SAI base pointer.
+ * param handle SAI eDMA handle pointer.
+ * param count Bytes count sent by SAI.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
 status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -353,12 +582,22 @@ status_t SAI_TransferGetSendCountEDMA(I2S_Type *base, sai_edma_handle_t *handle,
     else
     {
         *count = (handle->transferSize[handle->queueDriver] -
-                  EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+                  (uint32_t)handle->nbytes *
+                      EDMA_GetRemainingMajorLoopCount(handle->dmaHandle->base, handle->dmaHandle->channel));
     }
 
     return status;
 }
 
+/*!
+ * brief Gets byte count received by SAI.
+ *
+ * param base SAI base pointer
+ * param handle SAI eDMA handle pointer.
+ * param count Bytes count received by SAI.
+ * retval kStatus_Success Succeed get the transfer count.
+ * retval kStatus_NoTransferInProgress There is no non-blocking transaction in progress.
+ */
 status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *handle, size_t *count)
 {
     assert(handle);
@@ -372,7 +611,8 @@ status_t SAI_TransferGetReceiveCountEDMA(I2S_Type *base, sai_edma_handle_t *hand
     else
     {
         *count = (handle->transferSize[handle->queueDriver] -
-                  EDMA_GetRemainingBytes(handle->dmaHandle->base, handle->dmaHandle->channel));
+                  (uint32_t)handle->nbytes *
+                      EDMA_GetRemainingMajorLoopCount(handle->dmaHandle->base, handle->dmaHandle->channel));
     }
 
     return status;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_sai_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_sai_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_SAI_EDMA_H_
 #define _FSL_SAI_EDMA_H_
@@ -38,11 +16,14 @@
  * @{
  */
 
-/*! @file */
-
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_SAI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 1, 5)) /*!< Version 2.1.5 */
+/*@}*/
 
 typedef struct _sai_edma_handle sai_edma_handle_t;
 
@@ -52,18 +33,19 @@ typedef void (*sai_edma_callback_t)(I2S_Type *base, sai_edma_handle_t *handle, s
 /*! @brief SAI DMA transfer handle, users should not touch the content of the handle.*/
 struct _sai_edma_handle
 {
-    edma_handle_t *dmaHandle;                     /*!< DMA handler for SAI send */
-    uint8_t bytesPerFrame;                        /*!< Bytes in a frame */
-    uint8_t channel;                              /*!< Which data channel */
-    uint8_t count;                                /*!< The transfer data count in a DMA request */
-    uint32_t state;                               /*!< Internal state for SAI eDMA transfer */
-    sai_edma_callback_t callback;                 /*!< Callback for users while transfer finish or error occurs */
-    void *userData;                               /*!< User callback parameter */
-    edma_tcd_t tcd[SAI_XFER_QUEUE_SIZE + 1U];     /*!< TCD pool for eDMA transfer. */
-    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE]; /*!< Transfer queue storing queued transfer. */
-    size_t transferSize[SAI_XFER_QUEUE_SIZE];     /*!< Data bytes need to transfer */
-    volatile uint8_t queueUser;                   /*!< Index for user to queue transfer. */
-    volatile uint8_t queueDriver;                 /*!< Index for driver to get the transfer data and size */
+    edma_handle_t *dmaHandle;     /*!< DMA handler for SAI send */
+    uint8_t nbytes;               /*!< eDMA minor byte transfer count initially configured. */
+    uint8_t bytesPerFrame;        /*!< Bytes in a frame */
+    uint8_t channel;              /*!< Which data channel */
+    uint8_t count;                /*!< The transfer data count in a DMA request */
+    uint32_t state;               /*!< Internal state for SAI eDMA transfer */
+    sai_edma_callback_t callback; /*!< Callback for users while transfer finish or error occurs */
+    void *userData;               /*!< User callback parameter */
+    uint8_t tcd[(SAI_XFER_QUEUE_SIZE + 1U) * sizeof(edma_tcd_t)]; /*!< TCD pool for eDMA transfer. */
+    sai_transfer_t saiQueue[SAI_XFER_QUEUE_SIZE];                 /*!< Transfer queue storing queued transfer. */
+    size_t transferSize[SAI_XFER_QUEUE_SIZE];                     /*!< Data bytes need to transfer */
+    volatile uint8_t queueUser;                                   /*!< Index for user to queue transfer. */
+    volatile uint8_t queueDriver; /*!< Index for driver to get the transfer data and size */
 };
 
 /*******************************************************************************
@@ -183,7 +165,32 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
 status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_transfer_t *xfer);
 
 /*!
+ * @brief Terminate all SAI send.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortSendEDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
+ * @brief Terminate all SAI receive.
+ *
+ * This function will clear all transfer slots buffered in the sai queue. If users only want to abort the
+ * current transfer slot, please call SAI_TransferAbortReceiveEDMA.
+ *
+ * @param base SAI base pointer.
+ * @param handle SAI eDMA handle pointer.
+ */
+void SAI_TransferTerminateReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle);
+
+/*!
  * @brief Aborts a SAI transfer using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateSendEDMA.
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.
@@ -192,6 +199,9 @@ void SAI_TransferAbortSendEDMA(I2S_Type *base, sai_edma_handle_t *handle);
 
 /*!
  * @brief Aborts a SAI receive using eDMA.
+ *
+ * This function only aborts the current transfer slots, the other transfer slots' information still kept
+ * in the handler. If users want to terminate all transfer slots, just call SAI_TransferTerminateReceiveEDMA.
  *
  * @param base SAI base pointer
  * @param handle SAI eDMA handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_uart_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_uart_edma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * All rights reserved.
+ * Copyright 2016-2017 NXP
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -12,7 +12,7 @@
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
  *
- * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ * o Neither the name of the copyright holder nor the names of its
  *   contributors may be used to endorse or promote products derived from this
  *   software without specific prior written permission.
  *
@@ -38,8 +38,6 @@
  * @addtogroup uart_edma_driver
  * @{
  */
-
-/*! @file*/
 
 /*******************************************************************************
  * Definitions
@@ -67,6 +65,8 @@ struct _uart_edma_handle
     edma_handle_t *txEdmaHandle; /*!< The eDMA TX channel used. */
     edma_handle_t *rxEdmaHandle; /*!< The eDMA RX channel used. */
 
+    uint8_t nbytes; /*!< eDMA minor byte transfer count initially configured. */
+
     volatile uint8_t txState; /*!< TX transfer state. */
     volatile uint8_t rxState; /*!< RX transfer state */
 };
@@ -87,18 +87,18 @@ extern "C" {
 /*!
  * @brief Initializes the UART handle which is used in transactional functions.
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  * @param callback UART callback, NULL means no callback.
  * @param userData User callback function data.
- * @param rxEdmaHandle User requested DMA handle for RX DMA transfer.
- * @param txEdmaHandle User requested DMA handle for TX DMA transfer.
+ * @param rxEdmaHandle User-requested DMA handle for RX DMA transfer.
+ * @param txEdmaHandle User-requested DMA handle for TX DMA transfer.
  */
 void UART_TransferCreateHandleEDMA(UART_Type *base,
-                           uart_edma_handle_t *handle,
-                           uart_edma_transfer_callback_t callback,
-                           void *userData,
-                           edma_handle_t *txEdmaHandle,
-                           edma_handle_t *rxEdmaHandle);
+                                   uart_edma_handle_t *handle,
+                                   uart_edma_transfer_callback_t callback,
+                                   void *userData,
+                                   edma_handle_t *txEdmaHandle,
+                                   edma_handle_t *rxEdmaHandle);
 
 /*!
  * @brief Sends data using eDMA.
@@ -109,23 +109,23 @@ void UART_TransferCreateHandleEDMA(UART_Type *base,
  * @param base UART peripheral base address.
  * @param handle UART handle pointer.
  * @param xfer UART eDMA transfer structure. See #uart_transfer_t.
- * @retval kStatus_Success if succeed, others failed.
- * @retval kStatus_UART_TxBusy Previous transfer on going.
+ * @retval kStatus_Success if succeeded; otherwise failed.
+ * @retval kStatus_UART_TxBusy Previous transfer ongoing.
  * @retval kStatus_InvalidArgument Invalid argument.
  */
 status_t UART_SendEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer);
 
 /*!
- * @brief Receive data using eDMA.
+ * @brief Receives data using eDMA.
  *
  * This function receives data using eDMA. This is a non-blocking function, which returns
  * right away. When all data is received, the receive callback function is called.
  *
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  * @param xfer UART eDMA transfer structure. See #uart_transfer_t.
- * @retval kStatus_Success if succeed, others failed.
- * @retval kStatus_UART_RxBusy Previous transfer on going.
+ * @retval kStatus_Success if succeeded; otherwise failed.
+ * @retval kStatus_UART_RxBusy Previous transfer ongoing.
  * @retval kStatus_InvalidArgument Invalid argument.
  */
 status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_transfer_t *xfer);
@@ -136,7 +136,7 @@ status_t UART_ReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle, uart_tran
  * This function aborts sent data using eDMA.
  *
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  */
 void UART_TransferAbortSendEDMA(UART_Type *base, uart_edma_handle_t *handle);
 
@@ -146,12 +146,12 @@ void UART_TransferAbortSendEDMA(UART_Type *base, uart_edma_handle_t *handle);
  * This function aborts receive data using eDMA.
  *
  * @param base UART peripheral base address.
- * @param handle Pointer to uart_edma_handle_t structure.
+ * @param handle Pointer to the uart_edma_handle_t structure.
  */
 void UART_TransferAbortReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle);
 
 /*!
- * @brief Get the number of bytes that have been written to UART TX register.
+ * @brief Gets the number of bytes that have been written to UART TX register.
  *
  * This function gets the number of bytes that have been written to UART TX
  * register by DMA.
@@ -166,9 +166,9 @@ void UART_TransferAbortReceiveEDMA(UART_Type *base, uart_edma_handle_t *handle);
 status_t UART_TransferGetSendCountEDMA(UART_Type *base, uart_edma_handle_t *handle, uint32_t *count);
 
 /*!
- * @brief Get the number of bytes that have been received.
+ * @brief Gets the number of received bytes.
  *
- * This function gets the number of bytes that have been received.
+ * This function gets the number of received bytes.
  *
  * @param base UART peripheral base address.
  * @param handle UART handle pointer.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
@@ -118,16 +118,21 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/drivers/fsl_dspi.c
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_dspi.h"
@@ -33,6 +11,12 @@
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -137,9 +114,16 @@ static dspi_master_isr_t s_dspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
+/* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
@@ -158,9 +142,64 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
     return instance;
 }
 
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+{
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
+}
+
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
     uint32_t temp;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -171,6 +210,7 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -179,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -191,47 +229,85 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
     masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
     uint32_t temp = 0;
 
@@ -251,35 +327,57 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
+
+    DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
 
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
-    slaveConfig->whichCtar = kDSPI_Ctar0;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
     slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
@@ -309,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -328,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -394,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -418,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -440,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -471,87 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    assert(command);
+    assert(NULL != command);
 
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    assert(command);
+    assert(NULL != command);
 
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -560,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -576,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -594,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -641,15 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -661,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -702,24 +1013,25 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -727,13 +1039,13 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -741,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -754,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -807,26 +1120,27 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
                         if (rxData != NULL)
                         {
-                            *rxData = wordReceived;
+                            *rxData = (uint8_t)wordReceived;
                             ++rxData;
-                            *rxData = wordReceived >> 8;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
                             ++rxData;
                         }
-                        remainingReceiveByteCount -= 2;
+                        remainingReceiveByteCount -= 2U;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -838,31 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
-    dspi_command_data_config_t commandStruct;
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -870,62 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
-    DSPI_StartTransfer(base);
-
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
-    DSPI_MasterTransferFillUpTxFifo(base, handle);
 
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_StartTransfer(base);
+
+    /* Fill up the Tx FIFO to trigger the transfer. */
+    DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -937,13 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -952,41 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    handle->state = kDSPI_Idle;
-
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -994,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1002,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1018,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1053,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1063,86 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1151,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1179,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1211,86 +1736,107 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
+
+    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
+
+    /* Enable RX FIFO drain request, the slave only use this interrupt */
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
+
+    if (NULL != handle->rxData)
+    {
+        /* RX FIFO overflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
+    }
+    if (NULL != handle->txData)
+    {
+        /* TX FIFO underflow request enable */
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
+    }
 
     DSPI_StartTransfer(base);
 
     /* Prepare data to transmit */
     DSPI_SlaveTransferFillUpTxFifo(base, handle);
 
-    s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
-
-    /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
-
-    if (handle->rxData)
-    {
-        /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
-    }
-    if (handle->txData)
-    {
-        /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
-    }
-
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1302,24 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1337,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1384,26 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1412,69 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 
-    if (handle->callback)
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint8_t dummyPattern = DSPI_DUMMY_DATA;
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1492,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1508,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1581,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1614,12 +2188,17 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 #if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
@@ -1627,7 +2206,7 @@ void SPI0_DriverIRQHandler(void)
 #if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
@@ -1635,7 +2214,7 @@ void SPI1_DriverIRQHandler(void)
 #if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
@@ -1643,7 +2222,7 @@ void SPI2_DriverIRQHandler(void)
 #if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
@@ -1651,7 +2230,7 @@ void SPI3_DriverIRQHandler(void)
 #if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
@@ -1659,7 +2238,7 @@ void SPI4_DriverIRQHandler(void)
 #if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -37,15 +15,14 @@
  * @{
  */
 
-
 /**********************************************************************************************************************
  * Definitions
  *********************************************************************************************************************/
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.1.4. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 1, 4))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
 #ifndef DSPI_DUMMY_DATA
@@ -56,37 +33,37 @@
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All statuses above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -103,11 +80,12 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
- * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is valid
+ * @brief DSPI Sample Point: Controls when the DSPI master samples SIN in the Modified Transfer Format. This field is
+ * valid
  * only when the CPHA bit in the CTAR register is 0.
  */
 typedef enum _dspi_master_sample_point
@@ -132,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -216,8 +194,9 @@ enum _dspi_transfer_config_flag_for_master
     kDSPI_MasterPcs4 = 4U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS4 signal. */
     kDSPI_MasterPcs5 = 5U << DSPI_MASTER_PCS_SHIFT, /*!< DSPI master transfer use PCS5 signal. */
 
-    kDSPI_MasterPcsContinuous = 1U << 20,       /*!< Indicates whether the PCS signal is continuous. */
-    kDSPI_MasterActiveAfterTransfer = 1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    kDSPI_MasterPcsContinuous = 1U << 20, /*!< Indicates whether the PCS signal is continuous. */
+    kDSPI_MasterActiveAfterTransfer =
+        1U << 21, /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
 #define DSPI_SLAVE_CTAR_SHIFT (0U)   /*!< DSPI slave CTAR shift macro; used internally. */
@@ -240,7 +219,7 @@ enum _dspi_transfer_state
 /*! @brief DSPI master command date configuration used for the SPIx_PUSHR.*/
 typedef struct _dspi_command_data_config
 {
-    bool isPcsContinuous;            /*!< Option to enable the continuous assertion of the chip select between transfers.*/
+    bool isPcsContinuous; /*!< Option to enable the continuous assertion of the chip select between transfers.*/
     dspi_ctar_selection_t whichCtar; /*!< The desired Clock and Transfer Attributes
                                           Register (CTAR) to use for CTAS.*/
     dspi_which_pcs_t whichPcs;       /*!< The desired PCS signal to use for the data transfer.*/
@@ -257,10 +236,10 @@ typedef struct _dspi_master_ctar_config
     dspi_clock_phase_t cpha;          /*!< Clock phase. */
     dspi_shift_direction_t direction; /*!< MSB or LSB data shift direction. */
 
-    uint32_t pcsToSckDelayInNanoSec;        /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
-                                               delay. It also sets the boundary value if out of range.*/
-    uint32_t lastSckToPcsDelayInNanoSec;    /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
-                                               minimum delay. It also sets the boundary value if out of range.*/
+    uint32_t pcsToSckDelayInNanoSec;     /*!< PCS to SCK delay time in nanoseconds; setting to 0 sets the minimum
+                                            delay. It also sets the boundary value if out of range.*/
+    uint32_t lastSckToPcsDelayInNanoSec; /*!< The last SCK to PCS delay time in nanoseconds; setting to 0 sets the
+                                            minimum delay. It also sets the boundary value if out of range.*/
 
     uint32_t betweenTransferDelayInNanoSec; /*!< After the SCK delay time in nanoseconds; setting to 0 sets the minimum
                                              delay. It also sets the boundary value if out of range.*/
@@ -314,13 +293,13 @@ typedef struct _dspi_slave_config
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -355,11 +334,23 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
@@ -370,8 +361,9 @@ struct _dspi_master_handle
 
     uint8_t fifoSize; /*!< FIFO dataSize. */
 
-    volatile bool isPcsActiveAfterTransfer; /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
-    volatile bool isThereExtraByte;         /*!< Indicates whether there are extra bytes.*/
+    volatile bool
+        isPcsActiveAfterTransfer;   /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
+    volatile bool isThereExtraByte; /*!< Indicates whether there are extra bytes.*/
 
     uint8_t *volatile txData;                  /*!< Send buffer. */
     uint8_t *volatile rxData;                  /*!< Receive buffer. */
@@ -525,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -563,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -575,6 +567,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
  *
  * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
  * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
  *
  * @code
  *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
@@ -602,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -682,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -708,7 +707,14 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
@@ -746,8 +752,8 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -759,8 +765,8 @@ static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool en
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -950,10 +956,12 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  * @brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
  *        buffer master mode and waits till complete to return.
  *
- * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total 32-bit word
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
  * as the data to send.
  * The command portion provides characteristics of the data, such as the optional continuous chip select operation
- * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the desired PCS
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
@@ -968,20 +976,20 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
  * @param data The data word (command and data combined) to be sent.
  */
@@ -1023,8 +1031,16 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
 }
 
 /*!
+ * @brief Set up the dummy data.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1072,6 +1088,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1167,14 +1212,24 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -41,14 +19,20 @@
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
@@ -185,6 +169,21 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief DSPI master aborts a transfer which is using eDMA.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
@@ -128,16 +128,21 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
+                           char *rx_buffer, int rx_length, char write_fill)
+{
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->spi.instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->spi.instance], &(dspi_transfer_t) {
+        .txData = (uint8_t *)tx_buffer,
+        .rxData = (uint8_t *)rx_buffer,
+        .dataSize = total,
+        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->spi.instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.c
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_dspi.h"
@@ -33,6 +11,12 @@
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi"
+#endif
+
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
@@ -42,13 +26,6 @@ typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/
-/*!
- * @brief Get instance number for DSPI module.
- *
- * @param base DSPI peripheral base address.
- */
-uint32_t DSPI_GetInstance(SPI_Type *base);
-
 /*!
  * @brief Configures the DSPI peripheral chip select polarity.
  *
@@ -110,11 +87,11 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
 
 /* Defines constant value arrays for the baud rate pre-scalar and scalar divider values.*/
 static const uint32_t s_baudratePrescaler[] = {2, 3, 5, 7};
-static const uint32_t s_baudrateScaler[] = {2,   4,   6,    8,    16,   32,   64,    128,
+static const uint32_t s_baudrateScaler[]    = {2,   4,   6,    8,    16,   32,   64,    128,
                                             256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
 
 static const uint32_t s_delayPrescaler[] = {1, 3, 5, 7};
-static const uint32_t s_delayScaler[] = {2,   4,    8,    16,   32,   64,    128,   256,
+static const uint32_t s_delayScaler[]    = {2,   4,    8,    16,   32,   64,    128,   256,
                                          512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
 
 /*! @brief Pointers to dspi bases for each instance. */
@@ -138,10 +115,15 @@ static dspi_master_isr_t s_dspiMasterIsr;
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
-volatile uint8_t s_dummyData[ARRAY_SIZE(s_dspiBases)] = {0};
+volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
-* Code
-*********************************************************************************************************************/
+ * Code
+ *********************************************************************************************************************/
+/*!
+ * brief Get instance number for DSPI module.
+ *
+ * param base DSPI peripheral base address.
+ */
 uint32_t DSPI_GetInstance(SPI_Type *base)
 {
     uint32_t instance;
@@ -160,15 +142,64 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
     return instance;
 }
 
-void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+/*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
 {
-    uint32_t instance = DSPI_GetInstance(base);
-    s_dummyData[instance] = dummyData;
+    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+
+    return instance;
 }
 
+/*!
+ * brief Set up the dummy data.
+ *
+ * param base DSPI peripheral address.
+ * param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = dummyData;
+}
+
+/*!
+ * brief Initializes the DSPI master.
+ *
+ * This function initializes the DSPI master configuration. This is an example use case.
+ *  code
+ *   dspi_master_config_t  masterConfig;
+ *   masterConfig.whichCtar                                = kDSPI_Ctar0;
+ *   masterConfig.ctarConfig.baudRate                      = 500000000U;
+ *   masterConfig.ctarConfig.bitsPerFrame                  = 8;
+ *   masterConfig.ctarConfig.cpol                          = kDSPI_ClockPolarityActiveHigh;
+ *   masterConfig.ctarConfig.cpha                          = kDSPI_ClockPhaseFirstEdge;
+ *   masterConfig.ctarConfig.direction                     = kDSPI_MsbFirst;
+ *   masterConfig.ctarConfig.pcsToSckDelayInNanoSec        = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.lastSckToPcsDelayInNanoSec    = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.ctarConfig.betweenTransferDelayInNanoSec = 1000000000U / masterConfig.ctarConfig.baudRate ;
+ *   masterConfig.whichPcs                                 = kDSPI_Pcs0;
+ *   masterConfig.pcsActiveHighOrLow                       = kDSPI_PcsActiveLow;
+ *   masterConfig.enableContinuousSCK                      = false;
+ *   masterConfig.enableRxFifoOverWrite                    = false;
+ *   masterConfig.enableModifiedTimingFormat               = false;
+ *   masterConfig.samplePoint                              = kDSPI_SckToSin0Clock;
+ *   DSPI_MasterInit(base, &masterConfig, srcClock_Hz);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param masterConfig Pointer to the structure dspi_master_config_t.
+ * param srcClock_Hz Module source input clock in Hertz.
+ */
 void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, uint32_t srcClock_Hz)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
     uint32_t temp;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -179,6 +210,7 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     DSPI_Enable(base, true);
     DSPI_StopTransfer(base);
 
+    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
     DSPI_SetMasterSlaveMode(base, kDSPI_Master);
 
     temp = base->MCR & (~(SPI_MCR_CONT_SCKE_MASK | SPI_MCR_MTFE_MASK | SPI_MCR_ROOE_MASK | SPI_MCR_SMPL_PT_MASK |
@@ -187,11 +219,9 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     base->MCR = temp | SPI_MCR_CONT_SCKE(masterConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(masterConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(masterConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(masterConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
-    DSPI_SetOnePcsPolarity(base, masterConfig->whichPcs, masterConfig->pcsActiveHighOrLow);
-
-    if (0 == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
+    if (0U == DSPI_MasterSetBaudRate(base, masterConfig->whichCtar, masterConfig->ctarConfig.baudRate, srcClock_Hz))
     {
         assert(false);
     }
@@ -199,48 +229,85 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
     temp = base->CTAR[masterConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[masterConfig->whichCtar] =
-        temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1) | SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
-        SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) | SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
+    base->CTAR[masterConfig->whichCtar] = temp | SPI_CTAR_FMSZ(masterConfig->ctarConfig.bitsPerFrame - 1U) |
+                                          SPI_CTAR_CPOL(masterConfig->ctarConfig.cpol) |
+                                          SPI_CTAR_CPHA(masterConfig->ctarConfig.cpha) |
+                                          SPI_CTAR_LSBFE(masterConfig->ctarConfig.direction);
 
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
-                             masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
-                             masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
-    DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
-                             masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_PcsToSck, srcClock_Hz,
+                                   masterConfig->ctarConfig.pcsToSckDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_LastSckToPcs, srcClock_Hz,
+                                   masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec);
+    (void)DSPI_MasterSetDelayTimes(base, masterConfig->whichCtar, kDSPI_BetweenTransfer, srcClock_Hz,
+                                   masterConfig->ctarConfig.betweenTransferDelayInNanoSec);
 
     DSPI_SetDummyData(base, DSPI_DUMMY_DATA);
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_master_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_MasterInit().
+ * Users may use the initialized structure unchanged in the DSPI_MasterInit() or modify the structure
+ * before calling the DSPI_MasterInit().
+ * Example:
+ * code
+ *  dspi_master_config_t  masterConfig;
+ *  DSPI_MasterGetDefaultConfig(&masterConfig);
+ * endcode
+ * param masterConfig pointer to dspi_master_config_t structure
+ */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
 {
-    assert(masterConfig);
+    assert(NULL != masterConfig);
 
-    masterConfig->whichCtar = kDSPI_Ctar0;
-    masterConfig->ctarConfig.baudRate = 500000;
+    /* Initializes the configure structure to zero. */
+    (void)memset(masterConfig, 0, sizeof(*masterConfig));
+
+    masterConfig->whichCtar               = kDSPI_Ctar0;
+    masterConfig->ctarConfig.baudRate     = 500000;
     masterConfig->ctarConfig.bitsPerFrame = 8;
-    masterConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    masterConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
-    masterConfig->ctarConfig.direction = kDSPI_MsbFirst;
+    masterConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    masterConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
+    masterConfig->ctarConfig.direction    = kDSPI_MsbFirst;
 
-    masterConfig->ctarConfig.pcsToSckDelayInNanoSec = 1000;
-    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec = 1000;
+    masterConfig->ctarConfig.pcsToSckDelayInNanoSec        = 1000;
+    masterConfig->ctarConfig.lastSckToPcsDelayInNanoSec    = 1000;
     masterConfig->ctarConfig.betweenTransferDelayInNanoSec = 1000;
 
-    masterConfig->whichPcs = kDSPI_Pcs0;
+    masterConfig->whichPcs           = kDSPI_Pcs0;
     masterConfig->pcsActiveHighOrLow = kDSPI_PcsActiveLow;
 
-    masterConfig->enableContinuousSCK = false;
-    masterConfig->enableRxFifoOverWrite = false;
+    masterConfig->enableContinuousSCK        = false;
+    masterConfig->enableRxFifoOverWrite      = false;
     masterConfig->enableModifiedTimingFormat = false;
-    masterConfig->samplePoint = kDSPI_SckToSin0Clock;
+    masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief DSPI slave configuration.
+ *
+ * This function initializes the DSPI slave configuration. This is an example use case.
+ *  code
+ *   dspi_slave_config_t  slaveConfig;
+ *  slaveConfig->whichCtar                  = kDSPI_Ctar0;
+ *  slaveConfig->ctarConfig.bitsPerFrame    = 8;
+ *  slaveConfig->ctarConfig.cpol            = kDSPI_ClockPolarityActiveHigh;
+ *  slaveConfig->ctarConfig.cpha            = kDSPI_ClockPhaseFirstEdge;
+ *  slaveConfig->enableContinuousSCK        = false;
+ *  slaveConfig->enableRxFifoOverWrite      = false;
+ *  slaveConfig->enableModifiedTimingFormat = false;
+ *  slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
+ *   DSPI_SlaveInit(base, &slaveConfig);
+ *  endcode
+ *
+ * param base DSPI peripheral address.
+ * param slaveConfig Pointer to the structure dspi_master_config_t.
+ */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
     uint32_t temp = 0;
 
@@ -260,14 +327,14 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     base->MCR = temp | SPI_MCR_CONT_SCKE(slaveConfig->enableContinuousSCK) |
                 SPI_MCR_MTFE(slaveConfig->enableModifiedTimingFormat) |
                 SPI_MCR_ROOE(slaveConfig->enableRxFifoOverWrite) | SPI_MCR_SMPL_PT(slaveConfig->samplePoint) |
-                SPI_MCR_DIS_TXF(false) | SPI_MCR_DIS_RXF(false);
+                SPI_MCR_DIS_TXF(0U) | SPI_MCR_DIS_RXF(0U);
 
     DSPI_SetOnePcsPolarity(base, kDSPI_Pcs0, kDSPI_PcsActiveLow);
 
     temp = base->CTAR[slaveConfig->whichCtar] &
            ~(SPI_CTAR_FMSZ_MASK | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK | SPI_CTAR_LSBFE_MASK);
 
-    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1) |
+    base->CTAR[slaveConfig->whichCtar] = temp | SPI_CTAR_SLAVE_FMSZ(slaveConfig->ctarConfig.bitsPerFrame - 1U) |
                                          SPI_CTAR_SLAVE_CPOL(slaveConfig->ctarConfig.cpol) |
                                          SPI_CTAR_SLAVE_CPHA(slaveConfig->ctarConfig.cpha);
 
@@ -276,21 +343,41 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
     DSPI_StartTransfer(base);
 }
 
+/*!
+ * brief Sets the dspi_slave_config_t structure to a default value.
+ *
+ * The purpose of this API is to get the configuration structure initialized for the DSPI_SlaveInit().
+ * Users may use the initialized structure unchanged in the DSPI_SlaveInit() or modify the structure
+ * before calling the DSPI_SlaveInit().
+ * This is an example.
+ * code
+ *  dspi_slave_config_t  slaveConfig;
+ *  DSPI_SlaveGetDefaultConfig(&slaveConfig);
+ * endcode
+ * param slaveConfig Pointer to the dspi_slave_config_t structure.
+ */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
 {
-    assert(slaveConfig);
+    assert(NULL != slaveConfig);
 
-    slaveConfig->whichCtar = kDSPI_Ctar0;
+    /* Initializes the configure structure to zero. */
+    (void)memset(slaveConfig, 0, sizeof(*slaveConfig));
+
+    slaveConfig->whichCtar               = kDSPI_Ctar0;
     slaveConfig->ctarConfig.bitsPerFrame = 8;
-    slaveConfig->ctarConfig.cpol = kDSPI_ClockPolarityActiveHigh;
-    slaveConfig->ctarConfig.cpha = kDSPI_ClockPhaseFirstEdge;
+    slaveConfig->ctarConfig.cpol         = kDSPI_ClockPolarityActiveHigh;
+    slaveConfig->ctarConfig.cpha         = kDSPI_ClockPhaseFirstEdge;
 
-    slaveConfig->enableContinuousSCK = false;
-    slaveConfig->enableRxFifoOverWrite = false;
+    slaveConfig->enableContinuousSCK        = false;
+    slaveConfig->enableRxFifoOverWrite      = false;
     slaveConfig->enableModifiedTimingFormat = false;
-    slaveConfig->samplePoint = kDSPI_SckToSin0Clock;
+    slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+/*!
+ * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
+ * param base DSPI peripheral address.
+ */
 void DSPI_Deinit(SPI_Type *base)
 {
     DSPI_StopTransfer(base);
@@ -320,6 +407,19 @@ static void DSPI_SetOnePcsPolarity(SPI_Type *base, dspi_which_pcs_t pcs, dspi_pc
     base->MCR = temp;
 }
 
+/*!
+ * brief Sets the DSPI baud rate in bits per second.
+ *
+ * This function  takes in the desired baudRate_Bps (baud rate) and calculates the nearest possible baud rate without
+ * exceeding the desired baud rate, and returns the calculated baud rate in bits-per-second. It requires that the
+ * caller also provide the frequency of the module source clock (in Hertz).
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of the type dspi_ctar_selection_t
+ * param baudRate_Bps The desired baud rate in bits per second
+ * param srcClock_Hz Module source input clock in Hertz
+ * return The actual calculated baud rate
+ */
 uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
                                 dspi_ctar_selection_t whichCtar,
                                 uint32_t baudRate_Bps,
@@ -339,51 +439,82 @@ uint32_t DSPI_MasterSetBaudRate(SPI_Type *base,
     uint32_t baudrate = baudRate_Bps;
 
     /* find combination of prescaler and scaler resulting in baudrate closest to the requested value */
-    min_diff = 0xFFFFFFFFU;
+    min_diff      = 0xFFFFFFFFU;
     bestPrescaler = 0;
-    bestScaler = 0;
-    bestDbr = 1;
-    bestBaudrate = 0; /* required to avoid compilation warning */
+    bestScaler    = 0;
+    bestDbr       = 1;
+    bestBaudrate  = 0; /* required to avoid compilation warning */
 
     /* In all for loops, if min_diff = 0, the exit for loop*/
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0U; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0U; scaler < 16U; scaler++)
         {
-            for (dbr = 1; (dbr < 3) && min_diff; dbr++)
+            for (dbr = 1U; dbr < 3U; dbr++)
             {
                 realBaudrate = ((srcClock_Hz * dbr) / (s_baudratePrescaler[prescaler] * (s_baudrateScaler[scaler])));
 
                 /* calculate the baud rate difference based on the conditional statement that states that the calculated
-                * baud rate must not exceed the desired baud rate.
-                */
+                 * baud rate must not exceed the desired baud rate.
+                 */
                 if (baudrate >= realBaudrate)
                 {
                     diff = baudrate - realBaudrate;
                     if (min_diff > diff)
                     {
                         /* a better match found */
-                        min_diff = diff;
+                        min_diff      = diff;
                         bestPrescaler = prescaler;
-                        bestScaler = scaler;
-                        bestBaudrate = realBaudrate;
-                        bestDbr = dbr;
+                        bestScaler    = scaler;
+                        bestBaudrate  = realBaudrate;
+                        bestDbr       = dbr;
                     }
                 }
+                if (0U == min_diff)
+                {
+                    break;
+                }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
     /* write the best dbr, prescalar, and baud rate scalar to the CTAR */
     temp = base->CTAR[whichCtar] & ~(SPI_CTAR_DBR_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_BR_MASK);
 
-    base->CTAR[whichCtar] = temp | ((bestDbr - 1) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
+    base->CTAR[whichCtar] = temp | ((bestDbr - 1U) << SPI_CTAR_DBR_SHIFT) | (bestPrescaler << SPI_CTAR_PBR_SHIFT) |
                             (bestScaler << SPI_CTAR_BR_SHIFT);
 
     /* return the actual calculated baud rate */
     return bestBaudrate;
 }
 
+/*!
+ * brief Manually configures the delay prescaler and scaler for a particular CTAR.
+ *
+ * This function configures the PCS to SCK delay pre-scalar (PcsSCK) and scalar (CSSCK), after SCK delay pre-scalar
+ * (PASC) and scalar (ASC), and the delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes the delay to the configuration along with the prescaler and scaler value.
+ * This allows the user to directly set the prescaler/scaler values if pre-calculated or
+ * to manually increment either value.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param prescaler The prescaler delay value (can be an integer 0, 1, 2, or 3).
+ * param scaler The scaler delay value (can be any integer between 0 to 15).
+ * param whichDelay The desired delay to configure; must be of type dspi_delay_type_t
+ */
 void DSPI_MasterSetDelayScaler(
     SPI_Type *base, dspi_ctar_selection_t whichCtar, uint32_t prescaler, uint32_t scaler, dspi_delay_type_t whichDelay)
 {
@@ -405,11 +536,38 @@ void DSPI_MasterSetDelayScaler(
                                         SPI_CTAR_PDT(prescaler) | SPI_CTAR_DT(scaler);
                 break;
             default:
+                /* All cases have been listed above, the default clause should not be reached. */
+                assert(false);
                 break;
         }
     }
 }
 
+/*!
+ * brief Calculates the delay prescaler and scaler based on the desired delay input in nanoseconds.
+ *
+ * This function calculates the values for the following.
+ * PCS to SCK delay pre-scalar (PCSSCK) and scalar (CSSCK), or
+ * After SCK delay pre-scalar (PASC) and scalar (ASC), or
+ * Delay after transfer pre-scalar (PDT) and scalar (DT).
+ *
+ * These delay names are available in the type dspi_delay_type_t.
+ *
+ * The user passes which delay to configure along with the desired delay value in nanoseconds.  The function
+ * calculates the values needed for the prescaler and scaler. Note that returning the calculated delay as an exact
+ * delay match may not be possible. In this case, the closest match is calculated without going below the desired
+ * delay value input.
+ * It is possible to input a very large delay value that exceeds the capability of the part, in which case the maximum
+ * supported delay is returned. The higher-level peripheral driver alerts the user of an out of range delay
+ * input.
+ *
+ * param base DSPI peripheral address.
+ * param whichCtar The desired Clock and Transfer Attributes Register (CTAR) of type dspi_ctar_selection_t.
+ * param whichDelay The desired delay to configure, must be of type dspi_delay_type_t
+ * param srcClock_Hz Module source input clock in Hertz
+ * param delayTimeInNanoSec The desired delay value in nanoseconds.
+ * return The actual calculated delay value.
+ */
 uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
                                   dspi_ctar_selection_t whichCtar,
                                   dspi_delay_type_t whichDelay,
@@ -429,21 +587,21 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     uint32_t initialDelayNanoSec;
 
     /* find combination of prescaler and scaler resulting in the delay closest to the
-    * requested value
-    */
+     * requested value
+     */
     min_diff = 0xFFFFFFFFU;
     /* Initialize prescaler and scaler to their max values to generate the max delay */
     bestPrescaler = 0x3;
-    bestScaler = 0xF;
-    bestDelay = (((1000000000U * 4) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4;
+    bestScaler    = 0xF;
+    bestDelay = (((1000000000U * 4U) / srcClock_Hz) * s_delayPrescaler[bestPrescaler] * s_delayScaler[bestScaler]) / 4U;
 
     /* First calculate the initial, default delay */
-    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2;
+    initialDelayNanoSec = 1000000000U / srcClock_Hz * 2U;
 
     /* If the initial, default delay is already greater than the desired delay, then
-    * set the delays to their initial value (0) and return the delay. In other words,
-    * there is no way to decrease the delay value further.
-    */
+     * set the delays to their initial value (0) and return the delay. In other words,
+     * there is no way to decrease the delay value further.
+     */
     if (initialDelayNanoSec >= delayTimeInNanoSec)
     {
         DSPI_MasterSetDelayScaler(base, whichCtar, 0, 0, whichDelay);
@@ -451,27 +609,36 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     }
 
     /* In all for loops, if min_diff = 0, the exit for loop */
-    for (prescaler = 0; (prescaler < 4) && min_diff; prescaler++)
+    for (prescaler = 0; prescaler < 4U; prescaler++)
     {
-        for (scaler = 0; (scaler < 16) && min_diff; scaler++)
+        for (scaler = 0; scaler < 16U; scaler++)
         {
-            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4;
+            realDelay = ((4000000000U / srcClock_Hz) * s_delayPrescaler[prescaler] * s_delayScaler[scaler]) / 4U;
 
             /* calculate the delay difference based on the conditional statement
-            * that states that the calculated delay must not be less then the desired delay
-            */
+             * that states that the calculated delay must not be less then the desired delay
+             */
             if (realDelay >= delayTimeInNanoSec)
             {
                 diff = realDelay - delayTimeInNanoSec;
                 if (min_diff > diff)
                 {
                     /* a better match found */
-                    min_diff = diff;
+                    min_diff      = diff;
                     bestPrescaler = prescaler;
-                    bestScaler = scaler;
-                    bestDelay = realDelay;
+                    bestScaler    = scaler;
+                    bestDelay     = realDelay;
                 }
             }
+
+            if (0U == min_diff)
+            {
+                break;
+            }
+        }
+        if (0U == min_diff)
+        {
+            break;
         }
     }
 
@@ -482,87 +649,194 @@ uint32_t DSPI_MasterSetDelayTimes(SPI_Type *base,
     return bestDelay;
 }
 
+/*!
+ * brief Sets the dspi_command_data_config_t structure to default values.
+ *
+ * The purpose of this API is to get the configuration structure initialized for use in the DSPI_MasterWrite_xx().
+ * Users may use the initialized structure unchanged in the DSPI_MasterWrite_xx() or modify the structure
+ * before calling the DSPI_MasterWrite_xx().
+ * This is an example.
+ * code
+ *  dspi_command_data_config_t  command;
+ *  DSPI_GetDefaultDataCommandConfig(&command);
+ * endcode
+ * param command Pointer to the dspi_command_data_config_t structure.
+ */
 void DSPI_GetDefaultDataCommandConfig(dspi_command_data_config_t *command)
 {
-    assert(command);
+    assert(NULL != command);
 
-    command->isPcsContinuous = false;
-    command->whichCtar = kDSPI_Ctar0;
-    command->whichPcs = kDSPI_Pcs0;
-    command->isEndOfQueue = false;
+    /* Initializes the configure structure to zero. */
+    (void)memset(command, 0, sizeof(*command));
+
+    command->isPcsContinuous    = false;
+    command->whichCtar          = kDSPI_Ctar0;
+    command->whichPcs           = kDSPI_Pcs0;
+    command->isEndOfQueue       = false;
     command->clearTransferCount = false;
 }
 
+/*!
+ * brief Writes data into the data buffer master mode and waits till complete to return.
+ *
+ * In master mode, the 16-bit data is appended to the 16-bit command info. The command portion
+ * provides characteristics of the data, such as the optional continuous chip select
+ * operation between transfers, the desired Clock and Transfer Attributes register to use for the
+ * associated SPI frame, the desired PCS signal to use for the data transfer, whether the current
+ * transfer is the last in the queue, and whether to clear the transfer count (normally needed when
+ * sending the first frame of a data packet). This is an example.
+ * code
+ *  dspi_command_config_t commandConfig;
+ *  commandConfig.isPcsContinuous = true;
+ *  commandConfig.whichCtar = kDSPICtar0;
+ *  commandConfig.whichPcs = kDSPIPcs1;
+ *  commandConfig.clearTransferCount = false;
+ *  commandConfig.isEndOfQueue = false;
+ *  DSPI_MasterWriteDataBlocking(base, &commandConfig, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0). Because the SPI is a synchronous protocol,
+ * the received data is available when the transmit completes.
+ *
+ * param base DSPI peripheral address.
+ * param command Pointer to the command structure.
+ * param data The data word to be sent.
+ */
 void DSPI_MasterWriteDataBlocking(SPI_Type *base, dspi_command_data_config_t *command, uint16_t data)
 {
-    assert(command);
+    assert(NULL != command);
 
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = SPI_PUSHR_CONT(command->isPcsContinuous) | SPI_PUSHR_CTAS(command->whichCtar) |
                   SPI_PUSHR_PCS(command->whichPcs) | SPI_PUSHR_EOQ(command->isEndOfQueue) |
                   SPI_PUSHR_CTCNT(command->clearTransferCount) | SPI_PUSHR_TXDATA(data);
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes a 32-bit data word (16-bit command appended with 16-bit data) into the data
+ *        buffer master mode and waits till complete to return.
+ *
+ * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
+ * 32-bit word
+ * as the data to send.
+ * The command portion provides characteristics of the data, such as the optional continuous chip select operation
+ * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
+ * desired PCS
+ * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
+ * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
+ * appending this command with the data to send. This is an example:
+ * code
+ *  dataWord = <16-bit command> | <16-bit data>;
+ *  DSPI_MasterWriteCommandDataBlocking(base, dataWord);
+ * endcode
+ *
+ * Note that this function does not return until after the transmit is complete. Also note that the DSPI must be
+ * enabled and running to transmit data (MCR[MDIS] & [HALT] = 0).
+ * Because the SPI is a synchronous protocol, the received data is available when the transmit completes.
+ *
+ *  For a blocking polling transfer, see methods below.
+ *  Option 1:
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
+ * param base DSPI peripheral address.
+ * param data The data word (command and data combined) to be sent.
+ */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
+ *
+ * In slave mode, up to 16-bit words may be written. The function first clears the transmit complete flag, writes data
+ * into data register, and finally waits until the data is transmitted.
+ *
+ * param base DSPI peripheral address.
+ * param data The data to send.
+ */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
 {
     /* First, clear Transmit Complete Flag (TCF) */
-    DSPI_ClearStatusFlags(base, kDSPI_TxCompleteFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxCompleteFlag);
 
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 
     base->PUSHR_SLAVE = data;
 
-    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
     /* Wait till TCF sets */
-    while (!(DSPI_GetStatusFlags(base) & kDSPI_TxCompleteFlag))
+    while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxCompleteFlag))
     {
     }
 }
 
+/*!
+ * brief Enables the DSPI interrupts.
+ *
+ * This function configures the various interrupt masks of the DSPI.  The parameters are a base and an interrupt mask.
+ * Note, for Tx Fill and Rx FIFO drain requests, enable the interrupt request and disable the DMA request.
+ *       Do not use this API(write to RSER register) while DSPI is in running state.
+ *
+ * code
+ *  DSPI_EnableInterrupts(base, kDSPI_TxCompleteInterruptEnable | kDSPI_EndOfQueueInterruptEnable );
+ * endcode
+ *
+ * param base DSPI peripheral address.
+ * param mask The interrupt mask; use the enum _dspi_interrupt_enable.
+ */
 void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 {
-    if (mask & SPI_RSER_TFFF_RE_MASK)
+    if (0U != (mask & SPI_RSER_TFFF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_TFFF_DIRS_MASK;
     }
-    if (mask & SPI_RSER_RFDF_RE_MASK)
+    if (0U != (mask & SPI_RSER_RFDF_RE_MASK))
     {
         base->RSER &= ~SPI_RSER_RFDF_DIRS_MASK;
     }
@@ -571,15 +845,26 @@ void DSPI_EnableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*Transactional APIs -- Master*/
 
+/*!
+ * brief Initializes the DSPI master handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance,  call this API once to get the initialized handle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_handle_t.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_MasterTransferCreateHandle(SPI_Type *base,
                                      dspi_master_handle_t *handle,
                                      dspi_master_transfer_callback_t callback,
                                      void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -587,13 +872,23 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI master transfer data using polling.
+ *
+ * This function transfers data using polling. This is a blocking function, which does not return until all transfers
+ * have been completed.
+ *
+ * param base DSPI peripheral base address.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
-    assert(transfer);
+    assert(NULL != transfer);
 
-    uint16_t wordToSend = 0;
+    uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = s_dummyData[DSPI_GetInstance(base)];
+    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -605,45 +900,49 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     uint32_t remainingReceiveByteCount;
 
     uint32_t fifoSize;
+    uint32_t tmpMCR = 0;
     dspi_command_data_config_t commandStruct;
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     DSPI_StopTransfer(base);
-    DSPI_DisableInterrupts(base, kDSPI_AllInterruptEnable);
+    DSPI_DisableInterrupts(base, (uint32_t)kDSPI_AllInterruptEnable);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     /*Calculate the command and lastCommand*/
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
 
     command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     /*Calculate the bitsPerFrame*/
-    bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    bitsPerFrame = (uint8_t)(((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U);
 
-    txData = transfer->txData;
-    rxData = transfer->rxData;
-    remainingSendByteCount = transfer->dataSize;
+    txData                    = transfer->txData;
+    rxData                    = transfer->rxData;
+    remainingSendByteCount    = transfer->dataSize;
     remainingReceiveByteCount = transfer->dataSize;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
-        fifoSize = 1;
+        fifoSize = 1U;
     }
     else
     {
@@ -652,15 +951,15 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     DSPI_StartTransfer(base);
 
-    if (bitsPerFrame <= 8)
+    if (bitsPerFrame <= 8U)
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount == 1)
+            if (remainingSendByteCount == 1U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -672,35 +971,36 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 {
                     base->PUSHR = (lastCommand) | (dummyData);
                 }
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount--;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
                             /* Read data from POPR*/
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
                 if (txData != NULL)
                 {
@@ -713,24 +1013,25 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                 }
                 remainingSendByteCount--;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 while ((remainingReceiveByteCount - remainingSendByteCount) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
                         if (rxData != NULL)
                         {
-                            *(rxData) = DSPI_ReadData(base);
+                            *(rxData) = (uint8_t)DSPI_ReadData(base);
                             rxData++;
                         }
                         else
                         {
-                            DSPI_ReadData(base);
+                            (void)DSPI_ReadData(base);
                         }
                         remainingReceiveByteCount--;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -738,13 +1039,13 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
     }
     else
     {
-        while (remainingSendByteCount > 0)
+        while (remainingSendByteCount > 0U)
         {
-            if (remainingSendByteCount <= 2)
+            if (remainingSendByteCount <= 2U)
             {
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
@@ -752,9 +1053,9 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = *(txData);
                     ++txData;
 
-                    if (remainingSendByteCount > 1)
+                    if (remainingSendByteCount > 1U)
                     {
-                        wordToSend |= (unsigned)(*(txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(txData)) << 8U;
                         ++txData;
                     }
                 }
@@ -765,52 +1066,53 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
                 base->PUSHR = lastCommand | wordToSend;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 remainingSendByteCount = 0;
 
-                while (remainingReceiveByteCount > 0)
+                while (remainingReceiveByteCount > 0U)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
-                        if (remainingReceiveByteCount != 1)
+                        if (remainingReceiveByteCount != 1U)
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
-                                *(rxData) = wordReceived >> 8;
+                                *(rxData) = (uint8_t)(wordReceived >> 8U);
                                 ++rxData;
                             }
-                            remainingReceiveByteCount -= 2;
+                            remainingReceiveByteCount -= 2U;
                         }
                         else
                         {
                             if (rxData != NULL)
                             {
-                                *(rxData) = wordReceived;
+                                *(rxData) = (uint8_t)wordReceived;
                                 ++rxData;
                             }
                             remainingReceiveByteCount--;
                         }
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
             else
             {
                 /*Wait until Tx Fifo is not full*/
-                while (!(DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag))
+                while (0U == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
                 {
-                    DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 }
 
                 if (txData != NULL)
                 {
                     wordToSend = *(txData);
                     ++txData;
-                    wordToSend |= (unsigned)(*(txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(txData)) << 8U;
                     ++txData;
                 }
                 else
@@ -818,26 +1120,27 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
                     wordToSend = dummyData;
                 }
                 base->PUSHR = command | wordToSend;
-                remainingSendByteCount -= 2;
+                remainingSendByteCount -= 2U;
 
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                while (((remainingReceiveByteCount - remainingSendByteCount) / 2) >= fifoSize)
+                while (((remainingReceiveByteCount - remainingSendByteCount) / 2U) >= fifoSize)
                 {
-                    if (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+                    if ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                        (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
                     {
-                        wordReceived = DSPI_ReadData(base);
+                        wordReceived = (uint16_t)DSPI_ReadData(base);
 
                         if (rxData != NULL)
                         {
-                            *rxData = wordReceived;
+                            *rxData = (uint8_t)wordReceived;
                             ++rxData;
-                            *rxData = wordReceived >> 8;
+                            *rxData = (uint8_t)(wordReceived >> 8U);
                             ++rxData;
                         }
-                        remainingReceiveByteCount -= 2;
+                        remainingReceiveByteCount -= 2U;
 
-                        DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
                     }
                 }
             }
@@ -849,31 +1152,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
 static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
-    dspi_command_data_config_t commandStruct;
+    uint32_t tmpMCR                          = 0;
+    dspi_command_data_config_t commandStruct = {false, kDSPI_Ctar0, kDSPI_Pcs0, false, false};
 
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -881,62 +1188,221 @@ static void DSPI_MasterTransferPrepare(SPI_Type *base, dspi_master_handle_t *han
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 }
 
+/*!
+ * brief DSPI master transfer data using interrupts.
+ *
+ * This function transfers data using interrupts. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
+
+    /* Disable the NVIC for DSPI peripheral. */
+    (void)DisableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     DSPI_MasterTransferPrepare(base, handle, transfer);
 
-    /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
-
     /* RX FIFO Drain request: RFDF_RE to enable RFDF interrupt
-    * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
-    * The IRQ handler will get the status of RX and TX interrupt flags.
-    */
+     * Since SPI is a synchronous interface, we only need to enable the RX interrupt.
+     * The IRQ handler will get the status of RX and TX interrupt flags.
+     */
     s_dspiMasterIsr = DSPI_MasterTransferHandleIRQ;
 
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
     DSPI_StartTransfer(base);
 
     /* Fill up the Tx FIFO to trigger the transfer. */
     DSPI_MasterTransferFillUpTxFifo(base, handle);
+
+    /* Enable the NVIC for DSPI peripheral. */
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * param base DSPI base pointer
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    /* DSPI transfer blocking. */
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * param xfer pointer to dspi_half_duplex_transfer_t structure
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferNonBlocking(base, handle, &tempXfer);
+
+    return status;
+}
+
+/*!
+ * brief Gets the master transfer count.
+ *
+ * This function gets the master transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -948,13 +1414,14 @@ status_t DSPI_MasterTransferGetCount(SPI_Type *base, dspi_master_handle_t *handl
 
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -963,41 +1430,43 @@ static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *ha
         status = kStatus_Success;
     }
 
-    handle->state = kDSPI_Idle;
-
-    if (handle->callback)
+    if ((NULL != handle->callback) && ((uint8_t)kDSPI_Idle != handle->state))
     {
+        handle->state = (uint8_t)kDSPI_Idle;
         handle->callback(base, handle, status, handle->userData);
     }
 }
 
 static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = s_dummyData[DSPI_GetInstance(base)];
+    uint16_t wordToSend                 = 0;
+    uint8_t dummyData                   = DSPI_GetDummyDataInstance(base);
+    size_t tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+    size_t tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    uint8_t tmpFifoSize                 = handle->fifoSize;
 
     /* If bits/frame is greater than one byte */
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
-        * send data, hence the difference between the remainingReceiveByteCount and
-        * remainingSendByteCount must be divided by 2 to convert this difference into a
-        * 16-bit (2 byte) value.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) / 2 < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         * For this case where bitsPerFrame > 8, each entry in the FIFO contains 2 bytes of the
+         * send data, hence the difference between the remainingReceiveByteCount and
+         * remainingSendByteCount must be divided by 2 to convert this difference into a
+         * 16-bit (2 byte) value.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               (((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) / 2U) < tmpFifoSize))
         {
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         wordToSend = *(handle->txData);
                     }
@@ -1005,7 +1474,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData; /* increment to next data byte */
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                 }
                 else
@@ -1013,12 +1482,12 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                     wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount = 0;
-                base->PUSHR = handle->lastCommand | wordToSend;
+                base->PUSHR                    = handle->lastCommand | wordToSend;
             }
             /* For all words except the last word */
             else
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
@@ -1029,32 +1498,38 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 {
                     wordToSend = dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR = handle->command | wordToSend;
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop.
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == handle->totalByteCount - 2U))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         } /* End of TX FIFO fill while loop */
     }
     /* Optimized for bits/frame less than or equal to one byte. */
     else
     {
         /* Fill the fifo until it is full or until the send word count is 0 or until the difference
-        * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
-        * The reason for checking the difference is to ensure we only send as much as the
-        * RX FIFO can receive.
-        */
-        while ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag) &&
-               ((handle->remainingReceiveByteCount - handle->remainingSendByteCount) < handle->fifoSize))
+         * between the remainingReceiveByteCount and remainingSendByteCount equals the FIFO depth.
+         * The reason for checking the difference is to ensure we only send as much as the
+         * RX FIFO can receive.
+         */
+        while ((0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag)) &&
+               ((tmpRemainingReceiveByteCount - tmpRemainingSendByteCount) < tmpFifoSize))
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData;
@@ -1064,7 +1539,7 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 base->PUSHR = handle->lastCommand | wordToSend;
             }
@@ -1074,86 +1549,110 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
             }
 
             /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
             --handle->remainingSendByteCount;
 
-            /* exit loop if send count is zero, else update local variables for next loop */
-            if (handle->remainingSendByteCount == 0)
+            /* exit loop if send count is zero, else update local variables for next loop
+             * If this is the first time write to the PUSHR, write only once.
+             */
+            tmpRemainingSendByteCount = handle->remainingSendByteCount;
+            if ((tmpRemainingSendByteCount == 0U) || (tmpRemainingSendByteCount == (handle->totalByteCount - 1U)))
             {
                 break;
             }
+            tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+            tmpRemainingSendByteCount    = handle->remainingSendByteCount;
+            tmpFifoSize                  = handle->fifoSize;
         }
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests*/
-    DSPI_DisableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* RECEIVE IRQ handler: Check read buffer only if there are remaining bytes to read. */
-    if (handle->remainingReceiveByteCount)
+    if (0U != (handle->remainingReceiveByteCount))
     {
         /* Check read buffer.*/
         uint16_t wordReceived; /* Maximum supported data bit length in master mode is 16-bits */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* For the last word received, if there is an extra byte due to the odd transfer
-                    * byte count, only save the the last byte and discard the upper byte
-                    */
-                    if (handle->remainingReceiveByteCount == 1)
+                     * byte count, only save the last byte and discard the upper byte
+                     */
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
-                        *handle->rxData = wordReceived; /* Write first data byte */
+                        *handle->rxData = (uint8_t)wordReceived; /* Write first data byte */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        *handle->rxData = wordReceived;      /* Write first data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        *handle->rxData = wordReceived >> 8; /* Write second data byte */
-                        ++handle->rxData;                    /* increment to next data byte */
-                        handle->remainingReceiveByteCount -= 2;
+                        *handle->rxData = (uint8_t)wordReceived;         /* Write first data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        *handle->rxData = (uint8_t)(wordReceived >> 8U); /* Write second data byte */
+                        ++handle->rxData;                                /* increment to next data byte */
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1162,26 +1661,27 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
         /* Optimized for bits/frame less than or equal to one byte. */
         else
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+            while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
             {
-                wordReceived = DSPI_ReadData(base);
+                wordReceived = (uint16_t)DSPI_ReadData(base);
                 /* clear the rx fifo drain request, needed for non-DMA applications as this flag
-                * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-                * either remain clear if no more data is in the fifo, or it will set if there is
-                * more data in the fifo.
-                */
-                DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+                 * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+                 * either remain clear if no more data is in the fifo, or it will set if there is
+                 * more data in the fifo.
+                 */
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
                 /* Store read bytes into rx buffer only if a buffer pointer was provided */
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
-                    *handle->rxData = wordReceived;
+                    *handle->rxData = (uint8_t)wordReceived;
                     ++handle->rxData;
                 }
 
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingReceiveByteCount == 0)
+                if (handle->remainingReceiveByteCount == 0U)
                 {
                     break;
                 }
@@ -1190,31 +1690,45 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
     }
 
     /* Check write buffer. We always have to send a word in order to keep the transfer
-    * moving. So if the caller didn't provide a send buffer, we just send a zero.
-    */
-    if (handle->remainingSendByteCount)
+     * moving. So if the caller didn't provide a send buffer, we just send a zero.
+     */
+    if (0U != (handle->remainingSendByteCount))
     {
         DSPI_MasterTransferFillUpTxFifo(base, handle);
     }
 
     /* Check if we're done with this transfer.*/
-    if ((handle->remainingSendByteCount == 0) && (handle->remainingReceiveByteCount == 0))
+    if (handle->remainingSendByteCount == 0U)
     {
-        /* Complete the transfer and disable the interrupts */
-        DSPI_MasterTransferComplete(base, handle);
+        if (handle->remainingReceiveByteCount == 0U)
+        {
+            /* Complete the transfer and disable the interrupts */
+            DSPI_MasterTransferComplete(base, handle);
+        }
     }
 }
 
 /*Transactional APIs -- Slave*/
+/*!
+ * brief Initializes the DSPI slave handle.
+ *
+ * This function initializes the DSPI handle, which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * param handle DSPI handle pointer to the dspi_slave_handle_t.
+ * param base DSPI peripheral base address.
+ * param callback DSPI callback.
+ * param userData Callback function parameter.
+ */
 void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     g_dspiHandle[DSPI_GetInstance(base)] = handle;
 
@@ -1222,65 +1736,76 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
+/*!
+ * brief DSPI slave transfers data using an interrupt.
+ *
+ * This function transfers data using an interrupt. This is a non-blocking function, which returns right away. When all
+ * data is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ * param transfer Pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     /* Enable the NVIC for DSPI peripheral. */
-    EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
+    (void)EnableIRQ(s_dspiIRQ[DSPI_GetInstance(base)]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     handle->errorCount = 0;
 
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     s_dspiSlaveIsr = DSPI_SlaveTransferHandleIRQ;
 
     /* Enable RX FIFO drain request, the slave only use this interrupt */
-    DSPI_EnableInterrupts(base, kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable);
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
         /* RX FIFO overflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_RxFifoOverflowInterruptEnable);
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
     }
-    if (handle->txData)
+    if (NULL != handle->txData)
     {
         /* TX FIFO underflow request enable */
-        DSPI_EnableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable);
+        DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
     }
 
     DSPI_StartTransfer(base);
@@ -1291,17 +1816,27 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
     return kStatus_Success;
 }
 
+/*!
+ * brief Gets the slave transfer count.
+ *
+ * This function gets the slave transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_master_handle_t structure which stores the transfer state.
+ * param count The number of bytes transferred by using the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -1313,24 +1848,24 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
 
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     uint16_t transmitData = 0;
-    uint8_t dummyPattern = s_dummyData[DSPI_GetInstance(base)];
+    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
-    * else transmit dummy pattern
-    */
-    while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+     * else transmit dummy pattern
+     */
+    while ((uint32_t)kDSPI_TxFifoFillRequestFlag == (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
     {
         /* Transmit data */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             /* Have data to transmit, update the transmit data and push to FIFO */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 /* bits/frame is 1 byte */
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     /* Update transmit data and transmit pointer */
                     transmitData = *handle->txData;
@@ -1348,41 +1883,41 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
             else
             {
                 /* With multibytes per frame transmission, the transmit frame contains data from
-                * transmit buffer until sent dataSize matches user request. Other bytes will set to
-                * dummy pattern value.
-                */
-                if (handle->txData)
+                 * transmit buffer until sent dataSize matches user request. Other bytes will set to
+                 * dummy pattern value.
+                 */
+                if (NULL != handle->txData)
                 {
                     /* Update first byte of transmit data and transmit pointer */
                     transmitData = *handle->txData;
                     handle->txData++;
 
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         /* Decrease remaining dataSize */
                         --handle->remainingSendByteCount;
                         /* Update second byte of transmit data to second byte of dummy pattern */
-                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8);
+                        transmitData = transmitData | (uint16_t)(((uint16_t)dummyPattern) << 8U);
                     }
                     else
                     {
                         /* Update second byte of transmit data and transmit pointer */
-                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8);
+                        transmitData = transmitData | (uint16_t)((uint16_t)(*handle->txData) << 8U);
                         handle->txData++;
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
                 }
                 else
                 {
-                    if (handle->remainingSendByteCount == 1)
+                    if (handle->remainingSendByteCount == 1U)
                     {
                         --handle->remainingSendByteCount;
                     }
                     else
                     {
-                        handle->remainingSendByteCount -= 2;
+                        handle->remainingSendByteCount -= 2U;
                     }
-                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                    transmitData = (uint16_t)((uint16_t)(dummyPattern) << 8U) | dummyPattern;
                 }
             }
         }
@@ -1395,26 +1930,27 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         base->PUSHR_SLAVE = transmitData;
 
         /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+        DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
 
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
-    handle->txData = NULL;
-    handle->rxData = NULL;
+    handle->txData                    = NULL;
+    handle->rxData                    = NULL;
     handle->remainingReceiveByteCount = 0;
-    handle->remainingSendByteCount = 0;
+    handle->remainingSendByteCount    = 0;
 
     status_t status = 0;
-    if (handle->state == kDSPI_Error)
+    if (handle->state == (uint8_t)kDSPI_Error)
     {
         status = kStatus_DSPI_Error;
     }
@@ -1423,69 +1959,88 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         status = kStatus_Success;
     }
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 
-    if (handle->callback)
+    if (NULL != handle->callback)
     {
         handle->callback(base, handle, status, handle->userData);
     }
 }
 
+/*!
+ * brief DSPI slave aborts a transfer using an interrupt.
+ *
+ * This function aborts a transfer using an interrupt.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
     /* Disable interrupt requests */
-    DSPI_DisableInterrupts(base, kDSPI_TxFifoUnderflowInterruptEnable | kDSPI_TxFifoFillRequestInterruptEnable |
-                                     kDSPI_RxFifoOverflowInterruptEnable | kDSPI_RxFifoDrainRequestInterruptEnable);
+    DSPI_DisableInterrupts(
+        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
-    handle->state = kDSPI_Idle;
-    handle->remainingSendByteCount = 0;
+    handle->state                     = (uint8_t)kDSPI_Idle;
+    handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
 
+/*!
+ * brief DSPI Master IRQ handler function.
+ *
+ * This function processes the DSPI transmit and receive IRQ.
+ *
+ * param base DSPI peripheral base address.
+ * param handle Pointer to the dspi_slave_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    uint8_t dummyPattern = s_dummyData[DSPI_GetInstance(base)];
+    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
-    uint32_t dataSend = 0;
+    uint32_t dataSend                     = 0;
+    uint32_t tmpRemainingReceiveByteCount = 0;
 
     /* Because SPI protocol is synchronous, the number of bytes that that slave received from the
-    * master is the actual number of bytes that the slave transmitted to the master. So we only
-    * monitor the received dataSize to know when the transfer is complete.
-    */
-    if (handle->remainingReceiveByteCount > 0)
+     * master is the actual number of bytes that the slave transmitted to the master. So we only
+     * monitor the received dataSize to know when the transfer is complete.
+     */
+    if (handle->remainingReceiveByteCount > 0U)
     {
-        while (DSPI_GetStatusFlags(base) & kDSPI_RxFifoDrainRequestFlag)
+        while ((uint32_t)kDSPI_RxFifoDrainRequestFlag ==
+               (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoDrainRequestFlag))
         {
             /* Have received data in the buffer. */
             dataReceived = base->POPR;
             /*Clear the rx fifo drain request, needed for non-DMA applications as this flag
-            * will remain set even if the rx fifo is empty. By manually clearing this flag, it
-            * either remain clear if no more data is in the fifo, or it will set if there is
-            * more data in the fifo.
-            */
-            DSPI_ClearStatusFlags(base, kDSPI_RxFifoDrainRequestFlag);
+             * will remain set even if the rx fifo is empty. By manually clearing this flag, it
+             * either remain clear if no more data is in the fifo, or it will set if there is
+             * more data in the fifo.
+             */
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoDrainRequestFlag);
 
             /* If bits/frame is one byte */
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                if (handle->rxData)
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store data into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
                 }
                 /* Descrease remaining receive byte count */
                 --handle->remainingReceiveByteCount;
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
@@ -1503,15 +2058,15 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             else /* If bits/frame is 2 bytes */
             {
                 /* With multibytes frame receiving, we only receive till the received dataSize
-                * matches user request. Other bytes will be ignored.
-                */
-                if (handle->rxData)
+                 * matches user request. Other bytes will be ignored.
+                 */
+                if (NULL != handle->rxData)
                 {
                     /* Receive buffer is not null, store first byte into it */
-                    *handle->rxData = dataReceived;
+                    *handle->rxData = (uint8_t)dataReceived;
                     ++handle->rxData;
 
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
@@ -1519,72 +2074,73 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
                     else
                     {
                         /* Receive buffer is not null, store second byte into it */
-                        *handle->rxData = dataReceived >> 8;
+                        *handle->rxData = (uint8_t)(dataReceived >> 8U);
                         ++handle->rxData;
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
                 /* If no handle->rxData*/
                 else
                 {
-                    if (handle->remainingReceiveByteCount == 1)
+                    if (handle->remainingReceiveByteCount == 1U)
                     {
                         /* Decrease remaining receive byte count */
                         --handle->remainingReceiveByteCount;
                     }
                     else
                     {
-                        handle->remainingReceiveByteCount -= 2;
+                        handle->remainingReceiveByteCount -= 2U;
                     }
                 }
 
-                if (handle->remainingSendByteCount > 0)
+                if (handle->remainingSendByteCount > 0U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         dataSend = *handle->txData;
                         ++handle->txData;
 
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
-                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8);
+                            dataSend |= (uint16_t)((uint16_t)(dummyPattern) << 8U);
                         }
                         else
                         {
-                            dataSend |= (uint32_t)(*handle->txData) << 8;
+                            dataSend |= (uint32_t)(*handle->txData) << 8U;
                             ++handle->txData;
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
                     }
                     /* If no handle->txData*/
                     else
                     {
-                        if (handle->remainingSendByteCount == 1)
+                        if (handle->remainingSendByteCount == 1U)
                         {
                             --handle->remainingSendByteCount;
                         }
                         else
                         {
-                            handle->remainingSendByteCount -= 2;
+                            handle->remainingSendByteCount -= 2U;
                         }
-                        dataSend = (uint16_t)((uint16_t)(dummyPattern) << 8) | dummyPattern;
+                        dataSend = ((uint32_t)(dummyPattern) << 8U) | dummyPattern;
                     }
                     /* Write the data to the DSPI data register */
                     base->PUSHR_SLAVE = dataSend;
                 }
             }
             /* Try to clear TFFF by writing a one to it; it will not clear if TX FIFO not full */
-            DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-            if (handle->remainingReceiveByteCount == 0)
+            if (handle->remainingReceiveByteCount == 0U)
             {
                 break;
             }
         }
     }
     /* Check if remaining receive byte count matches user request */
-    if ((handle->remainingReceiveByteCount == 0) || (handle->state == kDSPI_Error))
+    tmpRemainingReceiveByteCount = handle->remainingReceiveByteCount;
+    if ((handle->state == (uint8_t)(kDSPI_Error)) || (tmpRemainingReceiveByteCount == 0U))
     {
         /* Other cases, stop the transfer. */
         DSPI_SlaveTransferComplete(base, handle);
@@ -1592,26 +2148,33 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
     }
 
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_TxFifoUnderflowFlag) && (base->RSER & SPI_RSER_TFUF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_TxFifoUnderflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_TFUF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoUnderflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
+
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
-    if ((DSPI_GetStatusFlags(base) & kDSPI_RxFifoOverflowFlag) && (base->RSER & SPI_RSER_RFOF_RE_MASK))
+    if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
     {
-        DSPI_ClearStatusFlags(base, kDSPI_RxFifoOverflowFlag);
-        /* Change state to error and clear flag */
-        if (handle->txData)
+        if (0U != (base->RSER & SPI_RSER_RFOF_RE_MASK))
         {
-            handle->state = kDSPI_Error;
+            DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_RxFifoOverflowFlag);
+            /* Change state to error and clear flag */
+            if (NULL != handle->txData)
+            {
+                handle->state = kDSPI_Error;
+            }
+            handle->errorCount++;
         }
-        handle->errorCount++;
     }
 }
 
@@ -1625,12 +2188,17 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+/* Add for ARM errata 838869, affects Cortex-M4, Cortex-M4F Store immediate overlapping
+  exception return operation might vector to incorrect interrupt */
+#if defined __CORTEX_M && (__CORTEX_M == 4U)
+    __DSB();
+#endif
 }
 
 #if defined(SPI0)
 void SPI0_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[0]);
+    assert(NULL != g_dspiHandle[0]);
     DSPI_CommonIRQHandler(SPI0, g_dspiHandle[0]);
 }
 #endif
@@ -1638,7 +2206,7 @@ void SPI0_DriverIRQHandler(void)
 #if defined(SPI1)
 void SPI1_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[1]);
+    assert(NULL != g_dspiHandle[1]);
     DSPI_CommonIRQHandler(SPI1, g_dspiHandle[1]);
 }
 #endif
@@ -1646,7 +2214,7 @@ void SPI1_DriverIRQHandler(void)
 #if defined(SPI2)
 void SPI2_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[2]);
+    assert(NULL != g_dspiHandle[2]);
     DSPI_CommonIRQHandler(SPI2, g_dspiHandle[2]);
 }
 #endif
@@ -1654,7 +2222,7 @@ void SPI2_DriverIRQHandler(void)
 #if defined(SPI3)
 void SPI3_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[3]);
+    assert(NULL != g_dspiHandle[3]);
     DSPI_CommonIRQHandler(SPI3, g_dspiHandle[3]);
 }
 #endif
@@ -1662,7 +2230,7 @@ void SPI3_DriverIRQHandler(void)
 #if defined(SPI4)
 void SPI4_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[4]);
+    assert(NULL != g_dspiHandle[4]);
     DSPI_CommonIRQHandler(SPI4, g_dspiHandle[4]);
 }
 #endif
@@ -1670,7 +2238,7 @@ void SPI4_DriverIRQHandler(void)
 #if defined(SPI5)
 void SPI5_DriverIRQHandler(void)
 {
-    assert(g_dspiHandle[5]);
+    assert(NULL != g_dspiHandle[5]);
     DSPI_CommonIRQHandler(SPI5, g_dspiHandle[5]);
 }
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_H_
 #define _FSL_DSPI_H_
@@ -43,8 +21,8 @@
 
 /*! @name Driver version */
 /*@{*/
-/*! @brief DSPI driver version 2.2.0. */
-#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 0))
+/*! @brief DSPI driver version 2.2.2. */
+#define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
 /*@}*/
 
 #ifndef DSPI_DUMMY_DATA
@@ -55,37 +33,37 @@
 /*! @brief Status for the DSPI driver.*/
 enum _dspi_status
 {
-    kStatus_DSPI_Busy = MAKE_STATUS(kStatusGroup_DSPI, 0),      /*!< DSPI transfer is busy.*/
-    kStatus_DSPI_Error = MAKE_STATUS(kStatusGroup_DSPI, 1),     /*!< DSPI driver error. */
-    kStatus_DSPI_Idle = MAKE_STATUS(kStatusGroup_DSPI, 2),      /*!< DSPI is idle.*/
-    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3) /*!< DSPI transfer out of range. */
+    kStatus_DSPI_Busy       = MAKE_STATUS(kStatusGroup_DSPI, 0), /*!< DSPI transfer is busy.*/
+    kStatus_DSPI_Error      = MAKE_STATUS(kStatusGroup_DSPI, 1), /*!< DSPI driver error. */
+    kStatus_DSPI_Idle       = MAKE_STATUS(kStatusGroup_DSPI, 2), /*!< DSPI is idle.*/
+    kStatus_DSPI_OutOfRange = MAKE_STATUS(kStatusGroup_DSPI, 3)  /*!< DSPI transfer out of range. */
 };
 
 /*! @brief DSPI status flags in SPIx_SR register.*/
 enum _dspi_flags
 {
-    kDSPI_TxCompleteFlag = SPI_SR_TCF_MASK,          /*!< Transfer Complete Flag. */
-    kDSPI_EndOfQueueFlag = SPI_SR_EOQF_MASK,         /*!< End of Queue Flag.*/
-    kDSPI_TxFifoUnderflowFlag = SPI_SR_TFUF_MASK,    /*!< Transmit FIFO Underflow Flag.*/
-    kDSPI_TxFifoFillRequestFlag = SPI_SR_TFFF_MASK,  /*!< Transmit FIFO Fill Flag.*/
-    kDSPI_RxFifoOverflowFlag = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
-    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK, /*!< Receive FIFO Drain Flag.*/
-    kDSPI_TxAndRxStatusFlag = SPI_SR_TXRXS_MASK,     /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag = SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK |
-                          SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK /*!< All statuses above.*/
+    kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
+    kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+    kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+    kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
+    kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
+    kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
+    kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
+                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
 enum _dspi_interrupt_enable
 {
-    kDSPI_TxCompleteInterruptEnable = SPI_RSER_TCF_RE_MASK,          /*!< TCF  interrupt enable.*/
-    kDSPI_EndOfQueueInterruptEnable = SPI_RSER_EOQF_RE_MASK,         /*!< EOQF interrupt enable.*/
-    kDSPI_TxFifoUnderflowInterruptEnable = SPI_RSER_TFUF_RE_MASK,    /*!< TFUF interrupt enable.*/
-    kDSPI_TxFifoFillRequestInterruptEnable = SPI_RSER_TFFF_RE_MASK,  /*!< TFFF interrupt enable, DMA disable.*/
-    kDSPI_RxFifoOverflowInterruptEnable = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
-    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK, /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
-                               SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK
+    kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
+    kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+    kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+    kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
+    kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
+    kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+                                     SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
 
@@ -102,7 +80,7 @@ enum _dspi_dma_enable
 typedef enum _dspi_master_slave_mode
 {
     kDSPI_Master = 1U, /*!< DSPI peripheral operates in master mode.*/
-    kDSPI_Slave = 0U   /*!< DSPI peripheral operates in slave mode.*/
+    kDSPI_Slave  = 0U  /*!< DSPI peripheral operates in slave mode.*/
 } dspi_master_slave_mode_t;
 
 /*!
@@ -132,26 +110,26 @@ typedef enum _dspi_which_pcs_config
 typedef enum _dspi_pcs_polarity_config
 {
     kDSPI_PcsActiveHigh = 0U, /*!< Pcs Active High (idles low). */
-    kDSPI_PcsActiveLow = 1U   /*!< Pcs Active Low (idles high). */
+    kDSPI_PcsActiveLow  = 1U  /*!< Pcs Active Low (idles high). */
 } dspi_pcs_polarity_config_t;
 
 /*! @brief DSPI Peripheral Chip Select (Pcs) Polarity.*/
 enum _dspi_pcs_polarity
 {
-    kDSPI_Pcs0ActiveLow = 1U << 0, /*!< Pcs0 Active Low (idles high). */
-    kDSPI_Pcs1ActiveLow = 1U << 1, /*!< Pcs1 Active Low (idles high). */
-    kDSPI_Pcs2ActiveLow = 1U << 2, /*!< Pcs2 Active Low (idles high). */
-    kDSPI_Pcs3ActiveLow = 1U << 3, /*!< Pcs3 Active Low (idles high). */
-    kDSPI_Pcs4ActiveLow = 1U << 4, /*!< Pcs4 Active Low (idles high). */
-    kDSPI_Pcs5ActiveLow = 1U << 5, /*!< Pcs5 Active Low (idles high). */
-    kDSPI_PcsAllActiveLow = 0xFFU  /*!< Pcs0 to Pcs5 Active Low (idles high). */
+    kDSPI_Pcs0ActiveLow   = 1U << 0, /*!< Pcs0 Active Low (idles high). */
+    kDSPI_Pcs1ActiveLow   = 1U << 1, /*!< Pcs1 Active Low (idles high). */
+    kDSPI_Pcs2ActiveLow   = 1U << 2, /*!< Pcs2 Active Low (idles high). */
+    kDSPI_Pcs3ActiveLow   = 1U << 3, /*!< Pcs3 Active Low (idles high). */
+    kDSPI_Pcs4ActiveLow   = 1U << 4, /*!< Pcs4 Active Low (idles high). */
+    kDSPI_Pcs5ActiveLow   = 1U << 5, /*!< Pcs5 Active Low (idles high). */
+    kDSPI_PcsAllActiveLow = 0xFFU    /*!< Pcs0 to Pcs5 Active Low (idles high). */
 };
 
 /*! @brief DSPI clock polarity configuration for a given CTAR.*/
 typedef enum _dspi_clock_polarity
 {
     kDSPI_ClockPolarityActiveHigh = 0U, /*!< CPOL=0. Active-high DSPI clock (idles low).*/
-    kDSPI_ClockPolarityActiveLow = 1U   /*!< CPOL=1. Active-low DSPI clock (idles high).*/
+    kDSPI_ClockPolarityActiveLow  = 1U  /*!< CPOL=1. Active-low DSPI clock (idles high).*/
 } dspi_clock_polarity_t;
 
 /*! @brief DSPI clock phase configuration for a given CTAR.*/
@@ -315,13 +293,13 @@ typedef struct _dspi_slave_config
 } dspi_slave_config_t;
 
 /*!
-* @brief Forward declaration of the _dspi_master_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_master_handle typedefs.
+ */
 typedef struct _dspi_master_handle dspi_master_handle_t;
 
 /*!
-* @brief Forward declaration of the _dspi_slave_handle typedefs.
-*/
+ * @brief Forward declaration of the _dspi_slave_handle typedefs.
+ */
 typedef struct _dspi_slave_handle dspi_slave_handle_t;
 
 /*!
@@ -356,11 +334,23 @@ typedef struct _dspi_transfer
     uint8_t *rxData;          /*!< Receive buffer. */
     volatile size_t dataSize; /*!< Transfer bytes. */
 
-    uint32_t
-        configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if the
-                        transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the transfer
-                        is used for slave.*/
+    uint32_t configFlags; /*!< Transfer transfer configuration flags; set from _dspi_transfer_config_flag_for_master if
+                             the transfer is used for master or _dspi_transfer_config_flag_for_slave enumeration if the
+                             transfer is used for slave.*/
 } dspi_transfer_t;
+
+/*! @brief DSPI half-duplex(master) transfer structure */
+typedef struct _dspi_half_duplex_transfer
+{
+    uint8_t *txData;            /*!< Send buffer */
+    uint8_t *rxData;            /*!< Receive buffer */
+    size_t txDataSize;          /*!< Transfer bytes for transmit */
+    size_t rxDataSize;          /*!< Transfer bytes */
+    uint32_t configFlags;       /*!< Transfer configuration flags; set from _dspi_transfer_config_flag_for_master. */
+    bool isPcsAssertInTransfer; /*!< If Pcs pin keep assert between transmit and receive. true for assert and false for
+                                   deassert. */
+    bool isTransmitFirst;       /*!< True for transmit first and false for receive first. */
+} dspi_half_duplex_transfer_t;
 
 /*! @brief DSPI master transfer handle structure used for transactional API. */
 struct _dspi_master_handle
@@ -527,7 +517,7 @@ static inline void DSPI_Enable(SPI_Type *base, bool enable)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Status
@@ -565,7 +555,7 @@ static inline void DSPI_ClearStatusFlags(SPI_Type *base, uint32_t statusFlags)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Interrupts
@@ -605,7 +595,7 @@ static inline void DSPI_DisableInterrupts(SPI_Type *base, uint32_t mask)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name DMA Control
@@ -685,12 +675,18 @@ static inline uint32_t DSPI_GetRxRegisterAddress(SPI_Type *base)
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Bus Operations
  * @{
  */
+/*!
+ * @brief Get instance number for DSPI module.
+ *
+ * @param base DSPI peripheral base address.
+ */
+uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /*!
  * @brief Configures the DSPI for master or slave.
@@ -711,7 +707,14 @@ static inline void DSPI_SetMasterSlaveMode(SPI_Type *base, dspi_master_slave_mod
  */
 static inline bool DSPI_IsMaster(SPI_Type *base)
 {
-    return (bool)((base->MCR) & SPI_MCR_MSTR_MASK);
+    if (0U != ((base->MCR) & SPI_MCR_MSTR_MASK))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 /*!
  * @brief Starts the DSPI transfers and clears HALT bit in MCR.
@@ -749,8 +752,8 @@ static inline void DSPI_StopTransfer(SPI_Type *base)
  */
 static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool enableRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) | SPI_MCR_DIS_TXF(!enableTxFifo) |
-                SPI_MCR_DIS_RXF(!enableRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK))) |
+                SPI_MCR_DIS_TXF((false == enableTxFifo ? 1U : 0U)) | SPI_MCR_DIS_RXF((false == enableRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -762,8 +765,8 @@ static inline void DSPI_SetFifoEnable(SPI_Type *base, bool enableTxFifo, bool en
  */
 static inline void DSPI_FlushFifo(SPI_Type *base, bool flushTxFifo, bool flushRxFifo)
 {
-    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) | SPI_MCR_CLR_TXF(flushTxFifo) |
-                SPI_MCR_CLR_RXF(flushRxFifo);
+    base->MCR = (base->MCR & (~(SPI_MCR_CLR_TXF_MASK | SPI_MCR_CLR_RXF_MASK))) |
+                SPI_MCR_CLR_TXF((true == flushTxFifo ? 1U : 0U)) | SPI_MCR_CLR_RXF((true == flushRxFifo ? 1U : 0U));
 }
 
 /*!
@@ -954,11 +957,11 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  *        buffer master mode and waits till complete to return.
  *
  * In this function, the user must append the 16-bit data to the 16-bit command information and then provide the total
-* 32-bit word
+ * 32-bit word
  * as the data to send.
  * The command portion provides characteristics of the data, such as the optional continuous chip select operation
  * between transfers, the desired Clock and Transfer Attributes register to use for the associated SPI frame, the
-* desired PCS
+ * desired PCS
  * signal to use for the data transfer, whether the current transfer is the last in the queue, and whether to clear the
  * transfer count (normally needed when sending the first frame of a data packet). The user is responsible for
  * appending this command with the data to send. This is an example:
@@ -973,20 +976,20 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  *
  *  For a blocking polling transfer, see methods below.
  *  Option 1:
-*   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
-*   uint32_t data0 = command_to_send | data_need_to_send_0;
-*   uint32_t data1 = command_to_send | data_need_to_send_1;
-*   uint32_t data2 = command_to_send | data_need_to_send_2;
-*
-*   DSPI_MasterWriteCommandDataBlocking(base,data0);
-*   DSPI_MasterWriteCommandDataBlocking(base,data1);
-*   DSPI_MasterWriteCommandDataBlocking(base,data2);
-*
-*  Option 2:
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
-*   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
-*
+ *   uint32_t command_to_send = DSPI_MasterGetFormattedCommand(&command);
+ *   uint32_t data0 = command_to_send | data_need_to_send_0;
+ *   uint32_t data1 = command_to_send | data_need_to_send_1;
+ *   uint32_t data2 = command_to_send | data_need_to_send_2;
+ *
+ *   DSPI_MasterWriteCommandDataBlocking(base,data0);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data1);
+ *   DSPI_MasterWriteCommandDataBlocking(base,data2);
+ *
+ *  Option 2:
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_0);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_1);
+ *   DSPI_MasterWriteDataBlocking(base,&command,data_need_to_send_2);
+ *
  * @param base DSPI peripheral address.
  * @param data The data word (command and data combined) to be sent.
  */
@@ -1037,7 +1040,7 @@ void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
 
 /*!
  *@}
-*/
+ */
 
 /*!
  * @name Transactional
@@ -1085,6 +1088,35 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferNonBlocking(SPI_Type *base, dspi_master_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a polling method.
+ *
+ * This function will do a half-duplex transfer for DSPI master, This is a blocking function,
+ * which does not retuen until all transfer have been completed. And data transfer will be half-duplex,
+ * users can set transmit first or receive first.
+ *
+ * @param base DSPI base pointer
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferBlocking(SPI_Type *base, dspi_half_duplex_transfer_t *xfer);
+
+/*!
+ * @brief Performs a non-blocking DSPI interrupt transfer.
+ *
+ * This function transfers data using interrupts, the transfer mechanism is half-duplex. This is a non-blocking
+ * function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI peripheral base address.
+ * @param handle pointer to dspi_master_handle_t structure which stores the transfer state
+ * @param xfer pointer to dspi_half_duplex_transfer_t structure
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferNonBlocking(SPI_Type *base,
+                                                  dspi_master_handle_t *handle,
+                                                  dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief Gets the master transfer count.
@@ -1180,14 +1212,24 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
 
 /*!
+ * brief Dummy data for each instance.
+ *
+ * The purpose of this API is to avoid MISRA rule8.5 : Multiple declarations of
+ * externally-linked object or function g_dspiDummyData.
+ *
+ * param base DSPI peripheral base address.
+ */
+uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+
+/*!
  *@}
-*/
+ */
 
 #if defined(__cplusplus)
 }
 #endif /*_cplusplus*/
        /*!
         *@}
-       */
+        */
 
 #endif /*_FSL_DSPI_H_*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi_edma.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi_edma.c
@@ -1,42 +1,25 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "fsl_dspi_edma.h"
 
 /***********************************************************************************************************************
-* Definitons
-***********************************************************************************************************************/
+ * Definitions
+ ***********************************************************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.dspi_edma"
+#endif
 
 /*!
-* @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_master_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_master_edma_private_handle
 {
     SPI_Type *base;                    /*!< DSPI peripheral base address. */
@@ -44,8 +27,8 @@ typedef struct _dspi_master_edma_private_handle
 } dspi_master_edma_private_handle_t;
 
 /*!
-* @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
-*/
+ * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
+ */
 typedef struct _dspi_slave_edma_private_handle
 {
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
@@ -53,48 +36,58 @@ typedef struct _dspi_slave_edma_private_handle
 } dspi_slave_edma_private_handle_t;
 
 /***********************************************************************************************************************
-* Prototypes
-***********************************************************************************************************************/
+ * Prototypes
+ ***********************************************************************************************************************/
 /*!
-* @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
-* This is not a public API.
-*/
+ * @brief EDMA_DspiMasterCallback after the DSPI master transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
 /*!
-* @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
-* This is not a public API.
-*/
+ * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
+ * This is not a public API.
+ */
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
-/*!
-* @brief Get instance number for DSPI module.
-*
-* This is not a public API and it's extern from fsl_dspi.c.
-*
-* @param base DSPI peripheral base address
-*/
-extern uint32_t DSPI_GetInstance(SPI_Type *base);
 
 /***********************************************************************************************************************
-* Variables
-***********************************************************************************************************************/
+ * Variables
+ ***********************************************************************************************************************/
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
 
-/*! @brief Global variable for dummy data value setting. */
-extern volatile uint8_t s_dummyData[];
 /***********************************************************************************************************************
-* Code
-***********************************************************************************************************************/
+ * Code
+ ***********************************************************************************************************************/
 
+/*!
+ * brief Initializes the DSPI master eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RX and TX as two sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1) For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaIntermediaryToTxRegHandle.
+ * (2) For the shared DMA request source, enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_master_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToIntermediaryHandle edmaTxDataToIntermediaryHandle pointer to edma_handle_t.
+ * param edmaIntermediaryToTxRegHandle edmaIntermediaryToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          dspi_master_edma_handle_t *handle,
                                          dspi_master_edma_transfer_callback_t callback,
@@ -103,59 +96,72 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
                                          edma_handle_t *edmaTxDataToIntermediaryHandle,
                                          edma_handle_t *edmaIntermediaryToTxRegHandle)
 {
-    assert(handle);
-    assert(edmaRxRegToRxDataHandle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
 #if (!(defined(FSL_FEATURE_DSPI_HAS_GASKET) && FSL_FEATURE_DSPI_HAS_GASKET))
-    assert(edmaTxDataToIntermediaryHandle);
+    assert(NULL != edmaTxDataToIntermediaryHandle);
 #endif
-    assert(edmaIntermediaryToTxRegHandle);
+    assert(NULL != edmaIntermediaryToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiMasterEdmaPrivateHandle[instance].base = base;
+    s_dspiMasterEdmaPrivateHandle[instance].base   = base;
     s_dspiMasterEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
     handle->userData = userData;
 
-    handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
+    handle->edmaRxRegToRxDataHandle        = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToIntermediaryHandle = edmaTxDataToIntermediaryHandle;
-    handle->edmaIntermediaryToTxRegHandle = edmaIntermediaryToTxRegHandle;
+    handle->edmaIntermediaryToTxRegHandle  = edmaIntermediaryToTxRegHandle;
 }
 
+/*!
+ * brief DSPI master transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If the transfer count is zero, then return immediately.*/
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
-    uint32_t instance = DSPI_GetInstance(base);
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = s_dummyData[DSPI_GetInstance(base)];
-    uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint32_t instance                = DSPI_GetInstance(base);
+    uint16_t wordToSend              = 0;
+    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint8_t dataAlreadyFed           = 0;
+    uint8_t dataFedMax               = 2;
+    uint32_t tmpMCR                  = 0;
+    size_t tmpRemainingSendByteCount = 0;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_MasterGetTxRegisterAddress(base);
@@ -165,29 +171,32 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     edma_transfer_config_t transferConfigA;
     edma_transfer_config_t transferConfigB;
 
-    handle->txBuffIfNull = ((uint32_t)dummyData << 8) | dummyData;
+    handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
 
     dspi_command_data_config_t commandStruct;
     DSPI_StopTransfer(base);
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
     commandStruct.whichPcs =
-        (dspi_which_pcs_t)(1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
-    commandStruct.isEndOfQueue = false;
+        (dspi_which_pcs_t)((uint32_t)1U << ((transfer->configFlags & DSPI_MASTER_PCS_MASK) >> DSPI_MASTER_PCS_SHIFT));
+    commandStruct.isEndOfQueue       = false;
     commandStruct.clearTransferCount = false;
     commandStruct.whichCtar =
         (dspi_ctar_selection_t)((transfer->configFlags & DSPI_MASTER_CTAR_MASK) >> DSPI_MASTER_CTAR_SHIFT);
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterPcsContinuous);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterPcsContinuous)) ? true : false;
     handle->command = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
     commandStruct.isEndOfQueue = true;
-    commandStruct.isPcsContinuous = (bool)(transfer->configFlags & kDSPI_MasterActiveAfterTransfer);
+    commandStruct.isPcsContinuous =
+        (0U != (transfer->configFlags & (uint32_t)kDSPI_MasterActiveAfterTransfer)) ? true : false;
     handle->lastCommand = DSPI_MasterGetFormattedCommand(&(commandStruct));
 
-    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+    handle->bitsPerFrame = ((base->CTAR[commandStruct.whichCtar] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1U;
 
-    if ((base->MCR & SPI_MCR_DIS_RXF_MASK) || (base->MCR & SPI_MCR_DIS_TXF_MASK))
+    tmpMCR = base->MCR;
+    if ((0U != (tmpMCR & SPI_MCR_DIS_RXF_MASK)) || (0U != (tmpMCR & SPI_MCR_DIS_TXF_MASK)))
     {
         handle->fifoSize = 1;
     }
@@ -195,15 +204,15 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         handle->fifoSize = FSL_FEATURE_DSPI_FIFO_SIZEn(base);
     }
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
     uint32_t limited_size = 0;
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
@@ -214,11 +223,11 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         limited_size = 511u;
     }
 
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         if (transfer->dataSize > (limited_size << 1u))
         {
-            handle->state = kDSPI_Idle;
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
@@ -226,19 +235,19 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         if (transfer->dataSize > limited_size)
         {
-            handle->state = kDSPI_Idle;
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
     /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize & 0x1))
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
-        handle->state = kDSPI_Idle;
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiMasterCallback,
                      &s_dspiMasterEdmaPrivateHandle[instance]);
@@ -271,47 +280,47 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with separate RX/TX DMA requests, we'll use the TX DMA request to
-        * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
-        */
+         * trigger the TX DMA channel and RX DMA request to trigger the RX DMA channel
+         */
 
         /*Prepare the firt data*/
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
             /* If it's the last word */
-            if (handle->remainingSendByteCount <= 2)
+            if (handle->remainingSendByteCount <= 2U)
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
-                handle->command = handle->lastCommand;
+                handle->command     = handle->lastCommand;
             }
             else /* For all words except the last word , frame > 8bits */
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* increment to next data byte */
-                    wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                    wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     ++handle->txData; /* increment to next data byte */
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            if (handle->txData)
+            if (NULL != handle->txData)
             {
                 wordToSend = *(handle->txData);
                 ++handle->txData; /* increment to next data word*/
@@ -321,10 +330,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 wordToSend = dummyData;
             }
 
-            if (handle->remainingSendByteCount == 1)
+            if (handle->remainingSendByteCount == 1U)
             {
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
-                handle->command = handle->lastCommand;
+                handle->command     = handle->lastCommand;
             }
             else
             {
@@ -340,50 +349,51 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
          */
 
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->remainingSendByteCount <= 2)
+                if (handle->remainingSendByteCount <= 2U)
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
                     handle->remainingSendByteCount = 0;
-                    base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
+                    base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
                 /* For all words except the last word */
                 else
                 {
-                    if (handle->txData)
+                    if (NULL != handle->txData)
                     {
                         wordToSend = *(handle->txData);
                         ++handle->txData;
-                        wordToSend |= (unsigned)(*(handle->txData)) << 8U;
+                        wordToSend |= (uint16_t)(*(handle->txData)) << 8U;
                         ++handle->txData;
                     }
                     else
                     {
-                        wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
                     }
-                    handle->remainingSendByteCount -= 2;
+                    handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -391,9 +401,10 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData;
@@ -403,7 +414,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     wordToSend = dummyData;
                 }
 
-                if (handle->remainingSendByteCount == 1)
+                if (handle->remainingSendByteCount == 1U)
                 {
                     base->PUSHR = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 }
@@ -413,14 +424,14 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -431,62 +442,63 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer(rxData)*/
     EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-    transferConfigA.srcAddr = (uint32_t)rxAddr;
+    transferConfigA.srcAddr   = (uint32_t)rxAddr;
     transferConfigA.srcOffset = 0;
 
-    if (handle->rxData)
+    if (NULL != handle->rxData)
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
         transferConfigA.destOffset = 1;
     }
     else
     {
-        transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+        transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
         transferConfigA.destOffset = 0;
     }
 
     transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-    if (handle->bitsPerFrame <= 8)
+    if (handle->bitsPerFrame <= 8U)
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-        transferConfigA.minorLoopBytes = 1;
+        transferConfigA.minorLoopBytes  = 1;
         transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
     }
     else
     {
         transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-        transferConfigA.minorLoopBytes = 2;
-        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+        transferConfigA.minorLoopBytes  = 2;
+        transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
     }
 
     /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
-    handle->nbytes = transferConfigA.minorLoopBytes;
+    handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
 
     EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                           &transferConfigA, NULL);
+                           (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
     EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                 kEDMA_MajorInterruptEnable);
+                                 (uint32_t)kEDMA_MajorInterruptEnable);
 
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
     /*Calculate the last data : handle->lastCommand*/
-    if (((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
-        ((((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8))) &&
-         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
+    if (((tmpRemainingSendByteCount > 0U) && (1U != (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
+        ((((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U))) &&
+         (1U == (uint8_t)FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
             uint32_t bufferIndex = 0;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                if (handle->bitsPerFrame <= 8)
+                if (handle->bitsPerFrame <= 8U)
                 {
-                    bufferIndex = handle->remainingSendByteCount - 1;
+                    bufferIndex = handle->remainingSendByteCount - 1U;
                 }
                 else
                 {
-                    bufferIndex = handle->remainingSendByteCount - 2;
+                    bufferIndex = handle->remainingSendByteCount - 2U;
                 }
             }
             else
@@ -494,26 +506,30 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 bufferIndex = handle->remainingSendByteCount;
             }
 
-            if (handle->bitsPerFrame <= 8)
+            uint32_t tmpLastCommand = handle->lastCommand;
+            uint8_t *tmpTxData      = handle->txData;
+
+            if (handle->bitsPerFrame <= 8U)
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) | handle->txData[bufferIndex - 1];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | tmpTxData[bufferIndex - 1U];
             }
             else
             {
-                handle->lastCommand = (handle->lastCommand & 0xffff0000U) |
-                                      ((uint32_t)handle->txData[bufferIndex - 1] << 8) |
-                                      handle->txData[bufferIndex - 2];
+                tmpLastCommand = (tmpLastCommand & 0xffff0000U) | ((uint32_t)tmpTxData[bufferIndex - 1U] << 8U) |
+                                 tmpTxData[bufferIndex - 2U];
             }
+
+            handle->lastCommand = tmpLastCommand;
         }
         else
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 wordToSend = dummyData;
             }
             else
             {
-                wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
             }
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
@@ -539,22 +555,22 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     if ((1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) ||
         ((handle->remainingSendByteCount > 0) && (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))))
     {
-        transferConfigB.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigB.destAddr = (uint32_t)txAddr;
-        transferConfigB.srcTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t)txAddr;
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
         transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigB.srcOffset = 0;
-        transferConfigB.destOffset = 0;
-        transferConfigB.minorLoopBytes = 4;
-        transferConfigB.majorLoopCounts = 1;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
         EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
     }
 
     /*User_Send_Buffer(txData) to PUSHR register. */
-    if (((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 4) && (handle->bitsPerFrame > 8)))
+    if (((handle->remainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+        ((handle->remainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U)))
     {
         if (handle->txData)
         {
@@ -564,7 +580,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                  * to handle->command, so need to reduce the pointer of txData.
                  */
                 transferConfigB.srcAddr =
-                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8) ? (1U) : (2U)));
+                    (uint32_t)((uint8_t *)(handle->txData) - ((handle->bitsPerFrame <= 8U) ? (1U) : (2U)));
                 transferConfigB.srcOffset = 1;
             }
             else
@@ -572,33 +588,33 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 /* For DSPI with shared RX and TX DMA requests, one or two frame data have been carry
                  * to PUSHR register, so no need to change the pointer of txData.
                  */
-                transferConfigB.srcAddr = (uint32_t)((uint8_t *)(handle->txData));
+                transferConfigB.srcAddr   = (uint32_t)((uint8_t *)(handle->txData));
                 transferConfigB.srcOffset = 1;
             }
         }
         else
         {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
             transferConfigB.srcOffset = 0;
         }
 
-        transferConfigB.destAddr = (uint32_t)txAddr;
+        transferConfigB.destAddr   = (uint32_t)txAddr;
         transferConfigB.destOffset = 0;
 
         transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
+            transferConfigB.minorLoopBytes   = 1;
 
-            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1;
+            transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 1U;
         }
         else
         {
             transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
-            transferConfigB.majorLoopCounts = (handle->remainingSendByteCount / 2) - 1;
+            transferConfigB.minorLoopBytes   = 2;
+            transferConfigB.majorLoopCounts  = (handle->remainingSendByteCount / 2U) - 1U;
         }
 
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
@@ -623,21 +639,21 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /*Set channel priority*/
-        uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+        uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
         uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-        uint8_t t = 0;
+        uint8_t t                   = 0;
 
         if (channelPriorityLow > channelPriorityHigh)
         {
-            t = channelPriorityLow;
-            channelPriorityLow = channelPriorityHigh;
+            t                   = channelPriorityLow;
+            channelPriorityLow  = channelPriorityHigh;
             channelPriorityHigh = t;
         }
 
         edma_channel_Preemption_config_t preemption_config_t;
         preemption_config_t.enableChannelPreemption = true;
-        preemption_config_t.enablePreemptAbility = true;
-        preemption_config_t.channelPriority = channelPriorityLow;
+        preemption_config_t.enablePreemptAbility    = true;
+        preemption_config_t.channelPriority         = channelPriorityLow;
 
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                         &preemption_config_t);
@@ -647,7 +663,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                                         handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
         /*if there is Rx DMA request , carry the 32bits data (handle->command) to user data first , then link to
           channelC to carry the next data to PUSHER register.(txData to PUSHER) */
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaIntermediaryToTxRegHandle->channel);
@@ -670,90 +686,94 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
      * (handle->lastCommand) to handle->Command*/
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        transferConfigB.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigB.destAddr = (uint32_t) & (handle->command);
-        transferConfigB.srcTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigB.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigB.destAddr         = (uint32_t) & (handle->command);
+        transferConfigB.srcTransferSize  = kEDMA_TransferSize4Bytes;
         transferConfigB.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigB.srcOffset = 0;
-        transferConfigB.destOffset = 0;
-        transferConfigB.minorLoopBytes = 4;
-        transferConfigB.majorLoopCounts = 1;
+        transferConfigB.srcOffset        = 0;
+        transferConfigB.destOffset       = 0;
+        transferConfigB.minorLoopBytes   = 4;
+        transferConfigB.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigB, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
     }
 
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
     /*User_Send_Buffer(txData) to intermediary(handle->command)*/
-    if (((((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame <= 8)) ||
-          ((handle->remainingSendByteCount > 4) && (handle->bitsPerFrame > 8))) &&
+    if (((((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame <= 8U)) ||
+          ((tmpRemainingSendByteCount > 4U) && (handle->bitsPerFrame > 8U))) &&
          (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))) ||
         (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
     {
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
-            transferConfigB.srcAddr = (uint32_t)(handle->txData);
+            transferConfigB.srcAddr   = (uint32_t)(handle->txData);
             transferConfigB.srcOffset = 1;
         }
         else
         {
-            transferConfigB.srcAddr = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigB.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
             transferConfigB.srcOffset = 0;
         }
 
-        transferConfigB.destAddr = (uint32_t)(&handle->command);
+        transferConfigB.destAddr   = (uint32_t)(&handle->command);
         transferConfigB.destOffset = 0;
 
         transferConfigB.srcTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigB.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigB.minorLoopBytes = 1;
+            transferConfigB.minorLoopBytes   = 1;
 
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2;
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount - 2U;
             }
             else
             {
                 /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
                 majorlink , the majorlink would not trigger the channel_C*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1;
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount + 1U;
             }
         }
         else
         {
             transferConfigB.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigB.minorLoopBytes = 2;
+            transferConfigB.minorLoopBytes   = 2;
             if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
             {
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 - 2;
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U - 2U;
             }
             else
             {
                 /*Only enable channel_B minorlink to channel_C , so need to add one count due to the last time is
-                * majorlink*/
-                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2 + 1;
+                 * majorlink*/
+                transferConfigB.majorLoopCounts = handle->remainingSendByteCount / 2U + 1U;
             }
         }
 
         if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
         {
             EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                   handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, softwareTCD);
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, softwareTCD);
             EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
                                        handle->edmaIntermediaryToTxRegHandle->channel, false);
         }
         else
         {
             EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                   handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
+                                   handle->edmaTxDataToIntermediaryHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
         }
     }
     else
     {
         EDMA_SetTransferConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                               handle->edmaTxDataToIntermediaryHandle->channel, &transferConfigB, NULL);
+                               handle->edmaTxDataToIntermediaryHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigB, NULL);
     }
 
     /***channel_C ***carry the "intermediary" to SPIx_PUSHR. used the edma Scatter Gather function on channel_C to
@@ -762,55 +782,59 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     edma_transfer_config_t transferConfigC;
     EDMA_ResetChannel(handle->edmaIntermediaryToTxRegHandle->base, handle->edmaIntermediaryToTxRegHandle->channel);
 
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
     /*For DSPI instances with shared RX/TX DMA requests: use the scatter/gather to prepare the last data
      * (handle->lastCommand) to SPI_PUSHR*/
-    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (handle->remainingSendByteCount > 0)))
+    if (((1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)) && (tmpRemainingSendByteCount > 0U)))
     {
-        transferConfigC.srcAddr = (uint32_t) & (handle->lastCommand);
-        transferConfigC.destAddr = (uint32_t)txAddr;
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcAddr          = (uint32_t) & (handle->lastCommand);
+        transferConfigC.destAddr         = (uint32_t)txAddr;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
         transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
-        transferConfigC.majorLoopCounts = 1;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
+        transferConfigC.majorLoopCounts  = 1;
 
         EDMA_TcdReset(softwareTCD);
-        EDMA_TcdSetTransferConfig(softwareTCD, &transferConfigC, NULL);
+        EDMA_TcdSetTransferConfig(softwareTCD, (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
-    if (((handle->remainingSendByteCount > 1) && (handle->bitsPerFrame <= 8)) ||
-        ((handle->remainingSendByteCount > 2) && (handle->bitsPerFrame > 8)) ||
+    tmpRemainingSendByteCount = handle->remainingSendByteCount;
+    if (((tmpRemainingSendByteCount > 1U) && (handle->bitsPerFrame <= 8U)) ||
+        ((tmpRemainingSendByteCount > 2U) && (handle->bitsPerFrame > 8U)) ||
         (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base)))
     {
-        transferConfigC.srcAddr = (uint32_t)(&(handle->command));
+        transferConfigC.srcAddr  = (uint32_t)(&(handle->command));
         transferConfigC.destAddr = (uint32_t)txAddr;
 
-        transferConfigC.srcTransferSize = kEDMA_TransferSize4Bytes;
+        transferConfigC.srcTransferSize  = kEDMA_TransferSize4Bytes;
         transferConfigC.destTransferSize = kEDMA_TransferSize4Bytes;
-        transferConfigC.srcOffset = 0;
-        transferConfigC.destOffset = 0;
-        transferConfigC.minorLoopBytes = 4;
+        transferConfigC.srcOffset        = 0;
+        transferConfigC.destOffset       = 0;
+        transferConfigC.minorLoopBytes   = 4;
         if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
         {
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
-                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1;
+                transferConfigC.majorLoopCounts = handle->remainingSendByteCount - 1U;
             }
             else
             {
-                transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2 - 1;
+                transferConfigC.majorLoopCounts = (handle->remainingSendByteCount / 2U) - 1U;
             }
 
             EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                   handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, softwareTCD);
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, softwareTCD);
         }
         else
         {
             transferConfigC.majorLoopCounts = 1;
 
             EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                   handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                                   handle->edmaIntermediaryToTxRegHandle->channel,
+                                   (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
         }
 
         EDMA_EnableAutoStopRequest(handle->edmaIntermediaryToTxRegHandle->base,
@@ -819,7 +843,8 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     else
     {
         EDMA_SetTransferConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                               handle->edmaIntermediaryToTxRegHandle->channel, &transferConfigC, NULL);
+                               handle->edmaIntermediaryToTxRegHandle->channel,
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
     }
 
     /*Start the EDMA channel_A , channel_B , channel_C transfer*/
@@ -828,60 +853,64 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     EDMA_StartTransfer(handle->edmaIntermediaryToTxRegHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
-    uint8_t channelPriorityMid = handle->edmaTxDataToIntermediaryHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityMid  = handle->edmaTxDataToIntermediaryHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaIntermediaryToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
     if (channelPriorityLow > channelPriorityMid)
     {
-        t = channelPriorityLow;
+        t                  = channelPriorityLow;
         channelPriorityLow = channelPriorityMid;
         channelPriorityMid = t;
     }
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     if (channelPriorityMid > channelPriorityHigh)
     {
-        t = channelPriorityMid;
-        channelPriorityMid = channelPriorityHigh;
+        t                   = channelPriorityMid;
+        channelPriorityMid  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaIntermediaryToTxRegHandle->base,
-                                        handle->edmaIntermediaryToTxRegHandle->channel, &preemption_config_t);
+                                        handle->edmaIntermediaryToTxRegHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityMid;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToIntermediaryHandle->base,
-                                        handle->edmaTxDataToIntermediaryHandle->channel, &preemption_config_t);
+                                        handle->edmaTxDataToIntermediaryHandle->channel,
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.*/
@@ -889,18 +918,18 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     {
         /*if there is Tx DMA request , carry the 32bits data (handle->command) to PUSHR first , then link to channelB
         to prepare the next 32bits data (txData to handle->command) */
-        if (handle->remainingSendByteCount > 1)
+        if (handle->remainingSendByteCount > 1U)
         {
             EDMA_SetChannelLink(handle->edmaIntermediaryToTxRegHandle->base,
                                 handle->edmaIntermediaryToTxRegHandle->channel, kEDMA_MajorLink,
                                 handle->edmaTxDataToIntermediaryHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
     else
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToIntermediaryHandle->channel);
@@ -910,7 +939,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                                 handle->edmaIntermediaryToTxRegHandle->channel);
         }
 
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
 #endif
     DSPI_StartTransfer(base);
@@ -918,55 +947,139 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
     return kStatus_Success;
 }
 
+/*!
+ * brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * param base DSPI base pointer
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer)
+{
+    assert(NULL != xfer);
+    assert(NULL != handle);
+    dspi_transfer_t tempXfer = {0};
+    status_t status;
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    /* If the pcs pin keep assert between transmit and receive. */
+    if (true == xfer->isPcsAssertInTransfer)
+    {
+        tempXfer.configFlags = (xfer->configFlags) | (uint32_t)kDSPI_MasterActiveAfterTransfer;
+    }
+    else
+    {
+        tempXfer.configFlags = (xfer->configFlags) & (~(uint32_t)kDSPI_MasterActiveAfterTransfer);
+    }
+
+    status = DSPI_MasterTransferBlocking(base, &tempXfer);
+    if (status != kStatus_Success)
+    {
+        return status;
+    }
+
+    if (true == xfer->isTransmitFirst)
+    {
+        tempXfer.txData   = NULL;
+        tempXfer.rxData   = xfer->rxData;
+        tempXfer.dataSize = xfer->rxDataSize;
+    }
+    else
+    {
+        tempXfer.txData   = xfer->txData;
+        tempXfer.rxData   = NULL;
+        tempXfer.dataSize = xfer->txDataSize;
+    }
+    tempXfer.configFlags = xfer->configFlags;
+
+    status = DSPI_MasterTransferEDMA(base, handle, &tempXfer);
+
+    return status;
+}
 static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     void *g_dspiEdmaPrivateHandle,
                                     bool transferDone,
                                     uint32_t tcds)
 {
-    assert(edmaHandle);
-    assert(g_dspiEdmaPrivateHandle);
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
 
     dspi_master_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_master_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
 }
 
+/*!
+ * brief DSPI master aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToIntermediaryHandle);
     EDMA_AbortTransfer(handle->edmaIntermediaryToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the master eDMA transfer count.
+ *
+ * This function gets the master eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;
@@ -982,6 +1095,25 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
     return kStatus_Success;
 }
 
+/*!
+ * brief Initializes the DSPI slave eDMA handle.
+ *
+ * This function initializes the DSPI eDMA handle which can be used for other DSPI transactional APIs.  Usually, for a
+ * specified DSPI instance, call this API once to get the initialized handle.
+ *
+ * Note that DSPI eDMA has separated (RN and TX in 2 sources) or shared (RX  and TX are the same source) DMA request
+ * source.
+ * (1)For the separated DMA request source, enable and set the RX DMAMUX source for edmaRxRegToRxDataHandle and
+ * TX DMAMUX source for edmaTxDataToTxRegHandle.
+ * (2)For the shared DMA request source,  enable and set the RX/RX DMAMUX source for the edmaRxRegToRxDataHandle.
+ *
+ * param base DSPI peripheral base address.
+ * param handle DSPI handle pointer to dspi_slave_edma_handle_t.
+ * param callback DSPI callback.
+ * param userData A callback function parameter.
+ * param edmaRxRegToRxDataHandle edmaRxRegToRxDataHandle pointer to edma_handle_t.
+ * param edmaTxDataToTxRegHandle edmaTxDataToTxRegHandle pointer to edma_handle_t.
+ */
 void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         dspi_slave_edma_handle_t *handle,
                                         dspi_slave_edma_transfer_callback_t callback,
@@ -989,16 +1121,16 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle)
 {
-    assert(handle);
-    assert(edmaRxRegToRxDataHandle);
-    assert(edmaTxDataToTxRegHandle);
+    assert(NULL != handle);
+    assert(NULL != edmaRxRegToRxDataHandle);
+    assert(NULL != edmaTxDataToTxRegHandle);
 
     /* Zero the handle. */
-    memset(handle, 0, sizeof(*handle));
+    (void)memset(handle, 0, sizeof(*handle));
 
     uint32_t instance = DSPI_GetInstance(base);
 
-    s_dspiSlaveEdmaPrivateHandle[instance].base = base;
+    s_dspiSlaveEdmaPrivateHandle[instance].base   = base;
     s_dspiSlaveEdmaPrivateHandle[instance].handle = handle;
 
     handle->callback = callback;
@@ -1008,39 +1140,52 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
 
+/*!
+ * brief DSPI slave transfer data using eDMA.
+ *
+ * This function transfers data using eDMA. This is a non-blocking function, which returns right away. When all data
+ * is transferred, the callback function is called.
+ * Note that the slave eDMA transfer doesn't support transfer_size is 1 when the bitsPerFrame is greater
+ * than eight.
+
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param transfer A pointer to the dspi_transfer_t structure.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer)
 {
-    assert(handle);
-    assert(transfer);
+    assert(NULL != handle);
+    assert(NULL != transfer);
 
     /* If send/receive length is zero */
-    if (transfer->dataSize == 0)
+    if (transfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }
 
     /* If both send buffer and receive buffer is null */
-    if ((!(transfer->txData)) && (!(transfer->rxData)))
+    if ((NULL == (transfer->txData)) && (NULL == (transfer->rxData)))
     {
         return kStatus_InvalidArgument;
     }
 
     /* Check that we're not busy.*/
-    if (handle->state == kDSPI_Busy)
+    if (handle->state == (uint8_t)kDSPI_Busy)
     {
         return kStatus_DSPI_Busy;
     }
 
-    handle->state = kDSPI_Busy;
+    handle->state = (uint8_t)kDSPI_Busy;
 
     uint32_t instance = DSPI_GetInstance(base);
-    uint8_t whichCtar = (transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT;
+    uint8_t whichCtar = (uint8_t)((transfer->configFlags & DSPI_SLAVE_CTAR_MASK) >> DSPI_SLAVE_CTAR_SHIFT);
     handle->bitsPerFrame =
-        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1;
+        (((base->CTAR_SLAVE[whichCtar]) & SPI_CTAR_SLAVE_FMSZ_MASK) >> SPI_CTAR_SLAVE_FMSZ_SHIFT) + 1U;
 
     /* If using a shared RX/TX DMA request, then this limits the amount of data we can transfer
-    * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
-    */
+     * due to the linked channel. The max bytes is 511 if 8-bit/frame or 1022 if 16-bit/frame
+     */
     uint32_t limited_size = 0;
     if (1 == FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
@@ -1051,11 +1196,11 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         limited_size = 511u;
     }
 
-    if (handle->bitsPerFrame > 8)
+    if (handle->bitsPerFrame > 8U)
     {
         if (transfer->dataSize > (limited_size << 1u))
         {
-            handle->state = kDSPI_Idle;
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
@@ -1063,31 +1208,31 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     {
         if (transfer->dataSize > limited_size)
         {
-            handle->state = kDSPI_Idle;
+            handle->state = (uint8_t)kDSPI_Idle;
             return kStatus_DSPI_OutOfRange;
         }
     }
 
     /*The data size should be even if the bitsPerFrame is greater than 8 (that is 2 bytes per frame in dspi) */
-    if ((handle->bitsPerFrame > 8) && (transfer->dataSize & 0x1))
+    if ((0U != (transfer->dataSize & 0x1U)) && (handle->bitsPerFrame > 8U))
     {
-        handle->state = kDSPI_Idle;
+        handle->state = (uint8_t)kDSPI_Idle;
         return kStatus_InvalidArgument;
     }
 
     EDMA_SetCallback(handle->edmaRxRegToRxDataHandle, EDMA_DspiSlaveCallback, &s_dspiSlaveEdmaPrivateHandle[instance]);
 
     /* Store transfer information */
-    handle->txData = transfer->txData;
-    handle->rxData = transfer->rxData;
-    handle->remainingSendByteCount = transfer->dataSize;
+    handle->txData                    = transfer->txData;
+    handle->rxData                    = transfer->rxData;
+    handle->remainingSendByteCount    = transfer->dataSize;
     handle->remainingReceiveByteCount = transfer->dataSize;
-    handle->totalByteCount = transfer->dataSize;
+    handle->totalByteCount            = transfer->dataSize;
 
-    uint16_t wordToSend = 0;
-    uint8_t dummyData = s_dummyData[DSPI_GetInstance(base)];
+    uint32_t wordToSend    = 0;
+    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
-    uint8_t dataFedMax = 2;
+    uint8_t dataFedMax     = 2;
 
     uint32_t rxAddr = DSPI_GetRxRegisterAddress(base);
     uint32_t txAddr = DSPI_SlaveGetTxRegisterAddress(base);
@@ -1098,9 +1243,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     DSPI_StopTransfer(base);
 
     DSPI_FlushFifo(base, true, true);
-    DSPI_ClearStatusFlags(base, kDSPI_AllStatusFlag);
+    DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_AllStatusFlag);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     DSPI_StartTransfer(base);
 
@@ -1110,14 +1255,15 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         /* For DSPI instances with shared RX/TX DMA requests, we'll use the RX DMA request to
-        * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
-        */
+         * trigger ongoing transfers and will link to the TX DMA channel from the RX DMA channel.
+         */
         /* If bits/frame is greater than one byte */
-        if (handle->bitsPerFrame > 8)
+        if (handle->bitsPerFrame > 8U)
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     ++handle->txData; /* Increment to next data byte */
@@ -1127,18 +1273,18 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8) | dummyData;
+                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
                 }
-                handle->remainingSendByteCount -= 2; /* decrement remainingSendByteCount by 2 */
+                handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
 
-                dataAlreadyFed += 2;
+                dataAlreadyFed += 2U;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == (dataFedMax * 2)))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == (dataFedMax * 2U)))
                 {
                     break;
                 }
@@ -1146,9 +1292,10 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         }
         else /* Optimized for bits/frame less than or equal to one byte. */
         {
-            while (DSPI_GetStatusFlags(base) & kDSPI_TxFifoFillRequestFlag)
+            while ((uint32_t)kDSPI_TxFifoFillRequestFlag ==
+                   (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoFillRequestFlag))
             {
-                if (handle->txData)
+                if (NULL != handle->txData)
                 {
                     wordToSend = *(handle->txData);
                     /* Increment to next data word*/
@@ -1162,14 +1309,14 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 base->PUSHR_SLAVE = wordToSend;
 
                 /* Try to clear the TFFF; if the TX FIFO is full this will clear */
-                DSPI_ClearStatusFlags(base, kDSPI_TxFifoFillRequestFlag);
+                DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
                 /* Decrement remainingSendByteCount*/
                 --handle->remainingSendByteCount;
 
                 dataAlreadyFed++;
 
                 /* Exit loop if send count is zero, else update local variables for next loop */
-                if ((handle->remainingSendByteCount == 0) || (dataAlreadyFed == dataFedMax))
+                if ((handle->remainingSendByteCount == 0U) || (dataAlreadyFed == dataFedMax))
                 {
                     break;
                 }
@@ -1178,92 +1325,92 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     }
 
     /***channel_A *** used for carry the data from Rx_Data_Register(POPR) to User_Receive_Buffer*/
-    if (handle->remainingReceiveByteCount > 0)
+    if (handle->remainingReceiveByteCount > 0U)
     {
         EDMA_ResetChannel(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel);
 
-        transferConfigA.srcAddr = (uint32_t)rxAddr;
+        transferConfigA.srcAddr   = (uint32_t)rxAddr;
         transferConfigA.srcOffset = 0;
 
-        if (handle->rxData)
+        if (NULL != handle->rxData)
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxData[0]);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxData[0]);
             transferConfigA.destOffset = 1;
         }
         else
         {
-            transferConfigA.destAddr = (uint32_t) & (handle->rxBuffIfNull);
+            transferConfigA.destAddr   = (uint32_t) & (handle->rxBuffIfNull);
             transferConfigA.destOffset = 0;
         }
 
         transferConfigA.destTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigA.minorLoopBytes = 1;
+            transferConfigA.minorLoopBytes  = 1;
             transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount;
         }
         else
         {
             transferConfigA.srcTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigA.minorLoopBytes = 2;
-            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2;
+            transferConfigA.minorLoopBytes  = 2;
+            transferConfigA.majorLoopCounts = handle->remainingReceiveByteCount / 2U;
         }
 
         /* Store the initially configured eDMA minor byte transfer count into the DSPI handle */
-        handle->nbytes = transferConfigA.minorLoopBytes;
+        handle->nbytes = (uint8_t)(transferConfigA.minorLoopBytes);
 
         EDMA_SetTransferConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                               &transferConfigA, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigA, NULL);
         EDMA_EnableChannelInterrupts(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                     kEDMA_MajorInterruptEnable);
+                                     (uint32_t)kEDMA_MajorInterruptEnable);
     }
 
-    if (handle->remainingSendByteCount > 0)
+    if (handle->remainingSendByteCount > 0U)
     {
         /***channel_C *** used for carry the data from User_Send_Buffer to Tx_Data_Register(PUSHR_SLAVE)*/
         EDMA_ResetChannel(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel);
 
-        transferConfigC.destAddr = (uint32_t)txAddr;
+        transferConfigC.destAddr   = (uint32_t)txAddr;
         transferConfigC.destOffset = 0;
 
-        if (handle->txData)
+        if (NULL != handle->txData)
         {
-            transferConfigC.srcAddr = (uint32_t)(&(handle->txData[0]));
+            transferConfigC.srcAddr   = (uint32_t)(&(handle->txData[0]));
             transferConfigC.srcOffset = 1;
         }
         else
         {
-            transferConfigC.srcAddr = (uint32_t)(&handle->txBuffIfNull);
+            transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
             transferConfigC.srcOffset = 0;
-            if (handle->bitsPerFrame <= 8)
+            if (handle->bitsPerFrame <= 8U)
             {
                 handle->txBuffIfNull = dummyData;
             }
             else
             {
-                handle->txBuffIfNull = ((uint32_t)dummyData << 8) | dummyData;
+                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
             }
         }
 
         transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;
 
-        if (handle->bitsPerFrame <= 8)
+        if (handle->bitsPerFrame <= 8U)
         {
             transferConfigC.destTransferSize = kEDMA_TransferSize1Bytes;
-            transferConfigC.minorLoopBytes = 1;
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount;
+            transferConfigC.minorLoopBytes   = 1;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount;
         }
         else
         {
             transferConfigC.destTransferSize = kEDMA_TransferSize2Bytes;
-            transferConfigC.minorLoopBytes = 2;
-            transferConfigC.majorLoopCounts = handle->remainingSendByteCount / 2;
+            transferConfigC.minorLoopBytes   = 2;
+            transferConfigC.majorLoopCounts  = handle->remainingSendByteCount / 2U;
         }
 
         EDMA_SetTransferConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                               &transferConfigC, NULL);
+                               (const edma_transfer_config_t *)(uint32_t)&transferConfigC, NULL);
 
         EDMA_StartTransfer(handle->edmaTxDataToTxRegHandle);
     }
@@ -1271,39 +1418,39 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     EDMA_StartTransfer(handle->edmaRxRegToRxDataHandle);
 
     /*Set channel priority*/
-    uint8_t channelPriorityLow = handle->edmaRxRegToRxDataHandle->channel;
+    uint8_t channelPriorityLow  = handle->edmaRxRegToRxDataHandle->channel;
     uint8_t channelPriorityHigh = handle->edmaTxDataToTxRegHandle->channel;
-    uint8_t t = 0;
+    uint8_t t                   = 0;
 
     if (channelPriorityLow > channelPriorityHigh)
     {
-        t = channelPriorityLow;
-        channelPriorityLow = channelPriorityHigh;
+        t                   = channelPriorityLow;
+        channelPriorityLow  = channelPriorityHigh;
         channelPriorityHigh = t;
     }
 
     edma_channel_Preemption_config_t preemption_config_t;
     preemption_config_t.enableChannelPreemption = true;
-    preemption_config_t.enablePreemptAbility = true;
-    preemption_config_t.channelPriority = channelPriorityLow;
+    preemption_config_t.enablePreemptAbility    = true;
+    preemption_config_t.channelPriority         = channelPriorityLow;
 
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
     else
     {
         EDMA_SetChannelPreemptionConfig(handle->edmaTxDataToTxRegHandle->base, handle->edmaTxDataToTxRegHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
 
         preemption_config_t.channelPriority = channelPriorityHigh;
         EDMA_SetChannelPreemptionConfig(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
-                                        &preemption_config_t);
+                                        (const edma_channel_Preemption_config_t *)(uint32_t)&preemption_config_t);
     }
 
     /*Set the channel link.
@@ -1313,16 +1460,16 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     Tx DMA request -> channel_C */
     if (1 != FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(base))
     {
-        if (handle->remainingSendByteCount > 0)
+        if (handle->remainingSendByteCount > 0U)
         {
             EDMA_SetChannelLink(handle->edmaRxRegToRxDataHandle->base, handle->edmaRxRegToRxDataHandle->channel,
                                 kEDMA_MinorLink, handle->edmaTxDataToTxRegHandle->channel);
         }
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable);
     }
     else
     {
-        DSPI_EnableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+        DSPI_EnableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
     }
 
     return kStatus_Success;
@@ -1333,49 +1480,67 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    bool transferDone,
                                    uint32_t tcds)
 {
-    assert(edmaHandle);
-    assert(g_dspiEdmaPrivateHandle);
+    assert(NULL != edmaHandle);
+    assert(NULL != g_dspiEdmaPrivateHandle);
 
     dspi_slave_edma_private_handle_t *dspiEdmaPrivateHandle;
 
     dspiEdmaPrivateHandle = (dspi_slave_edma_private_handle_t *)g_dspiEdmaPrivateHandle;
 
-    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA((dspiEdmaPrivateHandle->base), (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
-    dspiEdmaPrivateHandle->handle->state = kDSPI_Idle;
+    dspiEdmaPrivateHandle->handle->state = (uint8_t)kDSPI_Idle;
 
-    if (dspiEdmaPrivateHandle->handle->callback)
+    if (NULL != dspiEdmaPrivateHandle->handle->callback)
     {
         dspiEdmaPrivateHandle->handle->callback(dspiEdmaPrivateHandle->base, dspiEdmaPrivateHandle->handle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
 }
 
+/*!
+ * brief DSPI slave aborts a transfer which is using eDMA.
+ *
+ * This function aborts a transfer which is using eDMA.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle)
 {
-    assert(handle);
+    assert(NULL != handle);
 
     DSPI_StopTransfer(base);
 
-    DSPI_DisableDMA(base, kDSPI_RxDmaEnable | kDSPI_TxDmaEnable);
+    DSPI_DisableDMA(base, (uint32_t)kDSPI_RxDmaEnable | (uint32_t)kDSPI_TxDmaEnable);
 
     EDMA_AbortTransfer(handle->edmaRxRegToRxDataHandle);
     EDMA_AbortTransfer(handle->edmaTxDataToTxRegHandle);
 
-    handle->state = kDSPI_Idle;
+    handle->state = (uint8_t)kDSPI_Idle;
 }
 
+/*!
+ * brief Gets the slave eDMA transfer count.
+ *
+ * This function gets the slave eDMA transfer count.
+ *
+ * param base DSPI peripheral base address.
+ * param handle A pointer to the dspi_slave_edma_handle_t structure which stores the transfer state.
+ * param count A number of bytes transferred so far by the non-blocking transaction.
+ * return status of status_t.
+ */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count)
 {
-    assert(handle);
+    assert(NULL != handle);
 
-    if (!count)
+    if (NULL == count)
     {
         return kStatus_InvalidArgument;
     }
 
     /* Catch when there is not an active transfer. */
-    if (handle->state != kDSPI_Busy)
+    if (handle->state != (uint8_t)kDSPI_Busy)
     {
         *count = 0;
         return kStatus_NoTransferInProgress;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi_edma.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi_edma.h
@@ -1,31 +1,9 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2017 NXP
+ * Copyright 2016-2018 NXP
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * o Redistributions of source code must retain the above copyright notice, this list
- *   of conditions and the following disclaimer.
- *
- * o Redistributions in binary form must reproduce the above copyright notice, this
- *   list of conditions and the following disclaimer in the documentation and/or
- *   other materials provided with the distribution.
- *
- * o Neither the name of the copyright holder nor the names of its
- *   contributors may be used to endorse or promote products derived from this
- *   software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef _FSL_DSPI_EDMA_H_
 #define _FSL_DSPI_EDMA_H_
@@ -41,14 +19,20 @@
  * Definitions
  **********************************************************************************************************************/
 
+/*! @name Driver version */
+/*@{*/
+/*! @brief DSPI EDMA driver version 2.2.2. */
+#define FSL_DSPI_EDMA_DRIVER_VERSION (MAKE_VERSION(2, 2, 2))
+/*@}*/
+
 /*!
-* @brief Forward declaration of the DSPI eDMA master handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA master handle typedefs.
+ */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
 /*!
-* @brief Forward declaration of the DSPI eDMA slave handle typedefs.
-*/
+ * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
+ */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
 
 /*!
@@ -185,6 +169,21 @@ void DSPI_MasterTransferCreateHandleEDMA(SPI_Type *base,
  * @return status of status_t.
  */
 status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, dspi_transfer_t *transfer);
+
+/*!
+ * @brief Transfers a block of data using a eDMA method.
+ *
+ * This function transfers data using eDNA, the transfer mechanism is half-duplex. This is a non-blocking function,
+ * which returns right away. When all data is transferred, the callback function is called.
+ *
+ * @param base DSPI base pointer
+ * @param handle A pointer to the dspi_master_edma_handle_t structure which stores the transfer state.
+ * @param transfer A pointer to the dspi_half_duplex_transfer_t structure.
+ * @return status of status_t.
+ */
+status_t DSPI_MasterHalfDuplexTransferEDMA(SPI_Type *base,
+                                           dspi_master_edma_handle_t *handle,
+                                           dspi_half_duplex_transfer_t *xfer);
 
 /*!
  * @brief DSPI master aborts a transfer which is using eDMA.


### PR DESCRIPTION
### Description
Update Kinetis DSPI & SPI SDK drivers
    - Added dummy data setup API to allow users to configure the dummy data to be transferred.
    - Added new APIs for half-duplex transfer function. 
    - Fix for MISRA issues

Update the SPI HAL driver to use the SDK API for spi_master_block_write

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

