### PR TITLE
Member get_interface_name implemented  in ESP8266Interface

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -52,6 +52,8 @@
 
 #define TRACE_GROUP  "ESPI" // ESP8266 Interface
 
+#define ESP8266_WIFI_IF_NAME "es0"
+
 using namespace mbed;
 using namespace rtos;
 
@@ -411,6 +413,12 @@ const char *ESP8266Interface::get_gateway()
 const char *ESP8266Interface::get_netmask()
 {
     return _conn_stat != NSAPI_STATUS_DISCONNECTED ? _esp.netmask() : NULL;
+}
+
+char *ESP8266Interface::get_interface_name(char *interface_name)
+{
+    memcpy(interface_name, ESP8266_WIFI_IF_NAME, sizeof(ESP8266_WIFI_IF_NAME));
+    return interface_name;
 }
 
 int8_t ESP8266Interface::get_rssi()

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -158,6 +158,13 @@ public:
      */
     virtual const char *get_netmask();
 
+    /** Get the network interface name
+     *
+     *  @return         Null-terminated representation of the network interface name
+     *                  or null if interface not exists
+     */
+    virtual char *get_interface_name(char *interface_name);
+
     /** Gets the current radio signal strength for active connection
      *
      * @return          Connection strength in dBm (negative value)


### PR DESCRIPTION
### Description

Member get_interface_name implemented  in ESP8266Interface.


### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
 
@SeppoTakalo 
@mikaleppanen 
@kjbracey-arm 

### Release Notes

 