### PR TITLE
Fix online GCC export to remove absolute path to mbed_config.h

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import re
-from os.path import join, basename, splitext, dirname, exists
+from os.path import join, basename, splitext, dirname, exists, isabs
 from os import getenv
 from distutils.spawn import find_executable
 from distutils.version import LooseVersion
@@ -194,6 +194,10 @@ class GCC(mbedToolchain):
         return ["-MD", "-MF", dep_path]
 
     def get_config_option(self, config_header):
+        # If an absolute path is returned (which can happen with exports from the online compiler) strip
+        # off the path (as it will be relative to the filer) and use the parent directory.
+        if isabs(config_header):
+            config_header = join("..", basename(config_header))
         return ['-include', config_header]
 
     def get_compile_options(self, defines, includes, for_asm=False):


### PR DESCRIPTION
### Description

Correct path to `mbed_config.h` when using GCC online exporter, see https://github.com/ARMmbed/mbed-os/issues/9816


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mark-edgeworth 
