### PR TITLE
Stack type ip versions

### DIFF
--- a/UNITTESTS/stubs/CellularUtil_stub.cpp
+++ b/UNITTESTS/stubs/CellularUtil_stub.cpp
@@ -51,9 +51,9 @@ uint16_t char_str_to_hex(const char *str, uint16_t len, char *buf, bool omit_lea
     return CellularUtil_stub::uint16_value;
 }
 
-void convert_ipv6(char *ip)
+nsapi_version_t convert_ipv6(char *ip)
 {
-
+    return NSAPI_UNSPEC;
 }
 
 char *find_dot_number(char *str, int dot_number)

--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -60,7 +60,7 @@ public:
         PROPERTY_AT_CSDH,           // 0 = not supported, 1 = supported. Show text mode AT command
         PROPERTY_IPV4_PDP_TYPE,     // 0 = not supported, 1 = supported. Does modem support IPV4?
         PROPERTY_IPV6_PDP_TYPE,     // 0 = not supported, 1 = supported. Does modem support IPV6?
-        PROPERTY_IPV4V6_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support dual stack IPV4V6?
+        PROPERTY_IPV4V6_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support IPV4 and IPV6 simultaneously?
         PROPERTY_NON_IP_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support Non-IP?
         PROPERTY_AT_CGEREP,         // 0 = not supported, 1 = supported. Does modem support AT command AT+CGEREP.
 

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -369,8 +369,9 @@ bool AT_CellularContext::get_context()
                 // APN matched -> Check PDP type
                 pdp_type_t pdp_type = string_to_pdp_type(pdp_type_from_context);
 
-                // Accept exact matching PDP context type
-                if (get_property(pdp_type_t_to_cellular_property(pdp_type))) {
+                // Accept exact matching PDP context type or dual PDP context for modems that support both IPv4 and IPv6 stacks
+                if (get_property(pdp_type_t_to_cellular_property(pdp_type)) ||
+                        ((pdp_type == IPV4V6_PDP_TYPE && (get_property(PROPERTY_IPV4_PDP_TYPE) && get_property(PROPERTY_IPV6_PDP_TYPE))) && !_nonip_req)) {
                     _pdp_type = pdp_type;
                     _cid = cid;
                 }
@@ -403,7 +404,7 @@ bool AT_CellularContext::set_new_context(int cid)
     if (_nonip_req && _cp_in_use && get_property(PROPERTY_NON_IP_PDP_TYPE)) {
         strncpy(pdp_type_str, "Non-IP", sizeof(pdp_type_str));
         pdp_type = NON_IP_PDP_TYPE;
-    } else if (get_property(PROPERTY_IPV4V6_PDP_TYPE)) {
+    } else if (get_property(PROPERTY_IPV4V6_PDP_TYPE) || (get_property(PROPERTY_IPV4_PDP_TYPE) && get_property(PROPERTY_IPV6_PDP_TYPE))) {
         strncpy(pdp_type_str, "IPV4V6", sizeof(pdp_type_str));
         pdp_type = IPV4V6_PDP_TYPE;
     } else if (get_property(PROPERTY_IPV6_PDP_TYPE)) {

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -203,7 +203,7 @@ protected:
     // PDP context id
     int _cid;
 
-    // stack type from PDP context
+    // stack type - initialised as PDP type and set accordingly after CGPADDR checked
     nsapi_ip_stack_t _stack_type;
 
 private:

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -191,6 +191,11 @@ protected:
      */
     int find_socket_index(nsapi_socket_t handle);
 
+    /**
+     *  Checks if send to address is valid and if current stack type supports sending to that address type
+     */
+    bool is_addr_stack_compatible(const SocketAddress &addr);
+
     // socket container
     CellularSocket **_socket;
 
@@ -205,6 +210,9 @@ protected:
 
     // stack type - initialised as PDP type and set accordingly after CGPADDR checked
     nsapi_ip_stack_t _stack_type;
+
+    // IP version of send to address
+    nsapi_version_t _ip_ver_sendto;
 
 private:
 

--- a/features/cellular/framework/common/CellularUtil.cpp
+++ b/features/cellular/framework/common/CellularUtil.cpp
@@ -28,10 +28,10 @@
 using namespace mbed;
 namespace mbed_cellular_util {
 
-void convert_ipv6(char *ip)
+nsapi_version_t convert_ipv6(char *ip)
 {
     if (!ip) {
-        return;
+        return NSAPI_UNSPEC;
     }
 
     int len = strlen(ip);
@@ -49,7 +49,11 @@ void convert_ipv6(char *ip)
 
     // more that 3 periods mean that it was ipv6 but in format of a1.a2.a3.a4.a5.a6.a7.a8.a9.a10.a11.a12.a13.a14.a15.a16
     // we need to convert it to hexadecimal format separated with colons
-    if (pos > 3) {
+    if (pos == 3) {
+
+        return NSAPI_IPv4;
+
+    } else if (pos > 3) {
         pos = 0;
         int ip_pos = 0;
         char b;
@@ -74,7 +78,11 @@ void convert_ipv6(char *ip)
                 ip[pos] = '\0';
             }
         }
+
+        return NSAPI_IPv6;
     }
+
+    return NSAPI_UNSPEC;
 }
 
 // For example "32.1.13.184.0.0.205.48.0.0.0.0.0.0.0.0"

--- a/features/cellular/framework/common/CellularUtil.h
+++ b/features/cellular/framework/common/CellularUtil.h
@@ -48,8 +48,9 @@ static const char hex_values[] = "0123456789ABCDEF";
  *  where ax are in decimal format. In this case, function converts decimals to hex with separated with colons.
  *
  *  @param ip       IP address that can be IPv4 or IPv6 in different formats from AT command +CGPADDR. Converted result uses same buffer.
+ *  @return         IP version of the address or NSAPI_UNSPEC if param ip empty or if IPv4 or IPv6 version could not be concluded.
  */
-void convert_ipv6(char *ip);
+nsapi_version_t convert_ipv6(char *ip);
 
 /** Separates IP addresses from the given 'orig' string. 'orig' may contain zero, one or two IP addresses in various formats.
  *  See AT command +CGPIAF from 3GPP TS 27.007 for details. Does also needed conversions for IPv6 addresses.

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -57,7 +57,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // AT_CMGF
     1,  // AT_CSDH
     1,  // PROPERTY_IPV4_STACK
-    0,  // PROPERTY_IPV6_STACK
+    1,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     1,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP


### PR DESCRIPTION
### Description
- Set stack type based on the network assigned IP addresses
- Check send to address and stack compatibilty
- IP stack property redefined to be distinct from PDP context type 
- Enable IPv6 stack support for BG96

### Pull request type
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AriParkkila