### PR TITLE
Convert TZ target name to test spec platform name

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2272,9 +2272,20 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
 
 def test_spec_from_test_builds(test_builds):
     for build in test_builds:
-        if Target.get_target(test_builds[build]['platform']).is_PSA_non_secure_target:
+        # Convert TZ target name to test spec platform name
+        #
+        # 1. All TZ targets should have name pattern: PLATFORM_[PSA_]S/NS, where:
+        #    (1) 'PLATFORM' for test spec platform name
+        #    (2) 'PSA' is optional to distinguish PSA/non-PSA targets, especially when
+        #        both PSA/non-PSA targets are supported
+        #    (3) 'S'/'NS' for secure/non-secure targets
+        # 2. Secure target may participate in Greentea, so its name is also truncated here.
+        if Target.get_target(test_builds[build]['platform']).is_TrustZone_target:
             if test_builds[build]['platform'].endswith('_NS'):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-3]
+            elif test_builds[build]['platform'].endswith('_S'):
+                test_builds[build]['platform'] = test_builds[build]['platform'][:-2]
+            
             if test_builds[build]['platform'].endswith('_PSA'):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-4]
     return {


### PR DESCRIPTION
### Description

Originally, only the conversion of PSA non-secure target name to test spec platform name is supported for Greentea. This PR extends it by converting all TZ target names to test spec platform name:
1.  All TZ targets should have name pattern: **PLATFORM_[PSA_]S/NS**, where:
    1.  **PLATFORM** for test spe platform name registered in mbed-os-tools
    1.  **PSA** is optional to distinguish PSA/non-PSA targets, especially when both PSA/non-PSA targets are supported
    1.  **S/NS** for secure/non-secure targets
1. Secure target may participate in Greentea, so its name is also converted here.

#### Related PR

Split from #11288 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 
