### PR TITLE
STM32L4 USB device

### DIFF
--- a/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -250,6 +250,7 @@ void USBPhyHw::init(USBPhyEvents *events)
 #elif defined(TARGET_NUCLEO_L496ZG) || \
       defined(TARGET_NUCLEO_L496ZG_P) || \
       defined(TARGET_DISCO_L496AG) || \
+      defined(TARGET_DISCO_L4R9I) || \
       defined(TARGET_NUCLEO_L4R5ZI)
     __HAL_RCC_GPIOA_CLK_ENABLE();
     pin_function(PA_11, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF10_OTG_FS)); // DM

--- a/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -63,6 +63,7 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
 {
     USBPhyHw *priv = ((USBPhyHw *)(hpcd->pData));
     USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+    uint32_t USBx_BASE = (uint32_t)USBx;
     if (priv->sof_enabled) {
         priv->events->sof((USBx_DEVICE->DSTS & USB_OTG_DSTS_FNSOF) >> 8);
     }
@@ -530,8 +531,10 @@ bool USBPhyHw::endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size)
 
 void USBPhyHw::endpoint_abort(usb_ep_t endpoint)
 {
+#ifndef TARGET_STM32L4
     HAL_StatusTypeDef ret = HAL_PCD_EP_Abort(&hpcd, endpoint);
     MBED_ASSERT(ret == HAL_OK);
+#endif
 }
 
 void USBPhyHw::process()

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4329,6 +4329,7 @@
             "TRNG",
             "FLASH",
             "QSPI",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -4400,6 +4401,7 @@
             "TRNG",
             "FLASH",
             "QSPI",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -7984,6 +7986,7 @@
             "TRNG",
             "FLASH",
             "MPU",
+            "USBDEVICE",
             "QSPI"
         ],
         "release_versions": ["2", "5"],
@@ -8024,6 +8027,7 @@
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -8068,6 +8072,7 @@
             "SERIAL_ASYNCH",
             "TRNG",
             "FLASH",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -8119,6 +8124,7 @@
             "TRNG",
             "FLASH",
             "QSPI",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],


### PR DESCRIPTION
### Description

Since ST driver update, USB support was removed.

NB: only Mouse application tested.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes
