### PR TITLE
nsapi_dns: cleanup dns queue when running out or memory

### DIFF
--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -726,6 +726,7 @@ nsapi_value_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const
         if (nsapi_dns_call_in(query->call_in_cb, DNS_TIMER_TIMEOUT, mbed::callback(nsapi_dns_query_async_timeout)) != NSAPI_ERROR_OK) {
             delete[] query->host;
             delete query;
+            dns_query_queue[index] = NULL;
             dns_mutex->unlock();
             return NSAPI_ERROR_NO_MEMORY;
         }


### PR DESCRIPTION
### Description

Make sure that dns query queue is cleared when running out of memory.


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm, @yogpan01 


