### PR TITLE
Cellular: Add flow control (IFC) in BG96 AT driver

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -1368,7 +1368,7 @@ TEST_F(TestATHandler, test_ATHandler_sync)
     EXPECT_EQ(false, at.sync(100));
 
     fh1.size_value = 8;
-    char table[] = "OK\r\n\0";
+    char table[] = "+CMEE: 1\r\nOK\r\n\0";
     filehandle_stub_table = table;
 
     at.flush();

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1574,7 +1574,13 @@ bool ATHandler::sync(int timeout_ms)
         // especially a common response like OK could be response to previous request.
         clear_error();
         _start_time = rtos::Kernel::get_ms_count();
-        at_cmd_discard("+CMEE", "?");
+        cmd_start("AT+CMEE?");
+        cmd_stop();
+        resp_start();
+        set_stop_tag("+CMEE:");
+        consume_to_stop_tag();
+        set_stop_tag(OK);
+        consume_to_stop_tag();
         if (!_last_err) {
             _at_timeout = timeout;
             unlock();

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -102,15 +102,21 @@ nsapi_error_t QUECTEL_BG96::soft_power_on()
     if (_pwr.is_connected()) {
         tr_info("QUECTEL_BG96::soft_power_on");
         // check if modem was powered on already
-        if (wake_up()) {
-            return NSAPI_ERROR_OK;
-        }
-        if (!wake_up(true)) {
-            tr_error("Modem not responding");
-            soft_power_off();
-            return NSAPI_ERROR_DEVICE_ERROR;
+        if (!wake_up()) {
+            if (!wake_up(true)) {
+                tr_error("Modem not responding");
+                soft_power_off();
+                return NSAPI_ERROR_DEVICE_ERROR;
+            }
         }
     }
+
+#if defined (MBED_CONF_QUECTEL_BG96_RTS) && defined(MBED_CONF_QUECTEL_BG96_CTS)
+    if (_at->at_cmd_discard("+IFC", "=", "%d%d", 2, 2) != NSAPI_ERROR_OK) {
+        tr_warn("Set flow control failed");
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+#endif
 
     return NSAPI_ERROR_OK;
 }


### PR DESCRIPTION
### Description

Add flow control (IFC) in BG96 AT driver when `rts` and `cts` pins are defined in json configuration.
Also fixed `ATHandler::sync` to consume response `OK`.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kivaisan 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
