### PR TITLE
no-systick targets: fix systick irq handler setup

### DIFF
--- a/rtos/source/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/source/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -61,11 +61,9 @@ extern "C" {
         IRQn_Type irq = OsTimer::get_irq_number();
 
         NVIC_SetPriority(irq, 0xFF);
-#ifdef NVIC_RAM_VECTOR_ADDRESS
         NVIC_SetVector(irq, (uint32_t)handler);
-#else
         MBED_ASSERT(handler == (IRQHandler_t)NVIC_GetVector(irq));
-#endif
+
         if (irq >= 0) {
             NVIC_EnableIRQ(irq);
         }


### PR DESCRIPTION
### Description

Fix for the https://github.com/ARMmbed/mbed-os/issues/11426

For targets with no H/W systick (`NO_SYSTICK`), `SysTick_Handler` needs to be remapped to specific irq emulating systick.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
