### PR TITLE
Replace wait_ms calls with rtos::ThisThread::sleep_for

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -19,6 +19,8 @@
 #include "APN_db.h"
 #include "CellularLog.h"
 
+#include "rtos/ThisThread.h"
+
 namespace mbed {
 
 UBLOX_AT_CellularContext::UBLOX_AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req, bool nonip_req) :
@@ -236,7 +238,7 @@ bool UBLOX_AT_CellularContext::activate_profile(const char *apn,
                     if (activated) {  //If context is activated, exit while loop and return status
                         break;
                     }
-                    wait_ms(5000);    //Wait for 5 seconds and then try again
+                    rtos::ThisThread::sleep_for(5000);    //Wait for 5 seconds and then try again
                 }
                 t1.stop();
             }

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
@@ -17,6 +17,8 @@
 
 #include "UBLOX_AT_CellularNetwork.h"
 
+#include "rtos/ThisThread.h"
+
 using namespace mbed;
 
 UBLOX_AT_CellularNetwork::UBLOX_AT_CellularNetwork(ATHandler &atHandler) : AT_CellularNetwork(atHandler)
@@ -98,7 +100,7 @@ nsapi_error_t UBLOX_AT_CellularNetwork::ubx_reboot()
             break;
         } else {
             _at.clear_error();
-            wait_ms(1000);
+            rtos::ThisThread::sleep_for(1000);
         }
     }
     t1.stop();


### PR DESCRIPTION
## Description

`wait_ms` is deprecated and its use generates a warning.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon  @kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
