### PR TITLE
Update to Mbed TLS 2.19.1

### DIFF
--- a/features/mbedtls/VERSION.txt
+++ b/features/mbedtls/VERSION.txt
@@ -1,1 +1,1 @@
-mbedtls-2.19.0
+mbedtls-2.19.1

--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -27,7 +27,7 @@
 #
 
 # Set the mbed TLS release to import (this can/should be edited before import)
-MBED_TLS_RELEASE ?= mbedtls-2.19.0
+MBED_TLS_RELEASE ?= mbedtls-2.19.1
 MBED_TLS_REPO_URL ?= git@github.com:ARMmbed/mbedtls-restricted.git
 
 # Translate between mbed TLS namespace and mbed namespace

--- a/features/mbedtls/inc/mbedtls/check_config.h
+++ b/features/mbedtls/inc/mbedtls/check_config.h
@@ -305,6 +305,14 @@
 #error "MBEDTLS_MEMORY_BUFFER_ALLOC_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_MEMORY_BACKTRACE) && !defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+#error "MBEDTLS_MEMORY_BACKTRACE defined, but not all prerequesites"
+#endif
+
+#if defined(MBEDTLS_MEMORY_DEBUG) && !defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+#error "MBEDTLS_MEMORY_DEBUG defined, but not all prerequesites"
+#endif
+
 #if defined(MBEDTLS_PADLOCK_C) && !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_PADLOCK_C defined, but not all prerequisites"
 #endif

--- a/features/mbedtls/inc/mbedtls/ssl.h
+++ b/features/mbedtls/inc/mbedtls/ssl.h
@@ -970,7 +970,8 @@ struct mbedtls_ssl_config
      *  tls_prf and random bytes. Should replace f_export_keys    */
     int (*f_export_keys_ext)( void *, const unsigned char *,
                 const unsigned char *, size_t, size_t, size_t,
-                unsigned char[32], unsigned char[32], mbedtls_tls_prf_types );
+                const unsigned char[32], const unsigned char[32],
+                mbedtls_tls_prf_types );
     void *p_export_keys;            /*!< context for key export callback    */
 #endif
 
@@ -1925,8 +1926,8 @@ typedef int mbedtls_ssl_export_keys_ext_t( void *p_expkey,
                                            size_t maclen,
                                            size_t keylen,
                                            size_t ivlen,
-                                           unsigned char client_random[32],
-                                           unsigned char server_random[32],
+                                           const unsigned char client_random[32],
+                                           const unsigned char server_random[32],
                                            mbedtls_tls_prf_types tls_prf_type );
 #endif /* MBEDTLS_SSL_EXPORT_KEYS */
 

--- a/features/mbedtls/src/ssl_tls.c
+++ b/features/mbedtls/src/ssl_tls.c
@@ -1427,9 +1427,8 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
                                       master, keyblk,
                                       mac_key_len, keylen,
                                       iv_copy_len,
-                                      /* work around bug in exporter type */
-                                      (unsigned char *) randbytes + 32,
-                                      (unsigned char *) randbytes,
+                                      randbytes + 32,
+                                      randbytes,
                                       tls_prf_get_type( tls_prf ) );
     }
 #endif

--- a/features/nanostack/sal-stack-nanostack/source/Security/protocols/tls_sec_prot/tls_sec_prot_lib.c
+++ b/features/nanostack/sal-stack-nanostack/source/Security/protocols/tls_sec_prot/tls_sec_prot_lib.c
@@ -85,8 +85,8 @@ static int tls_sec_prot_lib_ssl_send(void *ctx, const unsigned char *buf, size_t
 static int tls_sec_prot_lib_ssl_recv(void *ctx, unsigned char *buf, size_t len);
 static int tls_sec_prot_lib_ssl_export_keys(void *p_expkey, const unsigned char *ms,
                                             const unsigned char *kb, size_t maclen, size_t keylen,
-                                            size_t ivlen, unsigned char client_random[32],
-                                            unsigned char server_random[32],
+                                            size_t ivlen, const unsigned char client_random[32],
+                                            const unsigned char server_random[32],
                                             mbedtls_tls_prf_types tls_prf_type);
 #ifdef TLS_SEC_PROT_LIB_TLS_DEBUG
 static void tls_sec_prot_lib_debug(void *ctx, int level, const char *file, int line, const char *string);
@@ -405,8 +405,8 @@ static int tls_sec_prot_lib_ssl_recv(void *ctx, unsigned char *buf, size_t len)
 
 static int tls_sec_prot_lib_ssl_export_keys(void *p_expkey, const unsigned char *ms,
                                             const unsigned char *kb, size_t maclen, size_t keylen,
-                                            size_t ivlen, unsigned char client_random[32],
-                                            unsigned char server_random[32],
+                                            size_t ivlen, const unsigned char client_random[32],
+                                            const unsigned char server_random[32],
                                             mbedtls_tls_prf_types tls_prf_type)
 {
     (void) kb;


### PR DESCRIPTION
### Description

Mbed TLS 2.19.1 will correct an API mistake in the key exporter feature.


### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [X] Breaking change

### Release Notes

The Mbed TLS key export feature's export keys callback, new in Mbed TLS 2.19.0, now requires use of `const` on its hello.random buffers (7th and 8th parameters). This is an API change.

`f_export_keys_ext` in ssl.h now has signature:
```C
     int (*f_export_keys_ext)( void *, const unsigned char *,
                 const unsigned char *, size_t, size_t, size_t,
                 const unsigned char[32], const unsigned char[32],
                 mbedtls_tls_prf_types );
```
