### PR TITLE
Refactor CRC constructor method to remove warning

### DIFF
--- a/drivers/MbedCRC.h
+++ b/drivers/MbedCRC.h
@@ -514,22 +514,19 @@ private:
         MBED_STATIC_ASSERT(width <= 32, "Max 32-bit CRC supported");
 
 #if DEVICE_CRC
-        if (POLY_32BIT_REV_ANSI == polynomial) {
-            _crc_table = (uint32_t *)Table_CRC_32bit_Rev_ANSI;
-            _mode = TABLE;
-            return;
-        }
-        crc_mbed_config_t config;
-        config.polynomial  = polynomial;
-        config.width       = width;
-        config.initial_xor = _initial_value;
-        config.final_xor   = _final_xor;
-        config.reflect_in  = _reflect_data;
-        config.reflect_out = _reflect_remainder;
+        if (POLY_32BIT_REV_ANSI != polynomial) {
+            crc_mbed_config_t config;
+            config.polynomial  = polynomial;
+            config.width       = width;
+            config.initial_xor = _initial_value;
+            config.final_xor   = _final_xor;
+            config.reflect_in  = _reflect_data;
+            config.reflect_out = _reflect_remainder;
 
-        if (hal_crc_is_supported(&config)) {
-            _mode = HARDWARE;
-            return;
+            if (hal_crc_is_supported(&config)) {
+                _mode = HARDWARE;
+                return;
+            }
         }
 #endif
 


### PR DESCRIPTION
## Description
The warning removed is 
`[Warning] MbedCRC.h@524,0: [Pe111]: statement is unreachable`
It can be observed when building `mbed-os-example-blinky` with the IAR toolchain.

The removed code is handled by the switch statement below where it was.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@deepikabhavnani 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
