### PR TITLE
ESP8266: Support power pin in custom wiring

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -78,7 +78,7 @@ public:
      * @param rx        RX pin
      * @param debug     Enable debugging
      */
-    ESP8266Interface(PinName tx, PinName rx, bool debug = false, PinName rts = NC, PinName cts = NC, PinName rst = NC);
+    ESP8266Interface(PinName tx, PinName rx, bool debug = false, PinName rts = NC, PinName cts = NC, PinName rst = NC, PinName pwr = NC);
 
     /**
      * @brief ESP8266Interface default destructor
@@ -392,6 +392,16 @@ private:
         mbed::DigitalOut  _rst_pin;
     } _rst_pin;
 
+    // HW power pin
+    class PowerPin {
+    public:
+        PowerPin(PinName pwr_pin);
+        void power_on();
+        void power_off();
+        bool is_connected();
+    private:
+        mbed::DigitalOut  _pwr_pin;
+    } _pwr_pin;
 
     // Credentials
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -21,6 +21,23 @@
             "help": "RESET pin for the modem, defaults to Not Connected",
             "value": null
         },
+        "pwr": {
+            "help": "POWER pin for the modem, defaults to Not Connected",
+            "value": null
+        },
+        "power-on-polarity": {
+            "help": "Polarity of power-on for the modem. 0 means 0/1 for power on/off; 1 means 1/0 for power on/off.",
+            "options": [0, 1],
+            "value": 0
+        },
+        "power-on-time-ms": {
+            "help": "Delay after powering on the modem in ms",
+            "value": 3
+        },
+        "power-off-time-ms": {
+            "help": "Delay after powering off the modem in ms",
+            "value": 3
+        },
         "debug": {
             "help": "Enable debug logs. [true/false]",
             "value": false


### PR DESCRIPTION
### Description

This PR tries to support power pin in custom wiring for the ESP8266 module. It allows for the following configurations:

- Power pin name
- Power pin polarity
- Power on/off time

#### Related PR

Replacement for #11299 and #11331 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@michalpasztamobica @kjbracey-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
