### PR TITLE
Revert "Enable stats reporting with a flag in targets.json"

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -14,7 +14,6 @@
         "public": false,
         "default_lib": "std",
         "bootloader_supported": false,
-        "static_memory_defines": true,
         "config": {
             "console-uart": {
                 "help": "Target has UART console on pins STDIO_UART_TX, STDIO_UART_RX. Value is only significant if target has SERIAL device.",
@@ -7342,7 +7341,6 @@
     "MCU_NRF52832": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
-        "static_memory_defines": false,
         "macros": [
             "BOARD_PCA10040",
             "NRF52",
@@ -7644,7 +7642,6 @@
         "inherits": ["Target"],
         "components_add": ["QSPIF"],
         "core": "Cortex-M4F",
-        "static_memory_defines": false,
         "macros": [
             "BOARD_PCA10056",
             "NRF52840_XXAA",

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -920,8 +920,6 @@ class mbedToolchain:
 
         try:
             # Add all available ROM regions to build profile
-            if not getattr(self.target, "static_memory_defines", False):
-                raise ConfigException()
             rom_available_regions = self.config.get_all_active_memories(
                 ROM_ALL_MEMORIES
             )
@@ -936,8 +934,6 @@ class mbedToolchain:
             pass
         try:
             # Add all available RAM regions to build profile
-            if not getattr(self.target, "static_memory_defines", False):
-                raise ConfigException()
             ram_available_regions = self.config.get_all_active_memories(
                 RAM_ALL_MEMORIES
             )


### PR DESCRIPTION
This reverts commit 9dbdbe8e857cad7ddb5c945e475e1a25caa54126 - PR #9072

The reason for reverting the change is that MBED_ROM_START and MBED_ROM_SIZE are needed for configuring bootloader for NRF52840_DK. The reverted change is a workaround for an issue with online compiler when using MCU_NRF52832 and MCU_NRF52840 based boards.  The workaround prevents generation of those two defines. 

The workaround should be removed by this commit but the original issue with the online tool should be fixed first, if it's still valid. Please see the original workaround commit for further details.

High possibility that this breaks online compiler when the forementioned boards are used.

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [X] Breaking change

### Reviewers
@kjbracey-arm 
~~@theotherjimmy~~
@SeppoTakalo 

### Release Notes
