### PR TITLE
Fix bare-metal configuration to support Pelion Device Management Client

### DIFF
--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#ifdef MBED_CONF_NANOSTACK_CONFIG
+#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
 
 #include "ns_types.h"
 #include "fhss_api.h"

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#ifdef MBED_CONF_NANOSTACK_CONFIG
+
 #include "ns_types.h"
 #include "fhss_api.h"
 #include "fhss_config.h"
@@ -179,3 +181,4 @@ fhss_timer_t fhss_functions = {
     .fhss_resolution_divider = 1
 };
 
+#endif

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#ifdef MBED_CONF_RTOS_PRESENT
+
 #include "mbed_assert.h"
 #include "cmsis.h"
 #include "cmsis_os2.h"
@@ -130,3 +132,5 @@ void ns_event_loop_thread_start(void)
 #endif
 
 #endif // !MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_USE_MBED_EVENTS
+
+#endif //MBED_CONF_RTOS_PRESENT

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop_mbed.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop_mbed.cpp
@@ -17,9 +17,11 @@
 
 #include "mbed_assert.h"
 #include "platform/arm_hal_interrupt.h"
+#ifdef MBED_CONF_RTOS_PRESENT
 #include "cmsis.h"
 #include "cmsis_os2.h"
 #include "mbed_rtos_storage.h"
+#endif
 #include "ns_trace.h"
 
 #include "eventOS_scheduler.h"

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop_mutex.c
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop_mutex.c
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
+#include "eventOS_scheduler.h"
+
+#include "ns_event_loop_mutex.h"
+
+#ifdef MBED_CONF_RTOS_PRESENT
 #include "mbed_assert.h"
 #include "cmsis.h"
 #include "cmsis_os2.h"
 #include "mbed_rtos_storage.h"
 #include "ns_trace.h"
 
-#include "eventOS_scheduler.h"
-
-#include "ns_event_loop_mutex.h"
 
 #define TRACE_GROUP "evlm"
 
@@ -67,3 +69,23 @@ void ns_event_loop_mutex_init(void)
     MBED_ASSERT(event_mutex_id != NULL);
 }
 
+#else
+
+void eventOS_scheduler_mutex_wait(void)
+{
+}
+
+void eventOS_scheduler_mutex_release(void)
+{
+}
+
+uint8_t eventOS_scheduler_mutex_is_owner(void)
+{
+    return 1;
+}
+
+void ns_event_loop_mutex_init(void)
+{
+}
+
+#endif // MBED_CONF_RTOS_PRESENT

--- a/rtos/EventFlags.h
+++ b/rtos/EventFlags.h
@@ -22,6 +22,7 @@
 #ifndef EVENT_FLAG_H
 #define EVENT_FLAG_H
 
+#include <cstddef>
 #include <stdint.h>
 #include "rtos/mbed_rtos_types.h"
 #include "rtos/mbed_rtos1_types.h"


### PR DESCRIPTION
### Description

This PR enables Pelion Device Management Client to adapt to bare metal configuration of mbed-os since Client uses nanostack event loop so this component must adhere to bare-metal configuration



### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
    @kjbracey-arm please review


