### PR TITLE
Correct force inline syntax for IAR compiler

### DIFF
--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -83,8 +83,12 @@ public:
      *  @param func pointer to the function to be called
      *  @param t the time between calls in seconds
      */
-    template <typename F>
-    MBED_FORCEINLINE void attach(F &&func, float t)
+#if defined(__ICCARM__)
+    MBED_FORCEINLINE template <typename F>
+#else
+    template <typename F> MBED_FORCEINLINE
+#endif
+    void attach(F &&func, float t)
     {
         attach_us(std::forward<F>(func), t * 1000000.0f);
     }


### PR DESCRIPTION
### Description
The IAR compiler generates the following warning:
`[Warning] Ticker.h@87,0: [Pe606]: this pragma must immediately precede a declaration`

Unlinke other compilers supported, the IAR compiler requires the
pre-processor extension to force inline a method to be placed before
the keyword `template` if the method is declared with one.




<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
