### PR TITLE
Fix USB tests working with python 3

### DIFF
--- a/TESTS/host_tests/pyusb_basic.py
+++ b/TESTS/host_tests/pyusb_basic.py
@@ -647,7 +647,7 @@ def get_descriptor_test(dev, vendor_id, product_id, log):
     # device descriptor
     try:
         ret = get_descriptor(dev, (DESC_TYPE_DEVICE << 8) | (0 << 0), 0, DEVICE_DESC_SIZE)
-        dev_desc = dict(zip(device_descriptor_keys, device_descriptor_parser.unpack(ret)))
+        dev_desc = dict(list(zip(device_descriptor_keys, device_descriptor_parser.unpack(ret))))
         raise_if_different(DEVICE_DESC_SIZE, dev_desc['bLength'], lineno(), text='Wrong device descriptor size !!!')
         raise_if_different(vendor_id, dev_desc['idVendor'], lineno(), text='Wrong vendor id !!!')
         raise_if_different(product_id, dev_desc['idProduct'], lineno(), text='Wrong product id !!!')
@@ -657,7 +657,7 @@ def get_descriptor_test(dev, vendor_id, product_id, log):
     # configuration descriptor
     try:
         ret = get_descriptor(dev, (DESC_TYPE_CONFIG << 8) | (0 << 0), 0, CONFIGURATION_DESC_SIZE)
-        conf_desc = dict(zip(configuration_descriptor_keys, configuration_descriptor_parser.unpack(ret)))
+        conf_desc = dict(list(zip(configuration_descriptor_keys, configuration_descriptor_parser.unpack(ret))))
         raise_if_different(CONFIGURATION_DESC_SIZE, conf_desc['bLength'], lineno(), text='Wrong configuration descriptor size !!!')
     except usb.core.USBError:
         raise_unconditionally(lineno(), "Requesting configuration descriptor failed")

--- a/TESTS/host_tests/usb_device_serial.py
+++ b/TESTS/host_tests/usb_device_serial.py
@@ -194,7 +194,7 @@ class USBSerialTest(mbed_host_tests.BaseHostTest):
             return
         mbed_serial.reset_output_buffer()
         mbed_serial.dtr = True
-        for byteval in itertools.chain(reversed(range(0x100)), range(0x100)):
+        for byteval in itertools.chain(reversed(list(range(0x100))), list(range(0x100))):
             try:
                 payload = bytearray(chunk_size * (byteval,))
                 mbed_serial.write(payload)


### PR DESCRIPTION
### Description

Fix USB related host_test python scripts to work on python 3 also


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jussisip could you test this?

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
