### PR TITLE
Add reserved resources metadata to Cypress BSPs

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_43012/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,48 @@
+[Device="CY8C624ABZI-D44"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[11].pin[1]
+# CYBSP_USER_LED2
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED3
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED4
+ioss[0].port[0].pin[5]
+# CYBSP_USER_LED5
+ioss[0].port[7].pin[3]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+# CYBSP_USER_BTN2
+ioss[0].port[1].pin[4] 
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+# CYBSP_DEBUG_UART_RTS
+ioss[0].port[5].pin[2]
+# CYBSP_DEBUG_UART_CTS 
+ioss[0].port[5].pin[3]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+sdhc[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062S2_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,42 @@
+[Device="CY8C624ABZI-D44"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED2
+ioss[0].port[13].pin[7]
+# CYBSP_USER_LED3
+ioss[0].port[0].pin[3]
+# CYBSP_USER_LED4
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED5
+ioss[0].port[11].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+sdhc[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_BLE/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,24 @@
+[Device="CY8C6347BZI-BLD53"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED2
+ioss[0].port[13].pin[7]
+# CYBSP_USER_LED3
+ioss[0].port[0].pin[3]
+# CYBSP_USER_LED4
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED5
+ioss[0].port[11].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_062_WIFI_BT/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,42 @@
+[Device="CY8C6247BZI-D54"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED2
+ioss[0].port[13].pin[7]
+# CYBSP_USER_LED3
+ioss[0].port[0].pin[3]
+# CYBSP_USER_LED4
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED5
+ioss[0].port[11].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+udb[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,42 @@
+[Device="CYB0644ABZI-D44"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED2
+ioss[0].port[13].pin[7]
+# CYBSP_USER_LED3
+ioss[0].port[0].pin[3]
+# CYBSP_USER_LED4
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED5
+ioss[0].port[11].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+sdhc[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062S3_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,34 @@
+[Device="CY8C6245LQI-S3D72"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[11].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[1]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[10].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[10].pin[1]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+sdhc[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_062_4343W/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,34 @@
+[Device="CY8C624ABZI-D44"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[13].pin[7]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+sdhc[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_063_BLE/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_063_BLE/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,18 @@
+[Device="CYBLE-416045-02"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[6].pin[3]
+# CYBSP_USER_LED2
+ioss[0].port[7].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,18 @@
+[Device="CYB06447BZI-D54"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[13].pin[7]
+# CYBSP_USER_LED2
+ioss[0].port[1].pin[5]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,38 @@
+[Device="CY8C6247BZI-D54"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[0].pin[3]
+# CYBSP_USER_LED2
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED3
+ioss[0].port[10].pin[6]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[6]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[13].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[13].pin[1]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+udb[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43012EVB_01/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,40 @@
+[Device="CY8C6247FDI-D32"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED2
+ioss[0].port[11].pin[1]
+# CYBSP_USER_BTN1
+ioss[0].port[1].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+# CYBSP_DEBUG_UART_RTS
+ioss[0].port[5].pin[2]
+# CYBSP_DEBUG_UART_CTS
+ioss[0].port[5].pin[3]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+udb[0]
+# CYBSP_WIFI_SDIO_D0
+ioss[0].port[12].pin[1]
+# CYBSP_WIFI_SDIO_D1
+ioss[0].port[12].pin[2]
+# CYBSP_WIFI_SDIO_D2
+ioss[0].port[12].pin[3]
+# CYBSP_WIFI_SDIO_D3
+ioss[0].port[12].pin[4]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[12].pin[5]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[12].pin[0]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[6].pin[2]

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW9P62S1_43438EVB_01/COMPONENT_BSP_DESIGN_MODUS/cyreservedresources.list
@@ -1,0 +1,48 @@
+[Device="CY8C6247BZI-D54"]
+ 
+[Blocks]
+# User IO
+# CYBSP_USER_LED1
+ioss[0].port[11].pin[1]
+# CYBSP_USER_LED2
+ioss[0].port[1].pin[5]
+# CYBSP_USER_LED3
+ioss[0].port[1].pin[1]
+# CYBSP_USER_LED4
+ioss[0].port[0].pin[5]
+# CYBSP_USER_LED5
+ioss[0].port[7].pin[3]
+# CYBSP_USER_BTN1
+ioss[0].port[0].pin[4]
+# CYBSP_USER_BTN2
+ioss[0].port[1].pin[4]
+
+# Debug
+# CYBSP_DEBUG_UART
+scb[5]
+# CYBSP_DEBUG_UART_RX
+ioss[0].port[5].pin[0]
+# CYBSP_DEBUG_UART_TX
+ioss[0].port[5].pin[1]
+# CYBSP_DEBUG_UART_RTS
+ioss[0].port[5].pin[2]
+# CYBSP_DEBUG_UART_CTS
+ioss[0].port[5].pin[3]
+
+# WIFI
+# CYBSP_WIFI_SDIO
+udb[0]
+# CYBSP_WIFI_SDIO_DAT0
+ioss[0].port[2].pin[0]
+# CYBSP_WIFI_SDIO_DAT1
+ioss[0].port[2].pin[1]
+# CYBSP_WIFI_SDIO_DAT2
+ioss[0].port[2].pin[2]
+# CYBSP_WIFI_SDIO_DAT3
+ioss[0].port[2].pin[3]
+# CYBSP_WIFI_SDIO_CMD
+ioss[0].port[2].pin[4]
+# CYBSP_WIFI_SDIO_CLK
+ioss[0].port[2].pin[5]
+# CYBSP_WIFI_WL_REG_ON
+ioss[0].port[2].pin[6]


### PR DESCRIPTION
### Description
These provide information to allow Cypress graphical configuration tools to avoid conflicting usage of hardware resources which are managed by firmware included with the BSP. There is no functional impact to mbed-os.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
