### PR TITLE
Convert TZ target name 'NPSA' to test spec platform name

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2274,9 +2274,9 @@ def test_spec_from_test_builds(test_builds):
     for build in test_builds:
         # Convert TZ target name to test spec platform name
         #
-        # 1. All TZ targets should have name pattern: PLATFORM_[PSA_/NPSA_]S/NS, where:
+        # 1. All TZ targets should have name pattern: PLATFORM_[NPSA_]S/NS, where:
         #    (1) 'PLATFORM' for test spec platform name
-        #    (2) 'PSA/NPSA' for PSA/non-PSA targets. Defaults to PSA target on absent.
+        #    (2) 'NPSA' for non-PSA targets. Defaults to PSA target if absent.
         #    (3) 'S'/'NS' for secure/non-secure targets
         # 2. Secure target may participate in Greentea, so its name is also truncated here.
         if Target.get_target(test_builds[build]['platform']).is_TrustZone_target:
@@ -2285,9 +2285,7 @@ def test_spec_from_test_builds(test_builds):
             elif test_builds[build]['platform'].endswith('_S'):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-2]
 
-            if test_builds[build]['platform'].endswith('_PSA'):
-                test_builds[build]['platform'] = test_builds[build]['platform'][:-4]
-            elif test_builds[build]['platform'].endswith('_NPSA'):
+            if test_builds[build]['platform'].endswith('_NPSA'):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-5]
     return {
         "builds": test_builds

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2274,10 +2274,9 @@ def test_spec_from_test_builds(test_builds):
     for build in test_builds:
         # Convert TZ target name to test spec platform name
         #
-        # 1. All TZ targets should have name pattern: PLATFORM_[PSA_]S/NS, where:
+        # 1. All TZ targets should have name pattern: PLATFORM_[PSA_/NPSA_]S/NS, where:
         #    (1) 'PLATFORM' for test spec platform name
-        #    (2) 'PSA' is optional to distinguish PSA/non-PSA targets, especially when
-        #        both PSA/non-PSA targets are supported
+        #    (2) 'PSA/NPSA' for PSA/non-PSA targets. Defaults to PSA target on absent.
         #    (3) 'S'/'NS' for secure/non-secure targets
         # 2. Secure target may participate in Greentea, so its name is also truncated here.
         if Target.get_target(test_builds[build]['platform']).is_TrustZone_target:
@@ -2285,9 +2284,11 @@ def test_spec_from_test_builds(test_builds):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-3]
             elif test_builds[build]['platform'].endswith('_S'):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-2]
-            
+
             if test_builds[build]['platform'].endswith('_PSA'):
                 test_builds[build]['platform'] = test_builds[build]['platform'][:-4]
+            elif test_builds[build]['platform'].endswith('_NPSA'):
+                test_builds[build]['platform'] = test_builds[build]['platform'][:-5]
     return {
         "builds": test_builds
     }


### PR DESCRIPTION
### Description

This PR is continuation of #11467 and to convert TZ target name with suffix **NPSA** https://github.com/ARMmbed/mbed-os/pull/11288#discussion_r324173785 to test spec platform name. With this PR, TZ targets are named as follows:

1.  All TZ targets should have name pattern: **PLATFORM_[PSA_/NPSA_]S/NS**, where:
    1.  **PLATFORM** for test spec platform name
    1.  **PSA/NPSA** for PSA/non-PSA targets. Defaults to PSA target on absent.
    1.  **S/NS** for secure/non-secure targets
1. Secure target may participate in Greentea, so its name is also truncated here.

#### Related PRs

Continuation of #11467 
Required by https://github.com/ARMmbed/mbed-os/pull/11288#discussion_r324173785

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@devran01 

### Release Notes

Define naming rule for TrustZone targets: 'PLATFORM'\_['NPSA\_']'S'/'NS', where:
1. 'PLATFORM' for test spec platform name, which is registered in platform database of mbed-os-tools.
2. 'NPSA' for non-PSA targets. Defaults to PSA target if absent.
3. 'S'/'NS' for secure/non-secure targets.