### PR TITLE
Remove Mbed Crypto source files before importing

### DIFF
--- a/features/mbedtls/mbed-crypto/importer/Makefile
+++ b/features/mbedtls/mbed-crypto/importer/Makefile
@@ -90,6 +90,7 @@ rsync:
 	# Copying Mbed Crypto into Mbed OS...
 	rm -rf $(TARGET_SRV_IMPL)
 	rm -rf $(TARGET_SPE)
+	rm -rf $(TARGET_SRC)
 
 	mkdir -p $(TARGET_SRV_IMPL)
 	mkdir -p $(TARGET_SPE)


### PR DESCRIPTION
### Description

Currently the Mbed Crypto importer doesn't handle file deletions properly when importing. This PR fixes the importer to remove the old src folder first before importing.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
