### PR TITLE
M263: Enlarge LPTICKER_DELAY_TICKS for safe

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9039,7 +9039,7 @@
         ],
         "macros": [
             "MBED_FAULT_HANDLER_DISABLED",
-            "LPTICKER_DELAY_TICKS=3"
+            "LPTICKER_DELAY_TICKS=4"
         ],
         "is_disk_virtual": true,
         "supported_toolchains": ["ARMC6", "GCC_ARM", "IAR"],


### PR DESCRIPTION
### Description

Continuation of #11021 and applies on **NUMAKER_IOT_M263A**. `lp_ticker_set_interrupt(...)` needs around 3 lp-ticker ticks to take effect. It may miss when current tick and match tick are very close (see **hal/LowPowerTickerWrapper.cpp**). This PR enlarges `LPTICKER_DELAY_TICKS` to 4 from 3 to address this boundary case.

#### Related PR

Continuation of #11021 and applies on M263 target

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
