### PR TITLE
Bux fix: Context can be cleared using CGDCONT after sim ready state

### DIFF
--- a/features/cellular/framework/device/CellularStateMachine.cpp
+++ b/features/cellular/framework/device/CellularStateMachine.cpp
@@ -165,6 +165,12 @@ bool CellularStateMachine::open_sim()
     bool sim_ready = state == CellularDevice::SimStateReady;
 
     if (sim_ready) {
+#ifdef MBED_CONF_CELLULAR_CLEAR_ON_CONNECT
+        if (_cellularDevice.clear() != NSAPI_ERROR_OK) {
+            tr_warning("CellularDevice clear failed");
+            return false;
+        }
+#endif
         _cb_data.error = _network.set_registration(_plmn);
         tr_debug("STM: set_registration: %d, plmn: %s", _cb_data.error, _plmn ? _plmn : "NULL");
         if (_cb_data.error) {
@@ -345,13 +351,6 @@ bool CellularStateMachine::device_ready()
     }
 #endif // MBED_CONF_CELLULAR_DEBUG_AT
 
-#ifdef MBED_CONF_CELLULAR_CLEAR_ON_CONNECT
-    if (_cellularDevice.clear() != NSAPI_ERROR_OK) {
-        tr_warning("CellularDevice clear failed");
-        return false;
-    }
-#endif
-
     send_event_cb(CellularDeviceReady);
     _cellularDevice.set_ready_cb(0);
 
@@ -410,7 +409,6 @@ void CellularStateMachine::state_sim_pin()
             retry_state_or_fail();
             return;
         }
-
         if (_network.is_active_context()) { // check if context was already activated
             tr_debug("Active context found.");
             _status |= ACTIVE_PDP_CONTEXT;


### PR DESCRIPTION
### Description

<!--
Context can be cleared using CGDCONT only after sim ready state. 
-->
Context can be cleared using CGDCONT only after sim ready state. 

Target: C030-U201, C027, C030-R412M

### Pull request type

    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@MarceloSalazar @AriParkkila 
### Release Notes

<!--

-->
Relevant tickets 
https://github.com/ARMmbed/mbed-os/issues/11505
https://github.com/ARMmbed/mbed-os/pull/11469
