### PR TITLE
KL43Z: Enable FALSHIAP storage

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1290,6 +1290,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM"],
         "macros": ["CPU_MKL43Z256VLH4", "FSL_RTOS_MBED"],
+        "components_add": ["FLASHIAP"],
         "is_disk_virtual": true,
         "inherits": ["Target"],
         "detect_code": ["0262"],


### PR DESCRIPTION
### Description
Test results:
mbedgt: test suite report:
| target        | platform_name | test suite                                                          | result | elapsed_time (sec) | copy_method |
|---------------|---------------|---------------------------------------------------------------------|--------|--------------------|-------------|
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-nvstore-tests-nvstore-functionality        | OK     | 26.0               | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-buffered_block_device    | OK     | 16.58              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-flashsim_block_device    | OK     | 16.75              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | OK     | 24.57              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-heap_block_device        | OK     | 18.14              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-mbr_block_device         | OK     | 18.61              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-util_block_device        | OK     | 16.68              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-direct_access_devicekey_test | OK     | 21.38              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | OK     | 31.28              | default     |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-tdbstore_whitebox            | OK     | 16.48              | default     |
mbedgt: test suite results: 10 OK
mbedgt: test case report:
| target        | platform_name | test suite                                                          | test case                                                           | passed | failed | result | elapsed_t
|---------------|---------------|---------------------------------------------------------------------|---------------------------------------------------------------------|--------|--------|--------|----------
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-nvstore-tests-nvstore-functionality        | NVStore: Basic functionality                                        | 1      | 0      | OK     | 0.3
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-nvstore-tests-nvstore-functionality        | NVStore: Multiple thread test                                       | 1      | 0      | OK     | 7.78
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-nvstore-tests-nvstore-functionality        | NVStore: Race test                                                  | 1      | 0      | OK     | 0.24
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-buffered_block_device    | BufferedBlockDevice functionality test                              | 1      | 0      | OK     | 0.48
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-flashsim_block_device    | FlashSimBlockDevice functionality test                              | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | DEFAULT Testing get type functionality                              | 1      | 0      | OK     | 0.11
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing BlockDevice erase functionality                    | 1      | 0      | OK     | 0.4
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Deinit block device                                | 1      | 0      | OK     | 0.1
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Init block device                                  | 1      | 0      | OK     | 0.1
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing contiguous erase, write and read                   | 1      | 0      | OK     | 0.51
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing multi threads erase program read                   | 1      | 0      | OK     | 1.76
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing program read small data sizes                      | 1      | 0      | OK     | 0.17
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing read write random blocks                           | 1      | 0      | OK     | 0.61
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing unaligned erase blocks                             | 1      | 0      | OK     | 0.12
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-heap_block_device        | Testing get type functionality                                      | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-heap_block_device        | Testing read write random blocks                                    | 1      | 0      | OK     | 1.95
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-mbr_block_device         | Testing formatting of master boot record                            | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-mbr_block_device         | Testing mbr attributes                                              | 1      | 0      | OK     | 0.59
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-mbr_block_device         | Testing mbr read write                                              | 1      | 0      | OK     | 0.09
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-util_block_device        | Testing chaining of block devices                                   | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-util_block_device        | Testing profiling of block devices                                  | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-blockdevice-util_block_device        | Testing slicing of a block device                                   | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over flashiap remainder | 1      | 0      | OK     | 0.18
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over last two sectors   | 1      | 0      | OK     | 0.17
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to injected devicekey                         | 1      | 0      | OK     | 0.09
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_buffer_null_size_not_zero                                       | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_buffer_size_bigger_than_data_real_size                          | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_buffer_size_is_zero                                             | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_buffer_size_smaller_than_data_real_size                         | 1      | 0      | OK     | 0.1
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_existed_key                                                | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_info_null                                                  | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_key_length_exceeds_max                                     | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_key_null                                                   | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_non_existing_key                                           | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_overwritten_key                                            | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_info_removed_key                                                | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_key_length_exceeds_max                                          | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_key_null                                                        | 1      | 0      | OK     | 0.04
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_key_that_was_set_twice                                          | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_non_existing_key                                                | 1      | 0      | OK     | 0.05
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_removed_key                                                     | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | get_several_keys_multithreaded                                      | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_close_right_after_iterator_open                            | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list                                            | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list_keys_removed                               | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list_non_matching_prefix                        | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_full_list                                             | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_key_size_zero                                         | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_one_key_list                                          | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_path_check                                            | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_remove_while_iterating                                | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_next_several_overwritten_keys                              | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | iterator_open_it_null                                               | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | kvstore_init                                                        | 1      | 0      | OK     | 0.09
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | remove_existed_key                                                  | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | remove_key_length_exceeds_max                                       | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | remove_key_null                                                     | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | remove_non_existing_key                                             | 1      | 0      | OK     | 0.05
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | remove_removed_key                                                  | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_buffer_null_size_not_zero                                       | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_buffer_size_is_zero                                             | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_length_exceeds_max                                          | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_null                                                        | 1      | 0      | OK     | 0.05
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_value_fifteen_byte_size                                     | 1      | 0      | OK     | 0.09
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_value_five_byte_size                                        | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_value_one_byte_size                                         | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_value_seventeen_byte_size                                   | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_key_value_two_byte_size                                         | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_same_key_several_time                                           | 1      | 0      | OK     | 0.07
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_several_key_value_sizes                                         | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_several_keys_multithreaded                                      | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_several_unvalid_key_names                                       | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_write_once_flag_try_remove                                      | 1      | 0      | OK     | 0.08
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-static_tests                 | set_write_once_flag_try_set_twice                                   | 1      | 0      | OK     | 0.06
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: Error inject test                                         | 1      | 0      | OK     | 0.12
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: Multiple set test                                         | 1      | 0      | OK     | 0.12
| KL43Z-GCC_ARM | KL43Z         | mbed-os-features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: White box test                                            | 1      | 0      | OK     | 0.11
mbedgt: test case results: 77 OK

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
