### PR TITLE
Enable tickless mode in MAX32630FTHR

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5969,7 +5969,8 @@
             "TARGET=MAX32630",
             "TARGET_REV=0x4132",
             "BLE_HCI_UART",
-            "OPEN_DRAIN_LEDS"
+            "OPEN_DRAIN_LEDS",
+            "MBED_TICKLESS"
         ],
         "extra_labels": ["Maxim", "MAX32630"],
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9411,7 +9411,7 @@
             "PORTIN",
             "PORTINOUT",
             "PORTOUT",
-            "PWMOUT",            
+            "PWMOUT",
             "SERIAL",
             "SERIAL_ASYNCH",
             "SERIAL_FC",
@@ -9434,7 +9434,7 @@
             "tickless-from-us-ticker": true
         },
         "forced_reset_timeout": 3
-    },    
+    },
     "__build_tools_metadata__": {
         "version": "1",
         "public": false


### PR DESCRIPTION
### Description

This PR is part of [IOTCLOUDPR-3223](https://jira.arm.com/browse/IOTCLOUDPR-3223). The requirement is to enable tickless mode in targets that CI can run tests on. In this first PR, tickless mode is enabled in MAX32630FTHR, which successfully passed all greentea tests with tickless mode.

An additional PR may follow with more targets that currently show minor greentea regressions, after it is confirmed tickless mode is not the cause.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@evedon @hugueskamba 