### PR TITLE
Fix missing offset in TBStore read from flash

### DIFF
--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -1418,7 +1418,7 @@ int TDBStore::do_reserved_data_get(void *reserved_data, size_t reserved_data_buf
 
     while (actual_size) {
         uint32_t chunk = std::min(work_buf_size, (uint32_t) actual_size);
-        ret = read_area(_active_area, offset, chunk, buf);
+        ret = read_area(_active_area, offset, chunk, buf + offset);
         if (ret) {
             return ret;
         }


### PR DESCRIPTION
### Description

When reading data from flash in more than one chunk, the current code reads every chunk to the same location in the output buffer. This change offset the read destination into the buffer by the current chunk's offset (similar to what is done for the CRC computation).

Submitting the pull request now to obtain feedback on the change. Greentea test logs will be attached soon.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
