### PR TITLE
Fix Coverity issue: Initialize FlashIAP non-static member in constructor

### DIFF
--- a/drivers/FlashIAP.h
+++ b/drivers/FlashIAP.h
@@ -63,8 +63,10 @@ namespace mbed {
  */
 class FlashIAP : private NonCopyable<FlashIAP> {
 public:
-    FlashIAP();
-    ~FlashIAP();
+    constexpr FlashIAP() : _flash(), _page_buf(nullptr)
+    {
+
+    }
 
     /** Initialize a flash IAP device
      *

--- a/drivers/source/FlashIAP.cpp
+++ b/drivers/source/FlashIAP.cpp
@@ -46,16 +46,6 @@ static inline bool is_aligned(uint32_t number, uint32_t alignment)
     }
 }
 
-FlashIAP::FlashIAP() : _page_buf(nullptr)
-{
-
-}
-
-FlashIAP::~FlashIAP()
-{
-
-}
-
 int FlashIAP::init()
 {
     int ret = 0;

--- a/platform/NonCopyable.h
+++ b/platform/NonCopyable.h
@@ -172,11 +172,11 @@ protected:
     /**
      * Disallow construction of NonCopyable objects from outside of its hierarchy.
      */
-    NonCopyable() { }
+    NonCopyable() = default;
     /**
      * Disallow destruction of NonCopyable objects from outside of its hierarchy.
      */
-    ~NonCopyable() { }
+    ~NonCopyable() = default;
 
 #if (!defined(MBED_DEBUG) && (MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR == 0))
     /**


### PR DESCRIPTION
### Description
Issue fixed:
`FlashIAP.cpp:52 Non-static class member field _flash.dummy is not initialized in this constructor nor in any functions that it calls.`
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
