### PR TITLE
Improve cellular unittests

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellularbase/at_cellularbasetest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularbase/at_cellularbasetest.cpp
@@ -53,6 +53,11 @@ public:
     {
         return get_property(PROPERTY_AT_CGDATA);
     }
+
+    void reset_property_array()
+    {
+        _property_array = NULL;
+    }
 };
 
 // AStyle ignored as the definition is not clear due to preprocessor usage
@@ -136,4 +141,19 @@ TEST_F(TestAT_CellularBase, test_AT_CellularBase_is_supported)
 
     EXPECT_EQ(true,  my_at.check_supported());
     EXPECT_EQ(false, my_at.check_not_supported());
+}
+
+TEST_F(TestAT_CellularBase, test_invalid_params)
+{
+    EventQueue eq;
+    FileHandle_stub fh;
+    ATHandler ah(&fh, eq, 0, ",");
+    my_base my_at(ah);
+
+    my_at.reset_property_array(); // as array is a static variable, it might have been set in previous tests
+
+    my_at.set_cellular_properties(NULL);
+
+    // Property array not set
+    EXPECT_EQ(0, my_at.get_property(AT_CellularBase::PROPERTY_IPV4_PDP_TYPE));
 }

--- a/UNITTESTS/features/cellular/framework/common/list/listtest.cpp
+++ b/UNITTESTS/features/cellular/framework/common/list/listtest.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gtest/gtest.h"
+#include "CellularList.h"
+
+using namespace mbed;
+
+// AStyle ignored as the definition is not clear due to preprocessor usage
+// *INDENT-OFF*
+class Testlist : public testing::Test {
+protected:
+
+    void SetUp()
+    {
+    }
+
+    void TearDown()
+    {
+    }
+};
+// *INDENT-ON*
+
+struct entry_t {
+    int i;
+    entry_t *next;
+};
+
+TEST_F(Testlist, test_list_int)
+{
+    CellularList<entry_t> list;
+    EXPECT_TRUE(NULL == list.get_head());
+
+    entry_t *first = list.add_new();
+    first->i = 1;
+    EXPECT_TRUE(NULL != first);
+
+    entry_t *second = list.add_new();
+    first->i = 2;
+    EXPECT_TRUE(NULL != second);
+
+    entry_t *third = list.add_new();
+    first->i = 3;
+    EXPECT_TRUE(NULL != third);
+
+    EXPECT_EQ(3, list.get_head()->i);
+
+    list.delete_last(); // Deletes first
+    EXPECT_EQ(3, list.get_head()->i);
+
+    list.delete_all();
+    EXPECT_TRUE(NULL == list.get_head());
+}
+
+TEST_F(Testlist, delete_last_until_empty)
+{
+    CellularList<entry_t> list;
+    list.add_new();
+    list.add_new();
+    list.delete_last();
+    list.delete_last();
+    EXPECT_TRUE(NULL == list.get_head());
+}
+
+TEST_F(Testlist, empty_list_delete_last)
+{
+    CellularList<entry_t> list;
+    list.delete_last();
+    EXPECT_TRUE(NULL == list.get_head());
+}
+
+TEST_F(Testlist, empty_list_delete_all)
+{
+    CellularList<entry_t> list;
+    list.delete_all();
+    EXPECT_TRUE(NULL == list.get_head());
+}

--- a/UNITTESTS/features/cellular/framework/common/list/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/common/list/unittest.cmake
@@ -1,0 +1,19 @@
+
+####################
+# UNIT TESTS
+####################
+
+# Add test specific include paths
+set(unittest-includes ${unittest-includes}
+  features/cellular/framework/common/util
+  ../features/cellular/framework/common
+)
+
+# Source files
+set(unittest-sources
+)
+
+# Test files
+set(unittest-test-sources
+  features/cellular/framework/common/list/listtest.cpp
+)

--- a/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
+++ b/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
@@ -53,6 +53,47 @@ TEST_F(Testutil, test_util_binary_str_to_uint)
     EXPECT_TRUE(0 == binary_str_to_uint(binary_str, 0));
 }
 
+TEST_F(Testutil, hex_to_char)
+{
+    char output;
+
+    // 0
+    hex_to_char("00", output);
+    EXPECT_EQ((char)0x00, output);
+
+    // <128
+    hex_to_char("10", output);
+    EXPECT_EQ((char)0x10, output);
+
+    // =128
+    hex_to_char("80", output);
+    EXPECT_EQ((char)0x80, output);
+
+    // >128
+    hex_to_char("FF", output);
+    EXPECT_EQ((char)0xFF, output);
+
+    // Null -> output is not modified
+    hex_to_char(NULL, output);
+    EXPECT_EQ((char)0xFF, output);
+}
+
+TEST_F(Testutil, hex_str_to_char_str)
+{
+    char input[] = "0165AABBCC";
+    char output[32];
+    EXPECT_EQ(5, hex_str_to_char_str(input, strlen(input), output));
+    EXPECT_EQ((char)0x01, output[0]);
+    EXPECT_EQ((char)0x65, output[1]);
+    EXPECT_EQ((char)0xAA, output[2]);
+    EXPECT_EQ((char)0xBB, output[3]);
+    EXPECT_EQ((char)0xCC, output[4]);
+
+    // NULL params
+    EXPECT_EQ(0, hex_str_to_char_str(NULL, 2, output));
+    EXPECT_EQ(0, hex_str_to_char_str(input, strlen(input), NULL));
+}
+
 TEST_F(Testutil, test_util_uint_to_binary_string)
 {
     char str[33];

--- a/UNITTESTS/features/cellular/framework/device/cellulardevice/cellulardevicetest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellulardevice/cellulardevicetest.cpp
@@ -240,3 +240,35 @@ TEST_F(TestCellularDevice, test_shutdown)
 
     delete dev;
 }
+
+TEST_F(TestCellularDevice, test_timeout_array)
+{
+    FileHandle_stub fh1;
+    myCellularDevice *dev = new myCellularDevice(&fh1);
+    EXPECT_TRUE(dev);
+
+    CellularStateMachine_stub::nsapi_error_value = NSAPI_ERROR_OK;
+
+    // Max size
+    uint16_t set_timeouts[CELLULAR_RETRY_ARRAY_SIZE + 1];
+    for (int i = 0; i < CELLULAR_RETRY_ARRAY_SIZE; i++) {
+        set_timeouts[i] = i + 100;
+    }
+    dev->set_retry_timeout_array(set_timeouts, CELLULAR_RETRY_ARRAY_SIZE);
+
+    uint16_t verify_timeouts[CELLULAR_RETRY_ARRAY_SIZE + 1];
+    for (int i = 0; i < CELLULAR_RETRY_ARRAY_SIZE; i++) {
+        verify_timeouts[i] = i + 100;
+    }
+    dev->verify_timeout_array(verify_timeouts, CELLULAR_RETRY_ARRAY_SIZE);
+
+    // Empty
+    dev->set_retry_timeout_array(NULL, 0);
+    dev->verify_timeout_array(NULL, 0);
+
+    // Oversize (returns only CELLULAR_RETRY_ARRAY_SIZE)
+    dev->set_retry_timeout_array(set_timeouts, CELLULAR_RETRY_ARRAY_SIZE + 1);
+    dev->verify_timeout_array(verify_timeouts, CELLULAR_RETRY_ARRAY_SIZE);
+
+    delete dev;
+}

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -54,6 +54,8 @@ int ATHandler_stub::int_valid_count_table[kRead_int_table_size];
 int ATHandler_stub::int_count = kRead_int_table_size;
 bool ATHandler_stub::process_oob_urc = false;
 
+std::vector<ATHandler_stub::urc_handler> ATHandler_stub::urc_handlers;
+
 int ATHandler_stub::read_string_index = kRead_string_table_size;
 const char *ATHandler_stub::read_string_table[kRead_string_table_size];
 int ATHandler_stub::resp_stop_success_count = kResp_stop_count_default;
@@ -111,6 +113,7 @@ bool ATHandler::get_debug() const
 
 ATHandler::~ATHandler()
 {
+    ATHandler_stub::urc_handlers.clear();
 }
 
 void ATHandler::inc_ref_count()
@@ -148,6 +151,9 @@ void ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()> cb)
     if (!cb) {
         return;
     }
+
+    ATHandler_stub::urc_handler handler = { .urc = urc, .cb = cb };
+    ATHandler_stub::urc_handlers.push_back(handler);
 
     if (ATHandler_stub::call_immediately) {
         cb();

--- a/UNITTESTS/stubs/ATHandler_stub.h
+++ b/UNITTESTS/stubs/ATHandler_stub.h
@@ -22,6 +22,7 @@
 #include "ATHandler.h"
 #include "FileHandle_stub.h"
 #include "Callback.h"
+#include "vector"
 
 #ifndef __AT_HANDLER_STUB_H__
 #define __AT_HANDLER_STUB_H__
@@ -60,6 +61,12 @@ extern int int_valid_count_table[kRead_int_table_size];
 extern int int_count;
 extern int resp_stop_success_count;
 extern bool process_oob_urc;
+
+struct urc_handler {
+    const char *urc;
+    mbed::Callback<void()> cb;
+};
+extern std::vector<urc_handler> urc_handlers;
 
 extern bool get_debug_flag;
 bool is_get_debug_run();

--- a/UNITTESTS/stubs/CellularStateMachine_stub.cpp
+++ b/UNITTESTS/stubs/CellularStateMachine_stub.cpp
@@ -24,10 +24,12 @@ nsapi_error_t CellularStateMachine_stub::nsapi_error_value = NSAPI_ERROR_OK;
 CellularStubState CellularStateMachine_stub::get_current_target_state = STATE_INIT;
 CellularStubState CellularStateMachine_stub::get_current_current_state = STATE_INIT;
 bool CellularStateMachine_stub::bool_value = false;
+std::vector<uint16_t> CellularStateMachine_stub::timeouts;
 
 CellularStateMachine::CellularStateMachine(CellularDevice &device, events::EventQueue &queue, CellularNetwork &nw) :
     _cellularDevice(device), _network(nw), _queue(queue)
 {
+    CellularStateMachine_stub::timeouts.clear();
 }
 
 CellularStateMachine::~CellularStateMachine()
@@ -77,11 +79,21 @@ void CellularStateMachine::cellular_event_changed(nsapi_event_t ev, intptr_t ptr
 
 void CellularStateMachine::get_retry_timeout_array(uint16_t *timeout, int &array_len) const
 {
-
+    const int array_size = CellularStateMachine_stub::timeouts.size();
+    for (int i = 0; i < array_size; i++) {
+        timeout[i] = CellularStateMachine_stub::timeouts[i];
+    }
+    array_len = array_size;
 }
 
 void CellularStateMachine::set_retry_timeout_array(const uint16_t timeout[], int array_len)
 {
+    CellularStateMachine_stub::timeouts.clear();
+
+    const int real_size = array_len > CELLULAR_RETRY_ARRAY_SIZE ? CELLULAR_RETRY_ARRAY_SIZE : array_len;
+    for (int i = 0; i < real_size; i++) {
+        CellularStateMachine_stub::timeouts.push_back(timeout[i]);
+    }
 }
 
 void CellularStateMachine::set_timeout(int timeout)

--- a/UNITTESTS/stubs/CellularStateMachine_stub.h
+++ b/UNITTESTS/stubs/CellularStateMachine_stub.h
@@ -18,6 +18,7 @@
 #define CELLULARSTATEMACHINE_STUB_H_
 
 #include "CellularStateMachine.h"
+#include <vector>
 
 enum CellularStubState {
     STATE_INIT = 0,
@@ -35,6 +36,7 @@ extern nsapi_error_t nsapi_error_value;
 extern CellularStubState get_current_target_state;
 extern CellularStubState get_current_current_state;
 extern bool bool_value;
+extern std::vector<uint16_t> timeouts;
 }
 
 

--- a/UNITTESTS/target_h/myCellularDevice.h
+++ b/UNITTESTS/target_h/myCellularDevice.h
@@ -22,6 +22,7 @@
 #include "FileHandle_stub.h"
 #include "ATHandler_stub.h"
 #include "AT_CellularContext.h"
+#include "gtest/gtest.h"
 
 using namespace events;
 
@@ -175,6 +176,24 @@ public:
     {
         return NSAPI_ERROR_OK;
     }
+
+    void verify_timeout_array(const uint16_t timeout[], int array_len)
+    {
+        if (array_len > CELLULAR_RETRY_ARRAY_SIZE) {
+            FAIL();
+        }
+        uint16_t get_timeouts[CELLULAR_RETRY_ARRAY_SIZE];
+        int get_timeouts_len = 0;
+
+        get_retry_timeout_array(get_timeouts, get_timeouts_len);
+
+        EXPECT_EQ(array_len, get_timeouts_len);
+
+        for (int i = 0; i < array_len; i++) {
+            EXPECT_EQ(timeout[i], get_timeouts[i]);
+        }
+    }
+
     AT_CellularNetwork *_network;
     AT_CellularContext *_context_list;
 };

--- a/UNITTESTS/target_h/myCellularDevice.h
+++ b/UNITTESTS/target_h/myCellularDevice.h
@@ -35,7 +35,7 @@ class FileHandle;
 class myCellularDevice : public CellularDevice {
 public:
     myCellularDevice(FileHandle *fh) : CellularDevice(fh), _context_list(0), _network(0) {}
-    ~myCellularDevice()
+    virtual ~myCellularDevice()
     {
         delete _context_list;
         delete _network;
@@ -121,11 +121,6 @@ public:
     virtual void modem_debug_on(bool on) {}
 
     virtual nsapi_error_t init()
-    {
-        return NSAPI_ERROR_OK;
-    }
-
-    virtual nsapi_error_t shutdown()
     {
         return NSAPI_ERROR_OK;
     }

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -338,8 +338,8 @@ public:
 
     /** Check if there is any PDP context active. If cid is given, then check is done only for that cid.
      *
-     *  @param number_of_active_contexts    If given then in return contains the number of active contexts
-     *  @param cid                          If given then active contexts are checked only against this cid
+     *  @param number_of_active_contexts    If given then in return contains the number of all active contexts
+     *  @param cid                          If given then check if the context with this cid is active
      *
      *  @return true if any (or the given cid) context is active, false otherwise or in case of error
      */

--- a/features/cellular/framework/common/CellularUtil.cpp
+++ b/features/cellular/framework/common/CellularUtil.cpp
@@ -278,11 +278,13 @@ int hex_str_to_int(const char *hex_string, int hex_string_length)
 int hex_str_to_char_str(const char *str, uint16_t len, char *buf)
 {
     int strcount = 0;
-    for (int i = 0; i + 1 < len; i += 2) {
-        char tmp;
-        hex_to_char(str + i, tmp);
-        buf[strcount] = tmp;
-        strcount++;
+    if (str && buf) {
+        for (int i = 0; i + 1 < len; i += 2) {
+            char tmp;
+            hex_to_char(str + i, tmp);
+            buf[strcount] = tmp;
+            strcount++;
+        }
     }
 
     return strcount;
@@ -290,9 +292,11 @@ int hex_str_to_char_str(const char *str, uint16_t len, char *buf)
 
 void hex_to_char(const char *hex, char &buf)
 {
-    int upper = hex_str_to_int(hex, 1);
-    int lower = hex_str_to_int(hex + 1, 1);
-    buf = ((upper << 4) & 0xF0) | (lower & 0x0F);
+    if (hex) {
+        int upper = hex_str_to_int(hex, 1);
+        int lower = hex_str_to_int(hex + 1, 1);
+        buf = ((upper << 4) & 0xF0) | (lower & 0x0F);
+    }
 }
 
 void uint_to_binary_str(uint32_t num, char *str, int str_size, int bit_cnt)


### PR DESCRIPTION
### Description

Improved UT test coverage of cellular components. 

No functional changes to actual code except some pointer validity checks on some methods. Also clarifiied documentation of `CellularNetwork::is_active_context` method. 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@OPpuolitaival @AnttiKauppila 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
