### PR TITLE
update googletest to v1.8.1

### DIFF
--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -52,8 +52,8 @@ add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
 # dependencies automatically when using CMake 2.8.11 or
 # later.
 target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
-  "${gtest_SOURCE_DIR}/include"
-  "${gmock_SOURCE_DIR}/include")
+  "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>")
 
 ####################
 # TESTING

--- a/UNITTESTS/README.md
+++ b/UNITTESTS/README.md
@@ -85,6 +85,8 @@ Mbed CLI supports unit tests through the `mbed test --unittests` command. For in
 
 A unit tests suite consists of one or more test cases. The test cases should cover all the functions in a class under test. All the external dependencies are stubbed including the other classes in the same module. Avoid stubbing header files. Finally, analyze code coverage to ensure all code is tested, and no dead code is found.
 
+Unit tests are written using [Google Test v1.8.1](https://github.com/google/googletest/releases/tag/release-1.8.1).
+
 Please see the [documentation for Google Test](https://github.com/google/googletest/blob/master/googletest/docs/primer.md) to learn how to write unit tests using its framework. See the [documentation for Google Mock](https://github.com/google/googletest/blob/master/googlemock/docs/Documentation.md) if you want to write and use C++ mock classes instead of stubs.
 
 #### Test suite configuration

--- a/UNITTESTS/googletest-CMakeLists.txt.in
+++ b/UNITTESTS/googletest-CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           8bc11c040a1dcbe50c340b21d78175d152dd3837
+  GIT_TAG           release-1.8.1
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

The PR updated googletest to [v1.8.1](https://github.com/google/googletest/releases/tag/release-1.8.1). It avoids having a "random" commit used.

Tested with `cmake ..` and gcc on macOS, ~~but could not test~~ **AND** with `mbed test --unittests` but could not complete (see #11485) -- googletest compiles correctly at the beginning though.

The update needs a small change in CMakeLists.txt, based on that: https://github.com/google/googletest/issues/1764#issuecomment-415865601

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

n/a

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

n/a