### PR TITLE
Equeue chain, add documentation of using equeue_destroy

### DIFF
--- a/TESTS/events/equeue/main.cpp
+++ b/TESTS/events/equeue/main.cpp
@@ -742,8 +742,8 @@ static void test_equeue_chain()
     TEST_ASSERT_EQUAL_UINT8(3, touched1);
     TEST_ASSERT_EQUAL_UINT8(3, touched2);
 
-    equeue_destroy(&q1);
     equeue_destroy(&q2);
+    equeue_destroy(&q1);
 }
 
 /** Test that unchaining equeues makes them work on their own.

--- a/UNITTESTS/events/equeue/test_equeue.cpp
+++ b/UNITTESTS/events/equeue/test_equeue.cpp
@@ -765,8 +765,8 @@ TEST_F(TestEqueue, test_equeue_chain)
     EXPECT_EQ(3, touched1);
     EXPECT_EQ(3, touched2);
 
-    equeue_destroy(&q1);
     equeue_destroy(&q2);
+    equeue_destroy(&q1);
 }
 
 /** Test that unchaining equeues makes them work on their own.

--- a/events/equeue.h
+++ b/events/equeue.h
@@ -93,6 +93,9 @@ typedef struct equeue {
 //
 // If the event queue creation fails, equeue_create returns a negative,
 // platform-specific error code.
+//
+// If queues are chained, it is needed to unchain them first, before calling destroy,
+// or call the destroy function on queues in order that chained queues are destroyed first.
 int equeue_create(equeue_t *queue, size_t size);
 int equeue_create_inplace(equeue_t *queue, size_t size, void *buffer);
 void equeue_destroy(equeue_t *queue);

--- a/events/source/tests/tests.c
+++ b/events/source/tests/tests.c
@@ -606,8 +606,8 @@ void chain_test(void)
 
     test_assert(touched == 6);
 
-    equeue_destroy(&q1);
     equeue_destroy(&q2);
+    equeue_destroy(&q1);
 }
 
 void unchain_test(void)


### PR DESCRIPTION
### Description
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

If queues are chained, it is needed to unchain them first, before calling destroy, or call the destroy function on queues in order that chained queues are destroyed first. Destroying queues in wrong order would result in errors or other program malfunctions.
Fixes: #11482

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@maciejbocianski @jamesbeyond @kimlep01 @geky @kjbracey-arm 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
