### PR TITLE
minimal-printf: Add capability to run floating point tests manually

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/README.md
+++ b/TESTS/mbed_platform/minimal-printf/compliance/README.md
@@ -6,6 +6,6 @@ This document describes how to run minimal-printf tests.
 
 You can use the following command to run tests:
 
-`mbed test -m K64F -t GCC_ARM -n *printf* -v -c`
+`mbed test -m K64F -t GCC_ARM -n *printf* -v -c --app-config TESTS/mbed_platform/minimal-printf/compliance/test_config.json`
 
 Do not use --profile minimal-printf so minimal-printf is not compared with itself.

--- a/TESTS/mbed_platform/minimal-printf/compliance/test_config.json
+++ b/TESTS/mbed_platform/minimal-printf/compliance/test_config.json
@@ -1,0 +1,7 @@
+{
+    "target_overrides": {
+        "*": {
+            "platform.minimal-printf-enable-floating-point": true
+        }
+    }
+}


### PR DESCRIPTION
### Description
There is currently no way for the CI to test features that are disabled by default. This PR provides a way to run the existing floating point tests manually by providing a configuration file that overwrite the default value of the attribute that disables floating point support in minimal-printf.

Floating point support is set to false by default [here](https://github.com/ARMmbed/mbed-os/pull/11450).

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers
@jamesbeyond @evedon 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
