### PR TITLE
K82F: Add USBDEVICE support

### DIFF
--- a/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
+++ b/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
@@ -17,7 +17,7 @@
 #if defined(DEVICE_USBDEVICE) && DEVICE_USBDEVICE && \
     (defined(TARGET_KL25Z) | defined(TARGET_KL43Z) | \
      defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | \
-     defined(TARGET_K64F) | defined(TARGET_K22F) | \
+     defined(TARGET_K64F) | defined(TARGET_K22F) | defined(TARGET_K82F) | \
      defined(TARGET_TEENSY3_1))
 
 #if defined(TARGET_KSDK2_MCUS)
@@ -134,7 +134,7 @@ void USBPhyHw::init(USBPhyEvents *events)
     SYSMPU->CESR = 0;
 #endif
 
-#if defined(TARGET_KL43Z) || defined(TARGET_K22F) || defined(TARGET_K64F)
+#if defined(TARGET_KL43Z) || defined(TARGET_K22F) || defined(TARGET_K64F) || defined(TARGET_K82F)
     // enable USBFS clock
     CLOCK_EnableUsbfs0Clock(kCLOCK_UsbSrcIrc48M, 48000000U);
 #else

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1854,6 +1854,7 @@
             "STDIO_MESSAGES",
             "TRNG",
             "FLASH",
+            "USBDEVICE",
             "QSPI"
         ],
         "release_versions": ["2", "5"],


### PR DESCRIPTION
### Description
Add USBDEVICE support for K82F, test results below:

mbedgt: test suite report:
| target       | platform_name | test suite                      | result | elapsed_time (sec) | copy_method |
|--------------|---------------|---------------------------------|--------|--------------------|-------------|
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | OK     | 60.99              | default     |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | OK     | 21.99              | default     |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-msd    | OK     | 88.64              | default     |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | OK     | 33.63              | default     |
mbedgt: test suite results: 4 OK
mbedgt: test case report:
| target       | platform_name | test suite                      | test case                                       | passed | failed | result | elapsed_time (sec) |
|--------------|---------------|---------------------------------|-------------------------------------------------|--------|--------|--------|--------------------|
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | endpoint test abort                             | 1      | 0      | OK     | 16.46              |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | endpoint test data correctness                  | 1      | 0      | OK     | 0.7                |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | endpoint test data toggle reset                 | 1      | 0      | OK     | 0.39               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | endpoint test halt                              | 1      | 0      | OK     | 8.86               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | endpoint test parallel transfers                | 1      | 0      | OK     | 4.42               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | endpoint test parallel transfers ctrl           | 1      | 0      | OK     | 4.76               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb control basic test                          | 1      | 0      | OK     | 0.54               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb control sizes test                          | 1      | 0      | OK     | 0.44               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb control stall test                          | 1      | 0      | OK     | 0.37               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb control stress test                         | 1      | 0      | OK     | 0.46               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb device reset test                           | 1      | 0      | OK     | 1.32               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb repeated construction destruction test      | 1      | 0      | OK     | 1.73               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-basic  | usb soft reconnection test                      | 1      | 0      | OK     | 1.73               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | Configuration descriptor, generic               | 1      | 0      | OK     | 0.56               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | Configuration descriptor, keyboard              | 1      | 0      | OK     | 0.33               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | Configuration descriptor, mouse                 | 1      | 0      | OK     | 0.33               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | HID class descriptors, generic                  | 1      | 0      | OK     | 0.31               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | HID class descriptors, keyboard                 | 1      | 0      | OK     | 0.34               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | HID class descriptors, mouse                    | 1      | 0      | OK     | 0.32               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | Raw input/output, 1-byte reports                | 1      | 0      | OK     | 0.42               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | Raw input/output, 20-byte reports               | 1      | 0      | OK     | 0.4                |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-hid    | Raw input/output, 64-byte reports               | 1      | 0      | OK     | 0.41               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-msd    | mount/unmount and data test - Heap block device | 1      | 0      | OK     | 19.65              |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-msd    | mount/unmount test - Heap block device          | 1      | 0      | OK     | 49.98              |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-msd    | storage initialization                          | 1      | 0      | OK     | 0.05               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | CDC RX multiple bytes                           | 1      | 0      | OK     | 3.49               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | CDC RX multiple bytes concurrent                | 1      | 0      | OK     | 3.36               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | CDC RX single bytes                             | 1      | 0      | OK     | 0.4                |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | CDC RX single bytes concurrent                  | 1      | 0      | OK     | 0.41               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | CDC USB reconnect                               | 1      | 0      | OK     | 0.85               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | CDC loopback                                    | 1      | 0      | OK     | 1.03               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | Serial USB reconnect                            | 1      | 0      | OK     | 1.04               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | Serial getc                                     | 1      | 0      | OK     | 0.39               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | Serial line coding change                       | 1      | 0      | OK     | 0.87               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | Serial printf/scanf                             | 1      | 0      | OK     | 1.64               |
| K82F-GCC_ARM | K82F          | mbed-os-tests-usb_device-serial | Serial terminal reopen                          | 1      | 0      | OK     | 0.59               |


### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
