### PR TITLE
Fix added to unlock AT handler mutex

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -117,7 +117,7 @@ nsapi_error_t UBLOX_AT::init()
     }
 #endif
 
-    return err;
+    return _at->unlock_return_error();
 }
 
 nsapi_error_t UBLOX_AT::config_authentication_parameters()


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Fix added to unlock AT handler mutex introduced in mbed-os 5.14 release candidates

Targets verified  with this fix : UBLOX_C030_U201 & UBLOX_C030_R412M

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@RobMeades @MarceloSalazar @AriParkkila 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
In mbed-os 5.14 release candidate1 and 2,  none of u-blox modem is working due to this problem 
