### PR TITLE
Delaying message id random initialization to later stage.

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v5.1.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.1)
+
+- Delay the random initialization of message id to a later phase and not during init() so there is enough time
+  for system to complete the rest of the initialization.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v5.1.0...v5.1.1)
+
+
 ## [v5.1.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.0)
 
 - Introduce SN_COAP_REDUCE_BLOCKWISE_HEAP_FOOTPRINT configuration flag. 

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -179,13 +179,7 @@ struct coap_s *sn_coap_protocol_init(void *(*used_malloc_func_ptr)(uint16_t), vo
 
 #endif /* ENABLE_RESENDINGS */
 
-    /* Randomize global message ID */
-    randLIB_seed_random();
-    message_id = randLIB_get_16bit();
-    if (message_id == 0) {
-        message_id = 1;
-    }
-
+    message_id = 0;
     return handle;
 }
 
@@ -2526,6 +2520,11 @@ static bool compare_address_and_port(const sn_nsdl_addr_s* left, const sn_nsdl_a
 
 static uint16_t get_new_message_id(void)
 {
+    if (message_id == 0) {
+        /* Randomize global message ID */
+        randLIB_seed_random();
+        message_id = randLIB_get_16bit();
+    }
     message_id++;
     if (message_id == 0) {
         message_id = 1;


### PR DESCRIPTION
### Description

Random initialization sequence is causing start up issues in multiple platform
when done at construction phase.
The right thing is to delay the random initialization to later stage when the
message id is actually required. This provides system to do all necessary allocation
upfront without causing any random race condition at startup phase.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

