### PR TITLE
Add ethernet support on NUCLEO_H743ZI board

### DIFF
--- a/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
@@ -47,6 +47,12 @@
 #  else
 #     define ETHMEM_SECTION __attribute__((section("AHBSRAM0"),aligned))
 #  endif
+#elif defined(TARGET_STM32H7)
+#  if defined (__ICCARM__)
+#     define ETHMEM_SECTION
+#  else
+#     define ETHMEM_SECTION __attribute__((section(".ethusbram")))
+#  endif
 #else
 #define ETHMEM_SECTION
 #endif

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F2/stm32xx_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F2/stm32xx_emac_config.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STM32XX_EMAC_CONFIG_H__
+#define STM32XX_EMAC_CONFIG_H__
+
+#define ETH_IP_VERSION_V1
+
+#define THREAD_STACKSIZE              512
+
+#endif // #define STM32XX_EMAC_CONFIG_H__

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F4/stm32xx_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F4/stm32xx_emac_config.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STM32XX_EMAC_CONFIG_H__
+#define STM32XX_EMAC_CONFIG_H__
+
+#define ETH_IP_VERSION_V1
+
+#define THREAD_STACKSIZE              512
+
+#endif // #define STM32XX_EMAC_CONFIG_H__

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F7/stm32xx_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32F7/stm32xx_emac_config.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2017 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STM32XX_EMAC_CONFIG_H__
+#define STM32XX_EMAC_CONFIG_H__
+
+#define ETH_IP_VERSION_V1
+
+#define THREAD_STACKSIZE              512
+
+#endif // #define STM32XX_EMAC_CONFIG_H__

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/TARGET_NUCLEO_H743ZI/lan8742/lan8742.c
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/TARGET_NUCLEO_H743ZI/lan8742/lan8742.c
@@ -1,0 +1,681 @@
+/** 
+  ******************************************************************************
+  * @file    lan8742.c
+  * @author  MCD Application Team
+  * @version V1.0.0
+  * @date    08-March-2017
+  * @brief   This file provides a set of functions needed to manage the LAN742
+  *          PHY devices.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */  
+
+/* Includes ------------------------------------------------------------------*/
+#include "lan8742.h"
+
+/** @addtogroup BSP
+  * @{
+  */
+
+/** @addtogroup Component
+  * @{
+  */ 
+  
+/** @defgroup LAN8742 LAN8742
+  * @{
+  */   
+  
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @defgroup LAN8742_Private_Defines LAN8742 Private Defines
+  * @{
+  */
+#define LAN8742_SW_RESET_TO    ((uint32_t)500U)
+#define LAN8742_INIT_TO        ((uint32_t)2000U)
+#define LAN8742_MAX_DEV_ADDR   ((uint32_t)31U)
+/**
+  * @}
+  */
+ 
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup LAN8742_Private_Functions LAN8742 Private Functions
+  * @{
+  */
+    
+/**
+  * @brief  Register IO functions to component object
+  * @param  pObj: device object  of LAN8742_Object_t. 
+  * @param  ioctx: holds device IO functions.  
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_ERROR if missing mandatory function
+  */
+int32_t  LAN8742_RegisterBusIO(lan8742_Object_t *pObj, lan8742_IOCtx_t *ioctx)
+{
+  if(!pObj || !ioctx->ReadReg || !ioctx->WriteReg || !ioctx->GetTick)
+  {
+    return LAN8742_STATUS_ERROR;
+  }
+  
+  pObj->IO.Init = ioctx->Init;
+  pObj->IO.DeInit = ioctx->DeInit;
+  pObj->IO.ReadReg = ioctx->ReadReg;
+  pObj->IO.WriteReg = ioctx->WriteReg;
+  pObj->IO.GetTick = ioctx->GetTick;
+  
+  return LAN8742_STATUS_OK;
+}
+
+/**
+  * @brief  Initialize the lan8742 and configure the needed hardware resources
+  * @param  pObj: device object LAN8742_Object_t. 
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_ADDRESS_ERROR if cannot find device address
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  *         LAN8742_STATUS_RESET_TIMEOUT if cannot perform a software reset
+  */
+ int32_t LAN8742_Init(lan8742_Object_t *pObj)
+ {
+   uint32_t tickstart = 0, regvalue = 0, addr = 0;
+   int32_t status = LAN8742_STATUS_OK;
+   
+   if(pObj->Is_Initialized == 0)
+   {
+     if(pObj->IO.Init != 0)
+     {
+       /* GPIO and Clocks initialization */
+       pObj->IO.Init();
+     }
+   
+     /* for later check */
+     pObj->DevAddr = LAN8742_MAX_DEV_ADDR + 1;
+   
+     /* Get the device address from special mode register */  
+     for(addr = 0; addr <= LAN8742_MAX_DEV_ADDR; addr ++)
+     {
+       if(pObj->IO.ReadReg(addr, LAN8742_SMR, &regvalue) < 0)
+       { 
+         status = LAN8742_STATUS_READ_ERROR;
+         /* Can't read from this device address 
+            continue with next address */
+         continue;
+       }
+     
+       if((regvalue & LAN8742_SMR_PHY_ADDR) == addr)
+       {
+         pObj->DevAddr = addr;
+         status = LAN8742_STATUS_OK;
+         break;
+       }
+     }
+   
+     if(pObj->DevAddr > LAN8742_MAX_DEV_ADDR)
+     {
+       status = LAN8742_STATUS_ADDRESS_ERROR;
+     }
+     
+     /* if device address is matched */
+     if(status == LAN8742_STATUS_OK)
+     {
+       /* set a software reset  */
+       if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, LAN8742_BCR_SOFT_RESET) >= 0)
+       { 
+         /* get software reset status */
+         if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &regvalue) >= 0)
+         { 
+           tickstart = pObj->IO.GetTick();
+           
+           /* wait until software reset is done or timeout occured  */
+           while(regvalue & LAN8742_BCR_SOFT_RESET)
+           {
+             if((pObj->IO.GetTick() - tickstart) <= LAN8742_SW_RESET_TO)
+             {
+               if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &regvalue) < 0)
+               { 
+                 status = LAN8742_STATUS_READ_ERROR;
+                 break;
+               }
+             }
+             else
+             {
+               status = LAN8742_STATUS_RESET_TIMEOUT;
+             }
+           } 
+         }
+         else
+         {
+           status = LAN8742_STATUS_READ_ERROR;
+         }
+       }
+       else
+       {
+         status = LAN8742_STATUS_WRITE_ERROR;
+       }
+     }
+   }
+      
+   if(status == LAN8742_STATUS_OK)
+   {
+     tickstart =  pObj->IO.GetTick();
+     
+     /* Wait for 2s to perform initialization */
+     while((pObj->IO.GetTick() - tickstart) <= LAN8742_INIT_TO)
+     {
+     }
+     pObj->Is_Initialized = 1;
+   }
+   
+   return status;
+ }
+
+/**
+  * @brief  De-Initialize the lan8742 and it's hardware resources
+  * @param  pObj: device object LAN8742_Object_t. 
+  * @retval None
+  */
+int32_t LAN8742_DeInit(lan8742_Object_t *pObj)
+{
+  if(pObj->Is_Initialized)
+  {
+    if(pObj->IO.DeInit != 0)
+    {
+      if(pObj->IO.DeInit() < 0)
+      {
+        return LAN8742_STATUS_ERROR;
+      }
+    }
+  
+    pObj->Is_Initialized = 0;  
+  }
+  
+  return LAN8742_STATUS_OK;
+}
+
+/**
+  * @brief  Disable the LAN8742 power down mode.
+  * @param  pObj: device object LAN8742_Object_t.  
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_DisablePowerDownMode(lan8742_Object_t *pObj)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &readval) >= 0)
+  {
+    readval &= ~LAN8742_BCR_POWER_DOWN;
+  
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, readval) < 0)
+    {
+      status =  LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+   
+  return status;
+}
+
+/**
+  * @brief  Enable the LAN8742 power down mode.
+  * @param  pObj: device object LAN8742_Object_t.  
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_EnablePowerDownMode(lan8742_Object_t *pObj)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &readval) >= 0)
+  {
+    readval |= LAN8742_BCR_POWER_DOWN;
+  
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, readval) < 0)
+    {
+      status =  LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+   
+  return status;
+}
+
+/**
+  * @brief  Start the auto negotiation process.
+  * @param  pObj: device object LAN8742_Object_t.  
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_StartAutoNego(lan8742_Object_t *pObj)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &readval) >= 0)
+  {
+    readval |= LAN8742_BCR_AUTONEGO_EN;
+  
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, readval) < 0)
+    {
+      status =  LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+   
+  return status;
+}
+
+/**
+  * @brief  Get the link state of LAN8742 device.
+  * @param  pObj: Pointer to device object. 
+  * @param  pLinkState: Pointer to link state
+  * @retval LAN8742_STATUS_LINK_DOWN  if link is down
+  *         LAN8742_STATUS_AUTONEGO_NOTDONE if Auto nego not completed 
+  *         LAN8742_STATUS_100MBITS_FULLDUPLEX if 100Mb/s FD
+  *         LAN8742_STATUS_100MBITS_HALFDUPLEX if 100Mb/s HD
+  *         LAN8742_STATUS_10MBITS_FULLDUPLEX  if 10Mb/s FD
+  *         LAN8742_STATUS_10MBITS_HALFDUPLEX  if 10Mb/s HD       
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_GetLinkState(lan8742_Object_t *pObj)
+{
+  uint32_t readval = 0;
+  
+  /* Read Status register  */
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BSR, &readval) < 0)
+  {
+    return LAN8742_STATUS_READ_ERROR;
+  }
+  
+  /* Read Status register again */
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BSR, &readval) < 0)
+  {
+    return LAN8742_STATUS_READ_ERROR;
+  }
+  
+  if((readval & LAN8742_BSR_LINK_STATUS) == 0)
+  {
+    /* Return Link Down status */
+    return LAN8742_STATUS_LINK_DOWN;    
+  }
+  
+  /* Check Auto negotiaition */
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &readval) < 0)
+  {
+    return LAN8742_STATUS_READ_ERROR;
+  }
+  
+  if((readval & LAN8742_BCR_AUTONEGO_EN) != LAN8742_BCR_AUTONEGO_EN)
+  {
+    if(((readval & LAN8742_BCR_SPEED_SELECT) == LAN8742_BCR_SPEED_SELECT) && ((readval & LAN8742_BCR_DUPLEX_MODE) == LAN8742_BCR_DUPLEX_MODE)) 
+    {
+      return LAN8742_STATUS_100MBITS_FULLDUPLEX;
+    }
+    else if ((readval & LAN8742_BCR_SPEED_SELECT) == LAN8742_BCR_SPEED_SELECT)
+    {
+      return LAN8742_STATUS_100MBITS_HALFDUPLEX;
+    }        
+    else if ((readval & LAN8742_BCR_DUPLEX_MODE) == LAN8742_BCR_DUPLEX_MODE)
+    {
+      return LAN8742_STATUS_10MBITS_FULLDUPLEX;
+    }
+    else
+    {
+      return LAN8742_STATUS_10MBITS_HALFDUPLEX;
+    }  		
+  }
+  else /* Auto Nego enabled */
+  {
+    if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_PHYSCSR, &readval) < 0)
+    {
+      return LAN8742_STATUS_READ_ERROR;
+    }
+    
+    /* Check if auto nego not done */
+    if((readval & LAN8742_PHYSCSR_AUTONEGO_DONE) == 0)
+    {
+      return LAN8742_STATUS_AUTONEGO_NOTDONE;
+    }
+    
+    if((readval & LAN8742_PHYSCSR_HCDSPEEDMASK) == LAN8742_PHYSCSR_100BTX_FD)
+    {
+      return LAN8742_STATUS_100MBITS_FULLDUPLEX;
+    }
+    else if ((readval & LAN8742_PHYSCSR_HCDSPEEDMASK) == LAN8742_PHYSCSR_100BTX_HD)
+    {
+      return LAN8742_STATUS_100MBITS_HALFDUPLEX;
+    }
+    else if ((readval & LAN8742_PHYSCSR_HCDSPEEDMASK) == LAN8742_PHYSCSR_10BT_FD)
+    {
+      return LAN8742_STATUS_10MBITS_FULLDUPLEX;
+    }
+    else
+    {
+      return LAN8742_STATUS_10MBITS_HALFDUPLEX;
+    }				
+  }
+}
+
+/**
+  * @brief  Set the link state of LAN8742 device.
+  * @param  pObj: Pointer to device object. 
+  * @param  pLinkState: link state can be one of the following
+  *         LAN8742_STATUS_100MBITS_FULLDUPLEX if 100Mb/s FD
+  *         LAN8742_STATUS_100MBITS_HALFDUPLEX if 100Mb/s HD
+  *         LAN8742_STATUS_10MBITS_FULLDUPLEX  if 10Mb/s FD
+  *         LAN8742_STATUS_10MBITS_HALFDUPLEX  if 10Mb/s HD   
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_ERROR  if parameter error  
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_SetLinkState(lan8742_Object_t *pObj, uint32_t LinkState)
+{
+  uint32_t bcrvalue = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &bcrvalue) >= 0)
+  {
+    /* Disable link config (Auto nego, speed and duplex) */
+    bcrvalue &= ~(LAN8742_BCR_AUTONEGO_EN | LAN8742_BCR_SPEED_SELECT | LAN8742_BCR_DUPLEX_MODE);
+    
+    if(LinkState == LAN8742_STATUS_100MBITS_FULLDUPLEX)
+    {
+      bcrvalue |= (LAN8742_BCR_SPEED_SELECT | LAN8742_BCR_DUPLEX_MODE);
+    }
+    else if (LinkState == LAN8742_STATUS_100MBITS_HALFDUPLEX)
+    {
+      bcrvalue |= LAN8742_BCR_SPEED_SELECT;
+    }
+    else if (LinkState == LAN8742_STATUS_10MBITS_FULLDUPLEX)
+    {
+      bcrvalue |= LAN8742_BCR_DUPLEX_MODE;
+    }
+    else
+    {
+      /* Wrong link status parameter */
+      status = LAN8742_STATUS_ERROR;
+    }	
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+  
+  if(status == LAN8742_STATUS_OK)
+  {
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, bcrvalue) < 0)
+    {
+      status = LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Enable loopback mode.
+  * @param  pObj: Pointer to device object. 
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_EnableLoopbackMode(lan8742_Object_t *pObj)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &readval) >= 0)
+  {
+    readval |= LAN8742_BCR_LOOPBACK;
+    
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, readval) < 0)
+    {
+      status = LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Disable loopback mode.
+  * @param  pObj: Pointer to device object. 
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_DisableLoopbackMode(lan8742_Object_t *pObj)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BCR, &readval) >= 0)
+  {
+    readval &= ~LAN8742_BCR_LOOPBACK;
+  
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_BCR, readval) < 0)
+    {
+      status =  LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+   
+  return status;
+}
+
+/**
+  * @brief  Enable IT source.
+  * @param  pObj: Pointer to device object. 
+  * @param  Interrupt: IT source to be enabled
+  *         should be a value or a combination of the following:
+  *         LAN8742_WOL_IT                     
+  *         LAN8742_ENERGYON_IT                
+  *         LAN8742_AUTONEGO_COMPLETE_IT       
+  *         LAN8742_REMOTE_FAULT_IT            
+  *         LAN8742_LINK_DOWN_IT               
+  *         LAN8742_AUTONEGO_LP_ACK_IT         
+  *         LAN8742_PARALLEL_DETECTION_FAULT_IT
+  *         LAN8742_AUTONEGO_PAGE_RECEIVED_IT
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_EnableIT(lan8742_Object_t *pObj, uint32_t Interrupt)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_IMR, &readval) >= 0)
+  {
+    readval |= Interrupt;
+  
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_IMR, readval) < 0)
+    {
+      status =  LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+   
+  return status;
+}
+
+/**
+  * @brief  Disable IT source.
+  * @param  pObj: Pointer to device object. 
+  * @param  Interrupt: IT source to be disabled
+  *         should be a value or a combination of the following:
+  *         LAN8742_WOL_IT                     
+  *         LAN8742_ENERGYON_IT                
+  *         LAN8742_AUTONEGO_COMPLETE_IT       
+  *         LAN8742_REMOTE_FAULT_IT            
+  *         LAN8742_LINK_DOWN_IT               
+  *         LAN8742_AUTONEGO_LP_ACK_IT         
+  *         LAN8742_PARALLEL_DETECTION_FAULT_IT
+  *         LAN8742_AUTONEGO_PAGE_RECEIVED_IT
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  *         LAN8742_STATUS_WRITE_ERROR if connot write to register
+  */
+int32_t LAN8742_DisableIT(lan8742_Object_t *pObj, uint32_t Interrupt)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_IMR, &readval) >= 0)
+  {
+    readval &= ~Interrupt;
+  
+    /* Apply configuration */
+    if(pObj->IO.WriteReg(pObj->DevAddr, LAN8742_IMR, readval) < 0)
+    {
+      status = LAN8742_STATUS_WRITE_ERROR;
+    }
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+   
+  return status;
+}
+
+/**
+  * @brief  Clear IT flag.
+  * @param  pObj: Pointer to device object. 
+  * @param  Interrupt: IT flag to be cleared
+  *         should be a value or a combination of the following:
+  *         LAN8742_WOL_IT                     
+  *         LAN8742_ENERGYON_IT                
+  *         LAN8742_AUTONEGO_COMPLETE_IT       
+  *         LAN8742_REMOTE_FAULT_IT            
+  *         LAN8742_LINK_DOWN_IT               
+  *         LAN8742_AUTONEGO_LP_ACK_IT         
+  *         LAN8742_PARALLEL_DETECTION_FAULT_IT
+  *         LAN8742_AUTONEGO_PAGE_RECEIVED_IT
+  * @retval LAN8742_STATUS_OK  if OK
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  */
+int32_t  LAN8742_ClearIT(lan8742_Object_t *pObj, uint32_t Interrupt)
+{
+  uint32_t readval = 0;
+  int32_t status = LAN8742_STATUS_OK;  
+  
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_ISFR, &readval) < 0)
+  {
+    status =  LAN8742_STATUS_READ_ERROR;
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Get IT Flag status.
+  * @param  pObj: Pointer to device object. 
+  * @param  Interrupt: IT Flag to be checked, 
+  *         should be a value or a combination of the following:
+  *         LAN8742_WOL_IT                     
+  *         LAN8742_ENERGYON_IT                
+  *         LAN8742_AUTONEGO_COMPLETE_IT       
+  *         LAN8742_REMOTE_FAULT_IT            
+  *         LAN8742_LINK_DOWN_IT               
+  *         LAN8742_AUTONEGO_LP_ACK_IT         
+  *         LAN8742_PARALLEL_DETECTION_FAULT_IT
+  *         LAN8742_AUTONEGO_PAGE_RECEIVED_IT  
+  * @retval 1 IT flag is SET
+  *         0 IT flag is RESET
+  *         LAN8742_STATUS_READ_ERROR if connot read register
+  */
+int32_t LAN8742_GetITStatus(lan8742_Object_t *pObj, uint32_t Interrupt)
+{
+  uint32_t readval = 0;
+  int32_t status = 0;
+
+  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_ISFR, &readval) >= 0)
+  {
+    status = ((readval & Interrupt) == Interrupt);
+  }
+  else
+  {
+    status = LAN8742_STATUS_READ_ERROR;
+  }
+	
+  return status;
+}
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */      
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/TARGET_NUCLEO_H743ZI/lan8742/lan8742.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/TARGET_NUCLEO_H743ZI/lan8742/lan8742.h
@@ -1,0 +1,466 @@
+/**
+  ******************************************************************************
+  * @file    lan8742.h
+  * @author  MCD Application Team
+  * @version V1.0.0
+  * @date    08-March-2017
+  * @brief   This file contains all the functions prototypes for the
+  *          lan8742.c PHY driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __LAN8742_H
+#define __LAN8742_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif   
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+
+/** @addtogroup BSP
+  * @{
+  */ 
+
+/** @addtogroup Component
+  * @{
+  */
+    
+/** @defgroup LAN8742
+  * @{
+  */    
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup LAN8742_Exported_Constants LAN8742 Exported Constants
+  * @{
+  */ 
+  
+/** @defgroup LAN8742_Registers_Mapping LAN8742 Registers Mapping
+  * @{
+  */ 
+#define LAN8742_BCR      ((uint16_t)0x0000U)
+#define LAN8742_BSR      ((uint16_t)0x0001U)
+#define LAN8742_PHYI1R   ((uint16_t)0x0002U)
+#define LAN8742_PHYI2R   ((uint16_t)0x0003U)
+#define LAN8742_ANAR     ((uint16_t)0x0004U)
+#define LAN8742_ANLPAR   ((uint16_t)0x0005U)
+#define LAN8742_ANER     ((uint16_t)0x0006U)
+#define LAN8742_ANNPTR   ((uint16_t)0x0007U)
+#define LAN8742_ANNPRR   ((uint16_t)0x0008U)
+#define LAN8742_MMDACR   ((uint16_t)0x000DU)
+#define LAN8742_MMDAADR  ((uint16_t)0x000EU)
+#define LAN8742_ENCTR    ((uint16_t)0x0010U)
+#define LAN8742_MCSR     ((uint16_t)0x0011U)
+#define LAN8742_SMR      ((uint16_t)0x0012U)
+#define LAN8742_TPDCR    ((uint16_t)0x0018U)
+#define LAN8742_TCSR     ((uint16_t)0x0019U)
+#define LAN8742_SECR     ((uint16_t)0x001AU)
+#define LAN8742_SCSIR    ((uint16_t)0x001BU)
+#define LAN8742_CLR      ((uint16_t)0x001CU)
+#define LAN8742_ISFR     ((uint16_t)0x001DU)
+#define LAN8742_IMR      ((uint16_t)0x001EU)
+#define LAN8742_PHYSCSR  ((uint16_t)0x001FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_BCR_Bit_Definition LAN8742 BCR Bit Definition
+  * @{
+  */    
+#define LAN8742_BCR_SOFT_RESET         ((uint16_t)0x8000U)
+#define LAN8742_BCR_LOOPBACK           ((uint16_t)0x4000U)
+#define LAN8742_BCR_SPEED_SELECT       ((uint16_t)0x2000U)
+#define LAN8742_BCR_AUTONEGO_EN        ((uint16_t)0x1000U)
+#define LAN8742_BCR_POWER_DOWN         ((uint16_t)0x0800U)
+#define LAN8742_BCR_ISOLATE            ((uint16_t)0x0400U)
+#define LAN8742_BCR_RESTART_AUTONEGO   ((uint16_t)0x0200U)
+#define LAN8742_BCR_DUPLEX_MODE        ((uint16_t)0x0100U) 
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_BSR_Bit_Definition LAN8742 BSR Bit Definition
+  * @{
+  */   
+#define LAN8742_BSR_100BASE_T4       ((uint16_t)0x8000U)
+#define LAN8742_BSR_100BASE_TX_FD    ((uint16_t)0x4000U)
+#define LAN8742_BSR_100BASE_TX_HD    ((uint16_t)0x2000U)
+#define LAN8742_BSR_10BASE_T_FD      ((uint16_t)0x1000U)
+#define LAN8742_BSR_10BASE_T_HD      ((uint16_t)0x0800U)
+#define LAN8742_BSR_100BASE_T2_FD    ((uint16_t)0x0400U)
+#define LAN8742_BSR_100BASE_T2_HD    ((uint16_t)0x0200U)
+#define LAN8742_BSR_EXTENDED_STATUS  ((uint16_t)0x0100U)
+#define LAN8742_BSR_AUTONEGO_CPLT    ((uint16_t)0x0020U)
+#define LAN8742_BSR_REMOTE_FAULT     ((uint16_t)0x0010U)
+#define LAN8742_BSR_AUTONEGO_ABILITY ((uint16_t)0x0008U)
+#define LAN8742_BSR_LINK_STATUS      ((uint16_t)0x0004U)
+#define LAN8742_BSR_JABBER_DETECT    ((uint16_t)0x0002U)
+#define LAN8742_BSR_EXTENDED_CAP     ((uint16_t)0x0001U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_PHYI1R_Bit_Definition LAN8742 PHYI1R Bit Definition
+  * @{
+  */
+#define LAN8742_PHYI1R_OUI_3_18           ((uint16_t)0xFFFFU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_PHYI2R_Bit_Definition LAN8742 PHYI2R Bit Definition
+  * @{
+  */
+#define LAN8742_PHYI2R_OUI_19_24          ((uint16_t)0xFC00U)
+#define LAN8742_PHYI2R_MODEL_NBR          ((uint16_t)0x03F0U)
+#define LAN8742_PHYI2R_REVISION_NBR       ((uint16_t)0x000FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_ANAR_Bit_Definition LAN8742 ANAR Bit Definition
+  * @{
+  */
+#define LAN8742_ANAR_NEXT_PAGE               ((uint16_t)0x8000U)
+#define LAN8742_ANAR_REMOTE_FAULT            ((uint16_t)0x2000U)
+#define LAN8742_ANAR_PAUSE_OPERATION         ((uint16_t)0x0C00U)
+#define LAN8742_ANAR_PO_NOPAUSE              ((uint16_t)0x0000U)
+#define LAN8742_ANAR_PO_SYMMETRIC_PAUSE      ((uint16_t)0x0400U)
+#define LAN8742_ANAR_PO_ASYMMETRIC_PAUSE     ((uint16_t)0x0800U)
+#define LAN8742_ANAR_PO_ADVERTISE_SUPPORT    ((uint16_t)0x0C00U)
+#define LAN8742_ANAR_100BASE_TX_FD           ((uint16_t)0x0100U)
+#define LAN8742_ANAR_100BASE_TX              ((uint16_t)0x0080U)
+#define LAN8742_ANAR_10BASE_T_FD             ((uint16_t)0x0040U)
+#define LAN8742_ANAR_10BASE_T                ((uint16_t)0x0020U)
+#define LAN8742_ANAR_SELECTOR_FIELD          ((uint16_t)0x000FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_ANLPAR_Bit_Definition LAN8742 ANLPAR Bit Definition
+  * @{
+  */
+#define LAN8742_ANLPAR_NEXT_PAGE            ((uint16_t)0x8000U)
+#define LAN8742_ANLPAR_REMOTE_FAULT         ((uint16_t)0x2000U)
+#define LAN8742_ANLPAR_PAUSE_OPERATION      ((uint16_t)0x0C00U)
+#define LAN8742_ANLPAR_PO_NOPAUSE           ((uint16_t)0x0000U)
+#define LAN8742_ANLPAR_PO_SYMMETRIC_PAUSE   ((uint16_t)0x0400U)
+#define LAN8742_ANLPAR_PO_ASYMMETRIC_PAUSE  ((uint16_t)0x0800U)
+#define LAN8742_ANLPAR_PO_ADVERTISE_SUPPORT ((uint16_t)0x0C00U)
+#define LAN8742_ANLPAR_100BASE_TX_FD        ((uint16_t)0x0100U)
+#define LAN8742_ANLPAR_100BASE_TX           ((uint16_t)0x0080U)
+#define LAN8742_ANLPAR_10BASE_T_FD          ((uint16_t)0x0040U)
+#define LAN8742_ANLPAR_10BASE_T             ((uint16_t)0x0020U)
+#define LAN8742_ANLPAR_SELECTOR_FIELD       ((uint16_t)0x000FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_ANER_Bit_Definition LAN8742 ANER Bit Definition
+  * @{
+  */
+#define LAN8742_ANER_RX_NP_LOCATION_ABLE    ((uint16_t)0x0040U)
+#define LAN8742_ANER_RX_NP_STORAGE_LOCATION ((uint16_t)0x0020U)
+#define LAN8742_ANER_PARALLEL_DETECT_FAULT  ((uint16_t)0x0010U)
+#define LAN8742_ANER_LP_NP_ABLE             ((uint16_t)0x0008U)
+#define LAN8742_ANER_NP_ABLE                ((uint16_t)0x0004U)
+#define LAN8742_ANER_PAGE_RECEIVED          ((uint16_t)0x0002U)
+#define LAN8742_ANER_LP_AUTONEG_ABLE        ((uint16_t)0x0001U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_ANNPTR_Bit_Definition LAN8742 ANNPTR Bit Definition
+  * @{
+  */
+#define LAN8742_ANNPTR_NEXT_PAGE         ((uint16_t)0x8000U)
+#define LAN8742_ANNPTR_MESSAGE_PAGE      ((uint16_t)0x2000U)
+#define LAN8742_ANNPTR_ACK2              ((uint16_t)0x1000U)
+#define LAN8742_ANNPTR_TOGGLE            ((uint16_t)0x0800U)
+#define LAN8742_ANNPTR_MESSAGGE_CODE     ((uint16_t)0x07FFU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_ANNPRR_Bit_Definition LAN8742 ANNPRR Bit Definition
+  * @{
+  */
+#define LAN8742_ANNPTR_NEXT_PAGE         ((uint16_t)0x8000U)
+#define LAN8742_ANNPRR_ACK               ((uint16_t)0x4000U)
+#define LAN8742_ANNPRR_MESSAGE_PAGE      ((uint16_t)0x2000U)
+#define LAN8742_ANNPRR_ACK2              ((uint16_t)0x1000U)
+#define LAN8742_ANNPRR_TOGGLE            ((uint16_t)0x0800U)
+#define LAN8742_ANNPRR_MESSAGGE_CODE     ((uint16_t)0x07FFU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_MMDACR_Bit_Definition LAN8742 MMDACR Bit Definition
+  * @{
+  */
+#define LAN8742_MMDACR_MMD_FUNCTION       ((uint16_t)0xC000U) 
+#define LAN8742_MMDACR_MMD_FUNCTION_ADDR  ((uint16_t)0x0000U)
+#define LAN8742_MMDACR_MMD_FUNCTION_DATA  ((uint16_t)0x4000U)
+#define LAN8742_MMDACR_MMD_DEV_ADDR       ((uint16_t)0x001FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_ENCTR_Bit_Definition LAN8742 ENCTR Bit Definition
+  * @{
+  */
+#define LAN8742_ENCTR_TX_ENABLE             ((uint16_t)0x8000U)
+#define LAN8742_ENCTR_TX_TIMER              ((uint16_t)0x6000U)
+#define LAN8742_ENCTR_TX_TIMER_1S           ((uint16_t)0x0000U)
+#define LAN8742_ENCTR_TX_TIMER_768MS        ((uint16_t)0x2000U)
+#define LAN8742_ENCTR_TX_TIMER_512MS        ((uint16_t)0x4000U)
+#define LAN8742_ENCTR_TX_TIMER_265MS        ((uint16_t)0x6000U)
+#define LAN8742_ENCTR_RX_ENABLE             ((uint16_t)0x1000U)
+#define LAN8742_ENCTR_RX_MAX_INTERVAL       ((uint16_t)0x0C00U)
+#define LAN8742_ENCTR_RX_MAX_INTERVAL_64MS  ((uint16_t)0x0000U)
+#define LAN8742_ENCTR_RX_MAX_INTERVAL_256MS ((uint16_t)0x0400U)
+#define LAN8742_ENCTR_RX_MAX_INTERVAL_512MS ((uint16_t)0x0800U)
+#define LAN8742_ENCTR_RX_MAX_INTERVAL_1S    ((uint16_t)0x0C00U)
+#define LAN8742_ENCTR_EX_CROSS_OVER         ((uint16_t)0x0002U)
+#define LAN8742_ENCTR_EX_MANUAL_CROSS_OVER  ((uint16_t)0x0001U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_MCSR_Bit_Definition LAN8742 MCSR Bit Definition
+  * @{
+  */
+#define LAN8742_MCSR_EDPWRDOWN        ((uint16_t)0x2000U)
+#define LAN8742_MCSR_FARLOOPBACK      ((uint16_t)0x0200U)
+#define LAN8742_MCSR_ALTINT           ((uint16_t)0x0040U)
+#define LAN8742_MCSR_ENERGYON         ((uint16_t)0x0002U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_SMR_Bit_Definition LAN8742 SMR Bit Definition
+  * @{
+  */
+#define LAN8742_SMR_MODE       ((uint16_t)0x00E0U)
+#define LAN8742_SMR_PHY_ADDR   ((uint16_t)0x001FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_TPDCR_Bit_Definition LAN8742 TPDCR Bit Definition
+  * @{
+  */
+#define LAN8742_TPDCR_DELAY_IN                 ((uint16_t)0x8000U)
+#define LAN8742_TPDCR_LINE_BREAK_COUNTER       ((uint16_t)0x7000U)
+#define LAN8742_TPDCR_PATTERN_HIGH             ((uint16_t)0x0FC0U)
+#define LAN8742_TPDCR_PATTERN_LOW              ((uint16_t)0x003FU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_TCSR_Bit_Definition LAN8742 TCSR Bit Definition
+  * @{
+  */
+#define LAN8742_TCSR_TDR_ENABLE           ((uint16_t)0x8000U)
+#define LAN8742_TCSR_TDR_AD_FILTER_ENABLE ((uint16_t)0x4000U)
+#define LAN8742_TCSR_TDR_CH_CABLE_TYPE    ((uint16_t)0x0600U)
+#define LAN8742_TCSR_TDR_CH_CABLE_DEFAULT ((uint16_t)0x0000U)
+#define LAN8742_TCSR_TDR_CH_CABLE_SHORTED ((uint16_t)0x0200U)
+#define LAN8742_TCSR_TDR_CH_CABLE_OPEN    ((uint16_t)0x0400U)
+#define LAN8742_TCSR_TDR_CH_CABLE_MATCH   ((uint16_t)0x0600U)
+#define LAN8742_TCSR_TDR_CH_STATUS        ((uint16_t)0x0100U)
+#define LAN8742_TCSR_TDR_CH_LENGTH        ((uint16_t)0x00FFU)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_SCSIR_Bit_Definition LAN8742 SCSIR Bit Definition
+  * @{
+  */
+#define LAN8742_SCSIR_AUTO_MDIX_ENABLE    ((uint16_t)0x8000U)
+#define LAN8742_SCSIR_CHANNEL_SELECT      ((uint16_t)0x2000U)
+#define LAN8742_SCSIR_SQE_DISABLE         ((uint16_t)0x0800U)
+#define LAN8742_SCSIR_XPOLALITY           ((uint16_t)0x0010U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_CLR_Bit_Definition LAN8742 CLR Bit Definition
+  * @{
+  */
+#define LAN8742_CLR_CABLE_LENGTH       ((uint16_t)0xF000U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_IMR_ISFR_Bit_Definition LAN8742 IMR ISFR Bit Definition
+  * @{
+  */
+#define LAN8742_INT_8       ((uint16_t)0x0100U)
+#define LAN8742_INT_7       ((uint16_t)0x0080U)
+#define LAN8742_INT_6       ((uint16_t)0x0040U)
+#define LAN8742_INT_5       ((uint16_t)0x0020U)
+#define LAN8742_INT_4       ((uint16_t)0x0010U)
+#define LAN8742_INT_3       ((uint16_t)0x0008U)
+#define LAN8742_INT_2       ((uint16_t)0x0004U)
+#define LAN8742_INT_1       ((uint16_t)0x0002U)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_PHYSCSR_Bit_Definition LAN8742 PHYSCSR Bit Definition
+  * @{
+  */
+#define LAN8742_PHYSCSR_AUTONEGO_DONE   ((uint16_t)0x1000U)
+#define LAN8742_PHYSCSR_HCDSPEEDMASK    ((uint16_t)0x001CU)
+#define LAN8742_PHYSCSR_10BT_HD         ((uint16_t)0x0004U)
+#define LAN8742_PHYSCSR_10BT_FD         ((uint16_t)0x0014U)
+#define LAN8742_PHYSCSR_100BTX_HD       ((uint16_t)0x0008U)
+#define LAN8742_PHYSCSR_100BTX_FD       ((uint16_t)0x0018U) 
+/**
+  * @}
+  */
+    
+/** @defgroup LAN8742_Status LAN8742 Status
+  * @{
+  */    
+
+#define  LAN8742_STATUS_READ_ERROR            ((int32_t)-5)
+#define  LAN8742_STATUS_WRITE_ERROR           ((int32_t)-4)
+#define  LAN8742_STATUS_ADDRESS_ERROR         ((int32_t)-3)
+#define  LAN8742_STATUS_RESET_TIMEOUT         ((int32_t)-2)
+#define  LAN8742_STATUS_ERROR                 ((int32_t)-1)
+#define  LAN8742_STATUS_OK                    ((int32_t) 0)
+#define  LAN8742_STATUS_LINK_DOWN             ((int32_t) 1)
+#define  LAN8742_STATUS_100MBITS_FULLDUPLEX   ((int32_t) 2)
+#define  LAN8742_STATUS_100MBITS_HALFDUPLEX   ((int32_t) 3)
+#define  LAN8742_STATUS_10MBITS_FULLDUPLEX    ((int32_t) 4)
+#define  LAN8742_STATUS_10MBITS_HALFDUPLEX    ((int32_t) 5)
+#define  LAN8742_STATUS_AUTONEGO_NOTDONE      ((int32_t) 6)
+/**
+  * @}
+  */
+
+/** @defgroup LAN8742_IT_Flags LAN8742 IT Flags
+  * @{
+  */     
+#define  LAN8742_WOL_IT                        LAN8742_INT_8
+#define  LAN8742_ENERGYON_IT                   LAN8742_INT_7
+#define  LAN8742_AUTONEGO_COMPLETE_IT          LAN8742_INT_6
+#define  LAN8742_REMOTE_FAULT_IT               LAN8742_INT_5
+#define  LAN8742_LINK_DOWN_IT                  LAN8742_INT_4
+#define  LAN8742_AUTONEGO_LP_ACK_IT            LAN8742_INT_3
+#define  LAN8742_PARALLEL_DETECTION_FAULT_IT   LAN8742_INT_2
+#define  LAN8742_AUTONEGO_PAGE_RECEIVED_IT     LAN8742_INT_1
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported types ------------------------------------------------------------*/ 
+/** @defgroup LAN8742_Exported_Types LAN8742 Exported Types
+  * @{
+  */
+typedef int32_t  (*lan8742_Init_Func) (void); 
+typedef int32_t  (*lan8742_DeInit_Func) (void);
+typedef int32_t  (*lan8742_ReadReg_Func)   (uint32_t, uint32_t, uint32_t *);
+typedef int32_t  (*lan8742_WriteReg_Func)  (uint32_t, uint32_t, uint32_t);
+typedef int32_t  (*lan8742_GetTick_Func)  (void);
+
+typedef struct 
+{                   
+  lan8742_Init_Func      Init; 
+  lan8742_DeInit_Func    DeInit;
+  lan8742_WriteReg_Func  WriteReg;
+  lan8742_ReadReg_Func   ReadReg; 
+  lan8742_GetTick_Func   GetTick;   
+} lan8742_IOCtx_t;  
+
+  
+typedef struct 
+{
+  uint32_t            DevAddr;
+  uint32_t            Is_Initialized;
+  lan8742_IOCtx_t     IO;
+  void               *pData;
+}lan8742_Object_t;
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup LAN8742_Exported_Functions LAN8742 Exported Functions
+  * @{
+  */
+int32_t LAN8742_RegisterBusIO(lan8742_Object_t *pObj, lan8742_IOCtx_t *ioctx);
+int32_t LAN8742_Init(lan8742_Object_t *pObj);
+int32_t LAN8742_DeInit(lan8742_Object_t *pObj);
+int32_t LAN8742_DisablePowerDownMode(lan8742_Object_t *pObj);
+int32_t LAN8742_EnablePowerDownMode(lan8742_Object_t *pObj);
+int32_t LAN8742_StartAutoNego(lan8742_Object_t *pObj);
+int32_t LAN8742_GetLinkState(lan8742_Object_t *pObj);
+int32_t LAN8742_SetLinkState(lan8742_Object_t *pObj, uint32_t LinkState);
+int32_t LAN8742_EnableLoopbackMode(lan8742_Object_t *pObj);
+int32_t LAN8742_DisableLoopbackMode(lan8742_Object_t *pObj);
+int32_t LAN8742_EnableIT(lan8742_Object_t *pObj, uint32_t Interrupt);
+int32_t LAN8742_DisableIT(lan8742_Object_t *pObj, uint32_t Interrupt);
+int32_t LAN8742_ClearIT(lan8742_Object_t *pObj, uint32_t Interrupt);
+int32_t LAN8742_GetITStatus(lan8742_Object_t *pObj, uint32_t Interrupt);
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __LAN8742_H */
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */       
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/stm32h7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/stm32h7_eth_init.c
@@ -1,0 +1,162 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef USE_USER_DEFINED_HAL_ETH_MSPINIT
+
+#include "stm32h7xx_hal.h"
+
+#define MCO_Pin GPIO_PIN_0
+#define MCO_GPIO_Port GPIOH
+#define RMII_MDC_Pin GPIO_PIN_1
+#define RMII_MDC_GPIO_Port GPIOC
+#define RMII_REF_CLK_Pin GPIO_PIN_1
+#define RMII_REF_CLK_GPIO_Port GPIOA
+#define RMII_MDIO_Pin GPIO_PIN_2
+#define RMII_MDIO_GPIO_Port GPIOA
+#define RMII_CRS_DV_Pin GPIO_PIN_7
+#define RMII_CRS_DV_GPIO_Port GPIOA
+#define RMII_RXD0_Pin GPIO_PIN_4
+#define RMII_RXD0_GPIO_Port GPIOC
+#define RMII_RXD1_Pin GPIO_PIN_5
+#define RMII_RXD1_GPIO_Port GPIOC
+#define RMII_TXD1_Pin GPIO_PIN_13
+#define RMII_TXD1_GPIO_Port GPIOB
+#define TMS_Pin GPIO_PIN_13
+#define TMS_GPIO_Port GPIOA
+#define TCK_Pin GPIO_PIN_14
+#define TCK_GPIO_Port GPIOA
+#define RMII_TX_EN_Pin GPIO_PIN_11
+#define RMII_TX_EN_GPIO_Port GPIOG
+#define RMII_TXD0_Pin GPIO_PIN_13
+#define RMII_TXD0_GPIO_Port GPIOG
+
+/**
+ * Override HAL Eth Init function
+ */
+void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
+{
+    GPIO_InitTypeDef GPIO_InitStruct;
+    if(heth->Instance == ETH)
+    {
+        /* Disable DCache for STM32H7 family */
+        SCB_DisableDCache();
+
+        /* GPIO Ports Clock Enable */
+        __HAL_RCC_GPIOH_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOG_CLK_ENABLE();
+
+        /* Enable Peripheral clock */
+        __HAL_RCC_ETH1MAC_CLK_ENABLE();
+        __HAL_RCC_ETH1TX_CLK_ENABLE();
+        __HAL_RCC_ETH1RX_CLK_ENABLE();
+
+        /**ETH GPIO Configuration
+            PC1     ------> ETH_MDC
+            PA1     ------> ETH_REF_CLK
+            PA2     ------> ETH_MDIO
+            PA7     ------> ETH_CRS_DV
+            PC4     ------> ETH_RXD0
+            PC5     ------> ETH_RXD1
+            PB13     ------> ETH_TXD1
+            PG11     ------> ETH_TX_EN
+            PG13     ------> ETH_TXD0
+        */
+        GPIO_InitStruct.Pin = RMII_MDC_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+        HAL_GPIO_Init(RMII_MDC_GPIO_Port, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = RMII_REF_CLK_Pin|RMII_MDIO_Pin|RMII_CRS_DV_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = RMII_RXD0_Pin|RMII_RXD1_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = RMII_TXD1_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+        HAL_GPIO_Init(RMII_TXD1_GPIO_Port, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = RMII_TX_EN_Pin|RMII_TXD0_Pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+        HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
+    }
+}
+
+/**
+ * Override HAL Eth DeInit function
+ */
+void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
+{
+    if(heth->Instance == ETH)
+    {
+        /* Disable Peripheral clock */
+        __HAL_RCC_ETH1MAC_CLK_DISABLE();
+        __HAL_RCC_ETH1TX_CLK_DISABLE();
+        __HAL_RCC_ETH1RX_CLK_DISABLE();
+
+        /**ETH GPIO Configuration
+            PC1     ------> ETH_MDC
+            PA1     ------> ETH_REF_CLK
+            PA2     ------> ETH_MDIO
+            PA7     ------> ETH_CRS_DV
+            PC4     ------> ETH_RXD0
+            PC5     ------> ETH_RXD1
+            PB13     ------> ETH_TXD1
+            PG11     ------> ETH_TX_EN
+            PG13     ------> ETH_TXD0
+        */
+        HAL_GPIO_DeInit(GPIOC, RMII_MDC_Pin|RMII_RXD0_Pin|RMII_RXD1_Pin);
+
+        HAL_GPIO_DeInit(GPIOA, RMII_REF_CLK_Pin|RMII_MDIO_Pin|RMII_CRS_DV_Pin);
+
+        HAL_GPIO_DeInit(RMII_TXD1_GPIO_Port, RMII_TXD1_Pin);
+
+        HAL_GPIO_DeInit(GPIOG, RMII_TX_EN_Pin|RMII_TXD0_Pin);
+    }
+}
+
+#endif /* USE_USER_DEFINED_HAL_ETH_MSPINIT */

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/stm32xx_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/TARGET_STM32H7/stm32xx_emac_config.h
@@ -17,6 +17,8 @@
 #ifndef STM32XX_EMAC_CONFIG_H__
 #define STM32XX_EMAC_CONFIG_H__
 
+#define ETH_IP_VERSION_V2
+
 #define THREAD_STACKSIZE              512
 
 #endif // #define STM32XX_EMAC_CONFIG_H__

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.h
@@ -167,6 +167,7 @@ private:
     osThreadId_t rmii_watchdog_thread; /**< Watchdog processing thread */
 #endif
     rtos::Mutex TXLockMutex;/**< TX critical section mutex */
+    rtos::Mutex RXLockMutex;/**< RX critical section mutex */
     emac_link_input_cb_t emac_link_input_cb; /**< Callback for incoming data */
     emac_link_state_change_cb_t emac_link_state_cb; /**< Link state change callback */
     EMACMemoryManager *memory_manager; /**< Memory manager */

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_ARM_STD/stm32h743xI.sct
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_ARM_STD/stm32h743xI.sct
@@ -28,9 +28,6 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F767ZI: 2048KB FLASH (0x200000) + 128KB DTCM RAM (0x20000)
-; 166 vectors = 664 bytes (0x298) to be reserved in RAM
-
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0x08000000
 #endif
@@ -45,8 +42,8 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-#define MBED_RAM_START              0x20000000
-#define MBED_RAM_SIZE               0x20000
+#define MBED_RAM_START              0x24000000
+#define MBED_RAM_SIZE               0x80000
 #define MBED_VECTTABLE_RAM_START    (MBED_RAM_START)
 #define MBED_VECTTABLE_RAM_SIZE     0x298
 #define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
@@ -61,7 +58,7 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  
+
   RW_m_crash_data MBED_CRASH_REPORT_RAM_START EMPTY MBED_CRASH_REPORT_RAM_SIZE { ; RW data
   }
 
@@ -71,4 +68,18 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
   ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
+
+  RW_DMARxDscrTab 0x30040000 0x60 {
+    *(.RxDecripSection)
+  }
+  RW_DMATxDscrTab 0x30040100 0x140 {
+    *(.TxDecripSection)
+  }
+  RW_Rx_Buffb 0x30040400 0x1800 {
+    *(.RxArraySection)
+  }
+  RW_Eth_Ram 0x30044000 0x4000 {
+    *(.ethusbram)
+  }
+
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_GCC_ARM/STM32H743xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_GCC_ARM/STM32H743xI.ld
@@ -18,8 +18,12 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x20000298, LENGTH = 128K - 0x298
+  FLASH (rx)     : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
+  DTCMRAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 128K
+  RAM (xrw)      : ORIGIN = 0x24000298, LENGTH = 512K - 0x298  /* end = 0x24080000 */
+  RAM_D2 (xrw)   : ORIGIN = 0x30000000, LENGTH = 288K
+  RAM_D3 (xrw)   : ORIGIN = 0x38000000, LENGTH = 64K
+  ITCMRAM (xrw)  : ORIGIN = 0x00000000, LENGTH = 64K
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -180,4 +184,19 @@ SECTIONS
 
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+    .lwip_sec (NOLOAD) : {
+        . = ABSOLUTE(0x30040000);
+        *(.RxDecripSection) 
+        
+        . = ABSOLUTE(0x30040100);
+        *(.TxDecripSection)
+        
+        . = ABSOLUTE(0x30040400);
+        *(.RxArraySection) 
+
+        . = ABSOLUTE(0x30044000);
+        *(.ethusbram) 
+
+    } >RAM_D2 AT> FLASH
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_IAR/stm32h743xI.icf
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_IAR/stm32h743xI.icf
@@ -7,21 +7,25 @@ define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
-// 128KB DTCM RAM (0x20000)
+// 512KB RAM (0x80000)
 // Vector table dynamic copy: 166 vectors = 664 bytes (0x298) reserved
 // Crash data area: 256 bytes (0x100) reserved
-define symbol __NVIC_start__                  = 0x20000000;
-define symbol __NVIC_end__                    = 0x20000297;
-define symbol __region_CRASH_DATA_RAM_start__ = 0x20000298; // Aligned on 8 bytes
-define symbol __region_CRASH_DATA_RAM_end__   = 0x20000397;
-define symbol __region_RAM_start__            = 0x20000398; // Aligned on 8 bytes
-define symbol __region_RAM_end__              = 0x20000000 + 0x20000 - 1;
+define symbol __NVIC_start__                  = 0x24000000;
+define symbol __NVIC_end__                    = 0x24000297;
+define symbol __region_CRASH_DATA_RAM_start__ = 0x24000298; // Aligned on 8 bytes
+define symbol __region_CRASH_DATA_RAM_end__   = 0x24000397;
+define symbol __region_RAM_start__            = 0x24000398; // Aligned on 8 bytes
+define symbol __region_RAM_end__              = 0x24000000 + 0x80000 - 1;
 
 // Memory regions
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
+
+// Memory region used for ethernet
+define region eth_mem_region = mem:[from 0x30044000 to 0x30048000 ];
+place in eth_mem_region	{ section .ethusbram };
 
 // Crash data symbols
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;

--- a/targets/TARGET_STM/TARGET_STM32H7/device/stm32h7xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/device/stm32h7xx_hal_conf.h
@@ -208,7 +208,7 @@
 #define  USE_HAL_WWDG_REGISTER_CALLBACKS    0U /* WWDG register callback disabled    */
 
 /* ########################### Ethernet Configuration ######################### */
-#define ETH_TX_DESC_CNT         4  /* number of Ethernet Tx DMA descriptors */
+#define ETH_TX_DESC_CNT         10  /* number of Ethernet Tx DMA descriptors */
 #define ETH_RX_DESC_CNT         4  /* number of Ethernet Rx DMA descriptors */
 
 #define ETH_MAC_ADDR0    ((uint8_t)0x02)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3222,8 +3222,7 @@
         "macros_add": [
             "STM32H743xx",
             "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS",
-            "ETH_IP_VERSION_V2"
+            "MBED_TICKLESS"
         ],
         "overrides": {
             "lpticker_delay_ticks": 0,

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3195,7 +3195,8 @@
         "core": "Cortex-M7FD",
         "extra_labels_add": [
             "STM32H7",
-            "STM32H743xI"
+            "STM32H743xI",
+            "STM_EMAC"
         ],
         "config": {
             "d11_configuration": {
@@ -3221,9 +3222,13 @@
         "macros_add": [
             "STM32H743xx",
             "EXTRA_IDLE_STACK_REQUIRED",
-            "MBED_TICKLESS"
+            "MBED_TICKLESS",
+            "ETH_IP_VERSION_V2"
         ],
-        "overrides": { "lpticker_delay_ticks": 0 },
+        "overrides": {
+            "lpticker_delay_ticks": 0,
+            "network-default-interface-type": "ETHERNET"
+        },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0813"],
         "device_has_add": [
@@ -3232,7 +3237,8 @@
             "CRC",
             "TRNG",
             "FLASH",
-            "MPU"
+            "MPU",
+            "EMAC"
         ],
         "release_versions": ["2", "5"],
         "device_name": "STM32H743ZI",
@@ -4029,7 +4035,7 @@
             "MBED_TICKLESS",
             "EXTRA_IDLE_STACK_REQUIRED"
         ],
-            "overrides": {
+        "overrides": {
             "lse_available": 0,
             "lpticker_delay_ticks": 0
         },


### PR DESCRIPTION
### Description

This pull request adds ethernet support on STM32 H7 platform.
It is based on the STM32 emac driver. As the H7 HAL is slightly different, I have added ETH_IP_VERSION_V2 switch. This has to be included in targets.json.

Work is based on @CurryGuy job and STM32 cube examples.

Tests done with this command (on IAR, ARM and GCC_ARM toolchains) :
    mbed test -t IAR -m NUCLEO_H743ZI -v -n tests*netsocket*


### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant @LMESTM 

