### PR TITLE
ESP8266: Add configurations for reset control

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -143,7 +143,7 @@ ESP8266Interface::ResetPin::ResetPin(PinName rst_pin) : _rst_pin(mbed::DigitalOu
 void ESP8266Interface::ResetPin::rst_assert()
 {
     if (_rst_pin.is_connected()) {
-        _rst_pin = 0;
+        _rst_pin = MBED_CONF_ESP8266_RST_PIN_POLARITY;
         tr_debug("HW reset asserted");
     }
 }
@@ -152,7 +152,7 @@ void ESP8266Interface::ResetPin::rst_deassert()
 {
     if (_rst_pin.is_connected()) {
         // Notice that Pin7 CH_EN cannot be left floating if used as reset
-        _rst_pin = 1;
+        _rst_pin = !MBED_CONF_ESP8266_RST_PIN_POLARITY;
         tr_debug("HW reset deasserted");
     }
 }

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -461,7 +461,7 @@ nsapi_error_t ESP8266Interface::_reset()
         _rst_pin.rst_assert();
         // If you happen to use Pin7 CH_EN as reset pin, not needed otherwise
         // https://www.espressif.com/sites/default/files/documentation/esp8266_hardware_design_guidelines_en.pdf
-        ThisThread::sleep_for(2); // Documentation says 200 us; need 2 ticks to get minimum 1 ms.
+        ThisThread::sleep_for(MBED_CONF_ESP8266_RST_ASSERT_TIME_US / 1000); // Documentation says 200 us; need 2 ticks to get minimum 1 ms.
         _esp.flush();
         _rst_pin.rst_deassert();
     } else {

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -26,6 +26,10 @@
             "options": [0, 1],
             "value": 0
         },
+        "rst-assert-time-us": {
+            "help": "Assert time of reset for the modem in us.",
+            "value": 2000
+        },
         "debug": {
             "help": "Enable debug logs. [true/false]",
             "value": false

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -67,6 +67,15 @@
         "NUCLEO_F411RE": {
             "tx": "D8",
             "rx": "D2"
+        },
+        "NUMAKER_PFM_M2351_CM": {
+            "tx"                    : "PD_1",
+            "rx"                    : "PD_0",
+            "rst"                   : "PD_7",
+            "rts"                   : "PD_3",
+            "cts"                   : "PD_2",
+            "rst-pin-polarity"      : 1,
+            "rst-assert-time-us"    : 3000
         }
     }
 }

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -21,6 +21,11 @@
             "help": "RESET pin for the modem, defaults to Not Connected",
             "value": null
         },
+        "rst-pin-polarity": {
+            "help": "Polarity of RESET pin for the modem. [0/1]",
+            "options": [0, 1],
+            "value": 0
+        },
         "debug": {
             "help": "Enable debug logs. [true/false]",
             "value": false


### PR DESCRIPTION
### Description

This PR is a replacement for #11299. By adding configurations for reset pin polarity and reset assert time in ESP8266 driver, the original reset logic `_rst_pin.rst_assert()`/`_rst_pin.rst_deassert()` can extend to support power on/off control for the ESP8266 module. This is what #11299 wants to achieve. 

This PR adds ESP8266 configurations:

- Add configuration for reset pin polarity
- Add configuration for reset assert time

#### Related PR

Replacement for #11299 
Rely on #11288 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@michalpasztamobica 
