### PR TITLE
Minimal-printf: Set default configurations to false

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -140,7 +140,7 @@
         },
         "minimal-printf-enable-floating-point": {
             "help": "Enable floating point printing when using mprintf profile",
-            "value": true
+            "value": false
         },
         "minimal-printf-set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed",

--- a/platform/source/minimal-printf/README.md
+++ b/platform/source/minimal-printf/README.md
@@ -41,7 +41,7 @@ Minimal printf is configured by the following parameters defined in `platform/mb
         },
         "minimal-printf-enable-floating-point": {
             "help": "Enable floating point printing when using minimal-printf profile",
-            "value": true
+            "value": false
         },
         "minimal-printf-set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed",
@@ -51,7 +51,7 @@ Minimal printf is configured by the following parameters defined in `platform/mb
 }
 ```
 
-By default, 64 bit integers, floating point  and FILE stream printing are enabled.
+By default, 64 bit integers support is enabled.
 
 If your target does not require some options then you can override the default configuration in your application `mbed_app.json` and achieve further memory optimisation (see next section for size comparison numbers).
 
@@ -87,33 +87,30 @@ https://github.com/ARMmbed/mbed-os-example-blinky application compiled with the 
 
 Blinky application size on K64F/GCC_ARM
 
-|             | File stream | Floating point | 64 bit integers | Flash  | RAM    |
-| -           | -           | -              | -               | -      | -      |
-| mbed-printf |             |                |                 | 30,944 | 12,096 |
-| mbed-printf |             |                | X               | 31,084 | 12,096 |
-| mbed-printf |             | X              | X               | 33,824 | 12,096 |
-| mbed-printf | X           | X              | X               | 34,304 | 12,096 |
-| std printf  | X           | X              | X               | 54,158 | 12,112 |
+|             | Floating point | 64 bit integers | Flash  | RAM    |
+| -           | -              | -               | -      | -      |
+| mbed-printf |                |                 | 32,972 | 11,608 |
+| mbed-printf |                | X               | 33,116 | 11,608 |
+| mbed-printf | X              | X               | 35,856 | 11,608 |
+| std printf  | X              | X               | 55,766 | 12,104 |
 
 Blinky application size on K64F/ARMC6
 
-|             | File stream | Floating point | 64 bit integers | Flash  | RAM   |
-| -           | -           | -              | -               | -      | -     |
-| mbed-printf |             |                |                 | 31,543 | xxxxx |
-| mbed-printf |             |                | X               | 31,691 | xxxxx |
-| mbed-printf |             | X              | X               | 34,515 | xxxxx |
-| mbed-printf | X           | X              | X               | 34,647 | xxxxx |
-| std printf  | X           | X              | X               | 37,458 | xxxxx |
+|             | Floating point | 64 bit integers | Flash  | RAM   |
+| -           | -              | -               | -      | -     |
+| mbed-printf |                |                 | 33,585 | xxxxx |
+| mbed-printf |                | X               | 33,679 | xxxxx |
+| mbed-printf | X              | X               | 36,525 | xxxxx |
+| std printf  | X              | X               | 39,128 | xxxxx |
 
 Blinky application size on K64F/IAR
 
-|             | File stream | Floating point | 64 bit integers | Flash  | RAM    |
-| -           | -           | -              | -               | -      | -      |
-| mbed-printf |             |                |                 | 28,713 | 8,546  |
-| mbed-printf |             |                | X               | 28,853 | 8,546  |
-| mbed-printf |             | X              | X               | 30,661 | 8,546  |
-| mbed-printf | X           | X              | X               | 32,047 | 8,594  |
-| std printf  | X           | X              | X               | 35,055 | 8,462  |
+|             | Floating point | 64 bit integers | Flash  | RAM    |
+| -           | -              | -               | -      | -      |
+| mbed-printf |                |                 | 31,439 | 8,493  |
+| mbed-printf |                | X               | 31,579 | 8,493  |
+| mbed-printf | X              | X               | 33,387 | 8,493  |
+| std printf  | X              | X               | 36,643 | 8,553  |
 
 ### Blinky bare metal application
 


### PR DESCRIPTION
### Description
Mbed OS should not require floating point in its base configuration.
This provides further code size savings out of the box.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
