### PR TITLE
K22F: Add FlashIAP for storage

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1208,6 +1208,7 @@
     "MCU_K22F512": {
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "components_add": ["FLASHIAP"],
         "extra_labels": [
             "Freescale",
             "MCUXpresso_MCUS",
@@ -8574,7 +8575,7 @@
         "bootloader_supported": true,
         "mbed_rom_start": "0x10000000",
         "mbed_rom_size": "0x100000",
-        "sectors": [[268435456, 512]],                            
+        "sectors": [[268435456, 512]],
         "overrides": {
             "network-default-interface-type": "WIFI"
         },
@@ -8589,7 +8590,7 @@
         "bootloader_supported": true,
         "mbed_rom_start": "0x10000000",
         "mbed_rom_size": "0x200000",
-        "sectors": [[268435456, 512]]                    
+        "sectors": [[268435456, 512]]
     },
     "CY8CKIT_062S2_43012": {
         "inherits": ["CY8CMOD_062S2_43012"],


### PR DESCRIPTION
### Description
Enable Flash storage, test results below:

mbedgt: test suite results: 6 OK
mbedgt: test case report:
| target   | platform_name | test suite                                                       | test case                                         | passed | failed | result | elapsed_time (sec) |
|----------|---------------|------------------------------------------------------------------|---------------------------------------------------|--------|--------|--------|--------------------|
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-buffered_block_device | BufferedBlockDevice functionality test            | 1      | 0      | OK     | 0.26               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-flashsim_block_device | FlashSimBlockDevice functionality test            | 1      | 0      | OK     | 0.06               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | DEFAULT Testing get type functionality            | 1      | 0      | OK     | 0.1                |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing BlockDevice erase functionality  | 1      | 0      | OK     | 0.44               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing Deinit block device              | 1      | 0      | OK     | 0.1                |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing Init block device                | 1      | 0      | OK     | 0.1                |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing contiguous erase, write and read | 1      | 0      | OK     | 0.63               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing multi threads erase program read | 1      | 0      | OK     | 3.75               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing program read small data sizes    | 1      | 0      | OK     | 0.18               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing read write random blocks         | 1      | 0      | OK     | 0.93               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-general_block_device  | FLASHIAP Testing unaligned erase blocks           | 1      | 0      | OK     | 0.13               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-heap_block_device     | Testing get type functionality                    | 1      | 0      | OK     | 0.06               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-heap_block_device     | Testing read write random blocks                  | 1      | 0      | OK     | 1.94               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-mbr_block_device      | Testing formatting of master boot record          | 1      | 0      | OK     | 0.07               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-mbr_block_device      | Testing mbr attributes                            | 1      | 0      | OK     | 0.62               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-mbr_block_device      | Testing mbr read write                            | 1      | 0      | OK     | 0.06               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-util_block_device     | Testing chaining of block devices                 | 1      | 0      | OK     | 0.06               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-util_block_device     | Testing profiling of block devices                | 1      | 0      | OK     | 0.06               |
| K22F-IAR | K22F          | mbed-os-features-storage-tests-blockdevice-util_block_device     | Testing slicing of a block device                 | 1      | 0      | OK     | 0.08               |
mbedgt: test case results: 19 OK


### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

