### PR TITLE
esp8266 nonblocking connect/disconnect

### DIFF
--- a/TESTS/network/wifi/README.md
+++ b/TESTS/network/wifi/README.md
@@ -62,7 +62,7 @@ Please refer to the following table for priorities of test cases. Priorities are
 | 9   | WIFI_CONNECT_PARAMS_CHANNEL             |                            | SHOULD   |
 | 10  | WIFI_CONNECT_PARAMS_CHANNEL_FAIL        |                            | SHOULD   |
 | 11  | WIFI_CONNECT                            |                            | MUST     |
-| 12  | WIFI_CONNECT_NONBLOCK                   |                            | SHOULD   |
+| 12  | WIFI_CONNECT_DISCONNECT_NONBLOCK        |                            | SHOULD   |
 | 13  | WIFI_CONNECT_SECURE                     | With security type:        |          |
 |     |                                         | NSAPI_SECURITY_WEP         | SHOULD   |
 |     |                                         | NSAPI_SECURITY_WPA         | SHOULD   |
@@ -385,7 +385,7 @@ Test `WiFiInterface::connect()` without parameters. Use `set_credentials()` for 
 
 `connect()` calls return `NSAPI_ERROR_OK`.
 
-### WIFI_CONNECT_NONBLOCK
+### WIFI_CONNECT_DISCONNECT_NONBLOCK
 
 **Description:**
 
@@ -399,18 +399,24 @@ Test `WiFiInterface::connect()` and `WiFiInterface::disconnect()` in non-blockin
 
 1.  Initialize the driver.
 2.  `Call WiFiInterface::set_credentials( <ssid:unsecure>, NULL)`.
-3.  `Call WiFiInterface::connect()`.
-4.  `Call WiFiInterface::set_blocking(false)`
-5.  `Call WiFiInterface::get_connection_status()`
-6.  `disconnect()`
-7.  `Call WiFiInterface::get_connection_status()`
-8.  `Call WiFiInterface::set_blocking(true)`
+3.  `Call WiFiInterface::set_blocking(false)`
+4.  `Call WiFiInterface::connect()`.
+5.  `Cal WiFiInterface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)`
+6.  `Call WiFiInterface::connect()`.
+7.  `disconnect()`
+8.  `disconnect()`
+9. `Call WiFiInterface::set_blocking(true)`
 
 **Expected result:**
 
- In case of drivers which do not support asynchronous mode `set_blocking(false)` call returns `NSAPI_ERROR_UNSUPPORTED` and skips test case, otherwise:
-`connect()` call returns  `NSAPI_ERROR_OK`. To confirm connection `get_connection_status()` calls return `NSAPI_STATUS_GLOBAL_UP` or `NSAPI_STATUS_LOCAL_UP`.
-`disconnect()` call returns `NSAPI_ERROR_OK`. To confirm disconnection `get_connection_status()` calls return `NSAPI_STATUS_DISCONNECTED`.
+1. Drivers which do not support asynchronous mode `set_blocking(false)` call returns `NSAPI_ERROR_UNSUPPORTED` and skips test case.
+2. `connect()` call returns  `NSAPI_ERROR_OK`. 
+3. `set_credentials(...)` call returns `NSAPI_ERROR_BUSY`. 
+4. Second `connect()` call returns `NSAPI_ERROR_BUSY` or `NSAPI_ERROR_IS_CONNECTED`.
+5. Attached callback informs about connection status. Callback reports status `NSAPI_STATUS_CONNECTING` and `NSAPI_STATUS_CONNECTED`. 
+6. `disconnect()` call returns `NSAPI_ERROR_OK`. 
+7. Second `disconnect()` call returns `NSAPI_ERROR_BUSY` or `NSAPI_ERROR_IS_CONNECTED`. 
+8. To confirm disconnection callback reports `NSAPI_STATUS_DISCONNECTED`.
 
 ### WIFI_CONNECT_SECURE
 

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -75,7 +75,7 @@ Case cases[] = {
     Case("WIFI-CONNECT-PARAMS-VALID-UNSECURE", wifi_connect_params_valid_unsecure),
     Case("WIFI-CONNECT", wifi_connect),
     //Most boards are not passing this test, but they should if they support non-blocking API.
-    //Case("WIFI-CONNECT-NONBLOCKING", wifi_connect_nonblock),
+    //Case("WIFI_CONNECT_DISCONNECT_NONBLOCK", wifi_connect_disconnect_nonblock),
     Case("WIFI-CONNECT-DISCONNECT-REPEAT", wifi_connect_disconnect_repeat),
 #endif
 #if defined(MBED_CONF_APP_WIFI_SECURE_SSID)

--- a/TESTS/network/wifi/wifi_tests.h
+++ b/TESTS/network/wifi/wifi_tests.h
@@ -63,8 +63,8 @@ void wifi_connect_params_channel_fail(void);
 /** Test WiFiInterface::connect() without parameters. Use set_credentials() for setting parameters. */
 void wifi_connect(void);
 
-/** Test WiFiInterface::connect() in nonblocking mode. Use set_credentials() for setting parameters. */
-void wifi_connect_nonblock(void);
+/** Test WiFiInterface::connect() and disconnect() in nonblocking mode. Use set_credentials() for setting parameters. */
+void wifi_connect_disconnect_nonblock(void);
 
 /** Test WiFiInterface::connect() without parameters. Don't set parameters with set_credentials() */
 void wifi_connect_nocredentials(void);

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -381,6 +381,15 @@ private:
     ESP8266 _esp;
     void refresh_conn_state_cb();
 
+    /** Status of software connection
+     */
+    typedef enum esp_connection_software_status {
+        IFACE_STATUS_DISCONNECTED = 0,
+        IFACE_STATUS_CONNECTING = 1,
+        IFACE_STATUS_CONNECTED = 2,
+        IFACE_STATUS_DISCONNECTING = 3
+    } esp_connection_software_status_t;
+
     // HW reset pin
     class ResetPin {
     public:
@@ -402,6 +411,12 @@ private:
     private:
         mbed::DigitalOut  _pwr_pin;
     } _pwr_pin;
+
+    /** Assert the reset and power pins
+     *  ESP8266 has two pins serving similar purpose and this function asserts them both
+     *  if they are configured in mbed_app.json.
+     */
+    void _power_off();
 
     // Credentials
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
@@ -437,6 +452,7 @@ private:
     // Driver's state
     int _initialized;
     nsapi_error_t _connect_retval;
+    nsapi_error_t _disconnect_retval;
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
     nsapi_error_t _reset();
@@ -459,9 +475,12 @@ private:
     events::EventQueue *_global_event_queue;
     int _oob_event_id;
     int _connect_event_id;
+    int _disconnect_event_id;
     void proc_oob_evnt();
     void _connect_async();
+    void _disconnect_async();
     rtos::Mutex _cmutex; // Protect asynchronous connection logic
+    esp_connection_software_status_t _software_conn_stat ;
 
 };
 #endif


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
`ESP8266Interface::connect()` and `ESP8266Interface::disconnect()` can be used in terms of asynchronous operations. Mainly, it is based on newly added private variable of type  `esp_connection_software_status` which is used to keep tracking of state of connection.
`wifi_connect_nonblock` test was renamed and amended to test both `connect()` and `disconnect()` operation

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@SeppoTakalo 
@michalpasztamobica 
@VeijoPesonen 
@teetak01 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
This release contains changes for ESP8266 non-blocking operations, which make them compliant with documentation:
- `connect()` and `disconnect()` will now return immediately in non-blocking mode and pass all blocking operations to asynchronous thread.
- in case of consecutive calls of `connect()` (or `disconnect()`) returned value from the second one may be `NSAPI_ERROR_BUSY`
- If `ESP8266Interface::set_credentials(...)` is called during connecting to the network, it is not executed and `NSAPI_ERROR_BUSY` is returned.

The change will not affect any users, unless they took advantage of the incorrect non-blocking behavior. 

