### PR TITLE
storage: fix potential memory corruption and check return values

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -936,7 +936,10 @@ int SPIFBlockDevice::_reset_flash_mem()
                 tr_error("Sending RST failed");
                 status = -1;
             }
-            _is_mem_ready();
+            if (false == _is_mem_ready()) {
+                tr_error("Device not ready, write failed");
+                status = -1;
+            }
         }
     }
 

--- a/features/storage/filesystem/fat/ChaN/ff.cpp
+++ b/features/storage/filesystem/fat/ChaN/ff.cpp
@@ -2719,7 +2719,7 @@ void get_fileinfo (
 		if (wc == 0) { di = 0; break; }		/* Buffer overflow? */
 		di += wc;
 #else					/* ANSI/OEM output */
-		if (di <= FF_SFN_BUF) fno->altname[di++] = (TCHAR)wc;	/* Store it without any conversion */
+		if (di < FF_SFN_BUF) fno->altname[di++] = (TCHAR)wc;	/* Store it without any conversion */
 #endif
 	}
 	fno->altname[di] = 0;	/* Terminate the SFN  (null string means SFN is invalid) */

--- a/features/storage/filesystem/littlefs/littlefs/lfs.c
+++ b/features/storage/filesystem/littlefs/littlefs/lfs.c
@@ -2481,7 +2481,7 @@ int lfs_deorphan(lfs_t *lfs) {
     }
 
     lfs_dir_t pdir = {.d.size = 0x80000000};
-    lfs_dir_t cwd = {.d.tail[0] = 0, .d.tail[1] = 1};
+    lfs_dir_t cwd = {.d.tail = {0,1}};
 
     // iterate over all directory directory entries
     while (!lfs_pairisnull(cwd.d.tail)) {


### PR DESCRIPTION
### Description

The change in [l. 2484 of lfs.c](https://github.com/ARMmbed/mbed-os/compare/master...michalpasztamobica:coverity_fixes?expand=1#diff-8d3bec3f825ec8c381e7e2ac98f9ddf0L2484) is not really a fix, as we can't see anything wrong with that line, but it will silence the Coverity tool warning (thanks, @JuhPuur ).

The two other changes are true code improvements.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@VeijoPesonen 
@geky 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
