### PR TITLE
Cellular: Fix get_interface_name to not include leading zero

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/at_cellularcontexttest.cpp
@@ -178,6 +178,18 @@ public:
     int _op;
 };
 
+class AT_CTX_cid: public AT_CellularContext {
+public:
+    AT_CTX_cid(ATHandler &at, CellularDevice *device, const char *apn = MBED_CONF_NSAPI_DEFAULT_CELLULAR_APN) :
+        AT_CellularContext(at, device, apn) {}
+    virtual ~AT_CTX_cid() {}
+
+    void set_cid(int cid)
+    {
+        _cid = cid;
+    }
+};
+
 static int network_cb_count;
 static void network_cb(nsapi_event_t ev, intptr_t intptr)
 {
@@ -248,6 +260,22 @@ TEST_F(TestAT_CellularContext, get_ip_address)
     my_AT_CTX ctx1(at, NULL);
     ip = ctx1.get_ip_address();
     EXPECT_TRUE(ip != NULL);
+}
+
+TEST_F(TestAT_CellularContext, get_interface_name)
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+    AT_CellularDevice dev(&fh1);
+    AT_CTX_cid ctx(at, &dev);
+
+    char ifn[5];
+    EXPECT_TRUE(NULL == ctx.get_interface_name(ifn));
+
+    ctx.set_cid(1);
+    EXPECT_STREQ("ce1", ctx.get_interface_name(ifn));
+    EXPECT_STREQ("ce1", ifn);
 }
 
 TEST_F(TestAT_CellularContext, attach)
@@ -746,5 +774,4 @@ TEST_F(TestAT_CellularContext, get_timeout_for_operation)
 
     ctx1._op = -1;
     EXPECT_EQ(1800 * 1000, ctx1.do_op());
-
 }

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -244,7 +244,7 @@ char *AT_CellularContext::get_interface_name(char *interface_name)
         return NULL;
     }
     MBED_ASSERT(interface_name);
-    sprintf(interface_name, "ce%02d", _cid);
+    sprintf(interface_name, "ce%d", _cid);
     return interface_name;
 }
 


### PR DESCRIPTION
Multihoming documentation about interface name:
"Two character name string is concatenated with 8 bit value containing index which is incremented on each netif addition"

Cellular uses context id as index and to follow LWIP (LWIP::Interface::get_interface_name) format, index should not include leading zeros.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@AriParkkila @kjbracey-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
