### PR TITLE
Mesh API, Wi-SUN: Initialize Wi-SUN settings with values from json

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -119,11 +119,11 @@
             "value": "3"
         },
         "wisun-operating-class": {
-            "help": "Operating class.",
+            "help": "Operating class. Use 255 to use Nanostack default",
             "value": "255"
         },
         "wisun-operating-mode": {
-            "help": "Operating mode.",
+            "help": "Operating mode. Use 255 to use Nanostack default",
             "value": "255"
         },
         "wisun-uc-channel-function": {

--- a/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/wisun_tasklet.c
@@ -95,7 +95,7 @@ typedef struct {
 /* Tasklet data */
 static wisun_tasklet_data_str_t *wisun_tasklet_data_ptr = NULL;
 static wisun_certificates_t *wisun_certificates_ptr = NULL;
-static wisun_network_settings_t wisun_settings_str = {NULL, WS_NA, WS_NA, WS_NA};
+static wisun_network_settings_t wisun_settings_str = {NULL, MBED_CONF_MBED_MESH_API_WISUN_REGULATORY_DOMAIN, MBED_CONF_MBED_MESH_API_WISUN_OPERATING_CLASS, MBED_CONF_MBED_MESH_API_WISUN_OPERATING_MODE};
 static mac_api_t *mac_api = NULL;
 
 extern fhss_timer_t fhss_functions;


### PR DESCRIPTION
### Description
Use regulation domain, operating class and operating mode configuration values from json-file to initialize Wi-SUN properly.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@artokin @mikter 

