### PR TITLE
STM32WB ADC : consecutive VBAT reading

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32WB/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/analogin_device.c
@@ -194,6 +194,11 @@ uint16_t adc_read(analogin_t *obj)
     if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
         adcValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
     }
+
+    if (HAL_ADC_Stop(&obj->handle) != HAL_OK) {
+        debug("HAL_ADC_Stop failed\r\n");
+    }
+
     LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE((&obj->handle)->Instance), LL_ADC_PATH_INTERNAL_NONE);
     return adcValue;
 }


### PR DESCRIPTION
### Description

Consecutive VBAT values reading was not possible.

@LMESTM 

CI OK:

| target                | platform_name | test suite                 | result | elapsed_time (sec) | copy_method |
|-----------------------|---------------|----------------------------|--------|--------------------|-------------|
| NUCLEO_WB55RG-ARMC6   | NUCLEO_WB55RG | tests-api-analogin         | OK     | 16.5               | default     |
| NUCLEO_WB55RG-ARMC6   | NUCLEO_WB55RG | tests-assumptions-analogin | OK     | 19.28              | default     |
| NUCLEO_WB55RG-GCC_ARM | NUCLEO_WB55RG | tests-api-analogin         | OK     | 17.06              | default     |
| NUCLEO_WB55RG-GCC_ARM | NUCLEO_WB55RG | tests-assumptions-analogin | OK     | 19.84              | default     |
| NUCLEO_WB55RG-IAR     | NUCLEO_WB55RG | tests-api-analogin         | OK     | 16.45              | default     |
| NUCLEO_WB55RG-IAR     | NUCLEO_WB55RG | tests-assumptions-analogin | OK     | 19.22              | default     |



### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


### Release Notes
