### PR TITLE
M263: Enlarge required deep sleep latency

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9093,7 +9093,10 @@
         "release_versions": ["5"],
         "device_name": "M263KIAAE",
         "bootloader_supported": true,
-        "tickless-from-us-ticker": true,
+        "overrides": {
+            "deep-sleep-latency": 1,
+            "tickless-from-us-ticker": true
+        },
         "forced_reset_timeout": 3
     },    
     "__build_tools_metadata__": {


### PR DESCRIPTION
### Description

Continuation of #11020, this PR is to pass wake-up from deep-sleep test such as `mbedmicro-rtos-mbed-systimer` on **NUMAKER_IOT_M263A** target when in tickless from lp-ticker mode.

#### Related PR

Continuation of #11020 and applies on M263

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
