### PR TITLE
RSSI getter fixed for ESP8266

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -450,9 +450,9 @@ int8_t ESP8266::rssi()
     _smutex.lock();
     set_timeout(ESP8266_CONNECT_TIMEOUT);
     if (!(_parser.send("AT+CWLAP=\"\",\"%s\",", bssid)
-          && _parser.recv("OK\n"))) {
+            && _parser.recv("OK\n"))) {
         rssi = 0;
-    } else if(_scan_r.cnt == 1) {
+    } else if (_scan_r.cnt == 1) {
         //All OK so read and return rssi
         rssi = ap[0].get_rssi();
     }

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -427,7 +427,7 @@ const char *ESP8266::netmask()
 
 int8_t ESP8266::rssi()
 {
-    int8_t rssi;
+    int8_t rssi = 0;
     char bssid[18];
 
     _smutex.lock();
@@ -438,17 +438,27 @@ int8_t ESP8266::rssi()
         _smutex.unlock();
         return 0;
     }
+
     set_timeout();
     _smutex.unlock();
+
+    WiFiAccessPoint ap[1];
+    _scan_r.res = ap;
+    _scan_r.limit = 1;
+    _scan_r.cnt = 0;
 
     _smutex.lock();
     set_timeout(ESP8266_CONNECT_TIMEOUT);
     if (!(_parser.send("AT+CWLAP=\"\",\"%s\",", bssid)
-            && _parser.recv("+CWLAP:(%*d,\"%*[^\"]\",%hhd,", &rssi)
-            && _parser.recv("OK\n"))) {
-        _smutex.unlock();
-        return 0;
+          && _parser.recv("OK\n"))) {
+        rssi = 0;
+    } else if(_scan_r.cnt == 1) {
+        //All OK so read and return rssi
+        rssi = ap[0].get_rssi();
     }
+
+    _scan_r.cnt = 0;
+    _scan_r.res = NULL;
     set_timeout();
     _smutex.unlock();
 
@@ -481,6 +491,7 @@ int ESP8266::scan(WiFiAccessPoint *res, unsigned limit, scan_mode mode, unsigned
             _scan_r.cnt = NSAPI_ERROR_DEVICE_ERROR;
         }
     }
+
 
     int cnt = _scan_r.cnt;
     _scan_r.res = NULL;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
ESP8266 RSSI getter issue fixed: https://github.com/ARMmbed/mbed-os/issues/11252
Issue was caused because for scan() a callback was added for results and rssi() adopted same mechanism but code was not updated to reflect changes. 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@star297 
@ARMmbed/mbed-os-wan 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
