### PR TITLE
Tweak stm_spi_api Coverity warning.

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -494,9 +494,8 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
     int total = (tx_length > rx_length) ? tx_length : rx_length;
-    int i = 0;
     if (handle->Init.Direction == SPI_DIRECTION_2LINES) {
-        for (i = 0; i < total; i++) {
+        for (int i = 0; i < total; i++) {
             char out = (i < tx_length) ? tx_buffer[i] : write_fill;
             char in = spi_master_write(obj, out);
             if (i < rx_length) {
@@ -661,7 +660,7 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
         case SPI_TRANSFER_TYPE_RX:
             // the receive function also "transmits" the receive buffer so in order
             // to guarantee that 0xff is on the line, we explicitly memset it here
-            memset(rx, SPI_FILL_WORD, length);
+            memset(rx, SPI_FILL_CHAR, length);
             rc = HAL_SPI_Receive_IT(handle, (uint8_t *)rx, words);
             break;
         default:


### PR DESCRIPTION
Coverity warining: "memset fill truncated (NO_EFFECT)" on line: https://github.com/ARMmbed/mbed-os/blob/590ce2c958dfcf25759d4eebe2405ce824c2cf2f/targets/TARGET_STM/stm_spi_api.c#L664
Changed SPI_FILL_WORD to SPI_FILL_CHAR.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @maciejbocianski 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
