### PR TITLE
mbed-os/LwIP changes and fixes in auto-IP for Bonjour Conformance Test

### DIFF
--- a/features/lwipstack/lwip/src/core/ipv4/lwip_autoip.c
+++ b/features/lwipstack/lwip/src/core/ipv4/lwip_autoip.c
@@ -94,6 +94,9 @@
 static err_t autoip_arp_announce(struct netif *netif);
 static void autoip_start_probing(struct netif *netif);
 
+/* static variables */
+static u8_t is_autoip_alloced = 0;      /* Set when 'struct autoip' is allocated dynamically and assigned to 'netif' */
+
 /**
  * @ingroup autoip
  * Set a statically allocated struct autoip to work with.
@@ -278,6 +281,7 @@ autoip_start(struct netif *netif)
                   ("autoip_start(): could not allocate autoip\n"));
       return ERR_MEM;
     }
+    is_autoip_alloced = 1;
     /* store this AutoIP client in the netif */
     netif_set_client_data(netif, LWIP_NETIF_CLIENT_DATA_INDEX_AUTOIP, autoip);
     LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE, ("autoip_start(): allocated autoip"));
@@ -318,7 +322,7 @@ autoip_start_probing(struct netif *netif)
    * acquiring and probing address
    * compliant to RFC 3927 Section 2.2.1
    */
-  if (autoip->tried_llipaddr > MAX_CONFLICTS) {
+  if (autoip->tried_llipaddr >= MAX_CONFLICTS) {
     autoip->ttw = RATE_LIMIT_INTERVAL * AUTOIP_TICKS_PER_SECOND;
   }
 }
@@ -353,6 +357,16 @@ autoip_stop(struct netif *netif)
   LWIP_ASSERT_CORE_LOCKED();
   if (autoip != NULL) {
     autoip->state = AUTOIP_STATE_OFF;
+    /* If autoip is dynamically allocated in start, free autoip structure and reset autoip index in netif */
+    if (is_autoip_alloced) {
+      /* Reset the auto IP index and then free autoip structure */
+      netif_set_client_data(netif, LWIP_NETIF_CLIENT_DATA_INDEX_AUTOIP, NULL);
+      mem_free(autoip);
+      autoip = NULL;
+      is_autoip_alloced = 0;
+    } else {
+      autoip->tried_llipaddr = 0;
+    }
     if (ip4_addr_islinklocal(netif_ip4_addr(netif))) {
       netif_set_addr(netif, IP4_ADDR_ANY4, IP4_ADDR_ANY4, IP4_ADDR_ANY4);
     }

--- a/features/lwipstack/lwip/src/core/ipv4/lwip_autoip.c
+++ b/features/lwipstack/lwip/src/core/ipv4/lwip_autoip.c
@@ -95,7 +95,7 @@ static err_t autoip_arp_announce(struct netif *netif);
 static void autoip_start_probing(struct netif *netif);
 
 /* static variables */
-static u8_t is_autoip_alloced = 0;      /* Set when 'struct autoip' is allocated dynamically and assigned to 'netif' */
+static u8_t is_autoip_allocated = 0;      /* Set when 'struct autoip' is allocated dynamically and assigned to 'netif' */
 
 /**
  * @ingroup autoip
@@ -281,7 +281,7 @@ autoip_start(struct netif *netif)
                   ("autoip_start(): could not allocate autoip\n"));
       return ERR_MEM;
     }
-    is_autoip_alloced = 1;
+    is_autoip_allocated = 1;
     /* store this AutoIP client in the netif */
     netif_set_client_data(netif, LWIP_NETIF_CLIENT_DATA_INDEX_AUTOIP, autoip);
     LWIP_DEBUGF(AUTOIP_DEBUG | LWIP_DBG_TRACE, ("autoip_start(): allocated autoip"));
@@ -358,12 +358,12 @@ autoip_stop(struct netif *netif)
   if (autoip != NULL) {
     autoip->state = AUTOIP_STATE_OFF;
     /* If autoip is dynamically allocated in start, free autoip structure and reset autoip index in netif */
-    if (is_autoip_alloced) {
+    if (is_autoip_allocated) {
       /* Reset the auto IP index and then free autoip structure */
       netif_set_client_data(netif, LWIP_NETIF_CLIENT_DATA_INDEX_AUTOIP, NULL);
       mem_free(autoip);
       autoip = NULL;
-      is_autoip_alloced = 0;
+      is_autoip_allocated = 0;
     } else {
       autoip->tried_llipaddr = 0;
     }

--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -57,7 +57,13 @@
 #define BOTH_ADDR_TIMEOUT           0
 #endif
 
+// Configurable DHCP timeout. DHCP timeout can be configured for specific usecase requirement.
+#ifdef MBED_CONF_LWIP_DHCP_TIMEOUT
+#define DHCP_TIMEOUT                (MBED_CONF_LWIP_DHCP_TIMEOUT)
+#else
 #define DHCP_TIMEOUT                60
+#endif
+
 #define LINK_TIMEOUT                60
 
 #define PREF_IPV4                   1


### PR DESCRIPTION

### Description
This PR is to fix the issues in LwIP for AutoIP which is required for passing Bonjour Conformance Test for mDNS. Following gives the summary of the changes/fixes added.

Changes:

1. Following issues are fixed in LwIP for AutoIP.
      - **Fixed bug in max conflict rate limiting:** According to RFC section RFC 3927 Section 2.2.1 conflict probe interval should be increased to 60 seconds, once conflict count reaches after MAX_CONFLICTS (i.e., 10) counts. The initial value of 'autoip->tried_llipaddr' is 0. Hence the probe interval (i.e., autoip->ttw) should be increased to 60 secs when 'autoip->tried_llipaddr >= MAX_CONFLICTS'
     - **Added code to free 'autoip' client in autoip_stop() API:**  New 'autoip' client is allocated in autoip_start() API, and the client is not freed during autoip_stop(). This would result in memory leak, if not freed. Updated autoip_stop() API to take care of releasing the memory allocated for 'autoip' client.

2. Introduced a configurable macro "MBED_CONF_LWIP_DHCP_TIMEOUT" in "lwipopts.h" to configure DHCP timeout based on the usecase requirement. For example: bonjour conformance test would need a DHCP timeout value which is grater than 320 secs to run mDNS probing test to verify protocol compilance of the implementation.

   Tested the fixes using Bonjour Conformance Test tool Version 1.5.0 for IPv4. It has successfully passed Bonjour Conformance Test.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AnttiKauppila 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
