### PR TITLE
KL43Z: Enable USBDevice

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1314,6 +1314,7 @@
             "SPI",
             "SPISLAVE",
             "STDIO_MESSAGES",
+            "USBDEVICE",
             "FLASH"
         ],
         "release_versions": ["2", "5"],


### PR DESCRIPTION
### Description
Test results below, the MSD test fails due to lack of HEAP space:
mbedgt: test case report:
| target        | platform_name | test suite                      | test case                                       | passed | failed | result  | elapsed_time (sec) |
|---------------|---------------|---------------------------------|-------------------------------------------------|--------|--------|---------|--------------------|
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | endpoint test abort                             | 1      | 0      | OK      | 16.4               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | endpoint test data correctness                  | 1      | 0      | OK      | 0.71               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | endpoint test data toggle reset                 | 1      | 0      | OK      | 0.4                |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | endpoint test halt                              | 1      | 0      | OK      | 9.15               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | endpoint test parallel transfers                | 1      | 0      | OK      | 4.41               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | endpoint test parallel transfers ctrl           | 1      | 0      | OK      | 4.67               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb control basic test                          | 1      | 0      | OK      | 0.53               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb control sizes test                          | 1      | 0      | OK      | 0.43               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb control stall test                          | 1      | 0      | OK      | 0.35               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb control stress test                         | 1      | 0      | OK      | 0.49               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb device reset test                           | 1      | 0      | OK      | 1.31               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb repeated construction destruction test      | 1      | 0      | OK      | 1.74               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-basic  | usb soft reconnection test                      | 1      | 0      | OK      | 1.65               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | Configuration descriptor, generic               | 1      | 0      | OK      | 0.78               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | Configuration descriptor, keyboard              | 1      | 0      | OK      | 0.32               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | Configuration descriptor, mouse                 | 1      | 0      | OK      | 0.31               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | HID class descriptors, generic                  | 1      | 0      | OK      | 0.32               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | HID class descriptors, keyboard                 | 1      | 0      | OK      | 0.34               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | HID class descriptors, mouse                    | 1      | 0      | OK      | 0.37               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | Raw input/output, 1-byte reports                | 1      | 0      | OK      | 0.44               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | Raw input/output, 20-byte reports               | 1      | 0      | OK      | 0.45               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-hid    | Raw input/output, 64-byte reports               | 1      | 0      | OK      | 0.4                |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-msd    | mount/unmount and data test - Heap block device | 0      | 0      | SKIPPED | 0.0                |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-msd    | mount/unmount test - Heap block device          | 0      | 0      | SKIPPED | 0.0                |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-msd    | storage initialization                          | 0      | 1      | FAIL    | 0.12               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | CDC RX multiple bytes                           | 1      | 0      | OK      | 3.6                |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | CDC RX multiple bytes concurrent                | 1      | 0      | OK      | 5.7                |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | CDC RX single bytes                             | 1      | 0      | OK      | 0.53               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | CDC RX single bytes concurrent                  | 1      | 0      | OK      | 0.45               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | CDC USB reconnect                               | 1      | 0      | OK      | 1.04               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | CDC loopback                                    | 1      | 0      | OK      | 1.12               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | Serial USB reconnect                            | 1      | 0      | OK      | 0.85               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | Serial getc                                     | 1      | 0      | OK      | 0.35               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | Serial line coding change                       | 1      | 0      | OK      | 0.91               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | Serial printf/scanf                             | 1      | 0      | OK      | 1.47               |
| KL43Z-GCC_ARM | KL43Z         | mbed-os-tests-usb_device-serial | Serial terminal reopen                          | 1      | 0      | OK      | 0.58               |
mbedgt: test case results: 1 FAIL / 2 SKIPPED / 33 OK




### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
