### PR TITLE
STM32H7: split RAM usage

### DIFF
--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -849,6 +849,7 @@ typedef struct _mbed_error_ctx {
     int32_t is_error_processed;//once this error is processed set this value to 1
     uint32_t crc_error_ctx;//crc_error_ctx should always be the last member in this struct
 #endif
+    uint64_t dummy; // dummy to force data to be written in RAM
 } mbed_error_ctx;
 
 /** To generate a fatal compile-time error, you can use the pre-processor #error directive.

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -336,6 +336,7 @@ WEAK MBED_NORETURN mbed_error_status_t mbed_error(mbed_error_status_t error_stat
     core_util_critical_section_enter();
     memcpy(report_error_ctx, &last_error_ctx, sizeof(mbed_error_ctx));
     core_util_critical_section_exit();
+
     //We need not call delete_mbed_crc(crc_obj) here as we are going to reset the system anyway, and calling delete while handling a fatal error may cause nested exception
 #if MBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED && (MBED_CONF_PLATFORM_ERROR_REBOOT_MAX > 0)
 #ifndef NDEBUG


### PR DESCRIPTION
### Description

Following latest patches done on STM32H743 for ethernet (PR #11274), the test "tests-mbed_platform-crash_reporting" was failing. This was due to RAM relocation from 0x20000000 to 0x24000000.

In order to make this test a success, we need to have crash data ram partition in 0x20000000 area.
So, I decided to use this memory layout :

0x20000000 => int vect (as before ethernet patches)
0x20000298 => crash data ram (as before ethernet patches)
0x24000000 => ram (mandatory for ethernet)

latest commit of this PR concern an issue seen on STM32H7. Due to ECC cache mechanism, there is no guarantee that last data is written before a system reset. Adding a dummy will avoid this situation. See #11422 for more details.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

