### PR TITLE
Move imgtool_lib import to init for python3 compatibility

### DIFF
--- a/tools/psa/tfm/bin_utils/__init__.py
+++ b/tools/psa/tfm/bin_utils/__init__.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 from .assemble import Assembly
+from .imgtool_lib import keys
+from .imgtool_lib import image
+from .imgtool_lib import version
 
 __all__ = [
     'Assembly'

--- a/tools/psa/tfm/bin_utils/imgtool.py
+++ b/tools/psa/tfm/bin_utils/imgtool.py
@@ -19,9 +19,6 @@ from __future__ import print_function
 import os
 import re
 import argparse
-from imgtool_lib import keys
-from imgtool_lib import image
-from imgtool_lib import version
 import sys
 
 def find_load_address(args):


### PR DESCRIPTION
### Description

Compiling with python3 for GR_LYCHEE or ARM_MUSCA_A1_NS causes ModuleNotFoundError:

In mbed-os/tools/psa/tfm/bin_utils.imgtool.py, line 22:
`    from imgtool_lib import keys`
`ModuleNotFoundError: No module named 'imgtool_lib'`

Moving the import to `__init__.py` allows imgtool to still be used directly or as a module, and allows the build to proceed.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@OPpuolitaival 
@jonikula 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
