### PR TITLE
Update template argument names to not collide with Arduino names

### DIFF
--- a/drivers/internal/Task.h
+++ b/drivers/internal/Task.h
@@ -29,7 +29,7 @@ namespace events {
  */
 
 
-template<typename F, typename A1 = void, typename A2 = void, typename A3 = void, typename A4 = void, typename A5 = void>
+template<typename F, typename ARG1 = void, typename ARG2 = void, typename ARG3 = void, typename ARG4 = void, typename ARG5 = void>
 struct AllArgs;
 
 template<typename B0>
@@ -543,22 +543,22 @@ private:
     All _args;
 };
 
-template <typename R, typename A0>
-class Task<R(A0)>: public TaskBase {
+template <typename R, typename ARG0>
+class Task<R(ARG0)>: public TaskBase {
 public:
 
-    Task(TaskQueue *q = NULL, mbed::Callback<R(A0)> cb = mbed::Callback<R(A0)>())
+    Task(TaskQueue *q = NULL, mbed::Callback<R(ARG0)> cb = mbed::Callback<R(ARG0)>())
         : TaskBase(q), _args(cb)
     {
     }
 
-    Task &operator=(mbed::Callback<R(A0)> cb)
+    Task &operator=(mbed::Callback<R(ARG0)> cb)
     {
         _args.b0 = cb;
         return *this;
     }
 
-    void call(A0 a0)
+    void call(ARG0 a0)
     {
         _args.b1 = a0;
         post();
@@ -578,7 +578,7 @@ protected:
     }
 
 private:
-    typedef AllArgs<mbed::Callback<R(A0)>, A0> All;
+    typedef AllArgs<mbed::Callback<R(ARG0)>, ARG0> All;
     All _args;
 };
 
@@ -586,8 +586,8 @@ private:
  *
  *  Representation of a postable task
  */
-template <typename R, typename A0, typename A1>
-class Task<R(A0, A1)>: public TaskBase {
+template <typename R, typename ARG0, typename ARG1>
+class Task<R(ARG0, ARG1)>: public TaskBase {
 public:
 
     /**
@@ -596,7 +596,7 @@ public:
      * @param q TaskQueue to post to
      * @param cb Callback to run
      */
-    Task(TaskQueue *q = NULL, mbed::Callback<R(A0, A1)> cb = mbed::Callback<R(A0, A1)>())
+    Task(TaskQueue *q = NULL, mbed::Callback<R(ARG0, ARG1)> cb = mbed::Callback<R(ARG0, ARG1)>())
         : TaskBase(q), _args(cb)
     {
     }
@@ -606,7 +606,7 @@ public:
      *
      * @param cb Callback to run
      */
-    Task &operator=(mbed::Callback<R(A0, A1)> cb)
+    Task &operator=(mbed::Callback<R(ARG0, ARG1)> cb)
     {
         _args.b0 = cb;
         return *this;
@@ -623,7 +623,7 @@ public:
      * @param a0 First callback parameter
      * @param a1 Second callback parameter
      */
-    void call(A0 a0, A1 a1)
+    void call(ARG0 a0, ARG1 a1)
     {
         _args.b1 = a0;
         _args.b2 = a1;
@@ -644,7 +644,7 @@ protected:
     }
 
 private:
-    typedef AllArgs<mbed::Callback<R(A0, A1)>, A0, A1> All;
+    typedef AllArgs<mbed::Callback<R(ARG0, ARG1)>, ARG0, ARG1> All;
     All _args;
 };
 

--- a/platform/FunctionPointer.h
+++ b/platform/FunctionPointer.h
@@ -32,37 +32,37 @@ namespace mbed {
 
 // Declarations for backwards compatibility
 // To be foward compatible, code should adopt the Callback class
-template <typename R, typename A1>
-class FunctionPointerArg1 : public Callback<R(A1)> {
+template <typename R, typename ARG1>
+class FunctionPointerArg1 : public Callback<R(ARG1)> {
 public:
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "FunctionPointerArg1<R, A> has been replaced by Callback<R(A)>")
-    FunctionPointerArg1(R(*function)(A1) = 0)
-        : Callback<R(A1)>(function) {}
+    FunctionPointerArg1(R(*function)(ARG1) = 0)
+        : Callback<R(ARG1)>(function) {}
 
     template<typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
                           "FunctionPointerArg1<R, A> has been replaced by Callback<R(A)>")
-    FunctionPointerArg1(T *object, R(T::*member)(A1))
-        : Callback<R(A1)>(object, member) {}
+    FunctionPointerArg1(T *object, R(T::*member)(ARG1))
+        : Callback<R(ARG1)>(object, member) {}
 
-    R(*get_function())(A1)
+    R(*get_function())(ARG1)
     {
-        return *reinterpret_cast<R(* *)(A1)>(this);
+        return *reinterpret_cast<R(* *)(ARG1)>(this);
     }
 
-    R call(A1 a1) const
+    R call(ARG1 a1) const
     {
-        if (!Callback<R(A1)>::operator bool()) {
+        if (!Callback<R(ARG1)>::operator bool()) {
             return (R)0;
         }
 
-        return Callback<R(A1)>::call(a1);
+        return Callback<R(ARG1)>::call(a1);
     }
 
-    R operator()(A1 a1) const
+    R operator()(ARG1 a1) const
     {
-        return Callback<R(A1)>::call(a1);
+        return Callback<R(ARG1)>::call(a1);
     }
 };
 


### PR DESCRIPTION
### Description
Several templated classes use "A1", "A2", etc as type argument names, which are the same as what mbed requires for Arduino header pin names, which can lead to naming conflicts when board targets define these names as macros.

We noticed this issue because the Cypress board-specific targets provide a header with macros which map arduino pin names to elements in a chip-specific enum. E.g.
```C
#define A1 P10_0
```
If parentheses are added around the macro value (per best practice), compilation fails with various, highly verbose errors related to the FunctionPointer template. Without the parentheses (what is in mbed today) the build succeeds, presumably because the #defines simply act as a still-valid rename of the template parameters.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
