### PR TITLE
Correct doxy-spellchecker error message

### DIFF
--- a/tools/test/travis-ci/doxy-spellchecker/spell.sh
+++ b/tools/test/travis-ci/doxy-spellchecker/spell.sh
@@ -121,6 +121,6 @@ echo "Total Errors Found: ${ERRORS}"
 
 if [ ${ERRORS} -ne 0 ]; then
     echo "If any of the failed words should be considered valid please add them to the ignore.en.pws file"\
-         "found in tools/test/scripts/doxy-spellchecker between the _code_ and _doxy_ tags."
+         "found in tools/test/travis-ci/doxy-spellchecker between the _code_ and _doxy_ tags."
     exit 1
 fi


### PR DESCRIPTION
### Description
Correct error message in doxy-spellchecker as it mentions a location that does not exist and the file to modify to add known words is elsewhere.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
