### PR TITLE
Cypress Cordio Driver Update

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.h
@@ -112,6 +112,10 @@ private:
 #define WAKE_EVENT_ACTIVE_HIGH ( 1 )      /* Interrupt Rising Edge  */
 #define WAKE_EVENT_ACTIVE_LOW  ( 0 )      /* Interrupt Falling Edge */
 
+#if (defined(TARGET_CY8CPROTO_062_4343W))
+#define BT_UART_NO_3M_SUPPORT  ( 1 )
+#endif
+
 ble::vendor::cypress_ble::CyH4TransportDriver& ble_cordio_get_default_h4_transport_driver();
 ble::vendor::cypress_ble::CyH4TransportDriver& ble_cordio_get_h4_transport_driver();
 #endif

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.h
@@ -66,6 +66,12 @@ public:
 
     void bt_host_wake_irq_handler();
 
+#if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
+    void on_host_stack_inactivity();
+#endif
+
+    void update_uart_baud_rate(int baud);
+
     bool get_enabled_powersave();
     uint8_t get_host_wake_irq_event();
     uint8_t get_dev_wake_irq_event();
@@ -101,6 +107,7 @@ private:
 } // namespace ble
 
 #define DEF_BT_BAUD_RATE    (115200)
+#define DEF_BT_3M_BAUD_RATE (3000000)     /* Both Host and BT device have to be adapt to this */
 
 #define WAKE_EVENT_ACTIVE_HIGH ( 1 )      /* Interrupt Rising Edge  */
 #define WAKE_EVENT_ACTIVE_LOW  ( 0 )      /* Interrupt Falling Edge */

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/HCIDriver.cpp
@@ -29,11 +29,18 @@
 extern const int brcm_patch_ram_length;
 extern const uint8_t brcm_patchram_buf[];
 
+#ifndef BT_UART_NO_3M_SUPPORT
 static const uint8_t pre_brcm_patchram_buf[] = {
     // RESET followed by update uart baudrate
     0x03, 0x0C, 0x00,
         0x18, 0xFC, 0x06, 0x00, 0x00, 0xC0, 0xC6, 0x2D, 0x00,   //update uart baudrate 3 mbp
 };
+#else /* BT_UART_NO_3M_SUPPORT */
+static const uint8_t pre_brcm_patchram_buf[] = {
+    // RESET cmd
+    0x03, 0x0C, 0x00,
+};
+#endif /* BT_UART_NO_3M_SUPPORT */
 
 static const uint8_t pre_brcm_patchram_buf2[] = {
         //download mini driver
@@ -126,7 +133,9 @@ public:
             /* decode opcode */
             switch (opcode) {
                 case HCI_VS_CMD_UPDATE_UART_BAUD_RATE:
+#ifndef BT_UART_NO_3M_SUPPORT
                     cy_transport_driver.update_uart_baud_rate(DEF_BT_3M_BAUD_RATE);
+#endif /* BT_UART_NO_3M_SUPPORT */
 #ifdef CY_DEBUG
                     HciReadLocalVerInfoCmd();
 #else
@@ -333,9 +342,11 @@ private:
     // on PSoC6 to send hci download minidriver
     void prepare_service_pack_transfert2(void)
     {
+#ifndef BT_UART_NO_3M_SUPPORT
         cy_transport_driver.update_uart_baud_rate(DEF_BT_3M_BAUD_RATE);
+#endif /* BT_UART_NO_3M_SUPPORT */
         service_pack_ptr = pre_brcm_patchram_buf2;
-	service_pack_length = pre_brcm_patch_ram_length2;
+        service_pack_length = pre_brcm_patch_ram_length2;
         service_pack_next = &HCIDriver::start_service_pack_transfert;
         service_pack_index = 0;
         service_pack_transfered = false;
@@ -374,7 +385,11 @@ private:
         service_pack_next = NULL;
         service_pack_index = 0;
         service_pack_transfered = true;
+#ifndef BT_UART_NO_3M_SUPPORT
         HciUpdateUartBaudRate();
+#else /* BT_UART_NO_3M_SUPPORT */
+        set_sleep_mode();
+#endif /* BT_UART_NO_3M_SUPPORT */
         sleep_manager_unlock_deep_sleep();
     }
 


### PR DESCRIPTION
### Description

This change applies to only to the HCI driver for Cypress WiFi+BT (4343W and 43012) combo chipsets.

The Cypress Specific HCI Cordio Driver has been updated to add:

1. MCU and BT device low-power support
2. HCI UART enhanced to work at 3M baud rate for improved BT performance. In order to put the UART interface at 3M baud rate the state machine for initialization has been modified
3. Updated BT device-wake pin drive mode from input to output mode to be able wake up the BT device from low-power state when needed
4. Added delays to BT device wake de-assert function to ensure that UART data is drained

These changes are inter-connected and hence being merged together.
Test: mbed-os-example-ble-LED application and mbed-os-example-ble-Beacon application have been tested with the changes. The applications run as expected.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
