### PR TITLE
Add pin speed controlling interface

### DIFF
--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -90,30 +90,30 @@ extern "C" {
 #define STM_PIN_ANALOG_CONTROL(X)   (((X) >> STM_PIN_AN_CTRL_SHIFT) & STM_PIN_AN_CTRL_MASK)
 
 #define STM_PIN_DEFINE(FUNC_OD, PUPD, AFNUM)  ((int)(FUNC_OD) |\
-						  ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-                          (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-                          (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
+            ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
 #define STM_PIN_DEFINE_SPEED(FUNC_OD, PUPD, AFNUM, SPEEDV)  ((int)(FUNC_OD) |\
-						  (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-                          (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-                          (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
+            (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
 #define STM_PIN_DEFINE_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV) \
-                                            ((int)(FUNC_OD) |\
-                       ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-                       (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-                       (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
-                       (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
-                       (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
+            ((int)(FUNC_OD) |\
+            ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
+            (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+            (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
 #define STM_PIN_DEFINE_SPEED_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEEDV) \
-                                            ((int)(FUNC_OD) |\
-                       (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-                       (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-                       (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
-                       (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
-                       (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
+            ((int)(FUNC_OD) |\
+            (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
+            (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+            (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
 /*
  * MACROS to support the legacy definition of PIN formats

--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -40,12 +40,12 @@ extern "C" {
  *   [2:0]  Function (like in MODER reg) : Input / Output / Alt / Analog
  *     [3]  Output Push-Pull / Open Drain (as in OTYPER reg)
  *   [5:4]  as in PUPDR reg: No Pull, Pull-up, Pull-Donc
- *   [7:6]  Reserved for speed config (as in OSPEEDR), but not used yet
- *  [11:8]  Alternate Num (as in AFRL/AFRG reg)
- * [16:12]  Channel (Analog/Timer specific)
- *    [17]  Inverted (Analog/Timer specific)
- *    [18]  Analog ADC control - Only valid for specific families
- * [32:19]  Reserved
+ *   [9:6]  speed config (as in OSPEEDR)
+ * [13:10]  Alternate Num (as in AFRL/AFRG reg)
+ * [17:14]  Channel (Analog/Timer specific)
+ *    [18]  Inverted (Analog/Timer specific)
+ *    [19]  Analog ADC control - Only valid for specific families
+ * [32:21]  Reserved
  */
 
 #define STM_PIN_FUNCTION_MASK 0x07
@@ -60,24 +60,24 @@ extern "C" {
 #define STM_PIN_PUPD_SHIFT 4
 #define STM_PIN_PUPD_BITS (STM_PIN_PUPD_MASK << STM_PIN_PUPD_SHIFT)
 
-#define STM_PIN_SPEED_MASK 0x03
+#define STM_PIN_SPEED_MASK 0x0F
 #define STM_PIN_SPEED_SHIFT 6
 #define STM_PIN_SPEED_BITS (STM_PIN_SPEED_MASK << STM_PIN_SPEED_SHIFT)
 
 #define STM_PIN_AFNUM_MASK 0x0F
-#define STM_PIN_AFNUM_SHIFT 8
+#define STM_PIN_AFNUM_SHIFT 10
 #define STM_PIN_AFNUM_BITS (STM_PIN_AFNUM_MASK << STM_PIN_AFNUM_SHIFT)
 
 #define STM_PIN_CHAN_MASK 0x1F
-#define STM_PIN_CHAN_SHIFT 12
+#define STM_PIN_CHAN_SHIFT 14
 #define STM_PIN_CHANNEL_BIT (STM_PIN_CHAN_MASK << STM_PIN_CHAN_SHIFT)
 
 #define STM_PIN_INV_MASK 0x01
-#define STM_PIN_INV_SHIFT 17
+#define STM_PIN_INV_SHIFT 19
 #define STM_PIN_INV_BIT (STM_PIN_INV_MASK << STM_PIN_INV_SHIFT)
 
 #define STM_PIN_AN_CTRL_MASK 0x01
-#define STM_PIN_AN_CTRL_SHIFT 18
+#define STM_PIN_AN_CTRL_SHIFT 20
 #define STM_PIN_ANALOG_CONTROL_BIT (STM_PIN_AN_CTRL_MASK << STM_PIN_AN_CTRL_SHIFT)
 
 #define STM_PIN_FUNCTION(X)         (((X) >> STM_PIN_FUNCTION_SHIFT) & STM_PIN_FUNCTION_MASK)
@@ -90,15 +90,30 @@ extern "C" {
 #define STM_PIN_ANALOG_CONTROL(X)   (((X) >> STM_PIN_AN_CTRL_SHIFT) & STM_PIN_AN_CTRL_MASK)
 
 #define STM_PIN_DEFINE(FUNC_OD, PUPD, AFNUM)  ((int)(FUNC_OD) |\
-                          ((PUPD  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-                          ((AFNUM & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
+						  ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+                          (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+                          (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
+
+#define STM_PIN_DEFINE_SPEED(FUNC_OD, PUPD, AFNUM, SPEED)  ((int)(FUNC_OD) |\
+						  (((SPEED)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+                          (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+                          (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
 #define STM_PIN_DEFINE_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV) \
                                             ((int)(FUNC_OD) |\
-                       ((PUPD   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-                       ((AFNUM  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
-                       ((CHAN   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
-                       ((INV    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
+                       ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+                       (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+                       (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
+                       (((CHANv   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+                       (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
+
+#define STM_PIN_DEFINE_EXT2(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEED) \
+                                            ((int)(FUNC_OD) |\
+                       (((SPEED)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+                       (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+                       (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
+                       (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+                       (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
 /*
  * MACROS to support the legacy definition of PIN formats

--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -107,7 +107,7 @@ extern "C" {
                        (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
                        (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
-#define STM_PIN_DEFINE_EXT2(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEEDV) \
+#define STM_PIN_DEFINE_SPEED_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEEDV) \
                                             ((int)(FUNC_OD) |\
                        (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
                        (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\

--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -94,8 +94,8 @@ extern "C" {
                           (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
                           (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
-#define STM_PIN_DEFINE_SPEED(FUNC_OD, PUPD, AFNUM, SPEED)  ((int)(FUNC_OD) |\
-						  (((SPEED)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+#define STM_PIN_DEFINE_SPEED(FUNC_OD, PUPD, AFNUM, SPEEDV)  ((int)(FUNC_OD) |\
+						  (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
                           (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
                           (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
@@ -107,9 +107,9 @@ extern "C" {
                        (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
                        (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
-#define STM_PIN_DEFINE_EXT2(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEED) \
+#define STM_PIN_DEFINE_EXT2(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEEDV) \
                                             ((int)(FUNC_OD) |\
-                       (((SPEED)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+                       (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
                        (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
                        (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
                        (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\

--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -104,7 +104,7 @@ extern "C" {
                        ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
                        (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
                        (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
-                       (((CHANv   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+                       (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
                        (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
 #define STM_PIN_DEFINE_EXT2(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEED) \

--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -90,30 +90,30 @@ extern "C" {
 #define STM_PIN_ANALOG_CONTROL(X)   (((X) >> STM_PIN_AN_CTRL_SHIFT) & STM_PIN_AN_CTRL_MASK)
 
 #define STM_PIN_DEFINE(FUNC_OD, PUPD, AFNUM)  ((int)(FUNC_OD) |\
-            ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-            (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            ((STM_PIN_SPEED_MASK & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD) & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
             (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
 #define STM_PIN_DEFINE_SPEED(FUNC_OD, PUPD, AFNUM, SPEEDV)  ((int)(FUNC_OD) |\
-            (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-            (((PUPD)  & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((SPEEDV) & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD) & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
             (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT))
 
 #define STM_PIN_DEFINE_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV) \
             ((int)(FUNC_OD) |\
             ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-            (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-            (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
-            (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
-            (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
+            (((PUPD) & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
+            (((CHAN) & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+            (((INV) & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
 #define STM_PIN_DEFINE_SPEED_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV, SPEEDV) \
             ((int)(FUNC_OD) |\
-            (((SPEEDV)   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
-            (((PUPD)   & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
-            (((AFNUM)  & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
-            (((CHAN)   & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
-            (((INV)    & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
+            (((SPEEDV) & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            (((PUPD) & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
+            (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
+            (((CHAN) & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\
+            (((INV) & STM_PIN_INV_MASK) << STM_PIN_INV_SHIFT))
 
 /*
  * MACROS to support the legacy definition of PIN formats

--- a/targets/TARGET_STM/PinNamesTypes.h
+++ b/targets/TARGET_STM/PinNamesTypes.h
@@ -101,7 +101,7 @@ extern "C" {
 
 #define STM_PIN_DEFINE_EXT(FUNC_OD, PUPD, AFNUM, CHAN, INV) \
             ((int)(FUNC_OD) |\
-            ((STM_PIN_SPEED_MASK   & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
+            ((STM_PIN_SPEED_MASK & STM_PIN_SPEED_MASK) << STM_PIN_SPEED_SHIFT) |\
             (((PUPD) & STM_PIN_PUPD_MASK) << STM_PIN_PUPD_SHIFT) |\
             (((AFNUM) & STM_PIN_AFNUM_MASK) << STM_PIN_AFNUM_SHIFT) |\
             (((CHAN) & STM_PIN_CHAN_MASK) << STM_PIN_CHAN_SHIFT) |\

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -80,15 +80,14 @@ void pin_function(PinName pin, int data)
 #if defined (TARGET_STM32F1)
     if (mode == STM_PIN_OUTPUT) {
 #endif
-		switch (speed)
-		{
+		switch (speed) {
 		/* Default value for backward compatibility */
 		case STM_PIN_SPEED_MASK:
-        #if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
+#if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
             LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
-        #else
+#else
             LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
-        #endif
+#endif
 			break;
 
 		default:

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -84,11 +84,11 @@ void pin_function(PinName pin, int data)
 		{
 		/* Default value for backward compatibility */
 		case STM_PIN_SPEED_MASK:
-#if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
-        LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
-#else
-        LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
-#endif
+    #if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
+            LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
+    #else
+            LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
+    #endif
 			break;
 
 		default:

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -80,23 +80,22 @@ void pin_function(PinName pin, int data)
 #if defined (TARGET_STM32F1)
     if (mode == STM_PIN_OUTPUT) {
 #endif
-		switch (speed) {
-		/* Default value for backward compatibility */
-		case STM_PIN_SPEED_MASK:
+        switch (speed) {
+            /* Default value for backward compatibility */
+            case STM_PIN_SPEED_MASK:
 #if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
-            LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
+                LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
 #else
-            LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
+                LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
 #endif
-			break;
-
-		default:
-		    LL_GPIO_SetPinSpeed(gpio, ll_pin, speed);
-			break;
-		}
+                break;
+            default:
+                LL_GPIO_SetPinSpeed(gpio, ll_pin, speed);
+                break;
+        }
 #if defined (TARGET_STM32F1)
     }
-#endif
+#endiff
 
     switch (mode) {
         case STM_PIN_INPUT:

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -95,7 +95,7 @@ void pin_function(PinName pin, int data)
         }
 #if defined (TARGET_STM32F1)
     }
-#endiff
+#endif
 
     switch (mode) {
         case STM_PIN_INPUT:

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -64,12 +64,13 @@ void pin_function(PinName pin, int data)
     // Get the pin informations
     uint32_t mode  = STM_PIN_FUNCTION(data);
     uint32_t afnum = STM_PIN_AFNUM(data);
+    uint32_t speed = STM_PIN_SPEED(data);
     uint32_t port = STM_PORT(pin);
     uint32_t ll_pin  = ll_pin_defines[STM_PIN(pin)];
     uint32_t ll_mode = 0;
 
     // Enable GPIO clock
-    GPIO_TypeDef *gpio = Set_GPIO_Clock(port);
+    GPIO_TypeDef * const gpio = Set_GPIO_Clock(port);
 
     /*  Set default speed to high.
      *  For most families there are dedicated registers so it is
@@ -79,13 +80,21 @@ void pin_function(PinName pin, int data)
 #if defined (TARGET_STM32F1)
     if (mode == STM_PIN_OUTPUT) {
 #endif
-
+		switch (speed)
+		{
+		/* Default value for backward compatibility */
+		case STM_PIN_SPEED_MASK:
 #if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
         LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
 #else
         LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
 #endif
+			break;
 
+		default:
+		    LL_GPIO_SetPinSpeed(gpio, ll_pin, speed);
+			break;
+		}
 #if defined (TARGET_STM32F1)
     }
 #endif

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -84,11 +84,11 @@ void pin_function(PinName pin, int data)
 		{
 		/* Default value for backward compatibility */
 		case STM_PIN_SPEED_MASK:
-    #if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
+        #if defined (LL_GPIO_SPEED_FREQ_VERY_HIGH)
             LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_VERY_HIGH);
-    #else
+        #else
             LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
-    #endif
+        #endif
 			break;
 
 		default:


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Adding pin speed limit control for STM32-based targets. No other changes need, transparent for exiting code.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
