### PR TITLE
I2 c sequential communication rework

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal_i2c.c
@@ -2592,7 +2592,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE));
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If size > MAX_NBYTE_SIZE, use reload mode */
@@ -2658,7 +2658,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE));
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If hi2c->XferCount > MAX_NBYTE_SIZE, use reload mode */

--- a/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_i2c.c
@@ -2592,7 +2592,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE)); // MBED patch
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If size > MAX_NBYTE_SIZE, use reload mode */
@@ -2666,7 +2666,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE)); // MBED patch
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If hi2c->XferCount > MAX_NBYTE_SIZE, use reload mode */

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_i2c.c
@@ -2598,7 +2598,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE)); // MBED: changed
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If size > MAX_NBYTE_SIZE, use reload mode */
@@ -2672,7 +2672,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE)); // MBED: changed
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If hi2c->XferCount > MAX_NBYTE_SIZE, use reload mode */

--- a/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal_i2c.c
@@ -2592,7 +2592,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE)); // MBED commit 23926a2418
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If size > MAX_NBYTE_SIZE, use reload mode */
@@ -2666,7 +2666,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE)); // MBED commit 23926a2418
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If hi2c->XferCount > MAX_NBYTE_SIZE, use reload mode */

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_i2c.c
@@ -3173,8 +3173,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    // Added for MBED PR #3324
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE));
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If hi2c->XferCount > MAX_NBYTE_SIZE, use reload mode */
@@ -3420,8 +3419,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_
     /* Prepare transfer parameters */
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
-    // Added for MBED PR #3324
-    hi2c->XferOptions = (XferOptions & (~I2C_RELOAD_MODE));
+    hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Master_ISR_IT;
 
     /* If hi2c->XferCount > MAX_NBYTE_SIZE, use reload mode */


### PR DESCRIPTION
### Description

Rework on STM I2C sequential transfert:
* TARGET_STM: I2C sequential communication revert PR #3324 to original cube HAL
* TARGET_STM: Fix I2C sequential communication (needed after revert of PR#3324)
* Fix I2C issue with test mbed_hal_fpga_ci_test_shield


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
