### PR TITLE
EvenQueue: fix template functions passing UserAllocatedEvent<...> as argument.

### DIFF
--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -167,8 +167,8 @@ public:
      *  @return         true  if event was successfully cancelled
      *                  false if event was not cancelled (invalid queue or executing already begun)
      */
-    template<typename... Args>
-    bool cancel(UserAllocatedEvent<Args...> *event)
+    template<typename F, typename A>
+    bool cancel(UserAllocatedEvent<F, A> *event)
     {
         if (event->_equeue != &_equeue) {
             return false;
@@ -213,8 +213,8 @@ public:
      *                  Undefined if id is invalid.
      *
      */
-    template<typename... Args>
-    int time_left(UserAllocatedEvent<Args...> *event)
+    template<typename F, typename A>
+    int time_left(UserAllocatedEvent<F, A> *event)
     {
         if (event && event->_equeue != &_equeue) {
             return -1;


### PR DESCRIPTION
Fix `EvenQueue` template functions passing UserAllocatedEvent<...> as argument.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
