### PR TITLE
Enable building feature storage with a bare metal profile

### DIFF
--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -774,6 +774,8 @@ int _storage_config_TDB_EXTERNAL()
     return MBED_ERROR_UNSUPPORTED;
 #endif
 
+#ifdef MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS
+
     bd_size_t internal_rbp_size = MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
     bd_addr_t internal_start_address = MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
 
@@ -842,6 +844,9 @@ int _storage_config_TDB_EXTERNAL()
     kvstore_config.flags_mask = ~(0);
 
     return _storage_config_tdb_external_common();
+#else
+    return MBED_ERROR_CONFIG_UNSUPPORTED;
+#endif
 }
 
 int _storage_config_TDB_EXTERNAL_NO_RBP()
@@ -849,6 +854,8 @@ int _storage_config_TDB_EXTERNAL_NO_RBP()
 #if !SECURESTORE_ENABLED
     return MBED_ERROR_UNSUPPORTED;
 #endif
+
+#ifdef MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS
     bd_size_t size = MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_SIZE;
     bd_addr_t address = MBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS;
 
@@ -879,6 +886,9 @@ int _storage_config_TDB_EXTERNAL_NO_RBP()
     kvstore_config.flags_mask = ~(KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
 
     return _storage_config_tdb_external_common();
+#else
+    return MBED_ERROR_CONFIG_UNSUPPORTED;
+#endif
 }
 
 int _storage_config_tdb_external_common()
@@ -938,6 +948,7 @@ int _storage_config_FILESYSTEM()
     return MBED_ERROR_UNSUPPORTED;
 #endif
 
+#ifdef MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS
     filesystemstore_folder_path = STR(MBED_CONF_STORAGE_FILESYSTEM_FOLDER_PATH);
 
     bd_size_t internal_rbp_size = MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
@@ -1017,6 +1028,9 @@ int _storage_config_FILESYSTEM()
     kvstore_config.flags_mask = ~(0);
 
     return _storage_config_filesystem_common();
+#else
+    return MBED_ERROR_CONFIG_UNSUPPORTED;
+#endif
 }
 
 int _storage_config_FILESYSTEM_NO_RBP()
@@ -1025,6 +1039,7 @@ int _storage_config_FILESYSTEM_NO_RBP()
     return MBED_ERROR_UNSUPPORTED;
 #endif
 
+#ifdef MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_BASE_ADDRESS
     filesystemstore_folder_path = STR(MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH);
 
     bd_size_t size = MBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_SIZE;
@@ -1059,6 +1074,9 @@ int _storage_config_FILESYSTEM_NO_RBP()
     kvstore_config.flags_mask = ~(KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
 
     return _storage_config_filesystem_common();
+#else
+    return MBED_ERROR_CONFIG_UNSUPPORTED;
+#endif
 }
 
 int _storage_config_filesystem_common()

--- a/features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.cpp
+++ b/features/storage/kvstore/direct_access_devicekey/DirectAccessDevicekey.cpp
@@ -118,15 +118,33 @@ int  get_expected_internal_TDBStore_position(uint32_t *out_tdb_start_offset, uin
     uint32_t tdb_size;
 
     if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "FILESYSTEM") == 0) {
+#ifndef MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS
+        return MBED_ERROR_ITEM_NOT_FOUND;
+#else
         *out_tdb_start_offset =  MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS;
         tdb_size = MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
+#endif
+
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_EXTERNAL") == 0) {
+#ifndef MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS
+        return MBED_ERROR_ITEM_NOT_FOUND;
+#else
         *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
         tdb_size = MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
+#endif
+
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_INTERNAL") == 0) {
+#ifndef MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS
+        return MBED_ERROR_ITEM_NOT_FOUND;
+#else
         *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
         tdb_size = MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
+#endif
+
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "default") == 0) {
+#ifndef MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS
+        return MBED_ERROR_ITEM_NOT_FOUND;
+#else
 #if COMPONENT_QSPIF || COMPONENT_SPIF || COMPONENT_DATAFLASH
         *out_tdb_start_offset =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
         tdb_size = MBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE;
@@ -134,7 +152,8 @@ int  get_expected_internal_TDBStore_position(uint32_t *out_tdb_start_offset, uin
         tdb_size = MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
 #else
         return MBED_ERROR_UNSUPPORTED;
-#endif
+#endif // COMPONENT_QSPIF || COMPONENT_SPIF || COMPONENT_DATAFLASH
+#endif // MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS
     } else {
         return MBED_ERROR_UNSUPPORTED;
     }

--- a/features/storage/nvstore/mbed_lib.json
+++ b/features/storage/nvstore/mbed_lib.json
@@ -3,7 +3,7 @@
     "config": {
         "enabled": {
             "macro_name": "NVSTORE_ENABLED",
-            "value": true,
+            "value": false,
             "help": "Enabled"
         },
         "max_keys": {

--- a/features/storage/nvstore/mbed_lib.json
+++ b/features/storage/nvstore/mbed_lib.json
@@ -3,7 +3,7 @@
     "config": {
         "enabled": {
             "macro_name": "NVSTORE_ENABLED",
-            "value": false,
+            "value": true,
             "help": "Enabled"
         },
         "max_keys": {


### PR DESCRIPTION
### Description
#### Enables building storage with bare metal profile.
To compile Mbed Bootloader with bare metal profile certain defines are
not added anymore automatically. Because of this checks for those
defines needed to be introduced.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@SeppoTakalo 
@teetak01 
@michalpasztamobica 
@JanneKiiskila 


### Release Notes
