### PR TITLE
Mutex: _count incrementation brought back

### DIFF
--- a/rtos/source/Mutex.cpp
+++ b/rtos/source/Mutex.cpp
@@ -97,6 +97,7 @@ bool Mutex::trylock_for(uint32_t millisec)
 {
     osStatus status = osMutexAcquire(_id, millisec);
     if (status == osOK) {
+        _count++;
         return true;
     }
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
_count++ was unintentionally dropped in: https://github.com/ARMmbed/mbed-os/commit/ca8070a482d159ea70f1ce549b6e80530238af0a

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@kjbracey-arm 
@michalpasztamobica 
@mprse 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
