### PR TITLE
Turn off STM32F303RE watchdog

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2474,6 +2474,7 @@
             "FLASH",
             "MPU"
         ],
+        "device_has_remove": ["WATCHDOG"],
         "release_versions": ["2", "5"],
         "bootloader_supported": true,
         "device_name": "STM32F303RE"


### PR DESCRIPTION
Turning it off for now because it fails nightly CI.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @fkjagodzinski @maciejbocianski @0xc0170 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
