### PR TITLE
Fix NRF52832 softdevice memory map

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7219,7 +7219,7 @@
     "MCU_NRF52832": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
-        "static_memory_defines": false,
+        "static_memory_defines": true,
         "macros": [
             "BOARD_PCA10040",
             "NRF52",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7219,7 +7219,6 @@
     "MCU_NRF52832": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
-        "static_memory_defines": true,
         "macros": [
             "BOARD_PCA10040",
             "NRF52",
@@ -7376,7 +7375,6 @@
         "inherits": ["Target"],
         "components_add": ["QSPIF"],
         "core": "Cortex-M4F",
-        "static_memory_defines": false,
         "macros": [
             "BOARD_PCA10056",
             "NRF52840_XXAA",


### PR DESCRIPTION
static_memory_defines controls the macro MBED_RAM_START AND MBED_RAM_SIZE
when nrf52832 to use softdevice, it need MBED_RAM_START to set the true application ram start
### Description
when nrf52832 use softdevice, the softdevice need some mem to work.
Like:
```
|-------------------|   APPLICATION_RAM_START + APPLICATION_RAM_SIZE == End of RAM
|                   |
...
|                   |
|    Application    |
|                   |
|                   |
+-------------------+   APPLICATION_RAM_START == SOFTDEVICE_RAM_START + SOFTDEVICE_RAM_SIZE
|                   |
|    Softdevice     |
|                   |
|                   |
+-------------------+   SOFTDEVICE_RAM_START == Start of RAM
```
It described by target.mbed_ram_start and target.mbed_ram_size in 
TARGET_NORDIC\TARGET_NRF5x\TARGET_SDK_XXX\TARGET_SOFTDEVICE_XXXX\mbed_lib.json
When static_memory_defines == true, it gen MBED_RAM_START macro.
In link file(NRF52832.ld), use MBED_RAM_START to set application ram_start.
I test both for Softdevice and Cordio.
### Pull request type
    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
### Reviewers
### Release Notes