### PR TITLE
ARMC6: To get the right stack trace, use `-O0`

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -16,7 +16,7 @@
                "-Wl,-n"]
     },
     "ARMC6": {
-        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O0",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-Wno-reserved-user-defined-literal", "-Wno-deprecated-register",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",


### PR DESCRIPTION
Verified that `-O1` does not make stack trace while `-O0` does.

### Description

#### Why required
Without this change, `ARM` toolchain's `--profile debug` build will not create stack trace. FYI, this is the gdb back trace result of `-O1`.
```
(gdb) bt
#0  generate_bus_fault_unaligned_access () at ./main.cpp:21
#1  0x000081c0 in main () at ./main.cpp:80
```
With `-O1`, this is the correct back trace acquired.
```
#0  generate_bus_fault_unaligned_access () at ./main.cpp:21
#1  0x000058e8 in func6 (debugP=1, param2=777) at ./main.cpp:32
#2  0x000058ba in func5 (debugP=1) at ./main.cpp:37
#3  0x000058a0 in func4 (str=0x1fff171c <_main_stack+3756> "\001") at ./main.cpp:43
#4  0x0000588a in func3 (f=0.333333343) at ./main.cpp:50
#5  0x00005870 in func2 (a=1, b=3) at ./main.cpp:55
#6  0x00005846 in func1 () at ./main.cpp:60
#7  0x00009a78 in main () at ./main.cpp:80
```
It looks like ARMC6's `-O1` level is quite optimizing than what we expect.
FYI. Here is the related document.
http://www.keil.com/support/man/docs/ARMCC/armcc_chr1359124935804.htm

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Reference
* Arm internal: IOTCLOUDPR-3438

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
