### PR TITLE
Remove mbed_trace dependency to Nanomesh headers

### DIFF
--- a/features/frameworks/mbed-trace/mbed-trace/mbed_trace.h
+++ b/features/frameworks/mbed-trace/mbed-trace/mbed_trace.h
@@ -48,15 +48,11 @@
 extern "C" {
 #endif
 
-#ifdef YOTTA_CFG
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#else
-#include "ns_types.h"
-#endif
-
 #include <stdarg.h>
+#include <inttypes.h>
 
 #ifndef YOTTA_CFG_MBED_TRACE
 #define YOTTA_CFG_MBED_TRACE 0

--- a/features/frameworks/nanostack-libservice/mbed-client-libservice/ns_trace.h
+++ b/features/frameworks/nanostack-libservice/mbed-client-libservice/ns_trace.h
@@ -28,6 +28,7 @@
 #define FEA_TRACE_SUPPORT
 #endif
 
+#include "ns_types.h"
 #include "mbed-trace/mbed_trace.h"
 
 #endif /* NS_TRACE_H_ */


### PR DESCRIPTION
### Description

This library only uses standard types from C99, and
thus does not need compiler specific tweaks from ns_types.h

Reason for dropping the Nanomesh header from mbed-trace, is that it now allows applications to use tracing library in BareMetal builds without dependency to Nanomesh.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
