### PR TITLE
S2-LP: Sync with development repository

### DIFF
--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.c
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.c
@@ -35,6 +35,10 @@
 // Use multiplier for better resolution
 #define RESOLUTION_MULTIPLIER   1000000
 
+// RSSI_TH is a 8-bit register which can be converted to dBm using formula RSSI_TH-146
+#define MIN_RSSI_THRESHOLD  -146
+#define MAX_RSSI_THRESHOLD  109
+
 void rf_conf_calculate_datarate_registers(uint32_t datarate, uint16_t *datarate_mantissa, uint8_t *datarate_exponent)
 {
     uint64_t datarate_m = (uint64_t)datarate * DEF_2EXP33;
@@ -149,6 +153,12 @@ void rf_conf_calculate_rx_filter_bandwidth_registers(uint32_t rx_bandwidth, uint
     }
     *chflt_m = chflt_m_tmp;
     *chflt_e = chflt_e_tmp;
+}
+
+int16_t rf_conf_cca_threshold_percent_to_rssi(uint8_t percent)
+{
+    uint8_t step = (MAX_RSSI_THRESHOLD-MIN_RSSI_THRESHOLD);
+    return MIN_RSSI_THRESHOLD + (step * percent) / 100;
 }
 
 void rf_conf_calculate_rssi_threshold_registers(int16_t rssi_threshold, uint8_t *rssi_th)

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.h
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/rf_configuration.h
@@ -32,6 +32,7 @@ int rf_conf_calculate_channel_spacing_registers(uint32_t channel_spacing, uint8_
 void rf_conf_calculate_rx_filter_bandwidth_registers(uint32_t rx_bandwidth, uint8_t *chflt_m, uint8_t *chflt_e);
 void rf_conf_calculate_rssi_threshold_registers(int16_t rssi_threshold, uint8_t *rssi_th);
 uint32_t rf_conf_calculate_deviation(phy_modulation_index_e modulation_index, uint32_t datarate);
+int16_t rf_conf_cca_threshold_percent_to_rssi(uint8_t percent);
 
 #ifdef __cplusplus
 }

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
@@ -229,7 +229,7 @@ extern "C" {
 
 #define DEFAULT_DEVIATION       125000
 #define RX_FILTER_BANDWIDTH     540000
-#define RSSI_THRESHOLD          -60
+#define RSSI_THRESHOLD          -85
 
 // PCKTCTRL6
 #define PCKT_SYNCLEN_FIELD      0xFC


### PR DESCRIPTION
### Description

Nanostack driver updates for Mbed OS 5.14.
Note: this change has dependencies to https://github.com/ARMmbed/mbed-os/pull/11335

S2-LP RF driver:
 * v0.0.7
 * Removed debug traces
 * Implemented CCA threshold setting
 * Implemented PHY statistics

Atmel RF driver:
 * v3.0.8

MCR20A RF driver:
 * v1.0.7


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mikter @artokin @SeppoTakalo 

### Release Notes
