### PR TITLE
Remove minor build warnings

### DIFF
--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/tfm_impl/attestation_core.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/tfm_impl/attestation_core.c
@@ -841,7 +841,6 @@ attest_create_token(struct useful_buf_c *challenge,
     enum attest_token_err_t token_err;
     struct attest_token_ctx attest_token_ctx;
     int32_t key_select;
-    int32_t alg_select;
     uint32_t option_flags = 0;
 
     if (challenge->len == 36) {
@@ -855,21 +854,13 @@ attest_create_token(struct useful_buf_c *challenge,
     /* Lower three bits are the key select */
     key_select = option_flags & 0x7;
 
-    /* Map the key select to an algorithm. Maybe someday we'll support something
-     * other than ES256
-     */
-    switch (key_select) {
-    default:
-        alg_select = COSE_ALGORITHM_ES256;
-    }
-
     /* Get started creating the token. This sets up the CBOR and COSE contexts
      * which causes the COSE headers to be constructed.
      */
     token_err = attest_token_start(&attest_token_ctx,
                                    option_flags,         /* option_flags */
                                    key_select,           /* key_select   */
-                                   alg_select,           /* alg_select   */
+                                   COSE_ALGORITHM_ES256, /* alg_select   */
                                    token);
 
     if (token_err != ATTEST_TOKEN_ERR_SUCCESS) {

--- a/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/tfm_impl/attestation_core.c
+++ b/components/TARGET_PSA/services/attestation/COMPONENT_PSA_SRV_IMPL/tfm_impl/attestation_core.c
@@ -869,7 +869,7 @@ attest_create_token(struct useful_buf_c *challenge,
     token_err = attest_token_start(&attest_token_ctx,
                                    option_flags,         /* option_flags */
                                    key_select,           /* key_select   */
-                                   COSE_ALGORITHM_ES256, /* alg_select   */
+                                   alg_select,           /* alg_select   */
                                    token);
 
     if (token_err != ATTEST_TOKEN_ERR_SUCCESS) {

--- a/drivers/source/usb/USBDevice.cpp
+++ b/drivers/source/usb/USBDevice.cpp
@@ -616,7 +616,7 @@ bool USBDevice::_request_setup()
     bool success = false;
 
     /* Process standard requests */
-    if ((_transfer.setup.bmRequestType.Type == STANDARD_TYPE)) {
+    if (_transfer.setup.bmRequestType.Type == STANDARD_TYPE) {
         switch (_transfer.setup.bRequest) {
             case GET_STATUS:
                 success = _request_get_status();

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1365,7 +1365,7 @@ void ATHandler::write_int(int32_t param)
     // write the integer subparameter
     const int32_t str_len = 12;
     char number_string[str_len];
-    int32_t result = sprintf(number_string, "%ld", param);
+    int32_t result = sprintf(number_string, "%" PRIi32, param);
     if (result > 0 && result < str_len) {
         (void)write(number_string, strlen(number_string));
     }

--- a/features/cellular/framework/AT/AT_CellularBase.cpp
+++ b/features/cellular/framework/AT/AT_CellularBase.cpp
@@ -51,6 +51,6 @@ intptr_t AT_CellularBase::get_property(CellularProperty key)
     if (_property_array) {
         return _property_array[key];
     } else {
-        return NULL;
+        return 0;
     }
 }

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -64,7 +64,7 @@ CellularContext::CellularContext() : _next(0), _stack(0), _pdp_type(DEFAULT_PDP_
     _apn(0), _uname(0), _pwd(0), _dcd_pin(NC), _active_high(false), _cp_netif(0), _retry_array_length(0),
     _retry_count(0), _device(0), _nw(0), _is_blocking(true), _nonip_req(false), _cp_in_use(false)
 {
-    memset(_retry_timeout_array, 0, CELLULAR_RETRY_ARRAY_SIZE);
+    memset(_retry_timeout_array, 0, sizeof(_retry_timeout_array));
 }
 
 void CellularContext::cp_data_received()

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -413,7 +413,6 @@ void QUECTEL_BG96_CellularStack::ip2dot(const SocketAddress &ip, char *dot)
 {
     if (ip.get_ip_version() == NSAPI_IPv6) {
         const uint8_t *bytes = (uint8_t *)ip.get_ip_bytes();
-        char *p = dot;
         for (int i = 0; i < NSAPI_IPv6_BYTES; i += 2) {
             if (i != 0) {
                 *dot++ = ':';

--- a/features/frameworks/TARGET_PSA/pal/pal_mbed_os_intf.cpp
+++ b/features/frameworks/TARGET_PSA/pal/pal_mbed_os_intf.cpp
@@ -58,9 +58,6 @@ static void psa_attestation_destroy_key_for_test()
 
 static void psa_attestation_inject_key_for_test(void)
 {
-
-
-    psa_status_t status = PSA_SUCCESS;
     size_t exported_length;
     uint8_t exported[sizeof(public_key_data)];
 

--- a/features/frameworks/TARGET_PSA/val_greentea.cpp
+++ b/features/frameworks/TARGET_PSA/val_greentea.cpp
@@ -67,7 +67,7 @@ val_status_t mbed_val_execute_non_secure_tests(uint32_t test_num, client_test_t 
     while (tests_list[i] != NULL)
     {
         memset(testcase_name, 0, 100);
-        sprintf(testcase_name, "Check%d", i);
+        sprintf(testcase_name, "Check%" PRIu32, i);
         GREENTEA_TESTCASE_START(testcase_name);
         if (server_hs == TRUE)
         {

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -1203,6 +1203,8 @@ void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle,
     (void)msg_id;
 #endif //SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 }
+
+#if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 static void sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_duplication_info_s *duplication_info_ptr)
 {
     if (duplication_info_ptr) {
@@ -1214,6 +1216,7 @@ static void sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_d
         handle->sn_coap_protocol_free(duplication_info_ptr);
     }
 }
+#endif // SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 /**************************************************************************//**

--- a/features/nfc/stack/transceiver/pn512/pn512_poll.c
+++ b/features/nfc/stack/transceiver/pn512/pn512_poll.c
@@ -537,7 +537,10 @@ void pn512_initiator_isob_anticollision_reqb(pn512_t *pPN512)
         ac_buffer_builder_write_nu8(pDataOutBldr, REQB);
         ac_buffer_builder_write_nu8(pDataOutBldr, 0x00); // AFI: All card types should respond
         uint8_t wup = 0;
-        if ((pPN512->anticollision.iso_b.slots_num_exponent == 0)) { //&& (pPN512->anticollision.iso_b.slot_number == 0))
+        if (
+            pPN512->anticollision.iso_b.slots_num_exponent == 0
+            //&& (pPN512->anticollision.iso_b.slot_number == 0)
+        ) {
             wup |= 0x8; // Send Wake-Up command on first iteration
         }
         ac_buffer_builder_write_nu8(pDataOutBldr, wup | (pPN512->anticollision.iso_b.slots_num_exponent & 0x7)); // Param: number of slots

--- a/features/nfc/stack/transceiver/pn512/pn512_rf.c
+++ b/features/nfc/stack/transceiver/pn512/pn512_rf.c
@@ -107,7 +107,10 @@ nfc_err_t pn512_framing_set(pn512_t *pPN512, nfc_framing_t framing)
             return NFC_ERR_UNSUPPORTED;
     }
 #if 1
-    if ((pPN512->framing == nfc_framing_initiator_a_106) /*|| (pPN512->framing == pn512_framing_target_iso14443a_106k)*/) {
+    if (
+        pPN512->framing == nfc_framing_initiator_a_106
+        //|| (pPN512->framing == pn512_framing_target_iso14443a_106k)
+    ) {
         //Enable 100% ASK Modulation
         pn512_register_write(pPN512, PN512_REG_TXAUTO, pn512_register_read(pPN512, PN512_REG_TXAUTO) | 0x40);
     } else {

--- a/features/storage/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.cpp
@@ -145,13 +145,13 @@ LittleFileSystem::LittleFileSystem(const char *name, BlockDevice *bd,
                                    lfs_size_t read_size, lfs_size_t prog_size,
                                    lfs_size_t block_size, lfs_size_t lookahead)
     : FileSystem(name)
+    , _lfs()
+    , _config()
+    , _bd(NULL)
     , _read_size(read_size)
     , _prog_size(prog_size)
     , _block_size(block_size)
     , _lookahead(lookahead)
-    , _lfs()
-    , _config()
-    , _bd(NULL)
 {
     if (bd) {
         mount(bd);

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -305,7 +305,7 @@ WEAK MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_stat
     mbed_error_printf("\n= System will be rebooted due to a fatal error =\n");
     if (report_error_ctx->error_reboot_count >= MBED_CONF_PLATFORM_ERROR_REBOOT_MAX) {
         //We have rebooted more than enough, hold the system here.
-        mbed_error_printf("= Reboot count(=%ld) reached maximum, system will halt after rebooting =\n", report_error_ctx->error_reboot_count);
+        mbed_error_printf("= Reboot count(=%" PRIi32") reached maximum, system will halt after rebooting =\n", report_error_ctx->error_reboot_count);
     }
 #endif
     system_reset();//do a system reset to get the system rebooted


### PR DESCRIPTION
### Description
The various warnings removed were observed when building `mbed-os-example-blinky` for the `K64F` target with the `GCC_ARM` toolchain.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kjbracey-arm @evedon 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
