### PR TITLE
Prevent unreachable statements and correct variable sizes.

### DIFF
--- a/drivers/USBAudio.h
+++ b/drivers/USBAudio.h
@@ -373,8 +373,8 @@ private:
     usb_ep_t _episo_in;     // tx endpoint
 
     // channel config in the configuration descriptor: master, left, right
-    uint8_t _channel_config_rx;
-    uint8_t _channel_config_tx;
+    uint16_t _channel_config_rx;
+    uint16_t _channel_config_tx;
 
     // configuration descriptor
     uint8_t _config_descriptor[183];

--- a/rtos/source/Semaphore.cpp
+++ b/rtos/source/Semaphore.cpp
@@ -212,8 +212,9 @@ osStatus Semaphore::release(void)
             return osErrorResource;
         }
     } while (!core_util_atomic_cas_s32(&_count, &old_count, old_count + 1));
-#endif
+
     return osOK;
+#endif // MBED_CONF_RTOS_PRESENT
 }
 
 Semaphore::~Semaphore()

--- a/rtos/source/TARGET_CORTEX/mbed_rtos_rtx.c
+++ b/rtos/source/TARGET_CORTEX/mbed_rtos_rtx.c
@@ -115,5 +115,4 @@ MBED_NORETURN void mbed_rtos_start()
 
     osKernelStart();
     MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_INITIALIZATION_FAILED), "Failed to start RTOS");
-    while (1); // Code should never get here
 }

--- a/rtos/source/TARGET_CORTEX/mbed_rtx_handlers.c
+++ b/rtos/source/TARGET_CORTEX/mbed_rtx_handlers.c
@@ -80,9 +80,6 @@ __NO_RETURN uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
             MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_KERNEL, MBED_ERROR_CODE_UNKNOWN), "CMSIS-RTOS error: Unknown", code);
             break;
     }
-
-    /* That shouldn't be reached */
-    for (;;) {}
 }
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED


### PR DESCRIPTION
### Description
Fix the following warnings:
```bash
[Warning] USBAudio.cpp@666,20: [Pa182]: bit mask appears to contain significant bits that do not affect the result 
[Warning] USBAudio.cpp@704,0: [Pa182]: bit mask appears to contain significant bits that do not affect the result
[Warning] mbed_rtos_rtx.c@118,0: [Pe128]: loop is not reachable
[Warning] mbed_rtx_handlers.c@85,0: [Pe128]: loop is not reachable
[Warning] Semaphore.cpp@216,0: [Pe111]: statement is unreachable
```
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
