### PR TITLE
QSPI : Define default pins at drivers level

### DIFF
--- a/TESTS/mbed_hal/qspi/flash_configs/flash_configs.h
+++ b/TESTS/mbed_hal/qspi/flash_configs/flash_configs.h
@@ -17,23 +17,8 @@
 #ifndef MBED_FLASH_CONFIGS_H
 #define MBED_FLASH_CONFIGS_H
 
-#if defined(TARGET_DISCO_L475VG_IOT01A)
-#include "MX25RXX35F_config.h" // MX25R6435F
-
-#elif defined(TARGET_DISCO_F413ZH)
-#include "N25Q128A_config.h" // N25Q128A13EF840F
-
-#elif defined(TARGET_DISCO_F746NG)
-#include "N25Q128A_config.h" // N25Q128A13EF840E
-
-#elif defined(TARGET_DISCO_F469NI)
-#include "N25Q128A_config.h" // N25Q128A13EF840E
-
-#elif defined(TARGET_DISCO_F769NI)
-#include "MX25L51245G_config.h" // MX25L51245G
-
-#elif defined(TARGET_DISCO_L4R9I)
-#include "MX25LM51245G_config.h" // MX25LM51245G
+#if defined(TARGET_MX25R6435F)
+#include "MX25RXX35F_config.h"
 
 #elif defined(TARGET_DISCO_L476VG)
 #include "N25Q128A_config.h" // N25Q128A13EF840E
@@ -43,6 +28,15 @@
 #undef QSPI_CMD_WRITE_DPI
 #undef QSPI_CMD_WRITE_QPI
 
+#elif defined(TARGET_N25Q128A)
+#include "N25Q128A_config.h"
+
+#elif defined(TARGET_MX25L51245G)
+#include "MX25L51245G_config.h"
+
+#elif defined(TARGET_MX25LM51245G)
+#include "MX25LM51245G_config.h"
+
 #elif defined(TARGET_RHOMBIO_L476DMW1K)
 #include "MT25Q_config.h" // MT25QL128ABA1EW7
 /* See STM32L476 Errata Sheet, it is not possible to use Dual-/Quad-mode for the command phase */
@@ -50,9 +44,6 @@
 #undef QSPI_CMD_READ_QPI
 #undef QSPI_CMD_WRITE_DPI
 #undef QSPI_CMD_WRITE_QPI
-
-#elif defined(TARGET_DISCO_L496AG)
-#include "MX25RXX35F_config.h" // MX25R6435F
 
 #elif defined(TARGET_NRF52840)
 #include "NORDIC/NRF52840_DK/flash_config.h"
@@ -88,5 +79,6 @@
 #include "S25FL128S_config.h"
 
 #endif
+
 #endif // MBED_FLASH_CONFIGS_H
 

--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -70,12 +70,12 @@ uint8_t rx_buf[DATA_SIZE_1024];
 
 
 // some target defines QSPI pins as integers thus conversion needed
-#define QPIN_0 static_cast<PinName>(QSPI_FLASH1_IO0)
-#define QPIN_1 static_cast<PinName>(QSPI_FLASH1_IO1)
-#define QPIN_2 static_cast<PinName>(QSPI_FLASH1_IO2)
-#define QPIN_3 static_cast<PinName>(QSPI_FLASH1_IO3)
-#define QSCK   static_cast<PinName>(QSPI_FLASH1_SCK)
-#define QCSN   static_cast<PinName>(QSPI_FLASH1_CSN)
+#define QPIN_0 static_cast<PinName>(MBED_CONF_DRIVERS_QSPI_IO0)
+#define QPIN_1 static_cast<PinName>(MBED_CONF_DRIVERS_QSPI_IO1)
+#define QPIN_2 static_cast<PinName>(MBED_CONF_DRIVERS_QSPI_IO2)
+#define QPIN_3 static_cast<PinName>(MBED_CONF_DRIVERS_QSPI_IO3)
+#define QSCK   static_cast<PinName>(MBED_CONF_DRIVERS_QSPI_SCK)
+#define QCSN   static_cast<PinName>(MBED_CONF_DRIVERS_QSPI_CSN)
 
 
 static uint32_t gen_flash_address()

--- a/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -13,26 +13,14 @@
         "QSPI_MIN_PROG_SIZE": "1"
     },
     "target_overrides": {
-        "DISCO_F413ZH": {
-            "QSPI_FREQ": "80000000"
-        },
-        "DISCO_L475VG_IOT01A": {
+        "MX25R6435F": {
             "QSPI_FREQ": "8000000"
         },
-        "DISCO_L476VG": {
-            "QSPI_FREQ": "80000000"
-        },
-        "DISCO_L496AG": {
+        "MX25L51245G": {
             "QSPI_FREQ": "8000000"
         },
-        "DISCO_F469NI": {
+        "N25Q128A": {
             "QSPI_FREQ": "80000000"
-        },
-        "DISCO_F746NG": {
-            "QSPI_FREQ": "80000000"
-        },
-        "DISCO_F769NI": {
-            "QSPI_FREQ": "8000000"
         },
         "MCU_NRF52840": {
             "QSPI_FREQ": "32000000",

--- a/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -1,12 +1,12 @@
 {
 "name": "qspif",
     "config": {
-        "QSPI_IO0": "QSPI_FLASH1_IO0",
-        "QSPI_IO1": "QSPI_FLASH1_IO1",
-        "QSPI_IO2": "QSPI_FLASH1_IO2",
-        "QSPI_IO3": "QSPI_FLASH1_IO3",
-        "QSPI_SCK": "QSPI_FLASH1_SCK",
-        "QSPI_CSN": "QSPI_FLASH1_CSN",
+        "QSPI_IO0": "MBED_CONF_DRIVERS_QSPI_IO0",
+        "QSPI_IO1": "MBED_CONF_DRIVERS_QSPI_IO1",
+        "QSPI_IO2": "MBED_CONF_DRIVERS_QSPI_IO2",
+        "QSPI_IO3": "MBED_CONF_DRIVERS_QSPI_IO3",
+        "QSPI_SCK": "MBED_CONF_DRIVERS_QSPI_SCK",
+        "QSPI_CSN": "MBED_CONF_DRIVERS_QSPI_CSN",
         "QSPI_POLARITY_MODE": 0,
         "QSPI_FREQ": "40000000",
         "QSPI_MIN_READ_SIZE": "1",

--- a/drivers/mbed_lib.json
+++ b/drivers/mbed_lib.json
@@ -12,6 +12,30 @@
         "spi_count_max": {
             "help": "The maximum number of SPI peripherals used at the same time. Determines RAM allocated for SPI peripheral management. If null, limit determined by hardware.",
             "value": null
+        },
+        "qspi_io0": {
+            "help": "QSPI data I/O 0 pin",
+            "value": "QSPI_FLASH1_IO0"
+        },
+        "qspi_io1": {
+            "help": "QSPI data I/O 1 pin",
+            "value": "QSPI_FLASH1_IO1"
+        },
+        "qspi_io2": {
+            "help": "QSPI data I/O 2 pin",
+            "value": "QSPI_FLASH1_IO2"
+        },
+        "qspi_io3": {
+            "help": "QSPI data I/O 3 pin",
+            "value": "QSPI_FLASH1_IO3"
+        },
+        "qspi_sck": {
+            "help": "QSPI clock pin",
+            "value": "QSPI_FLASH1_SCK"
+        },
+        "qspi_csn": {
+            "help": "QSPI chip select pin",
+            "value": "QSPI_FLASH1_CSN"
         }
     }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2745,6 +2745,7 @@
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
+            "N25Q128A",
             "STM32F4",
             "STM32F413xx",
             "STM32F413ZH",
@@ -4072,6 +4073,7 @@
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
+            "N25Q128A",
             "STM32F4",
             "STM32F469",
             "STM32F469NI",
@@ -4233,6 +4235,7 @@
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M7F",
         "extra_labels_add": [
+            "N25Q128A",
             "STM32F7",
             "STM32F746",
             "STM32F746xG",
@@ -4287,6 +4290,7 @@
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M7FD",
         "extra_labels_add": [
+            "MX25L51245G",
             "STM32F7",
             "STM32F769",
             "STM32F769xI",
@@ -4345,6 +4349,7 @@
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
+            "MX25R6435F",
             "STM32L4",
             "STM32L475xG",
             "STM32L475VG"
@@ -4418,6 +4423,7 @@
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
+            "N25Q128A",
             "STM32L4",
             "STM32L476xG",
             "STM32L476VG"
@@ -8248,6 +8254,7 @@
         "supported_form_factors": ["ARDUINO", "STMOD", "PMOD"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
+            "MX25R6435F",
             "STM32L4",
             "STM32L496AG",
             "STM32L496xG"


### PR DESCRIPTION
### Description

I had to make some tests with an existing MBED target and an external QSPI,
and it was not so easy, many patches were needed in several part.

This proposition is then to be able to make it easier.

QSPI and QSPIF tests are now possible only with mbed_app.json update:

Example:
````
        "NUCLEO_L4R5ZI": {
            "target.device_has_add": ["QSPI"],
            "target.components": ["QSPIF"],
            "drivers.qspi_io0": "PE_12",
            "drivers.qspi_io1": "PB_0",
            "drivers.qspi_io2": "PE_14",
            "drivers.qspi_io3": "PE_15",
            "drivers.qspi_sck": "PB_10",
            "drivers.qspi_csn": "PA_2",
            "target.extra_labels_add": ["MX25R6435F"]
        }, 
````

Addition of new board with some already defined QSPI memory is now very easy!

There is no change for existing targets with embedded QSPI.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


### Release Notes

