### PR TITLE
Bring down interface when stopping softap

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSoftAPInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSoftAPInterface.cpp
@@ -173,7 +173,19 @@ int WhdSoftAPInterface::stop(void)
         return NSAPI_ERROR_DHCP_FAILURE;
     }
     _dhcp_server.reset();
-    return whd_wifi_stop_ap(_whd_emac.ifp);
+
+    // bring down
+    int err = _interface->bringdown();
+    if (err) {
+        return err;
+    }
+
+    // stop softap
+    whd_result_t res = whd_wifi_stop_ap(_whd_emac.ifp);
+    if (res != WHD_SUCCESS) {
+        return whd_toerror(res);
+    }
+    return NSAPI_ERROR_OK;
 }
 
 int WhdSoftAPInterface::remove_custom_ie(const whd_custom_ie_info_t *ie_info)


### PR DESCRIPTION
### Description
Brought down the network interface when stopping SoftAP. This is to ensure that the network interface is in correct mode before next starting.

Note this PR depends on PR #11320
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
