### PR TITLE
Add missing documentation about tls testing

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -5,7 +5,6 @@ This is a test plan for the Mbed OS Socket API. This describes all test cases an
 
 **NOTE:** Because testing is a moving target, this test plan might define more test cases than Mbed OS implements. Refer to [test case priorities](#test-case-priorities) for a list of test cases that the target must pass to be compliant with the Mbed OS socket API.
 
-
 Target API
 ----------
 
@@ -17,13 +16,13 @@ The target for this plan is to test:
 -   [TLSSocket](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/TLSSocket.h).
 -   [DNS](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/DNS.h).
 
-Please see the [Network Socket Documentation](https://os.mbed.com/docs/mbed-os/latest/apis/network-socket.html) for reference.
+Please see the [Network Socket documentation](https://os.mbed.com/docs/mbed-os/latest/apis/network-socket.html) for reference.
 
 Tools to use
 ----------------
 
 -   Mbed OS.
--   Standard Mbed OS development tools as described in the [Arm Mbed tools overview](https://os.mbed.com/docs/latest/tools/index.html).
+-   Standard Mbed OS development tools as described in the [Mbed OS tools overview](https://os.mbed.com/docs/latest/tools/index.html).
 -   Test server.
 
 These test cases themselves do not require any special tooling, other than the test server described in "Test environment" chapter.
@@ -37,7 +36,7 @@ The test environment consist of DUTs, network connection and the test server. Ar
 
 ### Public test server
 
-Address: `echo.mbedcloudtesting.com'.
+Address: `echo.mbedcloudtesting.com`.
 
 Both IPv4 and IPv6 addresses are available from a public DNS service:
 
@@ -51,7 +50,7 @@ echo.mbedcloudtesting.com has IPv6 address 2a05:d018:21f:3800:8584:60f8:bc9f:e61
 
 -   Echo protocol, [RFC 862](https://tools.ietf.org/html/rfc862) is enabled on both TCP and UDP on port 7. Port 2007 for TLS
 -   Discard protocol, [RFC 863](https://tools.ietf.org/html/rfc863) is enabled in both TCP and UDP on port 9. Port 2009 for TLS.
--   Character generator protocol, [RFC 864](https://tools.ietf.org/html/rfc864) is enabled in both TCP and UDP on port 19. Port 2019 for TLS. Output pattern should follow the proposed example pattern in RFC.
+-   Character generator protocol, [RFC 864](https://tools.ietf.org/html/rfc864) is enabled in both TCP and UDP on port 19. Port 2019 for TLS. The output pattern follows the proposed example pattern in RFC.
 -   Daytime protocol, [RFC 867](https://tools.ietf.org/html/rfc867) in both TCP and UDP on port 13. Port 2013 for TLS.
 -   Time protocol, [RFC 868](https://tools.ietf.org/html/rfc868) in both TCP and UDP on port 37.
 
@@ -122,43 +121,42 @@ key = /etc/letsencrypt/live/<test_server_url>/privkey.pem
 
 Get, update and install certificate files by certbot (Provided by Let's Encrypt <https://letsencrypt.org/>).
 
--   Install lighthttpd server.
+-   Install lighthttpd server:
+   
+   ```.sh
+   $ sudo apt-get install lighttpd
+   $ sudo rm -rf /var/www/html/*
+   $ sudo echo "<html><body><h1>Empty</h1>" > /var/www/html/index.html
+   $ sudo echo "</body></html>" >> /var/www/html/index.html
+   $ sudo chown www-data:www-data /var/www/html/index.html
+   $ sudo systemctl restart lighttpd.service
+   ```
 
-```.sh
-$ sudo apt-get install lighttpd
-$ sudo rm -rf /var/www/html/*
-$ sudo echo "<html><body><h1>Empty</h1>" > /var/www/html/index.html
-$ sudo echo "</body></html>" >> /var/www/html/index.html
-$ sudo chown www-data:www-data /var/www/html/index.html
-$ sudo systemctl restart lighttpd.service
-```
-
--   Install and setup certbot.
-
-```.sh
-$ sudo apt-get update
-$ sudo apt-get install software-properties-common
-$ sudo add-apt-repository ppa:certbot/certbot
-$ sudo apt-get update
-$ sudo apt-get install certbot
-$ sudo certbot certonly
-$ sudo certbot certonly --webroot -w /var/www/html -d <test_server_url>
-```
-
+-   Install and set up certbot:
+   
+   ```.sh
+   $ sudo apt-get update
+   $ sudo apt-get install software-properties-common
+   $ sudo add-apt-repository ppa:certbot/certbot
+   $ sudo apt-get update
+   $ sudo apt-get install certbot
+   $ sudo certbot certonly
+   $ sudo certbot certonly --webroot -w /var/www/html -d <test_server_url>
+   ```
+   
 -   Set test server to renew certificate before expiry.
+   
+   ```.sh
+   $ sudo echo "SHELL=/bin/sh" > /etc/cron.d/certbot
+   $ sudo echo "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin" > /etc/cron.d/certbot
+   $ sudo echo "0 */12 * * * root test -x /usr/bin/certbot -a \! -d /run/systemd/system && perl -e 'sleep int(rand(43200))' && certbot -q renew" > /etc/cron.d/certbot
+   ```
 
-```.sh
-$ sudo echo "SHELL=/bin/sh" > /etc/cron.d/certbot
-$ sudo echo "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin" > /etc/cron.d/certbot
-$ sudo echo "0 */12 * * * root test -x /usr/bin/certbot -a \! -d /run/systemd/system && perl -e 'sleep int(rand(43200))' && certbot -q renew" > /etc/cron.d/certbot
-```
-
-Where:
- <test_server_url> is test server url.
+Where <test_server_url> is the test server URL.
 
 **Testing the connectivity**
 
-You can connect to the test server with an NMAP tool like this:
+You can connect to the test server with an NMAP tool:
 
 ```.sh
 $ nmap -sT -p7,9,13,37,2007,2009,2013 echo.mbedcloudtesting.com
@@ -202,7 +200,7 @@ Nmap done: 1 IP address (1 host up) scanned in 1.78 seconds
 
 ![Ethernet](eth_environment.png)
 
-The Ethernet test environment consists of devices, an ethernet switch and an optional firewall that allows connecting to the Echo server.
+The Ethernet test environment consists of devices, an Ethernet switch and an optional firewall that allows connecting to the Echo server.
 
 ### Wi-Fi test environment
 
@@ -299,7 +297,7 @@ Please refer to the following table for priorities of test cases. Priorities are
 Building test binaries
 --------------------------
 
-For testing the board and driver, test against the Mbed OS master branch to get the most recent, up-to-date test cases and drivers.
+To test the board and driver, test against the Mbed OS master branch to get the most recent, up-to-date test cases and drivers.
 
 To create a build environment:
 
@@ -404,9 +402,10 @@ Wi-Fi tests require some more configuration, so for Wi-Fi purposes, the `mbed_ap
     }
 }
 ```
+
 Please, see `mbed-os/tools/test_configs` folder for examples.
 
-Now build test binaries:
+Now build the test binaries:
 
 ```.sh
 mbed test --compile -t <toolchain> -m <target> -n mbed-os-tests-network-*,mbed-os-tests-netsocket*
@@ -415,7 +414,7 @@ mbed test --compile -t <toolchain> -m <target> -n mbed-os-tests-network-*,mbed-o
 Running tests
 -------------
 
-When device is connected to network, or in case of wireless device near the access point.
+Run this when the device is connected to network, or if the wireless device is near the access point:
 
 ```.sh
 mbed test -n mbed-os-tests-network-*,mbed-os-tests-netsocket*
@@ -424,156 +423,144 @@ mbed test -n mbed-os-tests-network-*,mbed-os-tests-netsocket*
 Test cases for Socket class
 ---------------------------
 
-These test are equal for UDPSocket and TCPSocket but are described here because of identical API and behaviour. Socket class is abstract so it cannot be instantiated, therefore these test cases are implemented using both TCPSocket and UDPSocket. Some of these tests are also implemented for TLSSocket class. In such case certificate has to be set for the Socket before calling `open()`, unless specified otherwise in the test's
+These tests are the same as those for UDPSocket and TCPSocket. The Socket class is abstract, so it cannot be instantiated; therefore, these test cases are implemented using both TCPSocket and UDPSocket. Some of these tests are also implemented for the TLSSocket class. In such case, the certificate has to be set for the Socket before calling `open()`, unless specified otherwise in the test's
 description.
 
 ### SOCKET_OPEN_DESTRUCT
 
 **Description:**
 
-Call `Socket::open()` and then destruct the socket.
+Call `Socket::open()`, and then destruct the socket.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create an object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Delete the object.
-4.  Repeat 100 times.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Delete the object.
+1. Repeat 100 times.
 
 **Expected result:**
 
-`Socket::open()` should always return `NSAPI_ERROR_OK`.
-
-
+`Socket::open()` always returns `NSAPI_ERROR_OK`.
 
 ### SOCKET_OPEN_LIMIT
 
 **Description:**
 
- Call `Socket::open()` until it runs out of memory or other internal limit
-in the stack is reached.
+ Call `Socket::open()` until it runs out of memory or another internal limit in the stack is reached.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Repeat until `NSAPI_ERROR_NO_MEMORY` or `NSAPI_ERROR_NO_SOCKET` error code is returned.
-4.  Call "delete" for all previously allocated sockets.
-5.  Repeat.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Repeat until `NSAPI_ERROR_NO_MEMORY` or `NSAPI_ERROR_NO_SOCKET` error code is returned.
+1. Call "delete" for all previously allocated sockets.
+1. Repeat.
 
 **Expected result:**
 
-Should be able to reserve at least 4 sockets. After freeing all sockets, should  be able to reserve same number of sockets.
-
-
+It can reserve at least four sockets. After freeing all sockets, it can reserve the same number of sockets.
 
 ### SOCKET_OPEN_TWICE
 
 **Description:**
 
-Call `Socket::open()` twice
+Call `Socket::open()` twice.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Call `Socket::open(stack)`.
-4.  Delete the socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Call `Socket::open(stack)`.
+1. Delete the socket.
 
 **Expected result:**
 
-`Socket::open()` should first return `NSAPI_ERROR_OK` and second call `NSAPI_ERROR_PARAMETER`.
-
-
+`Socket::open()` first returns `NSAPI_ERROR_OK` and then calls `NSAPI_ERROR_PARAMETER`.
 
 ### SOCKET_OPEN_CLOSE_REPEAT
 
 **Description:**
 
-Call `Socket::open()` followed by `Socket::close()` and then again `Socket::open()`. Should allow you to reuse the same object.
+Call `Socket::open()` followed by `Socket::close()` and then again `Socket::open()`. This allows you to reuse the same object.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Call `Socket::close(stack)`.
-4.  Call `Socket::open(stack)`.
-5.  Call `Socket::close(stack)`.
-6.  Delete the socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Call `Socket::close(stack)`.
+1. Call `Socket::open(stack)`.
+1. Call `Socket::close(stack)`.
+1. Delete the socket.
 
 **Expected result:**
 
-All `Socket::open()` and `Socket::close()` calls should return `NSAPI_ERROR_OK`.
-
+All `Socket::open()` and `Socket::close()` calls return `NSAPI_ERROR_OK`.
 
 ### SOCKET_BIND_PORT
 
 **Description:**
 
-Call `Socket::bind(port)'.
+Call `Socket::bind(port)`.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Call `Socket::bind(<any non-used port number>);`.
-4.  Destroy socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Call `Socket::bind(<any unused port number>);`.
+1. Destroy the socket.
 
 **Expected result:**
 
 All calls return `NSAPI_ERROR_OK`.
 
-
-
 ### SOCKET_BIND_PORT_FAIL
 
 **Description:**
 
-Call `Socket::bind(port)` on port number that is already used
+Call `Socket::bind(port)` on a port number that is already used.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Call `Socket::bind(<any non-used port number>);`.
-4.  Repeat 1-3 for a new socket.
-5.  Destroy both sockets.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Call `Socket::bind(<any unused port number>);`.
+1. Repeat steps 1-3 for a new socket.
+1. Destroy both sockets.
 
 **Expected result:**
 
-Second `Socket::bind()` should return `NSAPI_ERROR_PARAMETER`.
-
-
+The second `Socket::bind()` returns `NSAPI_ERROR_PARAMETER`.
 
 ### SOCKET_BIND_ADDRESS_PORT
 
@@ -583,22 +570,20 @@ Call `Socket::bind(addr, port)`.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Get address by calling `NetworkInterface::get_ip_address()`.
-4.  Call `Socket::bind(address, <any non-used port number>);`.
-5.  Destroy socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Get address by calling `NetworkInterface::get_ip_address()`.
+1. Call `Socket::bind(address, <any unused port number>);`.
+1. Destroy the socket.
 
 **Expected result:**
 
 All calls return `NSAPI_ERROR_OK`.
-
-
 
 ### SOCKET_BIND_ADDRESS_NULL
 
@@ -608,178 +593,164 @@ Call `Socket::bind(NULL, port)`.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Call `Socket::bind(NULL, <any non-used port number>);`.
-4.  Destroy socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Call `Socket::bind(NULL, <any unused port number>);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-`Socket::bind()` should return `NSAPI_ERROR_OK'.
-
-
+`Socket::bind()` returns `NSAPI_ERROR_OK`.
 
 ### SOCKET_BIND_ADDRESS_INVALID
 
 **Description:**
 
-Call `Socket::bind(address, port)` with and address that is not assigned
-to us.
+Call `Socket::bind(address, port)` with an address not assigned to you.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Check whether device is IPv4 or IPv6 connected.
-    1.  For IPv4: Call `Socket::bind("190.2.3.4", <any non-used port number>);`.
-    2.  For IPv6: Call `Socket::bind("fe80::ff01", <any non-used port number>);`.
-
-4.  Destroy socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Check whether the device is IPv4 or IPv6 connected.
+   1. For IPv4: Call `Socket::bind("190.2.3.4", <any unused port number>);`.
+   1. For IPv6: Call `Socket::bind("fe80::ff01", <any unused port number>);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-`Socket::bind()` should return `NSAPI_ERROR_PARAMETER'.
-
-
+`Socket::bind()` returns `NSAPI_ERROR_PARAMETER`.
 
 ### SOCKET_BIND_ADDRESS_WRONG_TYPE
 
 **Description:**
 
-Call `Socket::bind(SocketAddress)` with and address that is not wrong type for the connection.
+Call `Socket::bind(SocketAddress)` with an address that is not the wrong type for the connection.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Check whether device is IPv4 or IPv6 connected.
-    1.  For IPv4: Create `SocketAddress("fe80::ff01", <any non-used port number>);`.
-    2.  For IPv6: Create `SocketAddress("190.2.3.4", <any non-used port number>);`.
-
-4.  Call `Socket::bind(address);`.
-5.  Destroy socket.
+1. Create a object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Check whether the device is IPv4 or IPv6 connected:
+   - For IPv4: Create `SocketAddress("fe80::ff01", <any unused port number>);`.
+   - For IPv6: Create `SocketAddress("190.2.3.4", <any unused port number>);`.
+1. Call `Socket::bind(address);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-`Socket::bind()` should return `NSAPI_ERROR_PARAMETER'.
-
-
+`Socket::bind()` returns `NSAPI_ERROR_PARAMETER`.
 
 ### SOCKET_BIND_ADDRESS
 
 **Description:**
 
-Call `Socket::bind(SocketAddress)'.
+Call `Socket::bind(SocketAddress)`.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::open(stack)`.
-3.  Get address by calling NetworkInterface::get_ip_address();
-4.  Create a SocketAddress object using this address and any non-used.
-    port number.
-5.  Call `Socket::bind(address);`.
-6.  Destroy socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::open(stack)`.
+1. Get address by calling `NetworkInterface::get_ip_address();`.
+1. Create a SocketAddress object using this address and any unused port number.
+1. Call `Socket::bind(address);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-All calls return `NSAPI_ERROR_OK'.
-
-
+All calls return `NSAPI_ERROR_OK`.
 
 ### SOCKET_BIND_UNOPENED
 
 **Description:**
 
-Call `Socket::bind()` on socket that has not been opened.
+Call `Socket::bind()` on a socket that has not been opened.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create a object by calling `new Socket()`.
-2.  Call `Socket::bind(<any non-used port number>);`.
-3.  Destroy socket.
+1. Create an object by calling `new Socket()`.
+1. Call `Socket::bind(<any unused port number>);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-NSAPI_ERROR_NO_SOCKET
-
-
+`NSAPI_ERROR_NO_SOCKET`
 
 Test cases for UDPSocket class
 ------------------------------
 
 ### UDPSOCKET_OPEN_DESTRUCT
 
-**Description:** Run SOCKET_OPEN_DESTRUCT for UDPSocket.
+**Description:** Run `SOCKET_OPEN_DESTRUCT` for UDPSocket.
 
 ### UDPSOCKET_OPEN_LIMIT
 
-**Description:** Run SOCKET_OPEN_LIMIT for UDPSocket.
+**Description:** Run `SOCKET_OPEN_LIMIT` for UDPSocket.
 
 ### UDPSOCKET_OPEN_TWICE
 
-**Description:** Run SOCKET_OPEN_TWICE for UDPSocket.
+**Description:** Run `SOCKET_OPEN_TWICE` for UDPSocket.
 
 ### UDPSOCKET_OPEN_CLOSE_REPEAT
 
-**Description:** Run SOCKET_OPEN_CLOSE_REPEAT for UDPSocket.
+**Description:** Run `SOCKET_OPEN_CLOSE_REPEAT` for UDPSocket.
 
 ### UDPSOCKET_BIND_PORT
 
-**Description:** Run SOCKET_BIND_PORT for UDPSocket.
+**Description:** Run `SOCKET_BIND_PORT` for UDPSocket.
 
 ### UDPSOCKET_BIND_PORT_FAIL
 
-**Description:** Run SOCKET_BIND_PORT_FAIL for UDPSocket.
+**Description:** Run `SOCKET_BIND_PORT_FAIL` for UDPSocket.
 
 ### UDPSOCKET_BIND_ADDRESS_PORT
 
-**Description:** Run SOCKET_BIND_ADDRESS_PORT for UDPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS_PORT` for UDPSocket.
 
 ### UDPSOCKET_BIND_ADDRESS_NULL
 
-**Description:** Run SOCKET_BIND_ADDRESS_NULL for UDPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS_NULL` for UDPSocket.
 
 ### UDPSOCKET_BIND_ADDRESS_INVALID
 
-**Description:** Run SOCKET_BIND_ADDRESS_INVALID for UDPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS_INVALID` for UDPSocket.
 
 ### UDPSOCKET_BIND_WRONG_TYPE
 
-**Description:** Run SOCKET_BIND_WRONG_TYPE for UDPSocket.
+**Description:** Run `SOCKET_BIND_WRONG_TYPE` for UDPSocket.
 
 ### UDPSOCKET_BIND_ADDRESS
 
-**Description:** Run SOCKET_BIND_ADDRESS for UDPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS` for UDPSocket.
 
 ### UDPSOCKET_BIND_UNOPENED
 
-**Description:** Run SOCKET_BIND_UNOPENED for UDPSocket.
+**Description:** Run `SOCKET_BIND_UNOPENED` for UDPSocket.
 
 ### UDPSOCKET_SENDTO_INVALID
 
@@ -789,27 +760,25 @@ Call `UDPSocket::sendto()` with invalid parameters.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  UDPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. UDPSocket is open.
 
 **Test steps:**
 
-1.  Call `UDPSocket:sendto( NULL, 9, NULL, 0);`.
-2.  Call `UDPSocket:sendto( "", 9, NULL, 0);`.
-3.  Call `UDPSocket:sendto( "", 0, NULL, 0);`.
-4.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9,NULL, 0);`.
-5.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`.
-6.  Destroy the socket.
+1. Call `UDPSocket:sendto( NULL, 9, NULL, 0);`.
+1. Call `UDPSocket:sendto( "", 9, NULL, 0);`.
+1. Call `UDPSocket:sendto( "", 0, NULL, 0);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9,NULL, 0);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-All sendto() calls should return some error code except:
+All `sendto()` calls return an error code except:
 
--   step 4 should return 0
--   step 5 should return 5
-
-
+-   Step 4 returns 0.
+-   Step 5 returns 5.
 
 ### UDPSOCKET_SENDTO_REPEAT
 
@@ -819,87 +788,80 @@ Repeatedly send small packets.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  UDPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. UDPSocket is open.
 
 **Test steps:**
 
-1.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`.
-2.  Repeat 100 times.
-3.  Fail if `NSAPI_ERROR_NO_MEMORY` is returned two times in a row,.
-    Wait 1 second before retry
-4.  Destroy the socket.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`.
+1. Repeat 100 times.
+1. Fail if `NSAPI_ERROR_NO_MEMORY` is returned two times in a row.
+1. Wait 1 second before retrying.
+1. Destroy the socket.
 
 **Expected result:**
 
-All sendto() calls should return 5.
-
-
+All `sendto()` calls return 5.
 
 ### UDPSOCKET_ECHOTEST
 
 **Description:**
 
-Repeatedly send packets to echo server and read incoming packets back.
-Verify working of different packet sizes.
+Repeatedly send packets to echo server and read incoming packets back. Verify different packet sizes work.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  UDPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. UDPSocket is open.
 
 **Test steps:**
 
-1.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = loop index>, <loop index>);`.
-2.  Wait for incomming packet. If timeout happens, retry.
-    sending&receiving, max 3 times.
-3.  Verify incomming content was the same that was sent.
-4.  Repeat 1200 times.
-5.  Destroy the socket.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = loop index>, <loop index>);`.
+1. Wait for incoming packet.
+   - If timeout happens, retry sending and receiving a maximum of three times.
+1. Verify incoming content is the same as the sent content.
+1. Repeat 1,200 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-At least one sendto() call of every size should return the packet size.
-Errors returned from recvfrom() calls are tolerated. 
-Calculate packet loss rate, maximum tolerated packet loss rate is 30%.
-
-
+- At least one `sendto()` call of every size returns the packet size.
+- Errors returned from `recvfrom()` calls are tolerated. 
+- Calculate packet loss rate. The maximum tolerated packet loss rate is 30%.
 
 ### UDPSOCKET_ECHOTEST_NONBLOCK
 
 **Description:**
 
-Repeatedly send packets to echo server and read incoming packets back.
-Verify working of different packet sizes. Use socket in non-blocking
-mode
+Repeatedly send packets to echo server and read incoming packets back. Verify different packet sizes work. Use Socket in nonblocking
+mode.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  UDPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. UDPSocket is open.
 
 **Test steps:**
 
-1.  Call `UDPSocket::set_blocking(false)`.
-2.  Register event handler with `UDPSocket::sigio()`.
-3.  Create another thread that constantly waits signal from sigio() handler, when received try `UDPSocket::recvfrom()`.
-4.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = loop index>, <loop index>);`.
-5.  Wait for incomming packet for one second. If nothing received retry,
-    max 3 times.
-6.  Verify incomming content was the same that was sent.
-7.  Repeat 1200 times.
-8.  Destroy the socket.
+1. Call `UDPSocket::set_blocking(false)`.
+1. Register event handler with `UDPSocket::sigio()`.
+1. Create another thread that constantly waits for a signal from the `sigio()` handler.
+1. When it's received, try `UDPSocket::recvfrom()`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = loop index>, <loop index>);`.
+1. Wait for an incoming packet for one second.
+   - If nothing is received, retry a maximum of three times.
+1. Verify incoming content is the same as sent content.
+1. Repeat 1,200 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-At least one sendto() call of every size should return the packet size.
-Errors returned from recvfrom() calls are tolerated. 
-Calculate packet loss rate, maximum tolerated packet loss rate is 30%.
-
-
+- At least one `sendto()` call of every size returns the packet size.
+- Errors returned from `recvfrom()` calls are tolerated. 
+- Calculate packet loss rate. The maximum tolerated packet loss rate is 30%.
 
 ### UDPSOCKET_RECV_TIMEOUT
 
@@ -909,30 +871,26 @@ Test whether timeouts are obeyed in UDPSockets.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `UDPSocket::set_timeout(100)`.
-2.  Call `UDPSocket::sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 100>, 100);`.
-3.  Repeat 5 times.
-    1.  Record a time in millisecond precission.
-    2.  Call `UDPSocket::recvfrom()`.
-    3.  Record a time in millisecond precission.
-
-4.  Repeat testcase 10 times.
+1. Call `UDPSocket::set_timeout(100)`.
+1. Call `UDPSocket::sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 100>, 100);`.
+1. Repeat five times.
+   1. Record a time with millisecond precision.
+   1. Call `UDPSocket::recvfrom()`.
+   1. Record a time with millisecond precision.
+1. Repeat the test case 10 times.
 
 **Expected result:**
 
-Each `sendto()` calls should return 100.
+Each `sendto()` call returns 100.
 
-Within each loop, one `recvfrom()` may return the received packet size
-(100). Other calls should return `NSAPI_ERROR_WOULD_BLOCK`.
+Within each loop, one `recvfrom()` may return the received packet size (100). Other calls return `NSAPI_ERROR_WOULD_BLOCK`.
 
-When `NSAPI_ERROR_WOULD_BLOCK` is received, check that time consumed is
-more that 100 milliseconds but less than 200 milliseconds.
-
+When `NSAPI_ERROR_WOULD_BLOCK` is received, check that time consumed is more that 100 milliseconds but less than 200 milliseconds.
 
 ### UDPSOCKET_SENDTO_TIMEOUT
 
@@ -942,76 +900,74 @@ Test whether timeouts are obeyed in UDPSockets.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Record time.
-2.  Call `UDPSocket::sendto("echo.mbedcloudtesting.com", 9, <random packet, size = 100>, 100);`.
-3.  Record time.
-4.  Call `UDPSocket::set_timeout(1000)`.
-5.  Call `UDPSocket::sendto("echo.mbedcloudtesting.com", 9, <random packet, size = 100>, 100);`.
-6.  Record time.
+1. Record time.
+1. Call `UDPSocket::sendto("echo.mbedcloudtesting.com", 9, <random packet, size = 100>, 100);`.
+1. Record time.
+1. Call `UDPSocket::set_timeout(1000)`.
+1. Call `UDPSocket::sendto("echo.mbedcloudtesting.com", 9, <random packet, size = 100>, 100);`.
+1. Record time.
 
 **Expected result:**
 
-Each sendto() call should return 100.
+Each `sendto()` call returns 100.
 
-All sendto() calls should return faster than 100 milliseconds because
-UDP sending should not block that long.
-
+All `sendto()` calls return faster than 100 milliseconds because UDP sending does not block that long.
 
 Test cases for TCPSocket class
 ------------------------------
 
 ### TCPSOCKET_OPEN_DESTRUCT
 
-**Description:** Run SOCKET_OPEN_DESTRUCT for TCPSocket.
+**Description:** Run `SOCKET_OPEN_DESTRUCT` for TCPSocket.
 
 ### TCPSOCKET_OPEN_LIMIT
 
-**Description:** Run SOCKET_OPEN_LIMIT for TCPSocket.
+**Description:** Run `SOCKET_OPEN_LIMIT` for TCPSocket.
 
 ### TCPSOCKET_OPEN_TWICE
 
-**Description:** Run SOCKET_OPEN_TWICE for TCPSocket.
+**Description:** Run `SOCKET_OPEN_TWICE` for TCPSocket.
 
 ### TCPSOCKET_OPEN_CLOSE_REPEAT
 
-**Description:** Run SOCKET_OPEN_CLOSE_REPEAT for TCPSocket.
+**Description:** Run `SOCKET_OPEN_CLOSE_REPEAT` for TCPSocket.
 
 ### TCPSOCKET_BIND_PORT
 
-**Description:** Run SOCKET_BIND_PORT for TCPSocket.
+**Description:** Run `SOCKET_BIND_PORT` for TCPSocket.
 
 ### TCPSOCKET_BIND_PORT_FAIL
 
-**Description:** Run SOCKET_BIND_PORT_FAIL for TCPSocket.
+**Description:** Run `SOCKET_BIND_PORT_FAIL` for TCPSocket.
 
 ### TCPSOCKET_BIND_ADDRESS_PORT
 
-**Description:** Run SOCKET_BIND_ADDRESS_PORT for TCPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS_PORT` for TCPSocket.
 
 ### TCPSOCKET_BIND_ADDRESS_NULL
 
-**Description:** Run SOCKET_BIND_ADDRESS_NULL for TCPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS_NULL` for TCPSocket.
 
 ### TCPSOCKET_BIND_ADDRESS_INVALID
 
-**Description:** Run SOCKET_BIND_ADDRESS_INVALID for TCPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS_INVALID` for TCPSocket.
 
 ### TCPSOCKET_BIND_WRONG_TYPE
 
-**Description:** Run SOCKET_BIND_WRONG_TYPE for TCPSocket.
+**Description:** Run `SOCKET_BIND_WRONG_TYPE` for TCPSocket.
 
 ### TCPSOCKET_BIND_ADDRESS
 
-**Description:** Run SOCKET_BIND_ADDRESS for TCPSocket.
+**Description:** Run `SOCKET_BIND_ADDRESS` for TCPSocket.
 
 ### TCPSOCKET_BIND_UNOPENED
 
-**Description:** Run SOCKET_BIND_UNOPENED for TCPSocket.
+**Description:** Run `SOCKET_BIND_UNOPENED` for TCPSocket.
 
 ### TCPSOCKET_CONNECT_INVALID
 
@@ -1021,24 +977,21 @@ Call `TCPSocket::connect()` with invalid parameters.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket:connect( NULL, 9);`.
-2.  Call `TCPSocket:connect( "", 9);`.
-3.  Call `TCPSocket:connect( "", 0);`.
-4.  Call `TCPSocket:connect( "echo.mbedcloudtesting.com", 9);`.
-5.  Destroy the socket.
+1. Call `TCPSocket:connect( NULL, 9);`.
+1. Call `TCPSocket:connect( "", 9);`.
+1. Call `TCPSocket:connect( "", 0);`.
+1. Call `TCPSocket:connect( "echo.mbedcloudtesting.com", 9);`.
+1. Destroy the socket.
 
 **Expected result:**
 
-All connect() calls should return some error code except the number 4
-should return `NSAPI_ERROR_OK`.
-
-
+All `connect()` calls return an error code except the number 4, which returns `NSAPI_ERROR_OK`.
 
 ### TCPSOCKET_SEND_REPEAT
 
@@ -1048,92 +1001,83 @@ Repeatedly send small packets.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 9);`.
-2.  Call `TCPSocket::send("hello", 5);`.
-3.  Repeat 100 times.
-4.  Destroy the socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 9);`.
+1. Call `TCPSocket::send("hello", 5);`.
+1. Repeat 100 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-`TCPSocket::connect()` should return `NSAPI_ERROR_OK'.
+`TCPSocket::connect()` returns `NSAPI_ERROR_OK`.
 
-All send() calls should return 5.
-
-
+All `send()` calls return 5.
 
 ### TCPSOCKET_ECHOTEST
 
 **Description:**
 
-Repeatedly send packets to echo server and read incoming packets back.
-Verify working of different packet sizes.
+Repeatedly send packets to echo server and read incoming packets back. Verify different packet sizes work.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
-2.  Call `TCPSocket::send(<random packet, size = loop index>, <size>);`.
-    1.  If less than <loop index> was returned, size = sent bytes.
-
-3.  Call `TCPSocket::recv(buffer, <size>);`.
-4.  Verify incomming content was the same that was sent.
-5.  Repeat 1200 times.
-6.  Destroy the socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
+1. Call `TCPSocket::send(<random packet, size = loop index>, <size>);`.
+   1. If less than <loop index> was returned, size = sent bytes.
+1. Call `TCPSocket::recv(buffer, <size>);`.
+1. Verify incoming content is the same as sent content.
+1. Repeat 1,200 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-All send() calls should return the packet size or less. All recv() calls
-should return the same sized packet that was send with same content.
+All `send()` calls return the packet size or less. All `recv()` calls return the same sized packet that was sent with same content.
 
-NOTE: This is stream so recv() might return less data than what was
-requested. In this case you need to keep calling recv() until all data
-that you have sent is returned.
-
+NOTE: This is stream, so `recv()` might return less data than requested. Keep calling `recv()` until all data you have sent is returned.
 
 ### TCPSOCKET_ECHOTEST_NONBLOCK
 
 **Description:**
 
-Repeatedly send packets to echo server and read incoming packets back.
-Verify working of different packet sizes. Use socket in non-blocking
-mode
+Repeatedly send packets to echo server and read incoming packets back. Verify different packet sizes work. Use Socket in nonblocking
+mode.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
-2.  Call `TCPSocket::set_blocking(false)`.
-3.  Register event handler with `TCPSocket::sigio()`.
-4.  Create another thread that constantly waits signal from `sigio()` handler, when received try `TCPSocket::recv(buf+index, <loop index> - index)`, where index is the amount of data already received.
-5.  Call `TCPSocket:send(<random packet, size = loop index>, <loop index>);`.
-    1.  If less than <loop index> was returned, try immeadiately sending remaining bytes.
-    2.  If `NSAPI_ERROR_WOULD_BLOCK` is returned, wait for sigio() call to happen.
-
-6.  Wait for incomming packet for one second.
-7.  Verify incomming content was the same that was sent, set index for receiving thread to zero.
-8.  Repeat 1200 times.
-9.  Destroy the socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
+1. Call `TCPSocket::set_blocking(false)`.
+1. Register event handler with `TCPSocket::sigio()`.
+1. Create another thread that constantly waits for a signal from `sigio()` handler.
+1. When it's received, try `TCPSocket::recv(buf+index, <loop index> - index)`, where index is the amount of data already received.
+1. Call `TCPSocket:send(<random packet, size = loop index>, <loop index>);`.
+   1. If less than <loop index> is returned, try immediately sending the remaining bytes.
+   1. If `NSAPI_ERROR_WOULD_BLOCK` is returned, wait for `sigio()` call to happen.
+1. Wait for incoming packet for one second.
+1. Verify incoming content is the same as sent content.
+1. Set index for receiving thread to zero.
+1. Repeat 1,200 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-All send() calls should return the packet size or less. All recv() calls
-should return `NSAPI_ERROR_WOULD_BLOCK` or packet size that is equal or
+All `send()` calls return the packet size or less. All `recv()` calls return `NSAPI_ERROR_WOULD_BLOCK` or a packet size equal to or
 less than what has been sent.
 
 ### TCPSOCKET_RECV_TIMEOUT
@@ -1144,527 +1088,513 @@ Test whether timeouts are obeyed in TCPSockets.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
-2.  Call `TCPSocket::set_timeout(100);`.
-3.  Call `TCPSocket::send(<random packet, size = 100>;, 100);`.
-4.  Repeat 5 times.
-    1.  Record a time in millisecond precission.
-    2.  Call `TCPSocket::recv()`.
-    3.  Record a time in millisecond precission.
-
-5.  Repeat testcase 10 times.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
+1. Call `TCPSocket::set_timeout(100);`.
+1. Call `TCPSocket::send(<random packet, size = 100>;, 100);`.
+1. Repeat 5 times.
+   1. Record a time with millisecond precision.
+   1. Call `TCPSocket::recv()`.
+   1. Record a time with millisecond precision.
+1. Repeat the test case 10 times.
 
 **Expected result:**
 
-Each send() call should return 100.
+Each `send()` call returns 100.
 
-Within each loop, one recv() may return the received packet size (100).
-Other calls should return `NSAPI_ERROR_WOULD_BLOCK`.
+Within each loop, one `recv()` may return the received packet size (100). Other calls return `NSAPI_ERROR_WOULD_BLOCK`.
 
-When `NSAPI_ERROR_WOULD_BLOCK` is received, check that time consumed is
-more that 100 milliseconds but less than 200 milliseconds.
-
+When `NSAPI_ERROR_WOULD_BLOCK` is received, check the time consumed is more that 100 milliseconds but less than 200 milliseconds.
 
 ### TCPSOCKET_SEND_TIMEOUT
 
 **Description:**
 
-Repeatedly send small packets in a given time limit
+Repeatedly send small packets in a given time limit.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket:connect("echo.mbedcloudtesting.com", 9);`.
-3.  Call `TCPSocket:set_blocking(false);`.
-3.  Call `TCPSocket:send("hello", 5);`.
-4.  Repeat 10 times.
-5.  Destroy the socket.
+1. Call `TCPSocket:connect("echo.mbedcloudtesting.com", 9);`.
+1. Call `TCPSocket:set_blocking(false);`.
+1. Call `TCPSocket:send("hello", 5);`.
+1. Repeat 10 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-`TCPSocket::connect()` should return `NSAPI_ERROR_OK'.
+`TCPSocket::connect()` return `NSAPI_ERROR_OK`.
 
-All send() calls should return in less than 800 milliseconds
-
+All `send()` calls return in less than 800 milliseconds.
 
 ### TCPSOCKET_ENDPOINT_CLOSE
 
 **Description:**
 
-Test whether we tolerate endpoint closing the connection.
+Test whether you tolerate an endpoint closing the connection.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 13);`.
-2.  Call `TCPSocket::recv(<buffer>, 30);`.
-3.  Repeat until recv() returns 0.
-4.  Call `TCPSocket::close();`.
-5.  Delete socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 13);`.
+1. Call `TCPSocket::recv(<buffer>, 30);`.
+1. Repeat until `recv()` returns 0.
+1. Call `TCPSocket::close();`.
+1. Delete the socket.
 
 **Expected result:**
-Connect should return `NSAPI_ERROR_OK`.
 
-First recv() should return more that zero. Something between 10 and 30 bytes (datetime string)
+Connect returns `NSAPI_ERROR_OK`.
 
-Second recv() should return zero because endpoint closed the connection.
-close() should return `NSAPI_ERROR_OK'.
+The first `recv()` returns more that zero. Something between 10 and 30 bytes (datetime string).
+
+The second `recv()` returns zero because the endpoint closed the connection. `close()` returns `NSAPI_ERROR_OK`.
 
 ### TCPSOCKET_SETSOCKOPT_KEEPALIVE_VALID
 
 **Description:**
 
-Test we are able to request setting valid TCP keepalive values
+Test you can request setting valid TCP keepalive values.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `TCPSocket::setsockopt(keepalive, [0,1 or 7200]);`.
-2.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 9);`.
-3.  Call `TCPSocket::getsockopt(keepalive);`.
+1. Call `TCPSocket::setsockopt(keepalive, [0,1 or 7200]);`.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 9);`.
+1. Call `TCPSocket::getsockopt(keepalive);`.
 
 **Postconditions:**
 
-1.  Call `TCPSocket::close();`.
-2.  Delete socket.
+1. Call `TCPSocket::close();`.
+1. Delete the socket.
 
 **Expected result:**
 
-`TCPSocket::getsockopt(keepalive)` returns same value as was set with `TCPSocket::setsockopt()` or `NSAPI_ERROR_UNSUPPORTED'.
+`TCPSocket::getsockopt(keepalive)` returns the same value as that set with `TCPSocket::setsockopt()` or `NSAPI_ERROR_UNSUPPORTED`.
 
 Test cases for TLSSocket class
 ------------------------------
 
 ### TLSSOCKET_OPEN_DESTRUCT
 
-**Description:** Run�SOCKET_OPEN_DESTRUCT for TLSSocket.
+**Description:** Run `SOCKET_OPEN_DESTRUCT` for TLSSocket.
 
 ### TLSSOCKET_OPEN_LIMIT
 
-**Description:** Run�SOCKET_OPEN_LIMIT for TLSSocket.
+**Description:** Run `SOCKET_OPEN_LIMIT` for TLSSocket.
 
 ### TLSSOCKET_OPEN_TWICE
 
-**Description:** Run�SOCKET_OPEN_TWICE�for TLSSocket.
+**Description:** Run `SOCKET_OPEN_TWICE` for TLSSocket.
 
 ### TLSSOCKET_CONNECT_INVALID
 
-**Description:** Run�SOCKET_CONNECT_INVALID for TLSSocket.
+**Description:** Run `SOCKET_CONNECT_INVALID` for TLSSocket.
 
 ### TLSSOCKET_HANDSHAKE_INVALID
 
 **Description:**
 
-Execute TLS handshake by calling `TLSSocket::connect()` - server must not match to the certificate used by to os.mbed.com
+Execute the TLS handshake by calling `TLSSocket::connect()`. The server must not match the certificate used by os.mbed.com.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create TLSSocket.
-2.  Call `TLSSocket::open()`.
-3.  Call `TLSSocket::connect("os.mbed.com", 2009)`.
-4.  Call `TLSSocket::close()`.
+1. Create TLSSocket.
+1. Call `TLSSocket::open()`.
+1. Call `TLSSocket::connect("os.mbed.com", 2009)`.
+1. Call `TLSSocket::close()`.
 
 **Expected result:**
 
-TLSSocket::connect must return an error
+`TLSSocket::connect` must return an error.
 
 ### TLSSOCKET_SEND_CLOSED
 
 **Description:**
 
-Make a HTTP request to a closed socket.
+Make an HTTP request to a closed socket.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create TLSSocket.
-2.  Call `TLSSocket::open()`.
-3.  Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007)`.
-4.  Call `TLSSocket::close()`.
-5.  Call `TLSSocket::send("12345", 5)`.
+1. Create TLSSocket.
+1. Call `TLSSocket::open()`.
+1. Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007)`.
+1. Call `TLSSocket::close()`.
+1. Call `TLSSocket::send("12345", 5)`.
 
 **Expected result:**
 
-TLSSocket::send must return an error
+`TLSSocket::send` must return an error.
 
 ### TLSSOCKET_SEND_REPEAT
 
-**Description:** Run SOCKET_SEND_REPEAT for TLSSOCKET by using port number 2009.
+**Description:** Run `SOCKET_SEND_REPEATÂ` for TLSSOCKET by using port number 2009.
 
 ### TLSSOCKET_SEND_TIMEOUT
 
-**Description:** Run SOCKET_SEND_TIMEOUT for TLSSOCKET by using port number 2009.
+**Description:** Run `SOCKET_SEND_TIMEOUTÂ` for TLSSOCKET by using port number 2009.
 
 ### TLSSOCKET_SEND_UNCONNECTED
 
 **Description:** 
 
-Make a HTTP request to an unconnected socket.
+Make an HTTP request to an unconnected socket.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create TLSSocket.
-2.  Call `TLSSocket::open()`.
-3.  Call `TLSSocket::send("12345", 5)`.
-4.  Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007)`.
+1. Create TLSSocket.
+1. Call `TLSSocket::open()`.
+1. Call `TLSSocket::send("12345", 5)`.
+1. Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007)`.
 
 **Expected result:**
 
-TLSSocket::send must return an error
+`TLSSocket::send` must return an error.
 
 ### TLSSOCKET_ECHOTEST
 
-**Description:** Run SOCKET_ECHOTEST for TLSSOCKET by using port number 2007.
+**Description:** Run `SOCKET_ECHOTESTÂ` for TLSSOCKET by using port number 2007.
 
 ### TLSSOCKET_ECHOTEST_NONBLOCK
 
-**Description:** Run SOCKET_ECHOTEST_NONBLOCK for TLSSOCKET by using port number 2007.
+**Description:** Run `SOCKET_ECHOTEST_NONBLOCKÂ` for TLSSOCKET by using port number 2007.
 
 ### TLSSOCKET_ENDPOINT_CLOSE
 
-**Description:** Run SOCKET_ENDPOINT_CLOSE for TLSSOCKET by using port number 2013.
+**Description:** Run `SOCKET_ENDPOINT_CLOSE` for TLSSOCKET by using port number 2013.
 
 ### TLSSOCKET_NO_CERT
 
 **Description:**
 
-Verify that TLS Socket fails to connect without certificate.
+Verify TLS Socket fails to connect without a certificate.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
+1. Network interface and stack are initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Create TLSSocket, without adding a default certificate.
-2.  Call `TLSSocket::open()`.
-3.  Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2009)`.
+1. Create TLSSocket, without adding a default certificate.
+1. Call `TLSSocket::open()`.
+1. Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2009)`.
 
 **Expected result:**
 
-TLSSocket::connect must return an error if the certificate is not present.
+`TLSSocket::connect` must return an error if the certificate is not present.
 
 ### TLSSOCKET_RECV_TIMEOUT
 
 **Description:**
 
-Run TCPSOCKET_RECV_TIMEOUT for TLSSOCKET by using port number 2007.
+Run `TCPSOCKET_RECV_TIMEOUTÂ` for TLSSOCKET by using port number 2007.
 
 ### TLSSOCKET_SIMULTANEOUS_TEST
 
 **Description:**
 
-Simultaneously send packets to echo server on two opened sockets and read incoming packets back. Verify working of two TLS sockets open and operate simultaneously.
+Simultaneously send packets to echo server on two opened sockets and read incoming packets back. Verify TLS sockets open and operate simultaneously.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TLSSockets are open and one additional thread has been created.
-4.  Both threads get their own socket instance.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TLSSockets are open and one additional thread has been created.
+1. Both threads get their own socket instance.
 
 **Test steps:**
 
-1.  On main thread:
-    1.  Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007);`.
-    2.  Call `TLSSocket::send(<random packet, size = loop index>, <loop index>);`.
-        1.  If less than <loop index> was returned, size = sent bytes.
-
-    3.  `Call TLSSocket::recv(buffer, <size>);`.
-    4.  Verify incomming content was the same that was sent.
-    5.  Repeat 100 times.
-
-2.  Simultaneously with the earlier step do on the additional thread:
-    1.  Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007);`.
-    2.  Call `TLSSocket::send(<random packet, size = loop index>, <loop index>);'.
-        1.  If less than <loop index> was returned, size = sent bytes.
-
-    3.  Call `TLSSocket::recv(buffer, <size>);`.
-    4.  Verify incomming content was the same that was sent.
-    5.  Repeat 100 times.
-
-3.  Wait for end additional thread.
-4.  Close and destroy the sockets.
+1. (Simultaneously with step 2), on the main thread:
+   1. Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007);`.
+   1. Call `TLSSocket::send(<random packet, size = loop index>, <loop index>);`.
+      - If less than <loop index> is returned, size = sent bytes.
+   1. Call `TLSSocket::recv(buffer, <size>);`.
+   1. Verify incoming content is the same as sent content.
+   1. Repeat 100 times.
+1. (Simultaneously with step 1), on the additional thread:
+   1. Call `TLSSocket::connect("echo.mbedcloudtesting.com", 2007);`.
+   1. Call `TLSSocket::send(<random packet, size = loop index>, <loop index>);'.
+      - If less than <loop index> is returned, size = sent bytes.
+   1. Call `TLSSocket::recv(buffer, <size>);`.
+   1. Verify incoming content is the same as sent content.
+   1. Repeat 100 times.
+1. Wait for the additional thread to end.
+1. Close and destroy the sockets.
 
 **Expected result:**
 
-All send() calls should return the packet size or less. All recv() calls on main thread should return the same sized packet that was send with same content. All recv() calls on additional thread should return the valid daytime string . 
+All `send()` calls return the packet size or less. All `recv()` calls on the main thread return the same sized packet that was sent with the same content. All `recv()` calls on the additional thread return the valid daytime string.
 
 Performance tests
 -----------------
-
 
 ### UDPSOCKET_ECHOTEST_BURST
 
 **Description:**
 
-Send burst of packets to echo server and read incoming packets back.
+Send a burst of packets to the echo server and read incoming packets back.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  UDPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. UDPSocket is open.
 
 **Test steps:**
 
-1.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 100>, 100);`.
-2.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 200>, 200);`.
-3.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 300>, 300);`.
-4.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 120>, 120);`.
-5.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 500>, 500);`.
-6.  Wait for incomming packets for five second.
-7.  Verify incomming content was the same that was sent. Allow packet reordering.
-8.  Repeat 100 times.
-9.  Destroy the socket.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 100>, 100);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 200>, 200);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 300>, 300);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 120>, 120);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 500>, 500);`.
+1. Wait for incoming packets for five seconds.
+1. Verify incoming content is the same as sent content.
+1. Allow packet reordering.
+1. Repeat 100 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-All sendto() calls should return the packet size.
+All `sendto()` calls return the packet size.
 
-All recvfrom() calls should return the same sized packet that was send with same content. Allow packet reordering.
+All `recvfrom()` calls return the same sized packet that was sent with same content. Allow packet reordering.
 
-Calculate packet loss rate, maximum tolerated packet loss rate is 30%.
+Calculate packet loss rate. The maximum tolerated packet loss rate is 30%.
 
-Calculate number of succesfull rounds, it should be higher than 70.
-
+The number of succesful rounds is higher than 70.
 
 ### UDPSOCKET_ECHOTEST_BURST_NONBLOCK
 
 **Description:**
 
-Send burst of packets to echo server and read incoming packets back. Use socket in non-blocking mode.
+Send a burst of packets to the echo server and read incoming packets back. Use Socket in nonblocking mode.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  UDPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. UDPSocket is open.
 
 **Test steps:**
 
-1.  Call `UDPSocket::set_blocking(false)`.
-2.  Register event handler with `UDPSocket::sigio()`.
-3.  Create another thread that constantly waits signal from sigio() handler, when received try `UDPSocket::recvfrom()`.
-4.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 100>, 100);`.
-5.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 200>, 200);`.
-6.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 300>, 300);`.
-7.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 120>, 120);`.
-8.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 500>, 500);`.
-9.  Wait for incomming packets for five second.
-10. Verify incomming content was the same that was sent. Allow packet reordering.
-11. Repeat 100 times.
-12. Destroy the socket.
+1. Call `UDPSocket::set_blocking(false)`.
+1. Register event handler with `UDPSocket::sigio()`.
+1. Create another thread that constantly waits signal from sigio() handler.
+1. When received, try `UDPSocket::recvfrom()`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 100>, 100);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 200>, 200);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 300>, 300);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 120>, 120);`.
+1. Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 7, <random packet, size = 500>, 500);`.
+1. Wait for incoming packets for five seconds.
+1. Verify incoming content is the same as sent content.
+1. Allow packet reordering.
+1. Repeat 100 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-All sendto() calls should return the packet size.
+All `sendto()` calls return the packet size.
 
-All recvfrom() calls should return the same sized packet that was send with same content. Allow packet reordering.
+All `recvfrom()` calls return the same sized packet that was sent with the same content. Allow packet reordering.
 
-Calculate packet loss rate, maximum tolerated packet loss rate is 30%.
+Calculate packet loss rate. The maximum tolerated packet loss rate is 30%.
 
-Calculate number of succesfull rounds, it should be higher than 70.
-
-
+The number of succesful rounds is higher than 70.
 
 ### TCPSOCKET_ECHOTEST_BURST
 
 **Description:**
 
-Send burst of packets to echo server and read incoming packets back.
+Send a burst of packets to the echo server and read incoming packets back.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
-2.  Call `TCPSocket::send(<random packet, size = 100>, 100);`.
-3.  Call `TCPSocket::send(<random packet, size = 200>, 200);`.
-4.  Call `TCPSocket::send(<random packet, size = 300>, 300);`.
-5.  Call `TCPSocket::send(<random packet, size = 120>, 120);`.
-6.  Call `TCPSocket::send(<random packet, size = 500>, 500);`.
-7.  Call `TCPSocket::recv(buf, 1220)`.
-8.  Verify incomming content was the same that was sent.
-9.  Repeat 100 times.
-10. Destroy the socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
+1. Call `TCPSocket::send(<random packet, size = 100>, 100);`.
+1. Call `TCPSocket::send(<random packet, size = 200>, 200);`.
+1. Call `TCPSocket::send(<random packet, size = 300>, 300);`.
+1. Call `TCPSocket::send(<random packet, size = 120>, 120);`.
+1. Call `TCPSocket::send(<random packet, size = 500>, 500);`.
+1. Call `TCPSocket::recv(buf, 1220)`.
+1. Verify incoming content is the same as sent content.
+1. Repeat 100 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-All send() calls should return the packet size.
+All `send()` calls return the packet size.
 
-NOTE: This is stream so recv() might return less data than what was requested. In this case you need to keep calling recv() with remaining size until all data that you have sent is returned.
+NOTE: This is stream, so `recv()` might return less data than requested. Keep calling `recv()` with the remaining size until all data you have sent is returned.
 
-Consecutive calls to recv() should return all the data that has been send. Total amount of returned must match 1220.
-
+Consecutive calls to `recv()` return all the data that has been sent. The total amount of returned data must match 1220.
 
 ### TCPSOCKET_ECHOTEST_BURST_NONBLOCK
 
 **Description:**
 
-Send burst of packets to echo server and read incoming packets back. Use socket in non-blocking mode.
+Send a burst of packets to the echo server and read incoming packets back. Use Socket in nonblocking mode.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Register event handler with `TCPSocket::sigio()`.
-2.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
-3.  Call `TCPSocket::set_blocking(false)`.
-4.  Create another thread that constantly waits signal from sigio() handler, when received try `TCPSocket::recv()`.
-5.  For randomly generated packets, sized 100, 200, 300, 120 and 500 do
-    1.  Call `TCPSocket::send(packet, size);`.
-    2.  If less than size is sent, repeat with remaining.
-    3.  If `NSAPI_ERROR_WOULD_BLOCK` returned, wait for next sigio().
-
-6.  Wait for incomming packets for five second.
-7.  Verify incomming content was the same that was sent. Allow recv() to return smaller piezes.
-8.  Repeat 100 times.
-9.  Destroy the socket.
+1. Register event handler with `TCPSocket::sigio()`.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7);`.
+1. Call `TCPSocket::set_blocking(false)`.
+1. Create another thread that constantly waits for a signal from `sigio()` handler.
+1. When it's received, try `TCPSocket::recv()`.
+1. For randomly generated packets sized 100, 200, 300, 120 and 500:
+   1. Call `TCPSocket::send(packet, size);`.
+   1. If less than size is sent, repeat with remaining.
+   1. If `NSAPI_ERROR_WOULD_BLOCK` returned, wait for next `sigio()`.
+1. Wait for incoming packets for five seconds.
+1. Verify incoming content is the same as sent content.
+1. Allow `recv()` to return smaller pieces.
+1. Repeat 100 times.
+1. Destroy the socket.
 
 **Expected result:**
 
-All send() calls should return `NSAPI_ERROR_WOULD_BLOCK` or size which is equal or less than requested.
+All `send()` calls return `NSAPI_ERROR_WOULD_BLOCK` or a size less than or equal to what has been requested.
 
-All recv() calls should return value that is less or equal to what have been sent. With consecutive calls, size should match.
+All `recv()` calls return a value less than or equal to what has been sent. With consecutive calls, the sizes should match.
 
-When recv() returns `NSAPI_ERROR_WOULD_BLOCK` wait for next sigio() event. No other error codes allowed.
-
+When `recv()` returns `NSAPI_ERROR_WOULD_BLOCK`, wait for the next `sigio()` event. No other error codes are allowed.
 
 ### TCPSOCKET_RECV_100K
 
 **Description:**
 
-Download 100kB of data
+Download 100kB of data.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 19);`.
-2.  Call `TCPSocket::recv(buffer, 100);`.
-3.  Verify input according to known pattern.
-4.  Loop until 100kB of data received.
-5.  Close socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 19);`.
+1. Call `TCPSocket::recv(buffer, 100);`.
+1. Verify input according to a known pattern.
+1. Loop until 100kB of data received.
+1. Close socket.
 
 **Expected result:**
 
-Each recv() call should return equal or less than 100 bytes of data. No
-errors should be returned.
+Each `recv()` call returns 100 bytes of data or fewer. No errors are returned.
 
-Measure time taken for receiving, report speed
+Measure time taken for receiving and report speed.
 
 ### TCPSOCKET_RECV_100K_NONBLOCK
 
 **Description:**
 
-Download 100kB of data
+Download 100kB of data.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  TCPSocket is open.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. TCPSocket is open.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 19);`.
-2.  Call `TCPSocket::set_blocking(false)`.
-3.  Create another thread that constantly waits signal from sigio() handler, when received try `TCPSocket::recv()`.
-    1.  Call `TCPSocket::recv(buffer, 100);`.
-    2.  Verify input according to known pattern.
-
-4.  Wait until 100kB of data received.
-5.  Close socket.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 19);`.
+1. Call `TCPSocket::set_blocking(false)`.
+1. Create another thread that constantly waits for a signal from `sigio()` handler.
+1. When it's received, try `TCPSocket::recv()`.
+   1. Call `TCPSocket::recv(buffer, 100);`.
+   1. Verify input according to a known pattern.
+1. Wait until 100kB of data received.
+1. Close socket.
 
 **Expected result:**
 
-Each recv() call should return equal or less than 100 bytes of data or `NSAPI_ERROR_WOULD_BLOCK` in which case thread should wait for another sigio(). No errors should be returned.
+Each `recv()` call returns 100 bytes of data or less or `NSAPI_ERROR_WOULD_BLOCK`, in which case thread waits for another `sigio()`. No errors are returned.
 
-Measure time taken for receiving, report speed.
+Measure time taken for receiving and report speed.
 
 ### TCPSOCKET_THREAD_PER_SOCKET_SAFETY
 
 **Description:**
 
-Run two threads which both exercise the underlying stack and driver through a dedicated socket.
+Run two threads that both exercise the underlying stack and driver through a dedicated socket.
 
 **Preconditions:**
 
-1.  Network interface and stack are initialized.
-2.  Network connection is up.
-3.  2 TCPSockets are open and one additional thread has been created.
-4.  Both threads get their own socket instance.
+1. Network interface and stack are initialized.
+1. Network connection is up.
+1. Two TCPSockets are open, and one additional thread has been created.
+1. Both threads get their own socket instance.
 
 **Test steps:**
 
-1.  Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7)` in both threads - in the main thread executing the test case and on the additional one.
-2.  On main thread
-    1.  For randomly generated packets, sized 1001, 901, 801,...,101,1 do
-        1.  Call `TCPSocket::send(packet, size);`.
-        2.  Verify incoming content was the same that was sent.
-            Allow recv() to return smaller pieces.
-
-3.  Simultaneously with the earlier step do on the additional thread
-    1.  For randomly generated packets, sized 10 do
-        1.  Call `TCPSocket::send(packet, size);`.
-        2.  Verify incomming content was the same that was sent.
-            Allow recv() to return smaller piezes.
-        3.  Stop the thread if inconsistensies were found and report it to main thread.
-
-4.  Kill the additional thread.
-5.  Close and destroy the sockets.
+1. Call `TCPSocket::connect("echo.mbedcloudtesting.com", 7)` in both threads - in the main thread executing the test case and on the additional one.
+   - (Simultaneously with the next step) on the main thread:
+      1. For randomly generated packets, sized 1001, 901, 801,...,101,1 do
+         1. Call `TCPSocket::send(packet, size);`.
+         1. Verify incoming content was the same that was sent.
+         1. Allow `recv()` to return smaller pieces.
+   - (Simultaneously with the earlier step) on the additional thread:
+      1. For randomly generated packets, sized 10:
+         1. Call `TCPSocket::send(packet, size);`.
+         1. Verify incoming content is the same as sent content.
+         1. Allow `recv()` to return smaller pieces.
+         1. Stop the thread if inconsistencies are found, and report it to main thread.
+1. Kill the additional thread.
+1. Close and destroy the sockets.
 
 **Expected result:**
 
-Echo server returns data to both threads and received data matches to send data. The additional thread isn't stopped prematurely.
+The echo server returns data to both threads and received data matches to send data. The additional thread isn't stopped prematurely.
 
 Test cases for DNS class
 ---------------------------
@@ -1677,13 +1607,13 @@ Verify the basic functionality of asynchronous DNS. Call `NetworkInterface::geth
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` with a valid host name and a callback.
-2.  Verify that callback is called with correct parameters.
+1. Call `gethostbyname_async()` with a valid host name and a callback.
+1. Verify the callback is called with correct parameters.
 
 **Expected result:**
 
@@ -1693,201 +1623,201 @@ Callback is called with `NSAPI_ERROR_OK` and IP address.
 
 **Description:**
 
-Verify that simultaneous asynchronous DNS queries work correctly. Call `NetworkInterface::gethostbyname_async()` in a row 6 times with a different host names. Wait for all requests to complete, and verify the result. Cache should not contain host names used in asynchronous request.
+Verify simultaneous asynchronous DNS queries work correctly. Call `NetworkInterface::gethostbyname_async()` 6 times with different host names. Wait for all requests to complete, and verify the result. The cache does not contain host names used in asynchronous request.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` in a row 6 times with a different host names. Host names shall not be found from cache.
-2.  Verify that last `gethostbyname_async()` operation is rejected because there is room only for 5 simultaneous operations.
-3.  Verify that callback is called with correct parameters 5 times.
+1. Call `gethostbyname_async()` 6 times with different host names. Host names are not found from the cache.
+1. Verify the last `gethostbyname_async()` operation is rejected because there is room only for five simultaneous operations.
+1. Verify the callback is called with correct parameters five times.
 
 **Expected result:**
 
-Sixth `gethostbyname_async()` is rejected. Callback is called with `NSAPI_ERROR_OK` and IP address 5 times.
+The sixth `gethostbyname_async()` is rejected. Callback is called with `NSAPI_ERROR_OK` and IP address five times.
 
 ### ASYNCHRONOUS_DNS_SIMULTANEOUS_CACHE
 
 **Description:**
 
-Verify that the caching of DNS results works correctly with simultaneous asynchronous DNS queries. Call `NetworkInterface::gethostbyname_async()` in a row 6 times with a different host names. Wait for all requests to complete and verify result. Cache shall contain at least one host name used in asynchronous request. You can achieve this, for example, by running test "Asynchronous DNS simultaneous" before this test and using same host names in this run.
+Verify the caching of DNS results works correctly with simultaneous asynchronous DNS queries. Call `NetworkInterface::gethostbyname_async()` six times with different host names. Wait for all requests to complete, and verify the result. The cache contains at least one host name used in asynchronous request. You can achieve this, for example, by running the "Asynchronous DNS simultaneous" test before this test and using the same host names in this run.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` in a row 6 times with a different host names. At least one host name shall be found from cache.
-2.  Verify that callback is called with correct parameters 6 times.
+1. Call `gethostbyname_async()` six times with different host names. At least one host name is found from cache.
+1. Verify that callback is called with correct parameters six times.
 
 **Expected result:**
 
-Callback is called with `NSAPI_ERROR_OK` and IP address 6 times.
+Callback is called with `NSAPI_ERROR_OK` and IP address six times.
 
 ### ASYNCHRONOUS_DNS_CACHE
 
 **Description:**
 
-Verify that the caching of DNS results works correctly. Call `NetworkInterface::gethostbyname_async()` 5 times with the same host name and verify result after each request. For first request, cache shall not contain the host name. Verify that first request completes slower than the requests made after it (where the response is found from cache).
+Verify the caching of DNS results works correctly. Call `NetworkInterface::gethostbyname_async()` five times with the same host name and verify the result after each request. For the first request, the cache does not contain the host name. Verify the first request completes more slowly than the requests made after it (where the response is found from cache).
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` with a host name. For first request, host name shall not be found from cache.
-2.  Verify that callback is called with correct parameters.
-3.  Repeat the sequence 4 times using the same host name.
-4.  For each request, calculate how long time it takes for DNS query to complete.
+1. Call `gethostbyname_async()` with a host name. For the first request, the host name is not found from cache.
+1. Verify the callback is called with correct parameters.
+1. Repeat the sequence four times using the same host name.
+1. For each request, calculate how long it takes for the DNS query to complete.
 
 **Expected result:**
 
-Callback is called with `NSAPI_ERROR_OK` and IP address 5 times. First request shall complete before the requests made after it (where the response is found from cache).
+The callback is called with `NSAPI_ERROR_OK` and IP address five times. The first request is complete before the requests made after it (where the response is found from cache).
 
 ### ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC
 
 **Description:**
 
-Verify synchronous (in other words, blocking) DNS queries and asynchronous (in other words, non-blocking) queries work at the same time. Call `NetworkInterface::gethostbyname_async()`. Right after that, make 6 synchronous `NetworkInterface::gethostbyname()` calls with different host names.
+Verify synchronous (in other words, blocking) DNS queries and asynchronous (in other words, nonblocking) queries work at the same time. Call `NetworkInterface::gethostbyname_async()`. Right after that, make six synchronous `NetworkInterface::gethostbyname()` calls with different host names.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` with a host name. Host name shall not be found from cache.
-2.  Call `gethostbyname()` 6 times with a different host names (none of the names shall be same as in step 1).
-3.  Verify that each `gethostbyname()` returns success.
-4.  Verify that the asynchronous callback is called with correct parameters.
+1. Call `gethostbyname_async()` with a host name. The host name is not found from cache.
+1. Call `gethostbyname()` six times with different host names (none of the names are the same as that in step 1).
+1. Verify each `gethostbyname()` returns success.
+1. Verify the asynchronous callback is called with correct parameters.
 
 **Expected result:**
 
-All operations shall return `NSAPI_ERROR_OK` and IP address.
+All operations return `NSAPI_ERROR_OK` and IP address.
 
 ### ASYNCHRONOUS_DNS_CANCEL
 
 **Description:**
 
-Verify that asynchronous DNS query cancel works correctly. Call `NetworkInterface::gethostbyname_async()` in a row 6 times with a different host names. Cache shall contain 3 host names used in requests. This can be achieved e.g. by running test "Asynchronous DNS synchronous and asynchronous" before this test and using same host names in this run. For each request that was given an unique ID, call cancel. Verify that callback is not called for canceled requests.
+Verify the asynchronous DNS query cancel works correctly. Call `NetworkInterface::gethostbyname_async()` six times with different host names. The cache contains three host names used in requests. You can achieve this, for example, by running the "Asynchronous DNS synchronous and asynchronous" test before this test and using the same host names in this run. For each request that was given an unique ID, call cancel. Verify the callback is not called for canceled requests.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` in a row 6 times with a different host names. Cache shall contain in maximum 3 host names used in requests.
-2.  Call `gethostbyname_async_cancel()` for each request that was given an unique ID.
-3.  Verify that for canceled requests, callback is not called.
-4.  Verify that for other requests, callback is called.
+1. Call `gethostbyname_async()` six times with different host names. The cache contains a maximum of three host names used in requests.
+1. Call `gethostbyname_async_cancel()` for each request that was given an unique ID.
+1. Verify that for canceled requests, callback is not called.
+1. Verify that for other requests, callback is called.
 
 **Expected result:**
 
-Callback shall be called only for requests that were not canceled.
+Callback is called only for requests that were not canceled.
 
 ### ASYNCHRONOUS_DNS_EXTERNAL_EVENT_QUEUE
 
 **Description:**
 
-Verify that providing an external event queue works correctly. Define a thread and an event queue running on it. Define a DNS call in callback function that uses the event queue (call_in_callback_cb_t). Enable external event queue. Call `NetworkInterface::gethostbyname_async()` in a row 6 times with a different host names.
+Verify that providing an external event queue works correctly. Define a thread and an event queue running on it. Define a DNS call in callback function that uses the event queue (call_in_callback_cb_t). Enable external event queue. Call `NetworkInterface::gethostbyname_async()` six times with different host names.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Define a thread and an event queue running on it.
-2.  Define a DNS call in callback function that uses the event queue (call_in_callback_cb_t).
-3.  Start thread and event queue.
-4.  Set DNS callback function using the `nsapi_dns_call_in_set()` call.
-5.  Call `gethostbyname_async()` in a row 6 times with a different host names. Host names shall not be found from cache.
-6.  Verify that last `gethostbyname_async()` operation is rejected since there is room only for 5 simultaneous operations.
-7.  Verify that callback is called with correct parameters 5 times.
-8.  Restore default DNS callback function using the `nsapi_dns_call_in_set()` call.
+1. Define a thread and an event queue running on it.
+1. Define a DNS call in a callback function that uses the event queue (call_in_callback_cb_t).
+1. Start thread and event queue.
+1. Set DNS callback function using the `nsapi_dns_call_in_set()` call.
+1. Call `gethostbyname_async()` six times with different host names. The host names are not found from cache.
+1. Verify the last `gethostbyname_async()` operation is rejected because there is room only for five simultaneous operations.
+1. Verify the callback is called with correct parameters five times.
+1. Restore the default DNS callback function using the `nsapi_dns_call_in_set()` call.
 
 **Expected result:**
 
-Sixth `gethostbyname_async()` is rejected. Callback is called with `NSAPI_ERROR_OK` and IP address 5 times.
+The sixth `gethostbyname_async()` is rejected. Callback is called with `NSAPI_ERROR_OK` and IP address five times.
 
 ### ASYNCHRONOUS_DNS_INVALID_HOST
 
 **Description:**
 
-Verify that DNS failure error is provided for invalid hosts. Call `NetworkInterface::gethostbyname_async()` in a row 6 times with a different host names. First, third and fifth host name shall be invalid.
+Verify the DNS failure error is provided for invalid hosts. Call `NetworkInterface::gethostbyname_async()` six times with different host names. The first, third and fifth host names are invalid.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` in a row 6 times with a different host names. Host names shall not be found from cache. First, third and fifth host name shall be invalid.
-2.  Verify that last `gethostbyname_async()` operation is rejected since there is room only for 5 simultaneous operations.
-3.  Verify that callback is called with correct parameters 5 times.
+1. Call `gethostbyname_async()` six times with different host names. Host names are not found from cache. The first, third and fifth host names are invalid.
+1. Verify the last `gethostbyname_async()` operation is rejected because there is room only for five simultaneous operations.
+1. Verify the callback is called with correct parameters five times.
 
 **Expected result:**
 
-Sixth `gethostbyname_async()` is rejected. Callback is called with `NSAPI_ERROR_DNS_FAILURE` for first, third and fifth host name. Callback is called with `NSAPI_ERROR_OK` and IP address for second and fourth host name.
+The sixth `gethostbyname_async()` is rejected. Callback is called with `NSAPI_ERROR_DNS_FAILURE` for the first, third and fifth host names. Callback is called with `NSAPI_ERROR_OK` and IP address for the second and fourth host names.
 
 ### ASYNCHRONOUS_DNS_TIMEOUTS
 
 **Description:**
 
-Test DNS timeouts using an external event queue that is modified to timeout the events faster that standard event queue. In this test event queue shall not delay events, instead it handles those immediately. Call `NetworkInterface::gethostbyname_async()` in a row 6 times with a different host names. All or some of the request shall timeout and timeout return value is returned.
+Test DNS timeouts using an external event queue that is modified to time out the events faster than the standard event queue. In this test, the event queue does not delay events; instead, it handles those immediately. Call `NetworkInterface::gethostbyname_async()` six times with different host names. All or some of the request time out, and the timeout return value is returned.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Define a thread and an event queue running on it.
-2.  Define a DNS call in callback function that uses the event queue (call_in_callback_cb_t). Callback function shall not delay callbacks; instead it shall handle those immediately.
-3.  Start thread and event queue.
-4.  Set DNS callback function using the `nsapi_dns_call_in_set()` call.
-5.  Call `gethostbyname_async()` in a row 6 times with a different host names. Host names shall not be found from cache.
-6.  Verify that last `gethostbyname_async()` operation is rejected since there is room only for 5 simultaneous operations.
-7.  Verify that callback is called with correct parameters 5 times.
+1. Define a thread and an event queue running on it.
+1. Define a DNS call in callback function that uses the event queue (call_in_callback_cb_t). The callback function does not delay callbacks; instead it handles those immediately.
+1. Start thread and event queue.
+1. Set DNS callback function using the `nsapi_dns_call_in_set()` call.
+1. Call `gethostbyname_async()` six times with a different host names. Host names are not found from cache.
+1. Verify the last `gethostbyname_async()` operation is rejected because there is room only for five simultaneous operations.
+1. Verify the callback is called with correct parameters five times.
 
 **Expected result:**
 
-Sixth `gethostbyname_async()` is rejected. At least for one operation, callback is called with `NSAPI_ERROR_TIMEOUT` value.
+The sixth `gethostbyname_async()` is rejected. At least for one operation, the callback is called with the `NSAPI_ERROR_TIMEOUT` value.
 
 ### ASYNCHRONOUS_DNS_SIMULTANEOUS_REPEAT
 
 **Description:**
 
-Verify that simultaneous asynchronous DNS queries work correctly when repeated in sequence. Call `NetworkInterface::gethostbyname_async()` in a row 5 times with a different host names. Wait for all requests to complete and verify result. Repeat the procedure 100 times.
+Verify the simultaneous asynchronous DNS queries work correctly when repeated in sequence. Call `NetworkInterface::gethostbyname_async()` five times with different host names. Wait for all requests to complete, and verify the result. Repeat the procedure 100 times.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname_async()` in a row 5 times with a different host names, providing a callback to be called when the operation completes.
-2.  Verify that callback is called with correct parameters 5 times for the first operation.
-3.  Repeat 100 times steps 1 to 2.
+1. Call `gethostbyname_async()` five times with different host names, providing a callback to be called when the operation completes.
+1. Verify the callback is called with correct parameters five times for the first operation.
+1. Repeat steps 1-2 100 times.
 
 **Expected result:**
 
-Callback, registered for `gethostbyname_async()`, is called with `NSAPI_ERROR_OK` and an IP address 5 times for every one of a hundred repetitions of the test.
+A callback, registered for `gethostbyname_async()`, is called with `NSAPI_ERROR_OK` and an IP address five times for every one of 100 repetitions of the test.
 
 ### SYNCHRONOUS_DNS
 
@@ -1897,13 +1827,13 @@ Verify the basic functionality of synchronous DNS. Call `NetworkInterface::getho
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname()` with a valid host name.
-2.  Verify the address was resolved and the return value was valid.
+1. Call `gethostbyname()` with a valid host name.
+1. Verify the address was resolved and the return value was valid.
 
 **Expected result:**
 
@@ -1913,17 +1843,17 @@ Return value is `NSAPI_ERROR_OK` and IP address is obtained from the function ca
 
 **Description:**
 
-Verify the basic functionality of synchronous DNS. Call `NetworkInterface::gethostbyname()` with a list of 6 host names, and verify the result.
+Verify the basic functionality of synchronous DNS. Call `NetworkInterface::gethostbyname()` with a list of six host names, and verify the result.
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname()` with a list of 6 host names.
-2.  Verify that each of the addresses was resolved and the return value was valid.
+1. Call `gethostbyname()` with a list of six host names.
+1. Verify each of the addresses was resolved and the return value was valid.
 
 **Expected result:**
 
@@ -1933,65 +1863,65 @@ Return value is `NSAPI_ERROR_OK` and IP addresses are obtained from the function
 
 **Description:**
 
-Verify that the caching of DNS results works correctly. Call `NetworkInterface::gethostbyname()` 5 times with the same host name, and verify the result after each request. For first request, cache shall not contain the host name. Verify that first request completes before the requests made after it (where the response is found from cache).
+Verify the caching of DNS results works correctly. Call `NetworkInterface::gethostbyname()` five times with the same host name, and verify the result after each request. For the first request, the cache does not contain the host name. Verify the first request completes before the requests made after it (where the response is found from cache).
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname()` with a host name. For the first request, host name should not be found in cache and an error should be returned.
-2.  Verify that address was resolved and the return value was valid.
-3.  Repeat the sequence 4 times using the same host name.
-4.  For each request, calculate how long time it takes for DNS query to complete.
+1. Call `gethostbyname()` with a host name. For the first request, the host name is not found in cache, and an error is returned.
+1. Verify the address was resolved and the return value was valid.
+1. Repeat the sequence four times using the same host name.
+1. For each request, calculate how long it takes the DNS query to complete.
 
 **Expected result:**
 
-Return value is `NSAPI_ERROR_OK` and IP address is obtained from the function call 5 times. First request shall complete before the requests made after it (where the response is found from cache).
+The return value is `NSAPI_ERROR_OK`, and the IP address is obtained from the function call five times. The first request completes before the requests made after it (where the response is found from cache).
 
 ### SYNCHRONOUS_DNS_INVALID_HOST
 
 **Description:**
 
-Verify that DNS failure error is provided for invalid hosts. Call `NetworkInterface::gethostbyname()` in a row 6 times with different host names. First, third and fifth of the host names used in this test shall be invalid (for example by adding an incorrect suffic, like so: "google.com_invalid").
+Verify the DNS failure error is provided for invalid hosts. Call `NetworkInterface::gethostbyname()` six times with different host names. The first, third and fifth host names are invalid (for example by adding an incorrect suffix, such as "google.com_invalid").
 
 **Preconditions:**
 
-1.  Network interface is initialized.
-2.  Network connection is up.
+1. Network interface is initialized.
+1. Network connection is up.
 
 **Test steps:**
 
-1.  Call `gethostbyname()` in a row 6 times with a different host names. Host names shall not be found from cache. First, third and fifth host name shall be invalid.
-2.  Verify that return value was valid and for valid hostnames the address was resolved 6 times.
+1. Call `gethostbyname()` six times with different host names. Host names are not found from cache. The first, third and fifth host names are invalid.
+1. Verify the return value was valid and for valid hostnames the address was resolved six times.
 
 **Expected result:**
 
-Return value is `NSAPI_ERROR_DNS_FAILURE` for first, third and fifth host name, which were invalidated at the beginning of the test. Return value is `NSAPI_ERROR_OK` and IP address is obtained for second and fourth host name, which were valid.
+The return value is `NSAPI_ERROR_DNS_FAILURE` for the first, third and fifth host names, which were invalidated at the beginning of the test. The return value is `NSAPI_ERROR_OK`, and the IP address is obtained for the second and fourth host names, which were valid.
 
 Subset for driver test
 ----------------------
 
 ### For physical layer driver (emac, PPP):
 
--   TCPSOCKET_ECHOTEST
--   TCPSOCKET_ECHOTEST_BURST
--   TCPSOCKET_ECHOTEST_BURST_NONBLOCK
--   TCPSOCKET_ECHOTEST_NONBLOCK
--   TCPSOCKET_RECV_100K
--   TCPSOCKET_RECV_100K_NONBLOCK
--   TCPSOCKET_RECV_TIMEOUT
--   TCPSOCKET_SEND_REPEAT
--   UDPSOCKET_BIND_SENDTO
--   UDPSOCKET_ECHOTEST
--   UDPSOCKET_ECHOTEST_NONBLOCK
--   UDPSOCKET_RECV_TIMEOUT
--   UDPSOCKET_SENDTO_INVALID
--   UDPSOCKET_SENDTO_REPEAT
--   UDPSOCKET_SENDTO_TIMEOUT
+-   TCPSOCKET_ECHOTEST.
+-   TCPSOCKET_ECHOTEST_BURST.
+-   TCPSOCKET_ECHOTEST_BURST_NONBLOCK.
+-   TCPSOCKET_ECHOTEST_NONBLOCK.
+-   TCPSOCKET_RECV_100K.
+-   TCPSOCKET_RECV_100K_NONBLOCK.
+-   TCPSOCKET_RECV_TIMEOUT.
+-   TCPSOCKET_SEND_REPEAT.
+-   UDPSOCKET_BIND_SENDTO.
+-   UDPSOCKET_ECHOTEST.
+-   UDPSOCKET_ECHOTEST_NONBLOCK.
+-   UDPSOCKET_RECV_TIMEOUT.
+-   UDPSOCKET_SENDTO_INVALID.
+-   UDPSOCKET_SENDTO_REPEAT.
+-   UDPSOCKET_SENDTO_TIMEOUT.
 
 ### For socket layer driver (AT-driven, external IP stack):
 
-All Socket, UDPSocket, TCPSocket and TLSSocket testcases.
+All Socket, UDPSocket, TCPSocket and TLSSocket test cases.

--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -487,17 +487,17 @@ Call `Socket::open()` twice.
 1. Create an object by calling `new Socket()`.
 1. Call `Socket::open(stack)`.
 1. Call `Socket::open(stack)`.
-1. Delete the socket.
+1. Destroy the socket.
 
 **Expected result:**
 
-`Socket::open()` first returns `NSAPI_ERROR_OK` and then calls `NSAPI_ERROR_PARAMETER`.
+`Socket::open()` first call (socket was not opened) returns `NSAPI_ERROR_OK` and nexts calls (socet was opened by previous call Socket::open()) return `NSAPI_ERROR_PARAMETER`.
 
 ### SOCKET_OPEN_CLOSE_REPEAT
 
 **Description:**
 
-Call `Socket::open()` followed by `Socket::close()` and then again `Socket::open()`. This allows you to reuse the same object.
+Call `Socket::open()` followed by `Socket::close()` and then again `Socket::open()`. Should allows you to reuse the same object.
 
 **Preconditions:**
 
@@ -511,7 +511,7 @@ Call `Socket::open()` followed by `Socket::close()` and then again `Socket::open
 1. Call `Socket::close(stack)`.
 1. Call `Socket::open(stack)`.
 1. Call `Socket::close(stack)`.
-1. Delete the socket.
+1. Destroy the socket.
 
 **Expected result:**
 
@@ -1155,13 +1155,13 @@ Test whether you tolerate an endpoint closing the connection.
 1. Call `TCPSocket::recv(<buffer>, 30);`.
 1. Repeat until `recv()` returns 0.
 1. Call `TCPSocket::close();`.
-1. Delete the socket.
+1. Destroy the socket.
 
 **Expected result:**
 
 Connect returns `NSAPI_ERROR_OK`.
 
-The first `recv()` returns more that zero. Something between 10 and 30 bytes (datetime string).
+The first `recv()` returns datetime string length (It is between 10 and 30 bytes).
 
 The second `recv()` returns zero because the endpoint closed the connection. `close()` returns `NSAPI_ERROR_OK`.
 
@@ -1185,7 +1185,7 @@ Test you can request setting valid TCP keepalive values.
 **Postconditions:**
 
 1. Call `TCPSocket::close();`.
-1. Delete the socket.
+1. Destroy the socket.
 
 **Expected result:**
 
@@ -1257,11 +1257,11 @@ Make an HTTP request to a closed socket.
 
 ### TLSSOCKET_SEND_REPEAT
 
-**Description:** Run `SOCKET_SEND_REPEATÂ` for TLSSOCKET by using port number 2009.
+**Description:** Run `SOCKET_SEND_REPEAT` for TLSSOCKET by using port number 2009.
 
 ### TLSSOCKET_SEND_TIMEOUT
 
-**Description:** Run `SOCKET_SEND_TIMEOUTÂ` for TLSSOCKET by using port number 2009.
+**Description:** Run `SOCKET_SEND_TIMEOUT` for TLSSOCKET by using port number 2009.
 
 ### TLSSOCKET_SEND_UNCONNECTED
 
@@ -1287,11 +1287,11 @@ Make an HTTP request to an unconnected socket.
 
 ### TLSSOCKET_ECHOTEST
 
-**Description:** Run `SOCKET_ECHOTESTÂ` for TLSSOCKET by using port number 2007.
+**Description:** Run `SOCKET_ECHOTEST` for TLSSOCKET by using port number 2007.
 
 ### TLSSOCKET_ECHOTEST_NONBLOCK
 
-**Description:** Run `SOCKET_ECHOTEST_NONBLOCKÂ` for TLSSOCKET by using port number 2007.
+**Description:** Run `SOCKET_ECHOTEST_NONBLOCK` for TLSSOCKET by using port number 2007.
 
 ### TLSSOCKET_ENDPOINT_CLOSE
 
@@ -1322,7 +1322,7 @@ Verify TLS Socket fails to connect without a certificate.
 
 **Description:**
 
-Run `TCPSOCKET_RECV_TIMEOUTÂ` for TLSSOCKET by using port number 2007.
+Run `TCPSOCKET_RECV_TIMEOUT` for TLSSOCKET by using port number 2007.
 
 ### TLSSOCKET_SIMULTANEOUS_TEST
 

--- a/TESTS/netsocket/tls/cert.h
+++ b/TESTS/netsocket/tls/cert.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tls_tests.h"
+
+const char *tls_global::cert = \
+                               "-----BEGIN CERTIFICATE-----\n"
+                               "MIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/\n"
+                               "MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT\n"
+                               "DkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow\n"
+                               "SjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT\n"
+                               "GkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC\n"
+                               "AQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF\n"
+                               "q6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8\n"
+                               "SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0\n"
+                               "Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA\n"
+                               "a6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj\n"
+                               "/PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T\n"
+                               "AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG\n"
+                               "CCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv\n"
+                               "bTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k\n"
+                               "c3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw\n"
+                               "VAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC\n"
+                               "ARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz\n"
+                               "MDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu\n"
+                               "Y3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF\n"
+                               "AAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo\n"
+                               "uM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/\n"
+                               "wApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu\n"
+                               "X4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG\n"
+                               "PfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6\n"
+                               "KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==\n"
+                               "-----END CERTIFICATE-----\n";
+

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -27,6 +27,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "tls_tests.h"
+#include "cert.h"
 
 #ifndef ECHO_SERVER_ADDR
 #error [NOT_SUPPORTED] Requires parameters for echo server
@@ -46,35 +47,6 @@ mbed_stats_socket_t tls_stats[MBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT];
 
 char tls_global::rx_buffer[RX_BUFF_SIZE];
 char tls_global::tx_buffer[TX_BUFF_SIZE];
-
-const char *tls_global::cert = \
-                               "-----BEGIN CERTIFICATE-----\n"
-                               "MIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/\n"
-                               "MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT\n"
-                               "DkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow\n"
-                               "SjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT\n"
-                               "GkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC\n"
-                               "AQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF\n"
-                               "q6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8\n"
-                               "SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0\n"
-                               "Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA\n"
-                               "a6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj\n"
-                               "/PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T\n"
-                               "AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG\n"
-                               "CCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv\n"
-                               "bTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k\n"
-                               "c3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw\n"
-                               "VAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC\n"
-                               "ARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz\n"
-                               "MDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu\n"
-                               "Y3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF\n"
-                               "AAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo\n"
-                               "uM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/\n"
-                               "wApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu\n"
-                               "X4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG\n"
-                               "PfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6\n"
-                               "KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==\n"
-                               "-----END CERTIFICATE-----\n";
 
 void drop_bad_packets(TLSSocket &sock, int orig_timeout)
 {


### PR DESCRIPTION
### Description
In mbed-os/TESTS/netsocket/README.md we have example of setup test server only for unsecured sockets. This changes added manual how to setup test server for tls socket version.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ x ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@SeppoTakalo 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
