### PR TITLE
Return proper error if internal storage configuration not given

### DIFF
--- a/TESTS/psa/its_ps/main.cpp
+++ b/TESTS/psa/its_ps/main.cpp
@@ -123,6 +123,11 @@ void pits_ps_test()
 
     mbed::KVMap &kv_map = mbed::KVMap::get_instance();
     mbed::KVStore *kvstore = kv_map.get_main_kv_instance(STR_EXPAND(MBED_CONF_STORAGE_DEFAULT_KV));
+    if (!kvstore) {
+        TEST_SKIP_MESSAGE("KVStore not configured");
+        return;
+    }
+
     uint32_t kv_get_flags;
 
     flags = PSA_STORAGE_FLAG_NO_REPLAY_PROTECTION;

--- a/features/device_key/source/DeviceKey.h
+++ b/features/device_key/source/DeviceKey.h
@@ -20,12 +20,12 @@
 #include "stdint.h"
 #include "platform/NonCopyable.h"
 
-#define DEVICEKEY_ENABLED 1
-
 // Whole class is not supported if entropy is not enabled
 // Flash device is required as Device Key is currently depending on it
-#if !DEVICE_FLASH || !defined(COMPONENT_FLASHIAP)
-#undef DEVICEKEY_ENABLED
+// and KVStore needs to be configured properly, as Device key lives inside it
+#if DEVICE_FLASH && defined(COMPONENT_FLASHIAP) && MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE
+#define DEVICEKEY_ENABLED 1
+#else
 #define DEVICEKEY_ENABLED 0
 #endif
 

--- a/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
+++ b/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
@@ -15,14 +15,15 @@
 * limitations under the License.
 */
 
-#ifndef COMPONENT_FLASHIAP
-#error [NOT_SUPPORTED] Target must have internal FlashIAP for this test
+#include "mbed.h"
+#include "DeviceKey.h"
+
+#if !defined(COMPONENT_FLASHIAP) || !DEVICEKEY_ENABLED
+#error [NOT_SUPPORTED] Target must have internal FlashIAP and Device Key configured for this test
 #else
 
-#include "mbed.h"
 #include <stdio.h>
 #include <string.h>
-#include "DeviceKey.h"
 #include "KVStore.h"
 #include "KVMap.h"
 #include "kv_config.h"

--- a/features/storage/kvstore/conf/global/mbed_lib.json
+++ b/features/storage/kvstore/conf/global/mbed_lib.json
@@ -11,18 +11,6 @@
         }
     },
     "target_overrides": {
-        "K66F": {
-            "storage_type": "TDB_INTERNAL"
-        },
-        "NUCLEO_F411RE": {
-            "storage_type": "TDB_INTERNAL"
-        },
-        "NUCLEO_F429ZI": {
-            "storage_type": "TDB_INTERNAL"
-        },
-        "UBLOX_EVK_ODIN_W2": {
-            "storage_type": "TDB_INTERNAL"
-        },
         "LPC55S69_S": {
             "storage_type": "TDB_INTERNAL"
         },

--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -691,7 +691,9 @@ MBED_WEAK BlockDevice *get_other_blockdevice()
 
 int _storage_config_TDB_INTERNAL()
 {
-#if COMPONENT_FLASHIAP
+#if COMPONENT_FLASHIAP && \
+        MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE && \
+        MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS
     bd_size_t internal_size = MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
     bd_addr_t internal_start_address = MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
     int ret;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1794,8 +1794,7 @@
             "MCUXpresso_MCUS",
             "KSDK2_MCUS",
             "FRDM",
-            "Freescale_EMAC",
-            "PSA"
+            "Freescale_EMAC"
         ],
         "is_disk_virtual": true,
         "macros": ["CPU_MK66FN2M0VMD18", "FSL_RTOS_MBED", "MBED_SPLIT_HEAP", "MBED_TICKLESS"],
@@ -2859,8 +2858,7 @@
             "STM32F429ZI",
             "STM32F429xx",
             "STM32F429xI",
-            "STM_EMAC",
-            "PSA"
+            "STM_EMAC"
         ],
         "components_add": ["FLASHIAP"],
         "macros_add": [
@@ -4782,7 +4780,6 @@
         "release_versions": ["5"],
         "macros_add": ["MBED_TICKLESS"],
         "device_has_remove": [],
-        "extra_labels_add": ["PSA"],
         "components_add": ["SD", "FLASHIAP"],
         "config": {
             "stdio_uart_tx_help": {


### PR DESCRIPTION
### Description

If function _storage_config_TDB_INTERNAL() is called, but
proper configuration for TDBStore location in flash is not
given, return MBED_ERROR_UNSUPPORTED instead of dummy, that
does not work.

This fixes KVStore related nightly tests on LPC55S69_NS

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@VeijoPesonen 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
