### PR TITLE
Change stack sizes of threads used in tests. GR_LYCHEE failing CI

### DIFF
--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -29,7 +29,13 @@ using namespace utest::v1;
 
 DigitalOut led1(LED1);
 
+// Targets with these cores have their RAM enough size to create threads with bigger stacks
+#if defined(__CORTEX_A9) || defined(__CORTEX_M23) || defined(__CORTEX_M33) || defined(__CORTEX_M7)
+#define MAX_THREAD_STACK        512
+#else
 #define MAX_THREAD_STACK        384
+#endif
+
 #define SAMPLE_TIME             1000    // msec
 #define LOOP_TIME               2000    // msec
 

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -26,18 +26,14 @@
 #else
 
 #define THREAD_STACK_SIZE 512
-#if defined(__CORTEX_A9)
+#if defined(__CORTEX_A9) || defined(__CORTEX_M23) || defined(__CORTEX_M33) || defined(TARGET_ARM_FM) ||  defined(TARGET_CY8CKIT_062_WIFI_BT_PSA)
 #define PARALLEL_THREAD_STACK_SIZE 512
-#elif defined(__CORTEX_M23) || defined(__CORTEX_M33)
-#define PARALLEL_THREAD_STACK_SIZE 512
-#elif defined(TARGET_ARM_FM)
-#define PARALLEL_THREAD_STACK_SIZE 512
-#elif defined(TARGET_CY8CKIT_062_WIFI_BT_PSA)
-#define PARALLEL_THREAD_STACK_SIZE   512
+#define CHILD_THREAD_STACK_SIZE 512
 #else
 #define PARALLEL_THREAD_STACK_SIZE 384
-#endif
 #define CHILD_THREAD_STACK_SIZE 384
+#endif
+
 
 using namespace utest::v1;
 


### PR DESCRIPTION
Change stack sizes in test stats_cpu and mbedmicro-rtos-mbed-threads. The value 384 was declared to make this test pass on STM32F070RB, but its main stack value has been changed to 3KB so now it passes this test with 512 stack size. The change was needed to make GR_LYCHEE pass this test on ARM toolchain.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @maciejbocianski 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
