### PR TITLE
Explicitly set rbp_internal_size for TARGET_PSOC6

### DIFF
--- a/features/storage/kvstore/conf/filesystem/mbed_lib.json
+++ b/features/storage/kvstore/conf/filesystem/mbed_lib.json
@@ -33,6 +33,10 @@
             "help": "Path for the working directory where the FileSystemStore stores the data",
             "value": "kvstore"
         }
+    },
+    "target_overrides": {
+        "MCU_PSOC6": {
+            "rbp_internal_size": 7168
+        }
     }
 }
-

--- a/features/storage/kvstore/conf/tdb_external/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_external/mbed_lib.json
@@ -1,5 +1,4 @@
 {
-
     "name": "storage_tdb_external",
     "config": {
         "rbp_internal_size": {
@@ -21,6 +20,11 @@
         "external_base_address": {
             "help": "The default will set start address to address 0",
             "value": "0"
+        }
+    },
+    "target_overrides": {
+        "MCU_PSOC6": {
+            "rbp_internal_size": "7168"
         }
     }
 }


### PR DESCRIPTION
### Description
The default computation assumes that a flash sector is several times larger than a flash page. On PSoC 6 targets this is not the case (the two values are the same) so the computed size is too small.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
