### PR TITLE
Fix Coverity uninitialized pointer field Thread.h

### DIFF
--- a/rtos/source/Thread.cpp
+++ b/rtos/source/Thread.cpp
@@ -51,7 +51,8 @@ void Thread::constructor(uint32_t tz_module, osPriority priority,
     const uint32_t offset = aligned_mem - unaligned_mem;
     const uint32_t aligned_size = ALIGN_DOWN(stack_size - offset, 8);
 
-    _tid = 0;
+    memset(&_obj_mem, 0, sizeof(_obj_mem));
+    _tid = nullptr;
     _dynamic_stack = (stack_mem == nullptr);
     _finished = false;
     memset(&_attr, 0, sizeof(_attr));
@@ -106,7 +107,6 @@ osStatus Thread::start(mbed::Callback<void()> task)
         ((uint32_t *)_attr.stack_mem)[i] = osRtxStackMagicWord;
     }
 
-    memset(&_obj_mem, 0, sizeof(_obj_mem));
     _attr.cb_size = sizeof(_obj_mem);
     _attr.cb_mem = &_obj_mem;
     _task = task;


### PR DESCRIPTION
### Description

Changed _obj_mem to be initialized with creating new thread.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @maciejbocianski 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
