### PR TITLE
add queue static allocation support

### DIFF
--- a/TESTS/events/equeue/main.cpp
+++ b/TESTS/events/equeue/main.cpp
@@ -39,7 +39,10 @@ static void pass_func(void *eh)
 
 static void simple_func(void *p)
 {
-    (*(reinterpret_cast<uint8_t *>(p)))++;
+    uint8_t *d = reinterpret_cast<uint8_t *>(p);
+    if (*d < 255) {
+        (*d)++;
+    }
 }
 
 static void sloth_func(void *p)

--- a/TESTS/events/equeue/main.cpp
+++ b/TESTS/events/equeue/main.cpp
@@ -977,6 +977,65 @@ static void test_equeue_sibling()
     equeue_destroy(&q);
 }
 
+struct user_allocated_event {
+    struct equeue_event e;
+    uint8_t touched;
+};
+
+/** Test that equeue executes user allocated events passed by equeue_post.
+ *
+ *  Given queue is initialized and its size is set to store one event at max in its internal memory.
+ *  When post events allocated in queues internal memory (what is done by calling equeue_call).
+ *  Then only one event can be posted due to queue memory size.
+ *  When post user allocated events.
+ *  Then number of posted events is not limited by queue memory size.
+ *  When both queue allocaded and user allocated events are posted and equeue_dispatch is called.
+ *  Then both types of events are executed properly.
+ */
+static void test_equeue_user_allocated_event_post()
+{
+    equeue_t q;
+    int err = equeue_create(&q, EQUEUE_EVENT_SIZE);
+    TEST_ASSERT_EQUAL_INT(0, err);
+
+    uint8_t touched = 0;
+    user_allocated_event e1 = { { 0, 0, 0, NULL, NULL, NULL, 0, -1, NULL, NULL }, 0 };
+    user_allocated_event e2 = { { 0, 0, 0, NULL, NULL, NULL, 1, -1, NULL, NULL }, 0 };
+    user_allocated_event e3 = { { 0, 0, 0, NULL, NULL, NULL, 1, -1, NULL, NULL }, 0 };
+    user_allocated_event e4 = { { 0, 0, 0, NULL, NULL, NULL, 1, -1, NULL, NULL }, 0 };
+    user_allocated_event e5 = { { 0, 0, 0, NULL, NULL, NULL, 0, -1, NULL, NULL }, 0 };
+
+    TEST_ASSERT_NOT_EQUAL(0, equeue_call(&q, simple_func, &touched));
+    TEST_ASSERT_EQUAL_INT(0, equeue_call(&q, simple_func, &touched));
+    TEST_ASSERT_EQUAL_INT(0, equeue_call(&q, simple_func, &touched));
+
+    equeue_post_user_allocated(&q, simple_func, &e1.e);
+    equeue_post_user_allocated(&q, simple_func, &e2.e);
+    equeue_post_user_allocated(&q, simple_func, &e3.e);
+    equeue_post_user_allocated(&q, simple_func, &e4.e);
+    equeue_post_user_allocated(&q, simple_func, &e5.e);
+    equeue_cancel_user_allocated(&q, &e3.e);
+
+    equeue_dispatch(&q, 1);
+
+    TEST_ASSERT_EQUAL_UINT8(1, touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e1.touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e2.touched);
+    TEST_ASSERT_EQUAL_UINT8(0, e3.touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e4.touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e5.touched);
+
+    equeue_dispatch(&q, 10);
+
+    TEST_ASSERT_EQUAL_UINT8(1, touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e1.touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e2.touched);
+    TEST_ASSERT_EQUAL_UINT8(0, e3.touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e4.touched);
+    TEST_ASSERT_EQUAL_UINT8(1, e5.touched);
+
+    equeue_destroy(&q);
+}
 
 Case cases[] = {
     Case("simple call test", test_equeue_simple_call),
@@ -1006,7 +1065,8 @@ Case cases[] = {
     Case("fragmenting barrage test", test_equeue_fragmenting_barrage<10>),
     Case("multithreaded barrage test", test_equeue_multithreaded_barrage<10>),
     Case("break request cleared on timeout test", test_equeue_break_request_cleared_on_timeout),
-    Case("sibling test", test_equeue_sibling)
+    Case("sibling test", test_equeue_sibling),
+    Case("user allocated event test", test_equeue_user_allocated_event_post)
 
 };
 

--- a/UNITTESTS/events/equeue/test_equeue.cpp
+++ b/UNITTESTS/events/equeue/test_equeue.cpp
@@ -45,7 +45,10 @@ static void pass_func(void *eh)
 
 static void simple_func(void *p)
 {
-    (*(reinterpret_cast<uint8_t *>(p)))++;
+    uint8_t *d = reinterpret_cast<uint8_t *>(p);
+    if (*d < 255) {
+        (*d)++;
+    }
 }
 
 static void sloth_func(void *p)

--- a/UNITTESTS/stubs/EqueuePosix_stub.c
+++ b/UNITTESTS/stubs/EqueuePosix_stub.c
@@ -40,7 +40,10 @@ unsigned equeue_tick(void)
 // Mutex operations
 int equeue_mutex_create(equeue_mutex_t *m)
 {
-    return pthread_mutex_init(m, 0);
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    return pthread_mutex_init(m, &attr);
 }
 
 void equeue_mutex_destroy(equeue_mutex_t *m)

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -66,7 +66,7 @@ public:
      *  uses 1B dummy buffer if 0 size passed.
      *
      *  0 size queue is a special purpose queue to dispatch static events
-     *  only (see UserAllocatedEvent). Such a queue gives the guarantee 
+     *  only (see UserAllocatedEvent). Such a queue gives the guarantee
      *  that no dynamic memory allocation will take place while queue
      *  creation and events posting & dispatching.
      *

--- a/events/UserAllocatedEvent.h
+++ b/events/UserAllocatedEvent.h
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef USER_ALLOCATED_EVENT_H
+#define USER_ALLOCATED_EVENT_H
+
+#include "events/EventQueue.h"
+#include "platform/mbed_assert.h"
+#include "platform/mbed_atomic.h"
+
+namespace events {
+/**
+ * \addtogroup events-public-api Events
+ * \ingroup mbed-os-public
+ * @{
+ */
+template <typename F, typename A>
+class UserAllocatedEvent;
+
+/**
+ * \defgroup events_Event UserAllocatedEvent class
+ * @{
+ */
+
+/** UserAllocatedEvent
+ *
+ *  Representation of an static event for fine-grain dispatch control.
+ *
+ *  UserAllocatedEvent provides mechanism for event posting and dispatching
+ *  without utilization of queue internal memory. It embeds all underlying
+ *  event data and doesn't require any memory allocation while posting and dispatching.
+ *  All of these makes it cannot fail due to memory exhaustion while posting
+ *
+ * Usage:
+ * @code
+ *  #include "mbed.h"
+ *
+ *  void handler(int data) { ... }
+ *
+ *  class Device {
+ *     public:
+ *     void handler(int data) { ... }
+ *  };
+ *
+ *  Device dev;
+ *
+ *  // queue with not internal storage for dynamic events
+ *  // accepts only user allocated events
+ *  static EventQueue queue(0);
+ *  // Create events
+ *  static auto e1 = make_user_allocated_event(&dev, Device::handler, 2);
+ *  static auto e2 = queue.make_user_allocated_event(handler, 3);
+ *
+ *  int main()
+ *  {
+ *    e1.call_on(&queue);
+ *    e2.call();
+ *
+ *    queue.dispatch(1);
+ *  }
+ * @endcode
+ */
+template <typename F, typename... ArgTs>
+class UserAllocatedEvent<F, void(ArgTs...)> {
+public:
+    typedef EventQueue::context<F, ArgTs...> C;
+
+    /** Create an event
+     *
+     *  Constructs an event. The specified callback acts as the target
+     *  for the event and is executed in the context of the
+     *  event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param args     Arguments to bind to the callback
+     */
+    constexpr UserAllocatedEvent(F f,  ArgTs... args) : _e(get_default_equeue_event()), _c(f, args...), _equeue(), _post_ref()
+    {
+    }
+
+    /** Create an event
+     *
+     *  Constructs an event. The specified callback acts as the target
+     *  for the event and is executed in the context of the
+     *  event queue's dispatch loop once posted.
+     *
+     *  @param queue    Event queue to dispatch on
+     *  @param f        Function to execute when the event is dispatched
+     *  @param args     Arguments to bind to the callback
+     */
+    constexpr UserAllocatedEvent(EventQueue *queue, F f,  ArgTs... args) : _e(get_default_equeue_event()), _c(f, args...), _equeue(&queue->_equeue), _post_ref()
+    {
+    }
+
+    /** Destructor for events
+     */
+#if !defined(NDEBUG)
+    // Remove the user provided destructor in release to allow constexpr optimization
+    // constexpr requires destructor to be trivial and only default one is treated as trivial
+    ~UserAllocatedEvent()
+    {
+        MBED_ASSERT(!_post_ref);
+    }
+#endif
+
+    /** Posts an event onto the underlying event queue, returning void
+    *
+    *  The event is posted to the underlying queue and is executed in the
+    *  context of the event queue's dispatch loop.
+    *
+    *  This call cannot fail due queue memory exhaustion
+    *  because it doesn't allocate any memory
+    *
+    *  The post function is IRQ safe and can act as a mechanism for moving
+    *  events out of IRQ contexts.
+    *
+    */
+    void call()
+    {
+        MBED_ASSERT(!_post_ref);
+        MBED_ASSERT(_equeue);
+        MBED_UNUSED bool status = post();
+        MBED_ASSERT(status);
+    }
+
+    /** Posts an event onto the event queue passed as argument, returning void
+    *
+    *  The event is posted to the event queue passed as argument
+    *  and is executed in the context of the event queue's dispatch loop.
+    *
+    *  This call cannot fail due queue memory exhaustion
+    *  because it doesn't allocate any memory
+    *
+    *  The post function is IRQ safe and can act as a mechanism for moving
+    *  events out of IRQ contexts.
+    *
+    *  @param queue    Event queue to dispatch on. Will replace earlier bound EventQueue.
+    *
+    */
+    void call_on(EventQueue *queue)
+    {
+        MBED_ASSERT(!_post_ref);
+        MBED_UNUSED bool status = post_on(queue);
+        MBED_ASSERT(status);
+    }
+
+    /** Posts an event onto the underlying event queue
+    *
+    *  The event is posted to the event queue passed as argument
+    *  and is executed in the context of the event queue's dispatch loop.
+    *
+    *  This call cannot fail due queue memory exhaustion
+    *  because it doesn't allocate any memory
+    *
+    *  @return     False if the event was already posted
+    *              true otherwise
+    *
+    */
+    bool try_call()
+    {
+        return post();
+    }
+
+    /** Posts an event onto the event queue passed as argument,
+    *
+    *  The event is posted to the underlying queue and is executed in the
+    *  context of the event queue's dispatch loop.
+    *
+    *  This call cannot fail due queue memory exhaustion
+    *  because it doesn't allocate any memory
+    *
+    *  @param queue    Event queue to dispatch on. Will replace earlier bound EventQueue.
+    *  @return         False if the event was already posted
+    *                  true otherwise
+    *
+    */
+    bool try_call_on(EventQueue *queue)
+    {
+        return post_on(queue);
+    }
+
+    /** Posts an event onto the underlying event queue, returning void
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  This call cannot fail due queue memory exhaustion
+     *  because it doesn't allocate any memory
+     *
+     *  The post function is IRQ safe and can act as a mechanism for moving
+     *  events out of IRQ contexts.
+     *
+     */
+    void operator()()
+    {
+        return call();
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay)
+    {
+        equeue_event_delay(&_e + 1, delay);
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period)
+    {
+        equeue_event_period(&_e + 1, period);
+    }
+
+    /** Cancels posted event
+     *
+     *  Attempts to cancel posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is IRQ safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not guarantee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     *
+     *  @return     true if event was successfully cancelled
+     */
+    bool cancel()
+    {
+        return equeue_cancel_user_allocated(_equeue, &_e);
+    }
+
+
+private:
+    friend class EventQueue;
+    struct equeue_event _e;
+    C _c;
+    struct equeue *_equeue;
+    uint8_t _post_ref;
+
+    bool post()
+    {
+        if (_post_ref) {
+            return false;
+        }
+        core_util_atomic_incr_u8(&_post_ref, 1);
+        equeue_post_user_allocated(_equeue, &EventQueue::function_call<C>, &_e);
+        return true;
+    }
+
+    bool post_on(EventQueue *queue)
+    {
+        if (_post_ref) {
+            return false;
+        }
+        _equeue = &(queue->_equeue);
+        core_util_atomic_incr_u8(&_post_ref, 1);
+        equeue_post_user_allocated(_equeue, &EventQueue::function_call<C>, &_e);
+        return true;
+    }
+
+    static void event_dtor(void *p)
+    {
+        UserAllocatedEvent<F, void(ArgTs...)> *instance = (UserAllocatedEvent<F, void(ArgTs...)> *)(((equeue_event *)p) - 1);
+        core_util_atomic_decr_u8(&instance->_post_ref, 1);
+        MBED_ASSERT(!instance->_post_ref);
+    }
+
+    constexpr static equeue_event get_default_equeue_event()
+    {
+        return equeue_event{ 0, 0, 0, NULL, NULL, NULL, 0, -1, &UserAllocatedEvent::event_dtor, NULL };
+    }
+
+public:
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(T *obj, R(T::*method)(ArgTs...), ArgTs... args) :
+        UserAllocatedEvent(mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(EventQueue *q, T *obj, R(T::*method)(ArgTs...), ArgTs... args) :
+        UserAllocatedEvent(q, mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(const T *obj, R(T::*method)(ArgTs...) const, ArgTs... args) :
+        UserAllocatedEvent(mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(EventQueue *q, const T *obj, R(T::*method)(ArgTs...) const, ArgTs... args) :
+        UserAllocatedEvent(q, mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(volatile T *obj, R(T::*method)(ArgTs...) volatile, ArgTs... args) :
+        UserAllocatedEvent(mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(EventQueue *q, volatile T *obj, R(T::*method)(ArgTs...) volatile, ArgTs... args) :
+        UserAllocatedEvent(q, mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(const volatile T *obj, R(T::*method)(ArgTs...) const volatile, ArgTs... args) :
+        UserAllocatedEvent(mbed::callback(obj, method), args...) { }
+
+    /** Create an event
+     *  @see UserAllocatedEvent::UserAllocatedEvent
+     */
+    template <typename T, typename R>
+    constexpr UserAllocatedEvent(EventQueue *q, const volatile T *obj, R(T::*method)(ArgTs...) const volatile, ArgTs... args) :
+        UserAllocatedEvent(q, mbed::callback(obj, method), args...) { }
+};
+
+// Convenience functions declared here to avoid cyclic
+// dependency between Event and EventQueue
+template <typename F, typename... ArgTs>
+UserAllocatedEvent<F, void(ArgTs...)> EventQueue::make_user_allocated_event(F f, ArgTs... args)
+{
+    return UserAllocatedEvent<F, void(ArgTs...)>(this, f, args...);
+}
+
+template <typename T, typename R, typename... ArgTs>
+UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> EventQueue::make_user_allocated_event(T *obj, R(T::*method)(ArgTs... args), ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(this, mbed::callback(obj, method), args...);
+}
+
+template <typename T, typename R, typename... ArgTs>
+UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> EventQueue::make_user_allocated_event(const T *obj, R(T::*method)(ArgTs... args) const, ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(this, mbed::callback(obj, method), args...);
+}
+
+template <typename T, typename R, typename... ArgTs>
+UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> EventQueue::make_user_allocated_event(volatile T *obj, R(T::*method)(ArgTs... args) volatile, ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(this, mbed::callback(obj, method), args...);
+}
+
+template <typename T, typename R, typename... ArgTs>
+UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> EventQueue::make_user_allocated_event(const volatile T *obj, R(T::*method)(ArgTs... args) const volatile, ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(this, mbed::callback(obj, method), args...);
+}
+
+
+/** Creates a UserAllocatedEvent object, deducing the target type from the types of arguments
+ *
+ *  UserAllocatedEvent doesn't utilize EventQueue internal memory,
+ *  therefore it can be posted on the queue without being afraid
+ *  of post fail due to queue memory exhaustion
+ *
+ *  @return  UserAllocatedEvent object instance
+ *
+ */
+template <typename F, typename... ArgTs>
+constexpr UserAllocatedEvent<F, void(ArgTs...)> make_user_allocated_event(F f, ArgTs... args)
+{
+    return UserAllocatedEvent<F, void(ArgTs...)>(f, args...);
+}
+
+/** Creates a UserAllocatedEvent object, deducing the target type from the types of arguments
+ *
+ *  UserAllocatedEvent doesn't utilize EventQueue internal memory,
+ *  therefore it can be posted on the queue without being afraid
+ *  of post fail due to queue memory exhaustion
+ *
+ *  @return  UserAllocatedEvent object instance
+ *
+ */
+template <typename T, typename R, typename... ArgTs>
+constexpr UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> make_user_allocated_event(T *obj, R(T::*method)(ArgTs... args), ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(mbed::callback(obj, method), args...);
+}
+
+/** Creates a UserAllocatedEvent object, deducing the target type from the types of arguments
+ *
+ *  UserAllocatedEvent doesn't utilize EventQueue internal memory,
+ *  therefore it can be posted on the queue without being afraid
+ *  of post fail due to queue memory exhaustion
+ *
+ *  @return  UserAllocatedEvent object instance
+ *
+ */
+template <typename T, typename R, typename... ArgTs>
+constexpr UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> make_user_allocated_event(const T *obj, R(T::*method)(ArgTs... args) const, ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(mbed::callback(obj, method), args...);
+}
+
+/** Creates a UserAllocatedEvent object, deducing the target type from the types of arguments
+ *
+ *  UserAllocatedEvent doesn't utilize EventQueue internal memory,
+ *  therefore it can be posted on the queue without being afraid
+ *  of post fail due to queue memory exhaustion
+ *
+ *  @return  UserAllocatedEvent object instance
+ *
+ */
+template <typename T, typename R, typename... ArgTs>
+constexpr UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> make_user_allocated_event(volatile T *obj, R(T::*method)(ArgTs... args) volatile, ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(mbed::callback(obj, method), args...);
+}
+
+/** Creates a UserAllocatedEvent object, deducing the target type from the types of arguments
+ *
+ *  UserAllocatedEvent doesn't utilize EventQueue internal memory,
+ *  therefore it can be posted on the queue without being afraid
+ *  of post fail due to queue memory exhaustion
+ *
+ *  @return  UserAllocatedEvent object instance
+ *
+ */
+template <typename T, typename R, typename... ArgTs>
+constexpr UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)> make_user_allocated_event(const volatile T *obj, R(T::*method)(ArgTs... args) const volatile, ArgTs... args)
+{
+    return UserAllocatedEvent<mbed::Callback<void(ArgTs...)>, void(ArgTs...)>(mbed::callback(obj, method), args...);
+}
+
+/** @}*/
+
+/** @}*/
+}
+#endif

--- a/events/equeue.h
+++ b/events/equeue.h
@@ -176,6 +176,17 @@ void equeue_event_dtor(void *event, void (*dtor)(void *));
 // be passed to equeue_cancel.
 int equeue_post(equeue_t *queue, void (*cb)(void *), void *event);
 
+// Post an user allocated event onto the event queue
+//
+// The equeue_post_user_allocated function takes a callback and a pointer
+// to an event allocated by user. The specified callback will be executed
+// in the context of the event queue's dispatch loop with the allocated
+// event as its argument.
+//
+// The equeue_post_user_allocated function is irq safe and can act as
+// a mechanism for moving events out of irq contexts.
+void equeue_post_user_allocated(equeue_t *queue, void (*cb)(void *), void *event);
+
 // Cancel an in-flight event
 //
 // Attempts to cancel an event referenced by the unique id returned from
@@ -191,6 +202,20 @@ int equeue_post(equeue_t *queue, void (*cb)(void *), void *event);
 // Returning false if invalid id or already started executing.
 bool equeue_cancel(equeue_t *queue, int id);
 
+// Cancel an in-flight user allocated event
+//
+// Attempts to cancel an event referenced by its address.
+// It is safe to call equeue_cancel_user_allocated after an event
+// has already been dispatched.
+//
+// The equeue_cancel_user_allocated function is irq safe.
+//
+// If called while the event queue's dispatch loop is active,
+// equeue_cancel_user_allocated does not guarantee that the event
+// will not not execute after it returns as the event may have
+// already begun executing.
+bool equeue_cancel_user_allocated(equeue_t *queue, void *event);
+
 // Query how much time is left for delayed event
 //
 //  If event is delayed, this function can be used to query how much time
@@ -199,6 +224,15 @@ bool equeue_cancel(equeue_t *queue, int id);
 //  This function is irq safe.
 //
 int equeue_timeleft(equeue_t *q, int id);
+
+// Query how much time is left for delayed user allocated event
+//
+//  If event is delayed, this function can be used to query how much time
+//  is left until the event is due to be dispatched.
+//
+//  This function is irq safe.
+//
+int equeue_timeleft_user_allocated(equeue_t *q, void *event);
 
 // Background an event queue onto a single-shot timer
 //

--- a/events/mbed_events.h
+++ b/events/mbed_events.h
@@ -20,6 +20,7 @@
 
 #include "events/EventQueue.h"
 #include "events/Event.h"
+#include "events/UserAllocatedEvent.h"
 
 #include "events/mbed_shared_queues.h"
 

--- a/events/source/EventQueue.cpp
+++ b/events/source/EventQueue.cpp
@@ -1,5 +1,5 @@
 /* events
- * Copyright (c) 2016 ARM Limited
+ * Copyright (c) 2016-2019 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +23,16 @@ namespace events {
 
 EventQueue::EventQueue(unsigned event_size, unsigned char *event_pointer)
 {
-    if (!event_pointer) {
-        equeue_create(&_equeue, event_size);
+    if (event_size == 0) {
+        // As static queue (EventQueue(0)) won't perform any access to its dummy buffer
+        // set 1B dummy buffer as pointer to itself
+        equeue_create_inplace(&_equeue, 1, this);
     } else {
-        equeue_create_inplace(&_equeue, event_size, event_pointer);
+        if (!event_pointer) {
+            equeue_create(&_equeue, event_size);
+        } else {
+            equeue_create_inplace(&_equeue, event_size, event_pointer);
+        }
     }
 }
 

--- a/events/source/EventQueue.cpp
+++ b/events/source/EventQueue.cpp
@@ -24,9 +24,9 @@ namespace events {
 EventQueue::EventQueue(unsigned event_size, unsigned char *event_pointer)
 {
     if (event_size == 0) {
-        // As static queue (EventQueue(0)) won't perform any access to its dummy buffer
-        // set 1B dummy buffer as pointer to itself
-        equeue_create_inplace(&_equeue, 1, this);
+        // As static queue (EventQueue(0)) won't perform any access to its data buffer
+        // we can pass (0, NULL)
+        equeue_create_inplace(&_equeue, 0, NULL);
     } else {
         if (!event_pointer) {
             equeue_create(&_equeue, event_size);

--- a/events/source/equeue.c
+++ b/events/source/equeue.c
@@ -22,7 +22,7 @@
 #include <string.h>
 
 // check if the event is allocaded by user - event address is outside queues internal buffer address range
-#define EQUEUE_IS_USER_ALLOCATED_EVENT(e) (((uintptr_t)(e) < (uintptr_t)q->buffer) || ((uintptr_t)(e) > ((uintptr_t)q->slab.data)))
+#define EQUEUE_IS_USER_ALLOCATED_EVENT(e) ((q->buffer == NULL) || ((uintptr_t)(e) < (uintptr_t)q->buffer) || ((uintptr_t)(e) > ((uintptr_t)q->slab.data)))
 
 // calculate the relative-difference between absolute times while
 // correctly handling overflow conditions

--- a/events/source/equeue.c
+++ b/events/source/equeue.c
@@ -21,6 +21,9 @@
 #include <stdint.h>
 #include <string.h>
 
+// check if the event is allocaded by user - event address is outside queues internal buffer address range
+#define EQUEUE_IS_USER_ALLOCATED_EVENT(e) (((uintptr_t)(e) < (uintptr_t)q->buffer) || ((uintptr_t)(e) > ((uintptr_t)q->slab.data)))
+
 // calculate the relative-difference between absolute times while
 // correctly handling overflow conditions
 static inline int equeue_tickdiff(unsigned a, unsigned b)
@@ -64,9 +67,15 @@ int equeue_create_inplace(equeue_t *q, size_t size, void *buffer)
 {
     // setup queue around provided buffer
     // ensure buffer and size are aligned
-    q->buffer = (void *)(((uintptr_t) buffer + sizeof(void *) -1) & ~(sizeof(void *) -1));
-    size -= (char *) q->buffer - (char *) buffer;
-    size &= ~(sizeof(void *) -1);
+    if (size >= sizeof(void *)) {
+        q->buffer = (void *)(((uintptr_t) buffer + sizeof(void *) -1) & ~(sizeof(void *) -1));
+        size -= (char *) q->buffer - (char *) buffer;
+        size &= ~(sizeof(void *) -1);
+    } else {
+        // don't align when size less then pointer size
+        // e.g. static queue (size == 1)
+        q->buffer = buffer;
+    }
 
     q->allocated = 0;
 
@@ -220,15 +229,13 @@ void equeue_dealloc(equeue_t *q, void *p)
         e->dtor(e + 1);
     }
 
-    equeue_mem_dealloc(q, e);
+    if (!EQUEUE_IS_USER_ALLOCATED_EVENT(e)) {
+        equeue_mem_dealloc(q, e);
+    }
 }
 
-
-// equeue scheduling functions
-static int equeue_enqueue(equeue_t *q, struct equeue_event *e, unsigned tick)
+void equeue_enqueue(equeue_t *q, struct equeue_event *e, unsigned tick)
 {
-    // setup event and hash local id with buffer offset for unique id
-    int id = (e->id << q->npw2) | ((unsigned char *)e - q->buffer);
     e->target = tick + equeue_clampdiff(e->target, tick);
     e->generation = q->generation;
 
@@ -254,7 +261,6 @@ static int equeue_enqueue(equeue_t *q, struct equeue_event *e, unsigned tick)
         if (e->next) {
             e->next->ref = &e->next;
         }
-
         e->sibling = 0;
     }
 
@@ -267,24 +273,19 @@ static int equeue_enqueue(equeue_t *q, struct equeue_event *e, unsigned tick)
         q->background.update(q->background.timer,
                              equeue_clampdiff(e->target, tick));
     }
-
     equeue_mutex_unlock(&q->queuelock);
-
-    return id;
 }
 
-static struct equeue_event *equeue_unqueue(equeue_t *q, int id)
+// equeue scheduling functions
+static int equeue_event_id(equeue_t *q, struct equeue_event *e)
 {
-    // decode event from unique id and check that the local id matches
-    struct equeue_event *e = (struct equeue_event *)
-                             &q->buffer[id & ((1 << q->npw2) - 1)];
+    // setup event and hash local id with buffer offset for unique id
+    return ((e->id << q->npw2) | ((unsigned char *)e - q->buffer));
+}
 
+static struct equeue_event *equeue_unqueue_by_address(equeue_t *q, struct equeue_event *e)
+{
     equeue_mutex_lock(&q->queuelock);
-    if (e->id != id >> q->npw2) {
-        equeue_mutex_unlock(&q->queuelock);
-        return 0;
-    }
-
     // clear the event and check if already in-flight
     e->cb = 0;
     e->period = -1;
@@ -309,6 +310,26 @@ static struct equeue_event *equeue_unqueue(equeue_t *q, int id)
         if (e->next) {
             e->next->ref = e->ref;
         }
+    }
+    equeue_mutex_unlock(&q->queuelock);
+    return e;
+}
+
+static struct equeue_event *equeue_unqueue_by_id(equeue_t *q, int id)
+{
+    // decode event from unique id and check that the local id matches
+    struct equeue_event *e = (struct equeue_event *)
+                             &q->buffer[id & ((1 << q->npw2) - 1)];
+
+    equeue_mutex_lock(&q->queuelock);
+    if (e->id != id >> q->npw2) {
+        equeue_mutex_unlock(&q->queuelock);
+        return 0;
+    }
+
+    if (0 == equeue_unqueue_by_address(q, e)) {
+        equeue_mutex_unlock(&q->queuelock);
+        return 0;
     }
 
     equeue_incid(q, e);
@@ -369,9 +390,21 @@ int equeue_post(equeue_t *q, void (*cb)(void *), void *p)
     e->cb = cb;
     e->target = tick + e->target;
 
-    int id = equeue_enqueue(q, e, tick);
+    equeue_enqueue(q, e, tick);
+    int id = equeue_event_id(q, e);
     equeue_sema_signal(&q->eventsema);
     return id;
+}
+
+void equeue_post_user_allocated(equeue_t *q, void (*cb)(void *), void *p)
+{
+    struct equeue_event *e = (struct equeue_event *)p;
+    unsigned tick = equeue_tick();
+    e->cb = cb;
+    e->target = tick + e->target;
+
+    equeue_enqueue(q, e, tick);
+    equeue_sema_signal(&q->eventsema);
 }
 
 bool equeue_cancel(equeue_t *q, int id)
@@ -380,9 +413,24 @@ bool equeue_cancel(equeue_t *q, int id)
         return false;
     }
 
-    struct equeue_event *e = equeue_unqueue(q, id);
+    struct equeue_event *e = equeue_unqueue_by_id(q, id);
     if (e) {
         equeue_dealloc(q, e + 1);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool equeue_cancel_user_allocated(equeue_t *q, void *e)
+{
+    if (!e) {
+        return false;
+    }
+
+    struct equeue_event *_e = equeue_unqueue_by_address(q, e);
+    if (_e) {
+        equeue_dealloc(q, _e + 1);
         return true;
     } else {
         return false;
@@ -405,6 +453,21 @@ int equeue_timeleft(equeue_t *q, int id)
     if (e->id == id >> q->npw2) {
         ret = equeue_clampdiff(e->target, equeue_tick());
     }
+    equeue_mutex_unlock(&q->queuelock);
+    return ret;
+}
+
+int equeue_timeleft_user_allocated(equeue_t *q, void *e)
+{
+    int ret = -1;
+
+    if (!e) {
+        return -1;
+    }
+
+    struct equeue_event *_e = (struct equeue_event *)e;
+    equeue_mutex_lock(&q->queuelock);
+    ret = equeue_clampdiff(_e->target, equeue_tick());
     equeue_mutex_unlock(&q->queuelock);
     return ret;
 }

--- a/events/source/equeue_posix.c
+++ b/events/source/equeue_posix.c
@@ -40,7 +40,10 @@ unsigned equeue_tick(void)
 // Mutex operations
 int equeue_mutex_create(equeue_mutex_t *m)
 {
-    return pthread_mutex_init(m, 0);
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    return pthread_mutex_init(m, &attr);
 }
 
 void equeue_mutex_destroy(equeue_mutex_t *m)


### PR DESCRIPTION
### Description

This PR implements mechanism to allow static event posting and dispatching. `UserAllocatedEvent` provides mechanism for event posting and dispatching without utilization of queue internal memory. `UserAllocatedEvent` embeds all underlying event data and doesn't require any memory allocation while posting and dispatching. All of these makes it cannot fail due to memory exhaustion while posting.

Docs update will be provided in separate PR

 - adds user allocated event support to equeue
- update equeue tests 
- adds `UserAllocatedEvent` implementation
- update queue test

```c++
#include "mbed.h"

void handler(int data) { ... }

class Device {
    public:
    void handler(int data) { ... }
};

Device dev;

// queue with not internal storage for dynamic events
// accepts only user allocated events
static EventQueue queue(0);
// Create events
static auto e1 = make_user_allocated_event(&dev, Device::handler, 2);
static auto e2 = queue.make_user_allocated_event(handler, 3);

int main()
{
   e1.call_on(&queue);
   e2.call();

   queue.dispatch(1);
}
```
#9172

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [] Test update
    [] Breaking change

### Reviewers

@kjbracey-arm 
@pan- 
@jamesbeyond 
@geky 
@bulislaw 

### Release Notes

Adds UserAllocatedEvent API to provide mechanism for event posting and dispatching without utilization of queue internal memory.
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
