### PR TITLE
K22: Add USBDEVICE support

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1242,6 +1242,7 @@
             "SPISLAVE",
             "STDIO_MESSAGES",
             "TRNG",
+            "USBDEVICE",
             "FLASH"
         ],
         "device_name": "MK22DN512xxx5"
@@ -8574,7 +8575,7 @@
         "bootloader_supported": true,
         "mbed_rom_start": "0x10000000",
         "mbed_rom_size": "0x100000",
-        "sectors": [[268435456, 512]],                            
+        "sectors": [[268435456, 512]],
         "overrides": {
             "network-default-interface-type": "WIFI"
         },
@@ -8589,7 +8590,7 @@
         "bootloader_supported": true,
         "mbed_rom_start": "0x10000000",
         "mbed_rom_size": "0x200000",
-        "sectors": [[268435456, 512]]                    
+        "sectors": [[268435456, 512]]
     },
     "CY8CKIT_062S2_43012": {
         "inherits": ["CY8CMOD_062S2_43012"],


### PR DESCRIPTION
### Description
Add USBDevice support. Below is the test result:
| target   | platform_name | test suite                     | result | elapsed_time (sec) | copy_method |
|----------|---------------|--------------------------------|--------|--------------------|-------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | OK     | 58.72              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target   | platform_name | test suite                     | test case                                  | passed | failed | result | elapsed_time (sec) |
|----------|---------------|--------------------------------|--------------------------------------------|--------|--------|--------|--------------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | endpoint test abort                        | 1      | 0      | OK     | 16.43              |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | endpoint test data correctness             | 1      | 0      | OK     | 0.67               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | endpoint test data toggle reset            | 1      | 0      | OK     | 0.45               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | endpoint test halt                         | 1      | 0      | OK     | 8.94               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | endpoint test parallel transfers           | 1      | 0      | OK     | 4.42               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | endpoint test parallel transfers ctrl      | 1      | 0      | OK     | 4.76               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb control basic test                     | 1      | 0      | OK     | 0.51               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb control sizes test                     | 1      | 0      | OK     | 0.42               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb control stall test                     | 1      | 0      | OK     | 0.34               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb control stress test                    | 1      | 0      | OK     | 0.49               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb device reset test                      | 1      | 0      | OK     | 1.32               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb repeated construction destruction test | 1      | 0      | OK     | 1.71               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-basic | usb soft reconnection test                 | 1      | 0      | OK     | 1.62               |
mbedgt: test case results: 13 OK

| target   | platform_name | test suite                   | result | elapsed_time (sec) | copy_method |
|----------|---------------|------------------------------|--------|--------------------|-------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | OK     | 23.3               | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target   | platform_name | test suite                   | test case                          | passed | failed | result | elapsed_time (sec) |
|----------|---------------|------------------------------|------------------------------------|--------|--------|--------|--------------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | Configuration descriptor, generic  | 1      | 0      | OK     | 0.81               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | Configuration descriptor, keyboard | 1      | 0      | OK     | 0.34               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | Configuration descriptor, mouse    | 1      | 0      | OK     | 0.32               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | HID class descriptors, generic     | 1      | 0      | OK     | 0.31               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | HID class descriptors, keyboard    | 1      | 0      | OK     | 0.34               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | HID class descriptors, mouse       | 1      | 0      | OK     | 0.32               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | Raw input/output, 1-byte reports   | 1      | 0      | OK     | 0.64               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | Raw input/output, 20-byte reports  | 1      | 0      | OK     | 0.42               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-hid | Raw input/output, 64-byte reports  | 1      | 0      | OK     | 0.4                |
mbedgt: test case results: 9 OK

| target   | platform_name | test suite                      | result | elapsed_time (sec) | copy_method |
|----------|---------------|---------------------------------|--------|--------------------|-------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | OK     | 31.57              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target   | platform_name | test suite                      | test case                        | passed | failed | result | elapsed_time (sec) |
|----------|---------------|---------------------------------|----------------------------------|--------|--------|--------|--------------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | CDC RX multiple bytes            | 1      | 0      | OK     | 3.4                |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | CDC RX multiple bytes concurrent | 1      | 0      | OK     | 4.38               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | CDC RX single bytes              | 1      | 0      | OK     | 0.39               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | CDC RX single bytes concurrent   | 1      | 0      | OK     | 0.39               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | CDC USB reconnect                | 1      | 0      | OK     | 0.96               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | CDC loopback                     | 1      | 0      | OK     | 1.12               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | Serial USB reconnect             | 1      | 0      | OK     | 0.92               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | Serial getc                      | 1      | 0      | OK     | 0.38               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | Serial line coding change        | 1      | 0      | OK     | 0.88               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | Serial printf/scanf              | 1      | 0      | OK     | 1.37               |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-serial | Serial terminal reopen           | 1      | 0      | OK     | 0.59               |
mbedgt: test case results: 11 OK


The USB MSD tests uses RAM space to mount a filesystem. K22F does not have enough RAM space to run this test, below are test results when the test was modified to use FlashIAP
| target   | platform_name | test suite                   | result | elapsed_time (sec) | copy_method |
|----------|---------------|------------------------------|--------|--------------------|-------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-msd | OK     | 88.06              | default     |
mbedgt: test suite results: 1 OK
mbedgt: test case report:
| target   | platform_name | test suite                   | test case                                       | passed | failed | result | elapsed_time (sec) |
|----------|---------------|------------------------------|-------------------------------------------------|--------|--------|--------|--------------------|
| K22F-IAR | K22F          | mbed-os-tests-usb_device-msd | mount/unmount and data test - Heap block device | 1      | 0      | OK     | 20.58              |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-msd | mount/unmount test - Heap block device          | 1      | 0      | OK     | 51.01              |
| K22F-IAR | K22F          | mbed-os-tests-usb_device-msd | storage initialization                          | 1      | 0      | OK     | 0.74               |
mbedgt: test case results: 3 OK

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
