### PR TITLE
Sys timer should let deep sleep happen

### DIFF
--- a/platform/source/SysTimer.cpp
+++ b/platform/source/SysTimer.cpp
@@ -115,10 +115,9 @@ void SysTimer<US_IN_TICK, IRQ>::set_wake_time(uint64_t at)
         sleep_manager_lock_deep_sleep();
     }
 
-    /* If deep sleep is unlocked, and we have enough time, let's go for it */
+    /* If we have enough time for deep sleep, let's consider we may enter it */
     if (MBED_CONF_TARGET_DEEP_SLEEP_LATENCY > 0 &&
-            ticks_to_sleep > MBED_CONF_TARGET_DEEP_SLEEP_LATENCY &&
-            sleep_manager_can_deep_sleep()) {
+            ticks_to_sleep > MBED_CONF_TARGET_DEEP_SLEEP_LATENCY) {
         /* Schedule the wake up interrupt early, allowing for the deep sleep latency */
         _wake_early = true;
         insert_absolute(wake_time - MBED_CONF_TARGET_DEEP_SLEEP_LATENCY * US_IN_TICK);

--- a/platform/source/SysTimer.cpp
+++ b/platform/source/SysTimer.cpp
@@ -114,17 +114,21 @@ void SysTimer<US_IN_TICK, IRQ>::set_wake_time(uint64_t at)
         _deep_sleep_locked = true;
         sleep_manager_lock_deep_sleep();
     }
-
-    /* If we have enough time for deep sleep, let's consider we may enter it */
+    /* Consider whether we will need early or precise wake-up */
     if (MBED_CONF_TARGET_DEEP_SLEEP_LATENCY > 0 &&
-            ticks_to_sleep > MBED_CONF_TARGET_DEEP_SLEEP_LATENCY) {
-        /* Schedule the wake up interrupt early, allowing for the deep sleep latency */
+            ticks_to_sleep > MBED_CONF_TARGET_DEEP_SLEEP_LATENCY &&
+            !_deep_sleep_locked) {
+        /* If there is deep sleep latency, but we still have enough time,
+         * and we haven't blocked deep sleep ourselves,
+         * allow for that latency by requesting early wake-up.
+         * Actual sleep may or may not be deep, depending on other actors.
+         */
         _wake_early = true;
         insert_absolute(wake_time - MBED_CONF_TARGET_DEEP_SLEEP_LATENCY * US_IN_TICK);
     } else {
-        /* Otherwise, we'll set up for shallow sleep at the precise time.
-         * To make absolutely sure it's shallow so we don't incur the latency,
-         * take our own lock, to avoid a race on a thread unlocking it.
+        /* Otherwise, set up to wake at the precise time.
+         * If there is a deep sleep latency, ensure that we're holding the lock so the sleep
+         * is shallow. (If there is no deep sleep latency, we're fine with it being deep).
          */
         _wake_early = false;
         if (MBED_CONF_TARGET_DEEP_SLEEP_LATENCY > 0 && !_deep_sleep_locked) {


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type


<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kjbracey-arm @0xc0170 @jeromecoutant 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes
    When next SysTimer wake-up is scheduler far enough, always consider
    that deep sleep may be entered and program an early wake-up.

    So that even if deep sleep is only allowed some time later, it can be
    entered. If not doing this, then the deep sleep would be prevented by
    SysTimer itself and may not be entered at all.

    This has been proved to happen in a simple blinly example.

Proposed fixes to #11509

Has been tested with simple blinky example, but should be reviewed and tested by mbed-os core team.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
