### PR TITLE
Suppress Coverity warnings

### DIFF
--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -443,7 +443,7 @@ std::FILE *fdopen(FileHandle *fh, const char *mode)
 {
     // First reserve the integer file descriptor
     int fd = bind_to_fd(fh);
-    if (!fd) {
+    if (fd < 0) {
         return NULL;
     }
     // Then bind that to the C stream. If successful, C library
@@ -825,6 +825,7 @@ int _lseek(FILEHANDLE fh, int offset, int whence)
 
     off_t off = lseek(fh, offset, whence);
     // Assuming INT_MAX = LONG_MAX, so we don't care about prototype difference
+    // coverity[result_independent_of_operands]
     if (off > INT_MAX) {
         // Be cautious in case off_t is 64-bit
         errno = EOVERFLOW;

--- a/rtos/source/TARGET_CORTEX/rtx4/cmsis_os1.c
+++ b/rtos/source/TARGET_CORTEX/rtx4/cmsis_os1.c
@@ -267,6 +267,7 @@ osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
   }
 
   ptr->mp_id = osMemoryPoolNew  (queue_def->queue_sz, queue_def->item_sz, &queue_def->mp_attr);
+  // coverity[suspicious_sizeof]
   ptr->mq_id = osMessageQueueNew(queue_def->queue_sz, sizeof(void *), &queue_def->mq_attr);
   if ((ptr->mp_id == NULL) || (ptr->mq_id == NULL)) {
     if (ptr->mp_id != NULL) {


### PR DESCRIPTION
### Description
Ignore the following Coverity warnings:

```
* cmsis_os1.c:270 Passing argument 4UL /* sizeof (void *) */ to function osMessageQueueNew which returns a value of type void * is suspicious.
* mbed_retarget.cpp:451 Argument cannot be negative (NEGATIVE_RETURNS). negative_returns: fd is passed to a parameter that cannot be negative. [Note: The source code implementation of the function has been overridden by a builtin model.]
* mbed_retarget.cpp:828 result_independent_of_operands: off > 2147483647 is always false regardless of the values of its operands. This occurs as the logical operand of if.
```

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
