### PR TITLE
Fix Coverity issues

### DIFF
--- a/drivers/source/FlashIAP.cpp
+++ b/drivers/source/FlashIAP.cpp
@@ -46,7 +46,7 @@ static inline bool is_aligned(uint32_t number, uint32_t alignment)
     }
 }
 
-FlashIAP::FlashIAP()
+FlashIAP::FlashIAP() : _page_buf(nullptr)
 {
 
 }

--- a/drivers/source/Ticker.cpp
+++ b/drivers/source/Ticker.cpp
@@ -24,12 +24,12 @@
 
 namespace mbed {
 
-Ticker::Ticker() : TimerEvent(), _function(0), _lock_deepsleep(true)
+Ticker::Ticker() : TimerEvent(), _delay(0), _function(0), _lock_deepsleep(true)
 {
 }
 
 // When low power ticker is in use, then do not disable deep sleep.
-Ticker::Ticker(const ticker_data_t *data) : TimerEvent(data), _function(0), _lock_deepsleep(!data->interface->runs_in_deep_sleep)
+Ticker::Ticker(const ticker_data_t *data) : TimerEvent(data), _delay(0), _function(0), _lock_deepsleep(!data->interface->runs_in_deep_sleep)
 {
 }
 

--- a/platform/ATCmdParser.h
+++ b/platform/ATCmdParser.h
@@ -92,7 +92,7 @@ public:
      */
     ATCmdParser(FileHandle *fh, const char *output_delimiter = "\r",
                 int buffer_size = 256, int timeout = 8000, bool debug = false)
-        : _fh(fh), _buffer_size(buffer_size), _oob_cb_count(0), _in_prev(0), _oobs(NULL)
+        : _fh(fh), _buffer_size(buffer_size), _oob_cb_count(0), _in_prev(0), _aborted(false), _oobs(NULL)
     {
         _buffer = new char[buffer_size];
         set_timeout(timeout);

--- a/platform/source/ATCmdParser.cpp
+++ b/platform/source/ATCmdParser.cpp
@@ -397,7 +397,7 @@ void ATCmdParser::abort()
 bool ATCmdParser::process_oob()
 {
     int pre_count = _oob_cb_count;
-    recv(NULL);
+    static_cast<void>(recv(NULL));
     return _oob_cb_count != pre_count;
 }
 

--- a/platform/source/SysTimer.cpp
+++ b/platform/source/SysTimer.cpp
@@ -57,6 +57,7 @@ SysTimer<US_IN_TICK, IRQ>::SysTimer() :
     _unacknowledged_ticks(0),
     _wake_time_set(false),
     _wake_time_passed(false),
+    _wake_early(false),
     _ticking(false),
     _deep_sleep_locked(false)
 {
@@ -70,6 +71,7 @@ SysTimer<US_IN_TICK, IRQ>::SysTimer(const ticker_data_t *data) :
     _unacknowledged_ticks(0),
     _wake_time_set(false),
     _wake_time_passed(false),
+    _wake_early(false),
     _ticking(false),
     _deep_sleep_locked(false)
 {

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -826,6 +826,7 @@ int _lseek(FILEHANDLE fh, int offset, int whence)
     off_t off = lseek(fh, offset, whence);
     // Assuming INT_MAX = LONG_MAX, so we don't care about prototype difference
     if (off > INT_MAX) {
+        // Be cautious in case off_t is 64-bit
         errno = EOVERFLOW;
         return -1;
     }


### PR DESCRIPTION
### Description

Issues fixed:
```
* SysTimer.cpp:63 Non-static class member _wake_early is not initialized in this constructor nor in any functions that it calls.
* SysTimer.cpp:76 Non-static class member _wake_early is not initialized in this constructor nor in any functions that it calls.
* Ticker.cpp:34 Non-static class member _delay is not initialized in this constructor nor in any functions that it calls.
* ATCmdParser.cpp:400 Calling recv without checking return value (as is done elsewhere 39 out of 40 times).
* ATCmdParser.h:103 Non-static class member _aborted is not initialized in this constructor nor in any functions that it calls.
* mbed_retarget.cpp:828 result_independent_of_operands: off > 2147483647 is always false regardless of the values of its operands. This occurs as the logical operand of if.
* FlashIAP.cpp:52 Non-static class member _page_buf is not initialized in this constructor nor in any functions that it calls.
* Ticker.cpp:29 Non-static class member _delay is not initialized in this constructor nor in any functions that it calls.
```


<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
