### PR TITLE
Cast void pointer before deallocating with delete[]

### DIFF
--- a/rtos/source/Thread.cpp
+++ b/rtos/source/Thread.cpp
@@ -113,7 +113,8 @@ osStatus Thread::start(mbed::Callback<void()> task)
     _tid = osThreadNew(Thread::_thunk, this, &_attr);
     if (_tid == nullptr) {
         if (_dynamic_stack) {
-            delete[] _attr.stack_mem;
+            // Cast before deallocation as delete[] does not accept void*
+            delete[] static_cast<uint32_t *>(_attr.stack_mem);
             _attr.stack_mem = nullptr;
         }
         _mutex.unlock();
@@ -417,7 +418,8 @@ Thread::~Thread()
     // terminate is thread safe
     terminate();
     if (_dynamic_stack) {
-        delete[] _attr.stack_mem;
+        // Cast before deallocation as delete[] does not accept void*
+        delete[] static_cast<uint32_t *>(_attr.stack_mem);
         _attr.stack_mem = nullptr;
     }
 }


### PR DESCRIPTION
### Description
The stack memory is a `void*` which creates a warning when using
the `delete[]` operator because it is unable to call the destructor of
of an unknown object type.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kjbracey-arm @evedon 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
