### PR TITLE
BLE TEST: remove duplicated and failing test

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/transport/main.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/transport/main.cpp
@@ -225,23 +225,6 @@ static uint8_t reset_cmd[] = {
     0 // parameter length
 };
 
-void test_reset_command()
-{
-    CordioHCIDriver &driver = CordioHCIHook::get_driver();
-    CordioHCITransportDriver &transport_driver = CordioHCIHook::get_transport_driver();
-
-    driver.initialize();
-
-    CordioHCIHook::set_data_received_handler(hci_driver_rx_reset_handler);
-
-    transport_driver.write(HCI_CMD_TYPE, sizeof(reset_cmd), reset_cmd);
-    uint32_t events = wait_for_event();
-
-    TEST_ASSERT_EQUAL(RESET_RECEIVED_FLAG, events);
-
-    driver.terminate();
-}
-
 #define EXPECTED_CONSECUTIVE_RESET   10
 
 void test_multiple_reset_command()
@@ -266,7 +249,6 @@ void test_multiple_reset_command()
 }
 
 Case cases[] = {
-    Case("Test reset command", test_reset_command),
     Case("Test multiple reset commands", test_multiple_reset_command)
 };
 


### PR DESCRIPTION
### Description

Remove failed reset command test. because it duplicated with the later test and cause the later test failed


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@paul-szczepanek-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
