### PR TITLE
Remove unreachable statements warnings

### DIFF
--- a/drivers/source/usb/USBDevice.cpp
+++ b/drivers/source/usb/USBDevice.cpp
@@ -22,6 +22,7 @@
 #include "USBDescriptor.h"
 #include "usb_phy_api.h"
 #include "mbed_assert.h"
+#include "platform/mbed_error.h"
 
 //#define DEBUG
 
@@ -852,8 +853,17 @@ void USBDevice::ep0_setup()
     assert_locked();
 
     if (_device.state < Default) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_NOT_READY
+            ),
+            "Device state is \"Powered\" or \"Detached\""
+        );
+#else
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     _setup_ready = true;
@@ -874,15 +884,33 @@ void USBDevice::ep0_out()
     assert_locked();
 
     if (_device.state < Default) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_NOT_READY
+            ),
+            "Device state is \"Powered\" or \"Detached\""
+        );
+#else
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     if (_transfer.user_callback != None) {
         /* EP0 OUT should not receive data if the stack is waiting
            on a user callback for the buffer to fill or status */
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_NOT_READY
+            ),
+            "The stack is waiting on a user callback for the buffer to fill or status."
+        );
+#else
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     if (_transfer.stage == Status) {
@@ -903,8 +931,17 @@ void USBDevice::ep0_in()
     assert_locked();
 
     if (_device.state < Default) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_NOT_READY
+            ),
+            "Device state is \"Powered\" or \"Detached\""
+        );
+#else
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
 #ifdef DEBUG
@@ -928,8 +965,17 @@ void USBDevice::out(usb_ep_t endpoint)
     assert_locked();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -946,8 +992,17 @@ void USBDevice::in(usb_ep_t endpoint)
     assert_locked();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1056,9 +1111,18 @@ bool USBDevice::endpoint_add(usb_ep_t endpoint, uint32_t max_packet_size, usb_ep
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return false;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     if (!_endpoint_add_remove_allowed) {
@@ -1087,9 +1151,18 @@ void USBDevice::endpoint_remove(usb_ep_t endpoint)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     if (!_endpoint_add_remove_allowed) {
@@ -1133,9 +1206,18 @@ void USBDevice::endpoint_stall(usb_ep_t endpoint)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1161,9 +1243,18 @@ void USBDevice::endpoint_unstall(usb_ep_t endpoint)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1306,9 +1397,18 @@ void USBDevice::endpoint_abort(usb_ep_t endpoint)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1332,9 +1432,18 @@ bool USBDevice::read_start(usb_ep_t endpoint, uint8_t *buffer, uint32_t max_size
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return false;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1346,9 +1455,18 @@ bool USBDevice::read_start(usb_ep_t endpoint, uint8_t *buffer, uint32_t max_size
     }
 
     if (max_size < info->max_packet_size) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_SIZE
+            ),
+            "The size of the data to read is less than the max packet size for this endpoint."
+        );
+#else
         unlock();
         return false;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     if (info->pending) {
@@ -1372,9 +1490,18 @@ uint32_t USBDevice::read_finish(usb_ep_t endpoint)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return 0;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1396,9 +1523,18 @@ bool USBDevice::write_start(usb_ep_t endpoint, uint8_t *buffer, uint32_t size)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable"
+        );
+#else
         unlock();
         return false;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
@@ -1410,10 +1546,18 @@ bool USBDevice::write_start(usb_ep_t endpoint, uint8_t *buffer, uint32_t size)
     }
 
     if (size > info->max_packet_size) {
-        // Size being written is too large
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_SIZE
+            ),
+            "Size being written is too large."
+        );
+#else
         unlock();
         return false;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     if (info->pending) {
@@ -1442,9 +1586,18 @@ uint32_t USBDevice::write_finish(usb_ep_t endpoint)
     lock();
 
     if (!EP_INDEXABLE(endpoint)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_DRIVER_USB,
+                MBED_ERROR_CODE_INVALID_INDEX
+            ),
+            "The endpoint is not indexable."
+        );
+#else
         unlock();
         return 0;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];

--- a/hal/mbed_pinmap_common.c
+++ b/hal/mbed_pinmap_common.c
@@ -52,7 +52,6 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b)
 
     // mis-match error case
     MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap mis-match", a);
-    return (uint32_t)NC;
 }
 
 uint32_t pinmap_find_peripheral(PinName pin, const PinMap *map)

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -19,6 +19,7 @@
 #include "hal/ticker_api.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_assert.h"
+#include "platform/mbed_error.h"
 
 static void schedule_interrupt(const ticker_data_t *const ticker);
 static void update_present_time(const ticker_data_t *const ticker);
@@ -42,8 +43,17 @@ static void initialize(const ticker_data_t *ticker)
     const ticker_info_t *info = ticker->interface->get_info();
     uint32_t frequency = info->frequency;
     if (info->frequency == 0) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_HAL,
+                MBED_ERROR_CODE_NOT_READY
+            ),
+            "Ticker frequency is zero"
+        );
+#else
         frequency = 1000000;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
 
     uint8_t frequency_shifts = 0;
@@ -56,8 +66,17 @@ static void initialize(const ticker_data_t *ticker)
 
     uint32_t bits = info->bits;
     if ((info->bits > 32) || (info->bits < 4)) {
-        MBED_ASSERT(0);
+#if MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(
+            MBED_MAKE_ERROR(
+                MBED_MODULE_HAL,
+                MBED_ERROR_CODE_INVALID_SIZE
+            ),
+            "Ticker number of bit is greater than 32 or less than 4 bits"
+        );
+#else
         bits = 32;
+#endif // MBED_TRAP_ERRORS_ENABLED
     }
     uint32_t max_delta = 0x7 << (bits - 4); // 7/16th
     uint64_t max_delta_us =


### PR DESCRIPTION
### Description
Remove unreachable statements warnings reported when building with the IAR toolchain.

Warnings observed when building the `mbed-os-example-blinky` example project with the following command:
`mbed compile -t IAR -m K64F`

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
