### PR TITLE
Fixed smsc9220_emac link_out memory management.

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_ARM_SSG/COMPONENT_SMSC9220/smsc9220_emac.cpp
@@ -168,6 +168,7 @@ bool SMSC9220_EMAC::link_out(emac_mem_buf_t *buf)
                                       true,
                                       (const char*)_memory_manager->get_ptr(buf),
                                       _memory_manager->get_len(buf));
+        _memory_manager->free(buf);
         if (error != SMSC9220_ERROR_NONE) {
             _TXLockMutex.unlock();
             return false;


### PR DESCRIPTION
### Description
Emac driver for   smsc9220   is now  freeing buffers after sending packets.
This avoid lack of memory and crash after sending large packets. 

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

 @SeppoTakalo 
 @kjbracey-arm 

### Release Notes

 
