### PR TITLE
ESP8266Interface buffer null-terminated and parameters of scan function in correct order

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -319,7 +319,7 @@ int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_
     if (ssid_length > 0
             && ssid_length <= ESP8266_SSID_MAX_LENGTH) {
         memset(ap_ssid, 0, sizeof(ap_ssid));
-        strncpy(ap_ssid, ssid, sizeof(ap_ssid));
+        strncpy(ap_ssid, ssid, ESP8266_SSID_MAX_LENGTH);
     } else {
         return NSAPI_ERROR_PARAMETER;
     }
@@ -438,7 +438,7 @@ int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count, scan_mode mode,
     }
 
     return _esp.scan(res, count, (mode == SCANMODE_ACTIVE ? ESP8266::SCANMODE_ACTIVE : ESP8266::SCANMODE_PASSIVE),
-                     t_min, t_max);
+                     t_max, t_min);
 }
 
 bool ESP8266Interface::_get_firmware_ok()


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
According to Coverity warnings: 
In `ESP8266Interface::set_credentials(...)` buffer `ap_ssid` is null-terminated. 
Scan function parameters are passed in correct order. 


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@SeppoTakalo 
@michalpasztamobica 
@kjbracey-arm 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
