### PR TITLE
Change LSI_VALUE in STM implementation.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_ll_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_ll_rcc.h
@@ -141,7 +141,7 @@ typedef struct
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    40000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 #if defined(RCC_HSI48_SUPPORT)
 

--- a/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_ll_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_ll_rcc.h
@@ -146,7 +146,7 @@ typedef struct
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    40000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rcc.h
@@ -131,7 +131,7 @@ typedef struct
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    37000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 /**
   * @}


### PR DESCRIPTION
Wrong LSI value might be causing problems witch watchdogs. NUCLEO_F303RE failed watchdog simple reset test on nightly CI. Looking into STM drivers I have found that LSI_VALUE is defined in 
https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_conf.h 
and in
https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_ll_rcc.h
with different values (in first with 40 kHZ and in second with 32kHz). Is it intetional? I think that may be causing the problems. Fail is hard to reproduce because of high variance in LSI frequency on these boards.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @LMESTM @maciejbocianski @fkjagodzinski 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
