### PR TITLE
Cellular: Add API to clear CellularDevice

### DIFF
--- a/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularDevice_stub.cpp
@@ -256,3 +256,8 @@ void AT_CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, Cellul
 void AT_CellularDevice::set_at_urcs_impl()
 {
 }
+
+nsapi_error_t AT_CellularDevice::clear()
+{
+    return NSAPI_ERROR_OK;
+}

--- a/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -166,3 +166,8 @@ nsapi_error_t AT_CellularNetwork::set_packet_domain_event_reporting(bool on)
 {
     return NSAPI_ERROR_OK;
 }
+
+nsapi_error_t AT_CellularNetwork::clear()
+{
+    return NSAPI_ERROR_OK;
+}

--- a/UNITTESTS/stubs/CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/CellularDevice_stub.cpp
@@ -124,3 +124,8 @@ nsapi_error_t CellularDevice::shutdown()
 void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx)
 {
 }
+
+nsapi_error_t CellularDevice::clear()
+{
+    return NSAPI_ERROR_OK;
+}

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -90,6 +90,18 @@ public:
      */
     virtual ~CellularDevice();
 
+    /** Clear modem to a default initial state
+     *
+     *  Clear persistent user data from the modem, such as PDP contexts.
+     *
+     *  @pre All open network services on modem, such as contexts and sockets, must be closed.
+     *  @post Modem power off/on may be needed to clear modem's runtime state.
+     *  @remark CellularStateMachine calls this on connect when `cellular.clear-on-connect: true`.
+     *
+     *  @return         NSAPI_ERROR_OK on success, otherwise modem may be need power cycling
+     */
+    virtual nsapi_error_t clear();
+
     /** Sets the modem up for powering on
      *  This is equivalent to plugging in the device, i.e., attaching power and serial port.
      *  In general, hard_power_on and soft_power_on provides a simple hardware abstraction layer

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -624,3 +624,12 @@ void AT_CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, Cellul
     }
     CellularDevice::cellular_callback(ev, ptr, ctx);
 }
+
+nsapi_error_t AT_CellularDevice::clear()
+{
+    AT_CellularNetwork *net = static_cast<AT_CellularNetwork *>(open_network());
+    nsapi_error_t err = net->clear();
+    close_network();
+
+    return err;
+}

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -39,6 +39,8 @@ public:
     AT_CellularDevice(FileHandle *fh);
     virtual ~AT_CellularDevice();
 
+    virtual nsapi_error_t clear();
+
     virtual nsapi_error_t hard_power_on();
 
     virtual nsapi_error_t hard_power_off();

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -110,6 +110,13 @@ protected:
      *  Can be overridden by the target class.
      */
     virtual void get_context_state_command();
+
+    /** Clear the network and contexts to a known default state
+     *
+     *  @return         NSAPI_ERROR_OK on success
+     */
+    nsapi_error_t clear();
+
 private:
     void urc_creg();
     void urc_cereg();

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -34,7 +34,7 @@ MBED_WEAK CellularDevice *CellularDevice::get_target_default_instance()
 }
 
 CellularDevice::CellularDevice(FileHandle *fh) : _network_ref_count(0), _sms_ref_count(0),
-    _info_ref_count(0), _fh(fh), _queue(8 * EVENTS_EVENT_SIZE), _state_machine(0), _nw(0), _status_cb(0)
+    _info_ref_count(0), _fh(fh), _queue(10 * EVENTS_EVENT_SIZE), _state_machine(0), _nw(0), _status_cb(0)
 {
     MBED_ASSERT(fh);
     set_sim_pin(NULL);
@@ -248,6 +248,11 @@ void CellularDevice::set_retry_timeout_array(const uint16_t timeout[], int array
     if (create_state_machine() == NSAPI_ERROR_OK) {
         _state_machine->set_retry_timeout_array(timeout, array_len);
     }
+}
+
+nsapi_error_t CellularDevice::clear()
+{
+    return NSAPI_ERROR_OK;
 }
 
 } // namespace mbed

--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -345,6 +345,13 @@ bool CellularStateMachine::device_ready()
     }
 #endif // MBED_CONF_CELLULAR_DEBUG_AT
 
+#ifdef MBED_CONF_CELLULAR_CLEAR_ON_CONNECT
+    if (_cellularDevice.clear() != NSAPI_ERROR_OK) {
+        tr_warning("CellularDevice clear failed");
+        return false;
+    }
+#endif
+
     send_event_cb(CellularDeviceReady);
     _cellularDevice.set_ready_cb(0);
 
@@ -364,6 +371,13 @@ void CellularStateMachine::state_device_ready()
             if (device_ready()) {
                 _status = 0;
                 enter_to_state(STATE_SIM_PIN);
+            } else {
+                tr_warning("Power cycle CellularDevice and restart connecting");
+                (void) _cellularDevice.soft_power_off();
+                (void) _cellularDevice.hard_power_off();
+                _status = 0;
+                _is_retry = true;
+                enter_to_state(STATE_INIT);
             }
         } else {
             _status = 0;

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -24,6 +24,10 @@
         "offload-dns-queries" : {
             "help": "Use modem IP stack for DNS queries, null or numeric simultaneous queries",
             "value": null
+        },
+        "clear-on-connect" : {
+            "help": "Clear modem to a known default state on connect()",
+            "value": true
         }
     }
 }


### PR DESCRIPTION
A new API `CellularDevice::clear()` to clean-up the modem to a default initial state.
Function is virtual so it can be overridden. The default implementation clears all PDP contexts,
but the the first one if that has APN defined as `nsapi.default-cellular-apn`.

CellularStateMachine calls `clear()` to clean-up the modem on initial `connect()`,
if the flag `cellular.clear-on-connect: true` is defined.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica @jarvte 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

`CellularStateMachine` calls `CellularDevice::clear()` to clean-up the modem on initial `connect()`.
The previous functionality can be restored by defining the flag `cellular.clear-on-connect: false`.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
