### PR TITLE
Cellular: Disable cellular.clear-on-connect by default

### DIFF
--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -26,8 +26,8 @@
             "value": null
         },
         "clear-on-connect" : {
-            "help": "Clear modem to a known default state on connect()",
-            "value": true
+            "help": "Clear modem to a known default state on connect() before SIM pin is entered, null to disable",
+            "value": null
         }
     }
 }


### PR DESCRIPTION
### Description

Disable `cellular.clear-on-connect` configuration by default. It was a bit too bold assumption that it ca be always enabled, as it seems that clearing of PDP contexts may cause different kind of connectivity problems depending on a network environment confguration, such as auto-reconnect to network, create initial network context, SIM pin query disabled/enabled.

This change disables just automatic clearing, while `CellularDevice::clear()` API is still available for applications as previously.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

The release notes of PR #11414 are not anymore valid, as there is no change in functionality.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
