### PR TITLE
Coverity changes in USBDevice.cpp

### DIFF
--- a/drivers/source/usb/USBDevice.cpp
+++ b/drivers/source/usb/USBDevice.cpp
@@ -1272,6 +1272,7 @@ USBDevice::USBDevice(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint1
     _current_alternate = 0;
     _locked = 0;
     _post_process = NULL;
+    _max_packet_size_ep0 = 0;
 
     /* Set initial device state */
     _device.state = Powered;


### PR DESCRIPTION
### Description
Added initialization of variables, so the coverity doesn't produce an error. The variable is redefined in ``init()`` function.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @maciejbocianski 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
