### PR TITLE
Fix compilation warnings from GCC in netsocket/network tests

### DIFF
--- a/TESTS/netsocket/dns/synchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_cache.cpp
@@ -41,6 +41,7 @@ void SYNCHRONOUS_DNS_CACHE()
         SocketAddress address;
         int started_us = ticker_us;
         nsapi_error_t err = get_interface()->gethostbyname(dns_test_hosts[0], &address);
+        TEST_ASSERT_TRUE(err == NSAPI_ERROR_OK);
 
         int delay_ms = (ticker_us - started_us) / 1000;
 

--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -67,7 +67,7 @@ void TCPSOCKET_ECHOTEST()
 
     int recvd;
     int sent;
-    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); s_idx++) {
+    for (unsigned int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); s_idx++) {
         int pkt_s = pkt_sizes[s_idx];
         fill_tx_buffer_ascii(tcp_global::tx_buffer, BUFF_SIZE);
         sent = sock.send(tcp_global::tx_buffer, pkt_s);

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -146,7 +146,7 @@ void rcv_n_chk_against_rfc864_pattern_nonblock(TCPSocket &sock)
         int rd = sock.recv(buff, buff_size);
         TEST_ASSERT(rd > 0 || rd == NSAPI_ERROR_WOULD_BLOCK);
         if (rd > 0) {
-            if (rd > buff_size) {
+            if ((unsigned int) rd > buff_size) {
                 TEST_FAIL_MESSAGE("sock.recv returned more than requested.");
             }
             check_RFC_864_pattern(buff, rd, recvd_size);

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -70,7 +70,7 @@ void TLSSOCKET_ECHOTEST()
 
     int recvd;
     int sent;
-    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); s_idx++) {
+    for (unsigned int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); s_idx++) {
         int pkt_s = pkt_sizes[s_idx];
         fill_tx_buffer_ascii(tls_global::tx_buffer, BUFF_SIZE);
 

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -68,7 +68,7 @@ void UDPSOCKET_ECHOTEST()
     int sent;
     int packets_sent = 0;
     int packets_recv = 0;
-    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
+    for (unsigned int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
         int pkt_s = pkt_sizes[s_idx];
 
         fill_tx_buffer_ascii(tx_buffer, BUFF_SIZE);
@@ -127,7 +127,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
     int sent;
     int packets_sent = 0;
     int packets_recv = 0;
-    for (int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
+    for (unsigned int s_idx = 0; s_idx < sizeof(pkt_sizes) / sizeof(*pkt_sizes); ++s_idx) {
         int pkt_s = pkt_sizes[s_idx];
         int packets_sent_prev = packets_sent;
         for (int retry_cnt = 0; retry_cnt <= RETRIES; retry_cnt++) {

--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -83,14 +83,7 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI) && \
-!defined(TARGET_UBLOX_EVK_ODIN_W2)      && \
-!defined(TARGET_REALTEK_RTL8195AM)      && \
-!defined(TARGET_MTB_ADV_WISE_1530)      && \
-!defined(TARGET_MTB_USI_WM_BN_BM_22)    && \
-!defined(TARGET_MTB_MXCHIP_EMW3166)     && \
-!defined(TARGET_MTB_UBLOX_ODIN_W2)      && \
-!defined(TARGET_UNO_91H)
+#endif // (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI) && !defined(TARGET_*
 
 #endif // MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != ETHERNET && MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != WIFI
 #endif // !defined(MBED_CONF_APP_ECHO_SERVER) || !defined(MBED_CONF_APP_ECHO_SERVER_TRACE) || !defined(MBED_CONF_APP_WIFI_SCAN)

--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -132,7 +132,7 @@ void NETWORKINTERFACE_STATUS_NONBLOCK()
         status = wait_status_callback();
         TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
 
-        wait(1);    // In cellular there might still come disconnected messages from the network which are sent to callback.
+        ThisThread::sleep_for(1);    // In cellular there might still come disconnected messages from the network which are sent to callback.
         // This would cause this test to fail as next connect is already ongoing. So wait here a while until (hopefully)
         // all messages also from the network have arrived.
     }

--- a/TESTS/network/l3ip/main.cpp
+++ b/TESTS/network/l3ip/main.cpp
@@ -25,10 +25,6 @@
 
 using namespace utest::v1;
 
-namespace {
-NetworkInterface *l3interface;
-}
-
 void L3IP_START()
 {
     printf("MBED: L3IP_START\n");

--- a/TESTS/network/multihoming/multihoming_asynchronous_dns.cpp
+++ b/TESTS/network/multihoming/multihoming_asynchronous_dns.cpp
@@ -61,7 +61,7 @@ void MULTIHOMING_ASYNCHRONOUS_DNS()
                 continue;
             }
 
-            for (unsigned int j = 0; j < interface_num; j++) {
+            for (int j = 0; j < interface_num; j++) {
 
                 nsapi_error_t err = interface->gethostbyname_async(dns_test_hosts[i],
                                                                        mbed::Callback<void(nsapi_error_t, SocketAddress *)>(hostbyname_cb, (void *) &data), NSAPI_UNSPEC, interface_name[j]);

--- a/TESTS/network/multihoming/multihoming_synchronous_dns.cpp
+++ b/TESTS/network/multihoming/multihoming_synchronous_dns.cpp
@@ -51,7 +51,7 @@ void MULTIHOMING_SYNCHRONOUS_DNS()
                 continue;
             }
 
-            for (unsigned int j = 0; j < interface_num; j++) {
+            for (int j = 0; j < interface_num; j++) {
 
                 nsapi_error_t err = interface->gethostbyname(dns_test_hosts[i], &address, NSAPI_UNSPEC, interface_name[j]);
                 printf("DNS: query  interface_name %s %d \n", interface_name[j], j);

--- a/TESTS/network/multihoming/multihoming_udpsocket_echotest.cpp
+++ b/TESTS/network/multihoming/multihoming_udpsocket_echotest.cpp
@@ -66,7 +66,7 @@ void MULTIHOMING_UDPSOCKET_ECHOTEST()
 
         UDPSocket sock;
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(interface));
-        for (unsigned int j = 0; j < interface_num; j++) {
+        for (int j = 0; j < interface_num; j++) {
             int recvd;
             int sent;
             int s_idx = 0;
@@ -113,7 +113,7 @@ void udpsocket_echotest_nonblock_receiver(void *receive_bytes)
     for (int retry_cnt = 0; retry_cnt <= RETRIES; retry_cnt++) {
         recvd = sock.recvfrom(NULL, rx_buffer, expt2recv);
         if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
-            wait_ms(WAIT2RECV_TIMEOUT);
+            ThisThread::sleep_for(WAIT2RECV_TIMEOUT);
             --retry_cnt;
             continue;
         } else if (recvd == expt2recv) {
@@ -144,7 +144,7 @@ void MULTIHOMING_UDPSOCKET_ECHOTEST_NONBLOCK()
         TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(interface));
         sock.set_blocking(false);
         sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
-        for (unsigned int j = 0; j < interface_num; j++) {
+        for (int j = 0; j < interface_num; j++) {
             int s_idx = 0;
             int packets_sent = 0;
             int packets_recv = 0;

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -94,18 +94,8 @@ int main()
 {
     return !Harness::run(specification);
 }
-#endif // defined(MBED_CONF_APP_WIFI_UNSECURE_SSID) &&  \
-!defined(MBED_CONF_APP_AP_MAC_UNSECURE)    || \
-!defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
-!defined(MBED_CONF_APP_WIFI_CH_UNSECURE)   || \
-!defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
+#endif // defined(MBED_CONF_APP_WIFI_UNSECURE_SSID) && !defined(MBED_CONF_APP_*
 
-#endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID) && \
-(!defined(MBED_CONF_APP_AP_MAC_SECURE)      || \
-!defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
-!defined(MBED_CONF_APP_WIFI_CH_SECURE)     || \
-!defined(MBED_CONF_APP_WIFI_PASSWORD)      || \
-!defined(MBED_CONF_APP_WIFI_SECURE_SSID)   || \
-!defined MBED_CONF_APP_WIFI_SECURE_PROTOCOL)
+#endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID) && (!defined(MBED_CONF_APP_*
 
 #endif //!defined(MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE) || MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE != WIFI


### PR DESCRIPTION
### Description

Four kinds of warnings were occurring:
* singed vs unsigned comparison
* multiline comments (a backslash `\` at the end of a comment line renders this)
* unused variables
* usage of deprecated wait function

Warnings only occurred in the test code.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 
@VeijoPesonen 
@SeppoTakalo 
