### PR TITLE
Change reset_reason test timeout.

### DIFF
--- a/TESTS/mbed_drivers/reset_reason/main.cpp
+++ b/TESTS/mbed_drivers/reset_reason/main.cpp
@@ -137,7 +137,7 @@ void test_reset_reason()
 
 int main()
 {
-    GREENTEA_SETUP(60, "reset_reason");
+    GREENTEA_SETUP(90, "reset_reason");
     test_reset_reason(); // The result of this test suite is reported by the host side.
     GREENTEA_TESTSUITE_RESULT(0); // Fail on any error.
 }

--- a/TESTS/mbed_hal/reset_reason/main.cpp
+++ b/TESTS/mbed_hal/reset_reason/main.cpp
@@ -144,7 +144,7 @@ void test_reset_reason()
 
 int main()
 {
-    GREENTEA_SETUP(60, "reset_reason");
+    GREENTEA_SETUP(90, "reset_reason");
     test_reset_reason(); // The result of this test suite is reported by the host side.
     GREENTEA_TESTSUITE_RESULT(0); // Fail on any error.
 }


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Changed mbed_drivers-reset_reason and mbed_hal-reset_reason tests because sometimes for some devices it was a little bit to short. For example K64F was sometimes failing this test and when it passes it took it long time.
```
mbedgt: test suite 'tests-mbed_drivers-reset_reason' ................................................. OK in 55.23 sec
```


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@maciejbocianski @fkjagodzinski @jamesbeyond 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
