### PR TITLE
Offloaded TLSSocket and BG96 support for it

### DIFF
--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -84,15 +84,15 @@ nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
 
     printf("MBED: Server '%s', port %d\n", tls_addr.get_ip_address(), tls_addr.get_port());
 
-    nsapi_error_t err = sock.set_root_ca_cert(tls_global::cert);
+    nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.set_root_ca_cert: %d\n", err);
+        printf("Error from sock.open: %d\n", err);
         return err;
     }
 
-    err = sock.open(NetworkInterface::get_default_instance());
+    err = sock.set_root_ca_cert(tls_global::cert);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.open: %d\n", err);
+        printf("Error from sock.set_root_ca_cert: %d\n", err);
         return err;
     }
 

--- a/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tls/tlssocket_endpoint_close.cpp
@@ -48,6 +48,10 @@ static nsapi_error_t _tlssocket_connect_to_daytime_srv(TLSSocket &sock)
         return err;
     }
 
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));
+
+    sock.set_timeout(10000); // Set timeout for case TLSSocket does not support peer closed indication
+
     return sock.connect(tls_addr);
 }
 
@@ -62,7 +66,6 @@ void TLSSOCKET_ENDPOINT_CLOSE()
     tc_exec_time.start();
 
     TLSSocket sock;
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));
     if (_tlssocket_connect_to_daytime_srv(sock) != NSAPI_ERROR_OK) {
         TEST_FAIL();
         return;

--- a/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
+++ b/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
@@ -28,12 +28,18 @@ using namespace utest::v1;
 
 void TLSSOCKET_HANDSHAKE_INVALID()
 {
+    const int https_port = 443;
     SKIP_IF_TCP_UNSUPPORTED();
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE,
-                      sock.connect("google.com", 443)); // 443 is https port.
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("expired.badssl.com", https_port));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("wrong.host.badssl.com", https_port));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("self-signed.badssl.com", https_port));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("untrusted-root.badssl.com", https_port));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("revoked.badssl.com", https_port));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("pinning-test.badssl.com", https_port));
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_AUTH_FAILURE, sock.connect("sha1-intermediate.badssl.com", https_port));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }
 

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/at_cellularstacktest.cpp
@@ -244,7 +244,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_bind)
     MyStack st(at, 0, IPV6_STACK);
     SocketAddress addr;
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_ALREADY;
-    EXPECT_EQ(st.socket_bind(NULL, addr), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_bind(NULL, addr), NSAPI_ERROR_NO_SOCKET);
 
     EXPECT_EQ(st.socket_bind(&st.socket, addr), NSAPI_ERROR_ALREADY);
 }
@@ -267,7 +267,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_connect)
 
     MyStack st(at, 0, IPV6_STACK);
     SocketAddress addr;
-    EXPECT_EQ(st.socket_connect(NULL, addr), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_connect(NULL, addr), NSAPI_ERROR_NO_SOCKET);
 
     EXPECT_EQ(st.socket_connect(&st.socket, addr), NSAPI_ERROR_OK);
 }
@@ -290,9 +290,9 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_send)
     ATHandler at(&fh1, que, 0, ",");
 
     MyStack st(at, 0, IPV6_STACK);
-    EXPECT_EQ(st.socket_send(NULL, "addr", 4), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_send(NULL, "addr", 4), NSAPI_ERROR_NO_SOCKET);
 
-    EXPECT_EQ(st.socket_send(&st.socket, "addr", 4), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_send(&st.socket, "addr", 4), NSAPI_ERROR_NO_CONNECTION);
 
     SocketAddress addr;
     st.max_sock_value = 1;
@@ -312,7 +312,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_sendto)
     MyStack st(at, 0, IPV6_STACK);
 
     SocketAddress addr;
-    EXPECT_EQ(st.socket_sendto(NULL, addr, "addr", 4), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_sendto(NULL, addr, "addr", 4), NSAPI_ERROR_NO_SOCKET);
 
     st.max_sock_value = 1;
     st.bool_value = true;
@@ -334,7 +334,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_recv)
 
     MyStack st(at, 0, IPV6_STACK);
     char table[4];
-    EXPECT_EQ(st.socket_recv(NULL, table, 4), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_recv(NULL, table, 4), NSAPI_ERROR_NO_SOCKET);
 }
 
 TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_recvfrom)
@@ -345,7 +345,7 @@ TEST_F(TestAT_CellularStack, test_AT_CellularStack_socket_recvfrom)
 
     MyStack st(at, 0, IPV6_STACK);
     char table[4];
-    EXPECT_EQ(st.socket_recvfrom(NULL, NULL, table, 4), NSAPI_ERROR_DEVICE_ERROR);
+    EXPECT_EQ(st.socket_recvfrom(NULL, NULL, table, 4), NSAPI_ERROR_NO_SOCKET);
 
     SocketAddress addr;
     st.max_sock_value = 1;

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -156,7 +156,7 @@ nsapi_error_t AT_CellularStack::socket_close(nsapi_socket_t handle)
 
     struct CellularSocket *socket = (struct CellularSocket *)handle;
     if (!socket) {
-        return err;
+        return NSAPI_ERROR_NO_SOCKET;
     }
     int sock_id = socket->id;
 
@@ -192,7 +192,7 @@ nsapi_error_t AT_CellularStack::socket_bind(nsapi_socket_t handle, const SocketA
 {
     struct CellularSocket *socket = (CellularSocket *)handle;
     if (!socket) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return NSAPI_ERROR_NO_SOCKET;
     }
 
     if (addr) {
@@ -220,14 +220,14 @@ nsapi_error_t AT_CellularStack::socket_bind(nsapi_socket_t handle, const SocketA
 
 nsapi_error_t AT_CellularStack::socket_listen(nsapi_socket_t handle, int backlog)
 {
-    return NSAPI_ERROR_UNSUPPORTED;;
+    return NSAPI_ERROR_UNSUPPORTED;
 }
 
 nsapi_error_t AT_CellularStack::socket_connect(nsapi_socket_t handle, const SocketAddress &addr)
 {
     CellularSocket *socket = (CellularSocket *)handle;
     if (!socket) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return NSAPI_ERROR_NO_SOCKET;
     }
     socket->remoteAddress = addr;
     socket->connected = true;
@@ -237,14 +237,17 @@ nsapi_error_t AT_CellularStack::socket_connect(nsapi_socket_t handle, const Sock
 
 nsapi_error_t AT_CellularStack::socket_accept(void *server, void **socket, SocketAddress *addr)
 {
-    return NSAPI_ERROR_UNSUPPORTED;;
+    return NSAPI_ERROR_UNSUPPORTED;
 }
 
 nsapi_size_or_error_t AT_CellularStack::socket_send(nsapi_socket_t handle, const void *data, unsigned size)
 {
     CellularSocket *socket = (CellularSocket *)handle;
-    if (!socket || !socket->connected) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+    if (!socket->connected) {
+        return NSAPI_ERROR_NO_CONNECTION;
     }
     return socket_sendto(handle, socket->remoteAddress, data, size);
 }
@@ -253,7 +256,7 @@ nsapi_size_or_error_t AT_CellularStack::socket_sendto(nsapi_socket_t handle, con
 {
     CellularSocket *socket = (CellularSocket *)handle;
     if (!socket) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return NSAPI_ERROR_NO_SOCKET;
     }
 
     if (socket->closed && !socket->rx_avail) {
@@ -319,7 +322,7 @@ nsapi_size_or_error_t AT_CellularStack::socket_recvfrom(nsapi_socket_t handle, S
 {
     CellularSocket *socket = (CellularSocket *)handle;
     if (!socket) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return NSAPI_ERROR_NO_SOCKET;
     }
 
     if (socket->closed) {

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -102,6 +102,7 @@ protected:
             started(false),
             tx_ready(false),
             rx_avail(false),
+            tls_socket(false),
             pending_bytes(0)
         {
         }
@@ -119,6 +120,7 @@ protected:
         bool started; // socket has been opened on modem stack
         bool tx_ready; // socket is ready for sending on modem stack
         bool rx_avail; // socket has data for reading on modem stack
+        bool tls_socket; // socket uses modem's internal TLS socket functionality
         nsapi_size_t pending_bytes; // The number of received bytes pending
     };
 

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
@@ -55,6 +55,9 @@ protected: // NetworkStack
     virtual nsapi_error_t gethostbyname_async_cancel(int id);
 #endif
 
+    virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
+                                     int optname, const void *optval, unsigned optlen);
+
 protected: // AT_CellularStack
 
     virtual int get_max_socket_count();
@@ -79,7 +82,9 @@ private:
     // URC handler for socket being closed
     void urc_qiurc_closed();
 
-    void handle_open_socket_response(int &modem_connect_id, int &err);
+    void handle_open_socket_response(int &modem_connect_id, int &err, bool tlssocket);
+
+    nsapi_error_t set_to_modem_impl(const char *filename, const char *config, const char *data, size_t size);
 
 #ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES
     // URC handler for DNS query
@@ -89,6 +94,9 @@ private:
     hostbyname_cb_t _dns_callback;
     nsapi_version_t _dns_version;
 #endif
+
+    uint8_t _tls_sec_level;
+
     /** Convert IP address to dotted string representation
      *
      *  BG96 requires consecutive zeros so can't use get_ip_address or ip6tos directly.

--- a/features/netsocket/TLSSocket.cpp
+++ b/features/netsocket/TLSSocket.cpp
@@ -20,6 +20,8 @@
 #define TRACE_GROUP "TLSS"
 #include "mbed-trace/mbed_trace.h"
 
+#if !defined(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET) || !(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET)
+
 // This class requires Mbed TLS SSL/TLS client code
 #if defined(MBEDTLS_SSL_CLI_C)
 
@@ -46,5 +48,71 @@ TLSSocket::~TLSSocket()
      */
     close();
 }
-
 #endif // MBEDTLS_SSL_CLI_C
+
+#else // MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET
+
+TLSSocket::TLSSocket()
+{
+}
+
+TLSSocket::~TLSSocket()
+{
+}
+
+
+nsapi_error_t TLSSocket::set_hostname(const char *hostname)
+{
+    return setsockopt(NSAPI_TLSSOCKET_LEVEL, NSAPI_TLSSOCKET_SET_HOSTNAME, hostname, strlen(hostname));
+}
+
+nsapi_error_t TLSSocket::set_root_ca_cert(const void *root_ca, size_t len)
+{
+    return setsockopt(NSAPI_TLSSOCKET_LEVEL, NSAPI_TLSSOCKET_SET_CACERT, root_ca, len);
+}
+
+nsapi_error_t TLSSocket::set_root_ca_cert(const char *root_ca_pem)
+{
+    return set_root_ca_cert(root_ca_pem, strlen(root_ca_pem));
+}
+
+nsapi_error_t TLSSocket::set_client_cert_key(const void *client_cert, size_t client_cert_len,
+                                             const void *client_private_key_pem, size_t client_private_key_len)
+{
+    nsapi_error_t ret = setsockopt(NSAPI_TLSSOCKET_LEVEL, NSAPI_TLSSOCKET_SET_CLCERT, client_cert, client_cert_len);
+    if (ret == NSAPI_ERROR_OK) {
+        ret = setsockopt(NSAPI_TLSSOCKET_LEVEL, NSAPI_TLSSOCKET_SET_CLKEY, client_private_key_pem, client_private_key_len);
+    }
+    return ret;
+}
+
+nsapi_error_t TLSSocket::set_client_cert_key(const char *client_cert_pem, const char *client_private_key_pem)
+{
+    return set_client_cert_key(client_cert_pem, strlen(client_cert_pem), client_private_key_pem, strlen(client_private_key_pem));
+}
+
+nsapi_error_t TLSSocket::connect(const char *host, uint16_t port)
+{
+    nsapi_error_t ret = enable_tlssocket();
+    if (ret == NSAPI_ERROR_OK) {
+        ret = TCPSocket::connect(host, port);
+    }
+    return ret;
+}
+
+nsapi_error_t TLSSocket::connect(const SocketAddress &address)
+{
+    nsapi_error_t ret = enable_tlssocket();
+    if (ret == NSAPI_ERROR_OK) {
+        ret = TCPSocket::connect(address);
+    }
+    return ret;
+}
+
+nsapi_error_t TLSSocket::enable_tlssocket()
+{
+    bool enabled = true;
+    return setsockopt(NSAPI_TLSSOCKET_LEVEL, NSAPI_TLSSOCKET_ENABLE, &enabled, sizeof(enabled));
+}
+
+#endif // MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET

--- a/features/netsocket/TLSSocket.h
+++ b/features/netsocket/TLSSocket.h
@@ -23,7 +23,6 @@
 #define _MBED_HTTPS_TLS_TCP_SOCKET_H_
 
 #include "netsocket/TCPSocket.h"
-#include "TLSSocketWrapper.h"
 
 #include "mbedtls/platform.h"
 #include "mbedtls/ssl.h"
@@ -31,8 +30,12 @@
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/error.h"
 
+#if !defined(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET) || !(MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET)
+
 // This class requires Mbed TLS SSL/TLS client code
 #if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
+
+#include "TLSSocketWrapper.h"
 
 /**
  * \brief TLSSocket is a wrapper around TCPSocket for interacting with TLS servers.
@@ -62,7 +65,7 @@ public:
      *        clear internal TLS memory structures.
      *
      *  @param stack    Network stack as target for socket.
-     *  @return         0 on success, negative error code on failure.
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      */
     virtual nsapi_error_t open(NetworkStack *stack)
     {
@@ -87,15 +90,80 @@ public:
      *
      *  @param host     Hostname of the remote host.
      *  @param port     Port of the remote host.
-     *  @return         0 on success, negative error code on failure.
+     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
      */
     nsapi_error_t connect(const char *host, uint16_t port);
 
 private:
     TCPSocket tcp_socket;
 };
-
 #endif // MBEDTLS_SSL_CLI_C
+
+#else // MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET
+
+class TLSSocket : public TCPSocket {
+public:
+    TLSSocket();
+    virtual ~TLSSocket();
+
+    /** Set hostname.
+     *
+     * TLSSocket requires hostname used to verify the certificate.
+     * If hostname is not given in constructor, this function must be used before
+     * starting the TLS handshake.
+     *
+     * @param hostname     Hostname of the remote host, used for certificate checking.
+     */
+    nsapi_error_t set_hostname(const char *hostname);
+
+    /** Sets the certification of Root CA.
+     *
+     * @note Must be called after open() before calling connect()
+     *
+     * @param root_ca Root CA Certificate in any Mbed TLS-supported format.
+     * @param len     Length of certificate (including terminating 0 for PEM).
+     * @return        NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    virtual nsapi_error_t set_root_ca_cert(const void *root_ca, size_t len);
+
+    /** Sets the certification of Root CA.
+     *
+     * @note Must be called after open() before calling connect()
+     *
+     * @param root_ca_pem Root CA Certificate in PEM format.
+     */
+    virtual nsapi_error_t set_root_ca_cert(const char *root_ca_pem);
+
+
+    /** Sets client certificate, and client private key.
+     *
+     * @param client_cert Client certification in PEM or DER format.
+     * @param client_cert_len Certificate size including the terminating null byte for PEM data.
+     * @param client_private_key_pem Client private key in PEM or DER format.
+     * @param client_private_key_len Key size including the terminating null byte for PEM data
+     * @return   NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    virtual nsapi_error_t set_client_cert_key(const void *client_cert, size_t client_cert_len,
+                                              const void *client_private_key_pem, size_t client_private_key_len);
+
+    /** Sets client certificate, and client private key.
+     *
+     * @param client_cert_pem Client certification in PEM format.
+     * @param client_private_key_pem Client private key in PEM format.
+     * @return   NSAPI_ERROR_OK on success, negative error code on failure.
+     */
+    virtual nsapi_error_t set_client_cert_key(const char *client_cert_pem, const char *client_private_key_pem);
+
+    // From TCPSocket
+    virtual nsapi_error_t connect(const char *host, uint16_t port);
+    virtual nsapi_error_t connect(const SocketAddress &address);
+
+protected:
+    virtual nsapi_error_t enable_tlssocket();
+};
+
+#endif // MBED_CONF_NSAPI_OFFLOAD_TLSSOCKET
+
 #endif // _MBED_HTTPS_TLS_TCP_SOCKET_H_
 
 /** @} */

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -65,6 +65,10 @@
         "socket-stats-max-count": {
             "help": "Maximum number of socket statistics cached",
             "value": 10
+        },
+        "offload-tlssocket" : {
+            "help": "Use external TLSSocket implementation. Used network stack must support external TLSSocket setsockopt values (see nsapi_types.h)",
+            "value": null
         }
     },
     "target_overrides": {

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -269,6 +269,18 @@ typedef enum nsapi_socket_option {
     NSAPI_BIND_TO_DEVICE,        /*!< Bind socket network interface name*/
 } nsapi_socket_option_t;
 
+typedef enum nsapi_tlssocket_level {
+    NSAPI_TLSSOCKET_LEVEL   = 7099, /*!< TLSSocket option level - see nsapi_tlssocket_option_t for options*/
+} nsapi_tlssocket_level_t;
+
+typedef enum nsapi_tlssocket_option {
+    NSAPI_TLSSOCKET_SET_HOSTNAME,   /*!< Set host name */
+    NSAPI_TLSSOCKET_SET_CACERT,     /*!< Set server CA certificate */
+    NSAPI_TLSSOCKET_SET_CLCERT,     /*!< Set client certificate */
+    NSAPI_TLSSOCKET_SET_CLKEY,      /*!< Set client key */
+    NSAPI_TLSSOCKET_ENABLE          /*!< Enable TLSSocket */
+} nsapi_tlssocket_option_t;
+
 /** Supported IP protocol versions of IP stack
  *
  *  @enum nsapi_ip_stack


### PR DESCRIPTION
### Description

Some external modems have an internal TLSSocket implementation which can be used instead of mbedtls based TLSSocket. Using offloaded TLSSocket can result in significantly reduce ROM usage.

Offloaded TLSSocket can be enabled by enabling `"nsapi.offload-tlssocket"` and the used network stack (e.g. cellular modem's CellularStack class) must support the setsockopt's defined in nsapi_types.h.

Compared to original mbedtls based TLSSocket, offloaded TLSSocket brings in one significant API limitation. Offloaded TLSSocket requires setting of certificates and keys after `open()` and before `connect()` calls, where mbedtls based TLSSocket allows setting these before `open()` call.

This PR also includes a reference implementation for BG96 cellular modem.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@AnttiKauppila @kjbracey-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

Some external modems have an internal TLSSocket implementation which can be used instead of mbedtls based TLSSocket. Using offloaded TLSSocket can result in significantly reduce ROM usage.

Offloaded TLSSocket can be enabled by enabling `"nsapi.offload-tlssocket"` and the used network stack (e.g. cellular modem's CellularStack class) must support the setsockopt's defined in nsapi_types.h.

Compared to original mbedtls based TLSSocket, offloaded TLSSocket brings in one significant API limitation. Offloaded TLSSocket requires setting of certificates and keys after `open()` and before `connect()` calls, where mbedtls based TLSSocket allows setting these before `open()` call.

This PR also includes a reference implementation for BG96 cellular modem.