### PR TITLE
Remove floating point from AT_CellularSMS

### DIFF
--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -1140,7 +1140,7 @@ bool AT_CellularSMS::create_time(const char *time_string, time_t *time)
                &time_struct.tm_hour, &time_struct.tm_min, &time_struct.tm_sec, &sign, &gmt) == kNumberOfElements) {
         *time = mktime(&time_struct);
         // add timezone as seconds. gmt is in quarter of hours.
-        int x = (60 * 60 * gmt) / 4;
+        int x = (60 / 4) * 60 * gmt;
         if (sign == '+') {
             *time += x;
         } else {

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -1114,7 +1114,7 @@ int AT_CellularSMS::compare_time_strings(const char *time_string_1, const char *
     int retVal = -2;
 
     if (success) {
-        double diff = difftime(t1, t2);
+        time_t diff = t1 - t2;
 
         if (diff > 0) {
             retVal = 1;
@@ -1140,7 +1140,7 @@ bool AT_CellularSMS::create_time(const char *time_string, time_t *time)
                &time_struct.tm_hour, &time_struct.tm_min, &time_struct.tm_sec, &sign, &gmt) == kNumberOfElements) {
         *time = mktime(&time_struct);
         // add timezone as seconds. gmt is in quarter of hours.
-        int x = 60 * 60 * gmt * 0.25;
+        int x = (60 * 60 * gmt) / 4;
         if (sign == '+') {
             *time += x;
         } else {


### PR DESCRIPTION
### Description
Replace unneccesary floating point operations in AT_CellularSMS with integers.

This is part of the requirements in IOTCLOUDPR-3289.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @hugueskamba @AnttiKauppila 