### PR TITLE
Enable json overriding ESP8266 default baud rate

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -33,7 +33,6 @@
 
 #define TRACE_GROUP  "ESPA" // ESP8266 AT layer
 
-#define ESP8266_DEFAULT_BAUD_RATE   115200
 #define ESP8266_ALL_SOCKET_IDS      -1
 
 using namespace mbed;
@@ -43,7 +42,7 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
       _at_v(-1, -1, -1),
       _tcp_passive(false),
       _callback(0),
-      _serial(tx, rx, ESP8266_DEFAULT_BAUD_RATE),
+      _serial(tx, rx, MBED_CONF_ESP8266_SERIAL_BAUDRATE),
       _serial_rts(rts),
       _serial_cts(cts),
       _parser(&_serial),
@@ -62,7 +61,7 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
       _reset_done(false),
       _conn_status(NSAPI_STATUS_DISCONNECTED)
 {
-    _serial.set_baud(ESP8266_DEFAULT_BAUD_RATE);
+    _serial.set_baud(MBED_CONF_ESP8266_SERIAL_BAUDRATE);
     _parser.debug_on(debug);
     _parser.set_delimiter("\r\n");
     _parser.oob("+IPD", callback(this, &ESP8266::_oob_packet_hdlr));
@@ -185,7 +184,7 @@ bool ESP8266::stop_uart_hw_flow_ctrl(void)
         _serial.set_flow_control(SerialBase::Disabled, _serial_rts, _serial_cts);
 
         // Stop ESP8266's flow control
-        done = _parser.send("AT+UART_CUR=%u,8,1,0,0", ESP8266_DEFAULT_BAUD_RATE)
+        done = _parser.send("AT+UART_CUR=%u,8,1,0,0", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
                && _parser.recv("OK\n");
     }
 
@@ -201,7 +200,7 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
     _smutex.lock();
     if (_serial_rts != NC && _serial_cts != NC) {
         // Start ESP8266's flow control
-        done = _parser.send("AT+UART_CUR=%u,8,1,0,3", ESP8266_DEFAULT_BAUD_RATE)
+        done = _parser.send("AT+UART_CUR=%u,8,1,0,3", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
                && _parser.recv("OK\n");
 
         if (done) {
@@ -213,12 +212,12 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
         _serial.set_flow_control(SerialBase::RTS, _serial_rts, NC);
 
         // Enable ESP8266's CTS pin
-        done = _parser.send("AT+UART_CUR=%u,8,1,0,2", ESP8266_DEFAULT_BAUD_RATE)
+        done = _parser.send("AT+UART_CUR=%u,8,1,0,2", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
                && _parser.recv("OK\n");
 
     } else if (_serial_cts != NC) {
         // Enable ESP8266's RTS pin
-        done = _parser.send("AT+UART_CUR=%u,8,1,0,1", ESP8266_DEFAULT_BAUD_RATE)
+        done = _parser.send("AT+UART_CUR=%u,8,1,0,1", MBED_CONF_ESP8266_SERIAL_BAUDRATE)
                && _parser.recv("OK\n");
 
         if (done) {

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -17,6 +17,10 @@
             "help": "CTS pin for serial connection, defaults to Not Connected",
             "value": null
         },
+        "serial-baudrate": {
+            "help": "Serial baudrate for ESP8266, defaults to 115200",
+            "value": 115200
+        },
         "rst": {
             "help": "RESET pin for the modem, defaults to Not Connected",
             "value": null


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Got a [question here](https://os.mbed.com/questions/86806/How-to-change-ESP8266-default-WiFi-baud-) about configuring ESP8266_DEFAULT_BAUD_RATE in mbed_app.json, I think a small modification is able to achieve that.



### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
