### PR TITLE
mbed fault handler: fix mbed_fault_context parameter

### DIFF
--- a/platform/source/TARGET_CORTEX_M/TOOLCHAIN_ARM/except.S
+++ b/platform/source/TARGET_CORTEX_M/TOOLCHAIN_ARM/except.S
@@ -150,7 +150,8 @@ Fault_Handler_Continue2
                 MRS      R2,CONTROL               ; Get CONTROL Reg
                 STR      R2,[R1]
                 MOV      R0,R12
-                LDR      R1,=mbed_fault_context
+                LDR      R3,=mbed_fault_context
+                LDR      R1,[R3]
                 BL       mbed_fault_handler
 #endif                    
                 B        .                        ; Just in case we come back here                

--- a/platform/source/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
+++ b/platform/source/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
@@ -183,7 +183,8 @@ Fault_Handler_Continue2:
         MRS      R2,CONTROL               // Get CONTROL Reg
         STR      R2,[R1]
         MOV      R0,R12
-        LDR      R1,=mbed_fault_context
+        LDR      R3,=mbed_fault_context
+        LDR      R1,[R3]
         BL       mbed_fault_handler
 #endif
         B        .                        // Just in case we come back here   

--- a/platform/source/TARGET_CORTEX_M/TOOLCHAIN_IAR/except.S
+++ b/platform/source/TARGET_CORTEX_M/TOOLCHAIN_IAR/except.S
@@ -145,7 +145,8 @@ Fault_Handler_Continue2
                 MRS     R2,CONTROL               ; Get CONTROL Reg
                 STR     R2,[R1]
                 MOV     R0,R12
-                LDR     R1,=mbed_fault_context
+                LDR     R3,=mbed_fault_context
+                LDR     R1,[R3]
                 BL      mbed_fault_handler 
 #endif                
                 B       .                        ; Just in case we come back here    

--- a/platform/source/TARGET_CORTEX_M/mbed_fault_handler.c
+++ b/platform/source/TARGET_CORTEX_M/mbed_fault_handler.c
@@ -36,12 +36,12 @@ void print_context_info(void);
 mbed_fault_context_t *const mbed_fault_context = (mbed_fault_context_t *)(FAULT_CONTEXT_LOCATION);
 #else
 mbed_fault_context_t fault_context;
-mbed_fault_context_t *const mbed_fault_context = (mbed_fault_context_t *) &fault_context;
+mbed_fault_context_t *const mbed_fault_context = &fault_context;
 #endif
 
 //This is a handler function called from Fault handler to print the error information out.
 //This runs in fault context and uses special functions(defined in mbed_rtx_fault_handler.c) to print the information without using C-lib support.
-void mbed_fault_handler(uint32_t fault_type, void *mbed_fault_context_in)
+void mbed_fault_handler(uint32_t fault_type, const mbed_fault_context_t *mbed_fault_context_in)
 {
     mbed_error_status_t faultStatus = MBED_SUCCESS;
 

--- a/platform/source/TARGET_CORTEX_M/mbed_fault_handler.h
+++ b/platform/source/TARGET_CORTEX_M/mbed_fault_handler.h
@@ -57,7 +57,7 @@ typedef struct {
 
 //This is a handler function called from Fault handler to print the error information out.
 //This runs in fault context and uses special functions(defined in mbed_fault_handler.c) to print the information without using C-lib support.
-void mbed_fault_handler(uint32_t fault_type, void *mbed_fault_context_in);
+void mbed_fault_handler(uint32_t fault_type, const mbed_fault_context_t *mbed_fault_context_in);
 
 /**
  * Call this function to retrieve the fault context after a fatal exception which triggered a system reboot. The function retrieves the fault context stored in crash-report ram area which is preserved over reboot.


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

#### Why required
Without this fix, when `void mbed_fault_handler(uint32_t fault_type, void *mbed_fault_context_in)` is called, `mbed_fault_context_in` is in `**mbed_fault_context_t` type which is unnecessarily doubly pointered. Also, it's unintuitive, most users will expect to simply static cast the void pointer argument to `*mbed_fault_context_t` instead of `**mbed_fault_context_t`.

#### What's the change
The `except.S` Fault_Handler assembly code will prepare `mbed_fault_context_in` argument as `*mbed_fault_context_t` type instead of `**mbed_fault_context_t` type.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
