### PR TITLE
ST: Change the LSI_VALUE according to documentation

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_conf.h
@@ -114,7 +114,7 @@ extern "C" {
   * @brief Internal Low Speed oscillator (LSI) value.
   */
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE               32000U     /*!< LSI Typical Value in Hz */
+#define LSI_VALUE               40000U     /*!< LSI Typical Value in Hz */
 #endif /* LSI_VALUE */                     /*!< Value of the Internal Low Speed oscillator in Hz
                                                 The real value may vary depending on the variations
                                                 in voltage and temperature. */

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_ll_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_ll_rcc.h
@@ -120,7 +120,7 @@ typedef struct
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    40000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 /**
   * @}


### PR DESCRIPTION
### Description
Changed the LSI_VALUE of STM32F1, STM32L0, STM32L1 to match the typical value of their documentation.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@jamesbeyond @maciejbocianski @fkjagodzinski @jeromecoutant 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
