### PR TITLE
M2351: Integrate ESP8266 power on/off logic into ESP8266 driver main…

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -143,7 +143,12 @@ ESP8266Interface::ResetPin::ResetPin(PinName rst_pin) : _rst_pin(mbed::DigitalOu
 void ESP8266Interface::ResetPin::rst_assert()
 {
     if (_rst_pin.is_connected()) {
+#if defined(TARGET_NUMAKER_PFM_M2351_CM)
+        // For M2351, _rst_pin is power control pin. This is to power off the module.
+        _rst_pin = 1;
+#else
         _rst_pin = 0;
+#endif
         tr_debug("HW reset asserted");
     }
 }
@@ -151,8 +156,13 @@ void ESP8266Interface::ResetPin::rst_assert()
 void ESP8266Interface::ResetPin::rst_deassert()
 {
     if (_rst_pin.is_connected()) {
+#if defined(TARGET_NUMAKER_PFM_M2351_CM)
+        // For M2351, _rst_pin is power control pin. This is to power on the module.
+        _rst_pin = 0;
+#else
         // Notice that Pin7 CH_EN cannot be left floating if used as reset
         _rst_pin = 1;
+ #endif
         tr_debug("HW reset deasserted");
     }
 }


### PR DESCRIPTION
### Description

On the **NuMaker-PFM-M2351 board**, the **RST** pin of the on-board ESP8266 module is not connected. Instead, a GPIO `PD_7` is used to power on/off the module. This PR tries to integrate the power on/off logic into ESP8266 driver mainline. It has the following purposes:

1.  Application code can exempt from the power on/off logic and will get clear.
    <pre>
    ESP8266Interface esp(PD_1, PD_0, false, PD_3, PD_2, <b>PD_7</b>);
    </pre>
1.  Support reset in ESP8266 driver

#### Related PR

This PR relies on #11288 for M2351 target renaming.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
