### PR TITLE
Enable tickless mode in additional tested targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2536,7 +2536,7 @@
             }
         },
         "detect_code": ["0720"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "MBED_TICKLESS"],
         "device_has_add": [
             "SERIAL_ASYNCH",
             "FLASH",
@@ -2616,7 +2616,7 @@
                 "macro_name": "CLOCK_SOURCE"
             }
         },
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
+        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "MBED_TICKLESS"],
         "device_has_add": [
             "SERIAL_ASYNCH",
             "FLASH",
@@ -4780,6 +4780,7 @@
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "supported_form_factors": ["ARDUINO"],
         "release_versions": ["5"],
+        "macros_add": ["MBED_TICKLESS"],
         "device_has_remove": [],
         "extra_labels_add": ["PSA"],
         "components_add": ["SD", "FLASHIAP"],
@@ -9410,7 +9411,7 @@
             "PORTIN",
             "PORTINOUT",
             "PORTOUT",
-            "PWMOUT",            
+            "PWMOUT",
             "SERIAL",
             "SERIAL_ASYNCH",
             "SERIAL_FC",
@@ -9433,7 +9434,7 @@
             "tickless-from-us-ticker": true
         },
         "forced_reset_timeout": 3
-    },    
+    },
     "__build_tools_metadata__": {
         "version": "1",
         "public": false


### PR DESCRIPTION
### Description
This PR is part of [IOTCLOUDPR-3223](https://jira.arm.com/browse/IOTCLOUDPR-3223). The requirement is to enable tickless mode in targets that CI can run tests on. In this PR, tickless mode is enabled in 3 targets that have preexisting minor greentea errors, and tickless mode has not caused additional errors:

- NUCLEO_F401RE
- NUCLEO_F411RE
- UBLOX_EVK_ODIN_W2

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @hugueskamba 