### PR TITLE
Cellular: Fix stop tag for Quectel M26 send command

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -439,6 +439,7 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
     _at.resp_start(">");
     _at.write_bytes((uint8_t *)data, sent_len);
     _at.resp_start();
+    _at.set_stop_tag("\r\n");
     _at.resp_stop();
 
     if (_at.get_last_error() != NSAPI_ERROR_OK) {


### PR DESCRIPTION
### Description

Possible responses for send command are SEND OK, SEND FAIL or ERROR so normal OK response check does not work properly.

Issue: https://github.com/ARMmbed/mbed-os/issues/10854

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@mirelachirica 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
