### PR TITLE
ESP8266 unlocks deep sleep when disconnected

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1275,4 +1275,9 @@ bool ESP8266::set_country_code_policy(bool track_ap, const char *country_code, i
     return done;
 }
 
+int ESP8266::uart_enable_input(bool enabled)
+{
+    return _serial.enable_input(enabled);
+}
+
 #endif

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -405,6 +405,14 @@ public:
     static const int8_t WIFIMODE_STATION_SOFTAP = 3;
     static const int8_t SOCKET_COUNT = 5;
 
+    /**
+     * Enables or disables uart input and deep sleep
+     *
+     * @param lock if TRUE, uart input is enabled and  deep sleep is locked
+     * if FALSE, uart input is disabled and  deep sleep is unlocked
+     */
+    int uart_enable_input(bool lock);
+
 private:
     // FW version
     struct fw_sdk_version _sdk_v;


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
As requested in: https://github.com/ARMmbed/mbed-os/issues/10059 in ESP8266 deep sleep is locked only while the network is active or ESP8266 commands are triggered. 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@SeppoTakalo 
@AnttiKauppila 
@kjbracey-arm 
@michalpasztamobica 
### Release Notes
This release contains changes for ESP8266. 
UART input is enabled and deep sleep is locked :
- if module is connected to the network
- for operations which communicate with the device but do not require network connectivity

UART input is disabled and deep sleep is unlocked : 
- if module is disconnected 
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
