### PR TITLE
Update mbed-coap to version 4.8.1

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v4.8.1(https://github.com/ARMmbed/mbed-coap/releases/tag/v4.8.1)
+- Store ACK's also into duplicate info list.
+- ROM size optimization. Flash size has gone down ~1100 bytes.
+
+**Closed issues:**
+-  IOTCLT-3592 - Client does not handle Duplicate ACK messages during blockwise registration correctly
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.8.0...v4.8.1)
+
 ## [v4.8.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.8.0) 
 - Make `sn_coap_protocol_linked_list_duplication_info_remove` API to public. User might want to delete some messages from the duplicate list.
 - Enable support for unified client configuration.

--- a/features/frameworks/mbed-coap/Makefile.test
+++ b/features/frameworks/mbed-coap/Makefile.test
@@ -49,7 +49,7 @@ test: $(TESTDIRS)
 	@rm -f lcov/index.xml
 	@find ./ -name '*.gcno' | xargs cp --backup=numbered -t ./coverage/
 	@find ./ -name '*.gcda' | xargs cp --backup=numbered -t ./coverage/
-	@gcovr --object-directory ./coverage  --exclude-unreachable-branches -e '.*/builds/.*' -e '.*/test/.*' -e '.*/stubs/.*' -e '.*/mbed-coap/.*' -x -o ./lcov/gcovr.xml
+	@gcovr --object-directory ./coverage  --exclude-unreachable-branches -e '.*/builds/.*' -e '.*/CppUTest/.*' -e '.*/mbed-client-libservice/.*' -e '.*/test/.*' -e '.*/stubs/.*' -e '.*/mbed-coap/.*' -x -o ./lcov/gcovr.xml
 	@lcov -d test/. -c -o $(COVERAGEFILE)
 	@lcov -q -r $(COVERAGEFILE) "/usr*" -o $(COVERAGEFILE)
 	@lcov -q -r $(COVERAGEFILE) "/test*" -o $(COVERAGEFILE)

--- a/features/frameworks/mbed-coap/mbed-coap/sn_coap_header.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_coap_header.h
@@ -338,7 +338,7 @@ extern void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle,
  *          -1 = Failure in given CoAP header structure\n
  *          -2 = Failure in given pointer (= NULL)
  */
-extern int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr);
+extern int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr);
 
 /**
  * \fn uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_coap_msg_ptr)
@@ -351,7 +351,7 @@ extern int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_
  * \return Return value is count of needed memory as bytes for build Packet data
  *          Null if failed
  */
-extern uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_coap_msg_ptr);
+extern uint16_t sn_coap_builder_calc_needed_packet_data_size(const sn_coap_hdr_s *src_coap_msg_ptr);
 
 /**
  * \fn int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr,  uint16_t blockwise_size)
@@ -368,7 +368,7 @@ extern uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_
  *          -1 = Failure in given CoAP header structure\n
  *          -2 = Failure in given pointer (= NULL)
  */
-extern int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
+extern int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
 
 /**
  * \fn uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size)
@@ -382,7 +382,7 @@ extern int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *sr
  * \return Return value is count of needed memory as bytes for build Packet data
  *          Null if failed
  */
-extern uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
+extern uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
 
 /**
  * \fn sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
@@ -397,7 +397,7 @@ extern uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *sr
  *          NULL    Error in parsing the request
  *
  */
-extern sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code);
+extern sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, const sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code);
 
 /**
  * \brief Initialise a message structure to empty
@@ -435,6 +435,8 @@ extern sn_coap_hdr_s *sn_coap_parser_alloc_message(struct coap_s *handle);
  *          -Failure in memory allocation (malloc() returns NULL)
  */
 extern sn_coap_options_list_s *sn_coap_parser_alloc_options(struct coap_s *handle, sn_coap_hdr_s *coap_msg_ptr);
+
+extern sn_coap_hdr_s *sn_coap_parser_alloc_message_with_options(struct coap_s *handle);
 
 #ifdef __cplusplus
 }

--- a/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -38,7 +38,8 @@ extern "C" {
  *
  * \param *used_malloc_func_ptr is function pointer for used memory allocation function.
  *
- * \param *used_free_func_ptr is function pointer for used memory free function.
+ * \param *used_free_func_ptr is function pointer for used memory free function. Note: the implementation
+ *          must handle NULL parameter and ignore it just as typical libc's free() does.
  *
  * \param *used_tx_callback_ptr function callback pointer to tx function for sending coap messages
  *
@@ -234,7 +235,7 @@ extern int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint
  *
  * \brief If re-transmissions are enabled, this function removes message from retransmission buffer.
  */
-extern int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, uint8_t *token, uint8_t token_len);
+extern int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, const uint8_t *token, uint8_t token_len);
 
 /**
  * \fn int8_t sn_coap_convert_block_size(uint16_t block_size)

--- a/features/frameworks/mbed-coap/mbed-coap/sn_config.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_config.h
@@ -250,4 +250,14 @@
 #define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE     UINT16_MAX
 #endif
 
+/**
+ * \def SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED
+ * \brief A size optimization switch, which removes the blockwise Block2 response if set to 0.
+ * handling code which is typically overridden by a call of "sn_coap_protocol_handle_block2_response_internally(coap, false);".
+ * By default the code is there, so the override can be reversed by "sn_coap_protocol_handle_block2_response_internally(coap, true)".
+ */
+#ifndef SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED
+#define SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED  1
+#endif
+
 #endif // SN_CONFIG_H

--- a/features/frameworks/mbed-coap/source/include/sn_coap_header_internal.h
+++ b/features/frameworks/mbed-coap/source/include/sn_coap_header_internal.h
@@ -58,7 +58,7 @@ extern "C" {
  * \brief This structure is returned by sn_coap_exec() for sending
  */
 typedef struct sn_nsdl_transmit_ {
-    sn_nsdl_addr_s         *dst_addr_ptr;
+    sn_nsdl_addr_s          dst_addr_ptr;
 
     sn_nsdl_capab_e         protocol;
 
@@ -69,7 +69,7 @@ typedef struct sn_nsdl_transmit_ {
 /* * * * * * * * * * * * * * * * * * * * * * */
 /* * * * EXTERNAL FUNCTION PROTOTYPES  * * * */
 /* * * * * * * * * * * * * * * * * * * * * * */
-extern int8_t           sn_coap_header_validity_check(sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version);
+extern int8_t           sn_coap_header_validity_check(const sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version);
 
 #endif /* SN_COAP_HEADER_INTERNAL_H_ */
 

--- a/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
+++ b/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
@@ -48,9 +48,8 @@ typedef struct coap_send_msg_ {
     uint8_t             resending_counter;  /* Tells how many times message is still tried to resend */
     uint32_t            resending_time;     /* Tells next resending time */
 
-    sn_nsdl_transmit_s *send_msg_ptr;
+    sn_nsdl_transmit_s  send_msg_ptr;
 
-    struct coap_s       *coap;              /* CoAP library handle */
     void                *param;             /* Extra parameter that will be passed to TX/RX callback functions */
 
     ns_list_link_t      link;
@@ -64,7 +63,6 @@ typedef struct coap_duplication_info_ {
     uint16_t            msg_id;
     uint16_t            packet_len;
     uint8_t             *packet_ptr;
-    struct coap_s       *coap;  /* CoAP library handle */
     sn_nsdl_addr_s      *address;
     void                *param;
     ns_list_link_t      link;
@@ -77,7 +75,6 @@ typedef struct coap_blockwise_msg_ {
     uint32_t            timestamp;  /* Tells when Blockwise message is stored to Linked list */
 
     sn_coap_hdr_s       *coap_msg_ptr;
-    struct coap_s       *coap;      /* CoAP library handle */
 
     void                *param;
     uint16_t            msg_id;
@@ -100,7 +97,6 @@ typedef struct coap_blockwise_payload_ {
 
     uint16_t            payload_len;
     uint8_t             *payload_ptr;
-    struct coap_s       *coap;  /* CoAP library handle */
 
     ns_list_link_t     link;
 } coap_blockwise_payload_s;
@@ -138,6 +134,12 @@ struct coap_s {
     uint8_t sn_coap_duplication_buffer_size;
     uint8_t sn_coap_internal_block2_resp_handling; /* If this is set then coap itself sends a next GET request automatically */
 };
+
+/* Utility function which performs a call to sn_coap_protocol_malloc() and memset's the result to zero. */
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length);
+
+/* Utility function which performs a call to sn_coap_protocol_malloc() and memcopy's the source to result buffer. */
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length);
 
 #ifdef __cplusplus
 }

--- a/features/frameworks/mbed-coap/source/sn_coap_header_check.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_header_check.c
@@ -44,7 +44,7 @@
  * \return Return value is status of validity check. In ok cases 0 and in
  *         failure cases -1
  */
-int8_t sn_coap_header_validity_check(sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version)
+int8_t sn_coap_header_validity_check(const sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version)
 {
     /* * Check validity of CoAP Version * */
     if (coap_version != COAP_VERSION_1) {


### PR DESCRIPTION
### Description

- Store ACK's also into duplicate info list.
- ROM size optimization. Flash size has gone down ~1100 bytes.

**Closed issues:**
-  IOTCLT-3592 - Client does not handle Duplicate ACK messages during blockwise registration correctly

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@yogpan01, @teetak01 
