### PR TITLE
Improve QSPIFBlockDevice conformance to SFDP

### DIFF
--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -84,6 +84,7 @@ static uint32_t gen_flash_address()
 {
     srand(ticker_read(get_us_ticker_data()));
     uint32_t address = (((uint32_t)rand()) % QSPI_SECTOR_COUNT) * QSPI_SECTOR_SIZE;
+    address &= 0xFFFFFF; // Ensure address is within 24 bits so as to not have to deal with 4-byte addressing
     return address;
 }
 

--- a/TESTS/mbed_hal/qspi/qspi_test_utils.cpp
+++ b/TESTS/mbed_hal/qspi/qspi_test_utils.cpp
@@ -145,11 +145,11 @@ void flash_init(Qspi &qspi)
     // Zero out status register to attempt to clear block protection bits
     uint8_t blanks[QSPI_STATUS_REG_SIZE] = {0};
 
-    qspi.cmd.build(0x06);
+    qspi.cmd.build(QSPI_CMD_WREN);
     ret = qspi_command_transfer(&qspi.handle, qspi.cmd.get(), NULL, 0, NULL, 0);
     TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
 
-    qspi.cmd.build(0x01);
+    qspi.cmd.build(QSPI_CMD_WRSR);
     ret = qspi_command_transfer(&qspi.handle, qspi.cmd.get(), blanks, 1, NULL, 0);
     TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
 

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -31,7 +31,10 @@ using namespace mbed;
 /****************************/
 #define QSPIF_DEFAULT_PAGE_SIZE  256
 #define QSPIF_DEFAULT_SE_SIZE    4096
-#define QSPI_STATUS_REGISTER_COUNT 2
+// The SFDP spec only defines two status registers. But some devices,
+// have three "status-like" registers (one status, two config)
+#define QSPI_MAX_STATUS_REGISTERS 3
+#define QSPI_DEFAULT_STATUS_REGISTERS 2
 #ifndef UINT64_MAX
 #define UINT64_MAX -1
 #endif
@@ -110,6 +113,7 @@ using namespace mbed;
 
 // Device-specific instructions
 #define QSPIF_INST_ULBPR 0x98 // Clear all write-protection bits in the Block-Protection register
+#define QSPIF_INST_RDCR  0x15 // Read the two control registers
 
 // Default read/legacy erase instructions
 #define QSPIF_INST_READ_DEFAULT          0x03
@@ -174,6 +178,7 @@ QSPIFBlockDevice::QSPIFBlockDevice(PinName io0, PinName io1, PinName io2, PinNam
     _read_instruction = QSPIF_INST_READ_DEFAULT;
     _legacy_erase_instruction = QSPIF_INST_LEGACY_ERASE_DEFAULT;
 
+    _num_status_registers = QSPI_DEFAULT_STATUS_REGISTERS;
     // Set default status register 2 write/read instructions
     _write_status_reg_2_inst = QSPIF_INST_WSR2_DEFAULT;
     _read_status_reg_2_inst = QSPIF_INST_RSR2_DEFAULT;
@@ -757,8 +762,8 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, s
 
 int QSPIFBlockDevice::_sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr)
 {
-    uint8_t status_reg_setup[QSPI_STATUS_REGISTER_COUNT] = {0};
-    uint8_t status_regs[QSPI_STATUS_REGISTER_COUNT] = {0};
+    uint8_t status_reg_setup[QSPI_MAX_STATUS_REGISTERS] = {0};
+    uint8_t status_regs[QSPI_MAX_STATUS_REGISTERS] = {0};
 
     // QUAD Enable procedure is specified by 3 bits
     uint8_t qer_value = (basic_param_table_ptr[QSPIF_BASIC_PARAM_TABLE_QER_BYTE] & 0x70) >> 4;
@@ -807,7 +812,7 @@ int QSPIFBlockDevice::_sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr)
     _qspi_read_status_registers(status_regs);
 
     // Set Bits for Quad Enable
-    for (int i = 0; i < QSPI_STATUS_REGISTER_COUNT; i++) {
+    for (int i = 0; i < QSPI_MAX_STATUS_REGISTERS; i++) {
         status_regs[i] |= status_reg_setup[i];
     }
 
@@ -820,7 +825,7 @@ int QSPIFBlockDevice::_sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr)
     }
 
     // For Debug
-    memset(status_regs, 0, QSPI_STATUS_REGISTER_COUNT);
+    memset(status_regs, 0, QSPI_MAX_STATUS_REGISTERS);
     _qspi_read_status_registers(status_regs);
     if (((status_regs[0] & status_reg_setup[0]) | (status_regs[1] & status_reg_setup[1])) == 0) {
         tr_error("Status register not set correctly");
@@ -1233,6 +1238,14 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
             tr_debug("Applying quirks for SST");
             _clear_protection_method = QSPIF_BP_ULBPR;
             break;
+        case 0xc2:
+            // Macronix devices have two quirks:
+            // 1. Have one status register and 2 config registers, with a nonstandard instruction for reading the config registers
+            // 2. Require setting a "fast mode" bit in config register 2 to operate at higher clock rates
+            tr_debug("Applying quirks for macronix");
+            _num_status_registers = 3;
+            _read_status_reg_2_inst = QSPIF_INST_RDCR;
+            break;
     }
 
     return 0;
@@ -1240,7 +1253,7 @@ int QSPIFBlockDevice::_handle_vendor_quirks()
 
 int QSPIFBlockDevice::_clear_block_protection()
 {
-    uint8_t status_regs[QSPI_STATUS_REGISTER_COUNT] = {0};
+    uint8_t status_regs[QSPI_MAX_STATUS_REGISTERS] = {0};
 
     if (false == _is_mem_ready()) {
         tr_error("Device not ready, clearing block protection failed");
@@ -1329,10 +1342,9 @@ int QSPIFBlockDevice::_set_write_enable()
 
 int QSPIFBlockDevice::_enable_fast_mode()
 {
-    const int NUM_REGISTERS = QSPI_STATUS_REGISTER_COUNT + 1; // Status registers + one config register
-    char status_reg[NUM_REGISTERS] = {0};
+    char status_reg[QSPI_MAX_STATUS_REGISTERS] = {0};
     unsigned int read_conf_register_inst = 0x15;
-    char status_reg_qer_setup[NUM_REGISTERS] = {0};
+    char status_reg_qer_setup[QSPI_MAX_STATUS_REGISTERS] = {0};
 
     status_reg_qer_setup[2] = 0x2; // Bit 1 of config Reg 2
 
@@ -1347,7 +1359,7 @@ int QSPIFBlockDevice::_enable_fast_mode()
     // Read Status Register
     if (QSPI_STATUS_OK == _qspi_send_general_command(read_conf_register_inst, QSPI_NO_ADDRESS_COMMAND, NULL, 0,
                                                      &status_reg[1],
-                                                     NUM_REGISTERS - 1)) {  // store received values in status_value
+                                                     QSPI_MAX_STATUS_REGISTERS - 1)) {  // store received values in status_value
         tr_debug("Reading Config Register Success: value = 0x%x", (int)status_reg[2]);
     } else {
         tr_error("Reading Config Register failed");
@@ -1355,7 +1367,7 @@ int QSPIFBlockDevice::_enable_fast_mode()
     }
 
     // Set Bits for Quad Enable
-    for (int i = 0; i < NUM_REGISTERS; i++) {
+    for (int i = 0; i < QSPI_MAX_STATUS_REGISTERS; i++) {
         status_reg[i] |= status_reg_qer_setup[i];
     }
 
@@ -1366,7 +1378,7 @@ int QSPIFBlockDevice::_enable_fast_mode()
     }
 
     if (QSPI_STATUS_OK == _qspi_send_general_command(QSPIF_INST_WSR1, QSPI_NO_ADDRESS_COMMAND, status_reg,
-                                                     NUM_REGISTERS, NULL,
+                                                     QSPI_MAX_STATUS_REGISTERS, NULL,
                                                      0)) {   // Write Fast mode bit to status_register
         tr_debug("fast mode enable - Writing Config Register Success: value = 0x%x",
                  (int)status_reg[2]);
@@ -1381,10 +1393,10 @@ int QSPIFBlockDevice::_enable_fast_mode()
     }
 
     // For Debug
-    memset(status_reg, 0, NUM_REGISTERS);
+    memset(status_reg, 0, QSPI_MAX_STATUS_REGISTERS);
     if (QSPI_STATUS_OK == _qspi_send_general_command(read_conf_register_inst, QSPI_NO_ADDRESS_COMMAND, NULL, 0,
                                                      &status_reg[1],
-                                                     NUM_REGISTERS - 1)) {  // store received values in status_value
+                                                     QSPI_MAX_STATUS_REGISTERS - 1)) {  // store received values in status_value
         tr_debug("Verifying Config Register Success: value = 0x%x", (int)status_reg[2]);
     } else {
         tr_error("Verifying Config Register failed");
@@ -1647,12 +1659,16 @@ qspi_status_t QSPIFBlockDevice::_qspi_read_status_registers(uint8_t *reg_buffer)
         return status;
     }
 
-    // Read Status Register 2
+    // Read Status Register 2 (and beyond, if applicable)
+    unsigned int read_length = _num_status_registers - 1; // We already read status reg 1 above
     status = _qspi_send_general_command(_read_status_reg_2_inst, QSPI_NO_ADDRESS_COMMAND,
                                         NULL, 0,
-                                        (char *) &reg_buffer[1], 1);
+                                        (char *) &reg_buffer[1], read_length);
     if (QSPI_STATUS_OK == status) {
         tr_debug("Reading Status Register 2 Success: value = 0x%x", (int) reg_buffer[1]);
+        if (_num_status_registers > 2) {
+            tr_debug("Reading Register 3 Success: value = 0x%x", (int) reg_buffer[2]);
+        }
     } else {
         tr_error("Reading Status Register 2 failed");
         return status;
@@ -1672,17 +1688,21 @@ qspi_status_t QSPIFBlockDevice::_qspi_write_status_registers(uint8_t *reg_buffer
             return QSPI_STATUS_ERROR;
         }
         status = _qspi_send_general_command(QSPIF_INST_WSR1, QSPI_NO_ADDRESS_COMMAND,
-                                            (char *) reg_buffer, 2,
+                                            (char *) reg_buffer, _num_status_registers,
                                             NULL, 0);
         if (QSPI_STATUS_OK == status) {
             tr_debug("Writing Status Registers Success: reg 1 value = 0x%x, reg 2 value = 0x%x",
                      (int) reg_buffer[0], (int) reg_buffer[1]);
+            if (_num_status_registers > 2) {
+                tr_debug("Writing Register 3 Success: value = 0x%x", (int) reg_buffer[2]);
+            }
         } else {
             tr_error("Writing Status Registers failed");
             return status;
         }
     } else {
         // Status registers are written using different commands
+        MBED_ASSERT(_num_status_registers == 2); // This flow doesn't support a nonstandard third status/config register
 
         // Write status register 1
         if (_set_write_enable() != 0) {

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -1383,6 +1383,8 @@ qspi_status_t QSPIFBlockDevice::_qspi_update_4byte_ext_addr_reg(bd_addr_t addr)
 qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(qspi_inst_t read_inst, void *buffer, bd_addr_t addr,
                                                         bd_size_t size)
 {
+    tr_debug("Inst: 0x%xh, addr: %llu, size: %llu", read_inst, addr, size);
+
     size_t buf_len = size;
 
     qspi_status_t status = _qspi_update_4byte_ext_addr_reg(addr);
@@ -1422,6 +1424,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(qspi_inst_t read_inst, v
 qspi_status_t QSPIFBlockDevice::_qspi_send_program_command(qspi_inst_t progInst, const void *buffer, bd_addr_t addr,
                                                            bd_size_t *size)
 {
+    tr_debug("Inst: 0x%xh, addr: %llu, size: %llu", prog_inst, addr, *size);
 
     qspi_status_t status = _qspi_update_4byte_ext_addr_reg(addr);
     if (QSPI_STATUS_OK != status) {
@@ -1466,6 +1469,8 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_general_command(qspi_inst_t instructi
                                                            const char *tx_buffer,
                                                            mbed::bd_size_t tx_length, const char *rx_buffer, mbed::bd_size_t rx_length)
 {
+    tr_debug("Inst: 0x%xh, addr: %llu, tx length: %llu, rx length: %llu", instruction, addr, tx_length, rx_length);
+
     qspi_status_t status = _qspi_update_4byte_ext_addr_reg(addr);
     if (QSPI_STATUS_OK != status) {
         tr_error("QSPI Generic command - Updating 4-byte addressing extended address register failed");

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -1079,6 +1079,15 @@ int QSPIFBlockDevice::_sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_pa
             tr_debug("_sfdp_detect_and_enable_4byte_addressing - 4-byte addressing not supported, falling back to 3-byte addressing");
             _address_size = QSPI_CFG_ADDR_SIZE_24;
         }
+
+        if (_address_size == QSPI_CFG_ADDR_SIZE_32) {
+            // Update 1-1-1 format to match new address size
+            if (QSPI_STATUS_OK != _qspi.configure_format(QSPI_CFG_BUS_SINGLE, QSPI_CFG_BUS_SINGLE, _address_size, QSPI_CFG_BUS_SINGLE,
+                                                         0, QSPI_CFG_BUS_SINGLE, 0)) {
+                tr_error("_qspi_configure_format failed");
+                status = QSPIF_BD_ERROR_DEVICE_ERROR;
+            }
+        }
     }
 
     return status;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -1457,9 +1457,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_erase_command(qspi_inst_t erase_inst,
     }
 
     // Send erase command to driver
-    status = _qspi.command_transfer(erase_inst,
-                                    (((int) addr) & 0x00FFF000), // Align addr to 4096
-                                    NULL, 0, NULL, 0); // Do not transmit or receive
+    status = _qspi.command_transfer(erase_inst, (int) addr, NULL, 0, NULL, 0);
 
     if (QSPI_STATUS_OK != status) {
         tr_error("QSPI Erase failed");

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -113,9 +113,6 @@ enum qspif_default_instructions {
     QSPIF_ULBPR = 0x98, // Clears all write-protection bits in the Block-Protection register
 };
 
-// Local Function
-static int local_math_power(int base, int exp);
-
 // General QSPI instructions
 #define QSPIF_INST_WSR1  0x01 // Write status register 1
 #define QSPIF_INST_RSR1  0x05 // Read status register 1
@@ -882,7 +879,7 @@ int QSPIFBlockDevice::_sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int
     if (basic_param_table_size > QSPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE) {
         // Page Size is specified by 4 Bits (N), calculated by 2^N
         int page_to_power_size = ((int)basic_param_table_ptr[QSPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE]) >> 4;
-        page_size = local_math_power(2, page_to_power_size);
+        page_size = 1 << page_to_power_size;
         tr_debug("Detected Page Size: %d", page_size);
     } else {
         tr_debug("Using Default Page Size: %d", page_size);
@@ -1609,18 +1606,4 @@ qspi_status_t QSPIFBlockDevice::_qspi_write_status_registers(uint8_t *reg_buffer
     }
 
     return QSPI_STATUS_OK;
-}
- 
-/*********************************************/
-/************** Local Functions **************/
-/*********************************************/
-static int local_math_power(int base, int exp)
-{
-    // Integer X^Y function, used to calculate size fields given in 2^N format
-    int result = 1;
-    while (exp) {
-        result *= base;
-        exp--;
-    }
-    return result;
 }

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -31,7 +31,7 @@ using namespace mbed;
 /****************************/
 #define QSPIF_DEFAULT_PAGE_SIZE  256
 #define QSPIF_DEFAULT_SE_SIZE    4096
-#define QSPI_MAX_STATUS_REGISTER_SIZE 3
+#define QSPI_STATUS_REGISTER_COUNT 2
 #ifndef UINT64_MAX
 #define UINT64_MAX -1
 #endif
@@ -100,6 +100,14 @@ enum qspif_default_instructions {
 // Local Function
 static int local_math_power(int base, int exp);
 
+// General QSPI instructions
+#define QSPIF_INST_WSR1  0x01 // Write status register 1
+#define QSPIF_INST_RSR1  0x05 // Read status register 1
+
+// Default status register 2 read/write instructions
+#define QSPIF_INST_WSR2_DEFAULT    QSPI_NO_INST
+#define QSPIF_INST_RSR2_DEFAULT    0x35
+
 /* Init function to initialize Different Devices CS static list */
 static PinName *generate_initialized_active_qspif_csel_arr();
 // Static Members for different devices csel
@@ -125,6 +133,10 @@ QSPIFBlockDevice::QSPIFBlockDevice(PinName io0, PinName io1, PinName io2, PinNam
     } else {
         tr_error("Too many different QSPIFBlockDevice devices - max allowed: %d", QSPIF_MAX_ACTIVE_FLASH_DEVICES);
     }
+
+    // Set default status register 2 write/read instructions
+    _write_status_reg_2_inst = QSPIF_INST_WSR2_DEFAULT;
+    _read_status_reg_2_inst = QSPIF_INST_RSR2_DEFAULT;
 }
 
 int QSPIFBlockDevice::init()
@@ -172,9 +184,6 @@ int QSPIFBlockDevice::init()
     _alt_size = 0;
     _dummy_cycles = 0;
     _data_width = QSPI_CFG_BUS_SINGLE;
-    _write_register_inst = QSPIF_WRSR;
-    _read_register_inst = QSPIF_RDSR;
-
     if (QSPI_STATUS_OK != _qspi_set_frequency(_freq)) {
         tr_error("QSPI Set Frequency Failed");
         status = QSPIF_BD_ERROR_DEVICE_ERROR;
@@ -708,7 +717,6 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, s
     // Detect and Set fastest Bus mode (default 1-1-1)
     _sfdp_detect_best_bus_read_mode(param_table, basic_table_size, shouldSetQuadEnable, is_qpi_mode, _read_instruction);
     if (true == shouldSetQuadEnable) {
-        _enable_fast_mdoe();
         // Set Quad Enable and QPI Bus modes if Supported
         tr_debug("Init - Setting Quad Enable");
         if (0 != _sfdp_set_quad_enabled(param_table)) {
@@ -854,47 +862,34 @@ int QSPIFBlockDevice::_sfdp_set_qpi_enabled(uint8_t *basic_param_table_ptr)
 
 int QSPIFBlockDevice::_sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr)
 {
-    int sr_read_size = QSPI_MAX_STATUS_REGISTER_SIZE;
-    int sr_write_size = QSPI_MAX_STATUS_REGISTER_SIZE;
-
-    char status_reg_setup[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
-    char status_reg[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
+    uint8_t status_reg_setup[QSPI_STATUS_REGISTER_COUNT] = {0};
+    uint8_t status_regs[QSPI_STATUS_REGISTER_COUNT] = {0};
 
     // QUAD Enable procedure is specified by 3 bits
     uint8_t qer_value = (basic_param_table_ptr[QSPIF_BASIC_PARAM_TABLE_QER_BYTE] & 0x70) >> 4;
-
 
     switch (qer_value) {
         case 0:
             tr_debug("Device Does not Have a QE Bit, continue based on Read Inst");
             return 0;
-
         case 1:
         case 4:
-            status_reg_setup[1] = 0x02;  //Bit 1 of Status Reg 2
-            sr_write_size = 2;
+            status_reg_setup[1] = 1 << 1;  // Bit 1 of Status Reg 2
             tr_debug("Setting QE Bit, Bit 1 of Status Reg 2");
             break;
-
         case 2:
-            status_reg_setup[0] = 0x40; // Bit 6 of Status Reg 1
-            sr_write_size = 1;
+            status_reg_setup[0] = 1 << 6; // Bit 6 of Status Reg 1
             tr_debug("Setting QE Bit, Bit 6 of Status Reg 1");
             break;
-
         case 3:
-            status_reg_setup[0] = 0x80; // Bit 7 of Status Reg 1
-            sr_write_size = 1;
-            _write_register_inst = 0x3E;
-            _read_register_inst = 0x3F;
+            status_reg_setup[0] = 1 << 7; // Bit 7 of Status Reg 1
+            _write_status_reg_2_inst = 0x3E;
+            _read_status_reg_2_inst = 0x3F;
             tr_debug("Setting QE Bit, Bit 7 of Status Reg 1");
             break;
         case 5:
-            status_reg_setup[1] = 0x2; // Bit 1 of status Reg 2
-            _read_register_inst = 0x35;
-            sr_read_size = 1;
-            sr_write_size = 2;
-            tr_debug("Setting QE Bit, Bit 1 of Status Reg 2 -special read command");
+            status_reg_setup[1] = 1 << 1; // Bit 1 of status Reg 2
+            tr_debug("Setting QE Bit, Bit 1 of Status Reg 2");
             break;
         default:
             tr_warning("Unsuported QER configuration");
@@ -908,51 +903,27 @@ int QSPIFBlockDevice::_sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr)
         return -1;
     }
 
-    // Read Status Register
-    if (QSPI_STATUS_OK == _qspi_send_general_command(_read_register_inst, QSPI_NO_ADDRESS_COMMAND, NULL, 0,
-                                                     status_reg,
-                                                     sr_read_size)) {   // store received values in status_value
-        tr_debug("Reading Status Register Success: value = 0x%x", (int)status_reg[0]);
-    } else {
-        tr_error("Reading Status Register failed");
-        return -1;
-    }
+    // Read existing status register values
+    _qspi_read_status_registers(status_regs);
 
     // Set Bits for Quad Enable
-    for (int i = 0; i < QSPI_MAX_STATUS_REGISTER_SIZE; i++) {
-        status_reg[i] |= status_reg_setup[i];
+    for (int i = 0; i < QSPI_STATUS_REGISTER_COUNT; i++) {
+        status_regs[i] |= status_reg_setup[i];
     }
 
     // Write new Status Register Setup
-    if (_set_write_enable() != 0) {
-        tr_error("Write Enabe failed");
-        return -1;
-    }
-
-    if (QSPI_STATUS_OK == _qspi_send_general_command(_write_register_inst, QSPI_NO_ADDRESS_COMMAND, (char *)status_reg,
-                                                     sr_write_size, NULL,
-                                                     0)) {   // Write QE to status_register
-        tr_debug("_setQuadEnable - Writing Status Register Success: value = 0x%x",
-                 (int)status_reg[0]);
-    } else {
-        tr_error("_setQuadEnable - Writing Status Register failed");
-        return -1;
-    }
+    _qspi_write_status_registers(status_regs);
 
     if (false == _is_mem_ready()) {
         tr_error("Device not ready after write, failed");
         return -1;
     }
 
-
     // For Debug
-    memset(status_reg, 0, QSPI_MAX_STATUS_REGISTER_SIZE);
-    if (QSPI_STATUS_OK == _qspi_send_general_command(_read_register_inst, QSPI_NO_ADDRESS_COMMAND, NULL, 0,
-                                                     (char *)status_reg,
-                                                     sr_read_size)) {   // store received values in status_value
-        tr_debug("Reading Status Register Success: value = 0x%x", (int)status_reg[0]);
-    } else {
-        tr_error("Reading Status Register failed");
+    memset(status_regs, 0, QSPI_STATUS_REGISTER_COUNT);
+    _qspi_read_status_registers(status_regs);
+    if (((status_regs[0] & status_reg_setup[0]) | (status_regs[1] & status_reg_setup[1])) == 0) {
+        tr_error("Status register not set correctly");
         return -1;
     }
 
@@ -1125,14 +1096,14 @@ int QSPIFBlockDevice::_reset_flash_mem()
 {
     // Perform Soft Reset of the Device prior to initialization
     int status = 0;
-    char status_value[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
+    uint8_t status_value = 0;
     tr_debug("_reset_flash_mem:");
     //Read the Status Register from device
-    if (QSPI_STATUS_OK == _qspi_send_general_command(QSPIF_RDSR, QSPI_NO_ADDRESS_COMMAND, NULL, 0, status_value,
-                                                     QSPI_MAX_STATUS_REGISTER_SIZE)) {   // store received values in status_value
-        tr_debug("Reading Status Register Success: value = 0x%x", (int)status_value[0]);
+    if (QSPI_STATUS_OK == _qspi_send_general_command(QSPIF_INST_RSR1, QSPI_NO_ADDRESS_COMMAND, NULL, 0, (char *) &status_value,
+                                                     1)) {   // store received values in status_value
+        tr_debug("Reading Status Register Success: value = 0x%x", status_value);
     } else {
-        tr_error("Reading Status Register failed: value = 0x%x", (int)status_value[0]);
+        tr_error("Reading Status Register failed: value = 0x%x", status_value);
         status = -1;
     }
 
@@ -1167,7 +1138,7 @@ int QSPIFBlockDevice::_reset_flash_mem()
 bool QSPIFBlockDevice::_is_mem_ready()
 {
     // Check Status Register Busy Bit to Verify the Device isn't Busy
-    char status_value[QSPI_MAX_STATUS_REGISTER_SIZE];
+    uint8_t status_value = 0;
     int retries = 0;
     bool mem_ready = true;
 
@@ -1176,14 +1147,14 @@ bool QSPIFBlockDevice::_is_mem_ready()
         retries++;
         //Read the Status Register from device
         memset(status_value, 0xFF, QSPI_MAX_STATUS_REGISTER_SIZE);
-        if (QSPI_STATUS_OK != _qspi_send_general_command(QSPIF_RDSR, QSPI_NO_ADDRESS_COMMAND, NULL, 0, status_value,
-                                                         QSPI_MAX_STATUS_REGISTER_SIZE)) {   // store received values in status_value
+        if (QSPI_STATUS_OK != _qspi_send_general_command(QSPIF_INST_RSR1, QSPI_NO_ADDRESS_COMMAND, NULL, 0, (char *) &status_value,
+                                                         1)) {   // store received values in status_value
             tr_error("Reading Status Register failed");
         }
-    } while ((status_value[0] & QSPIF_STATUS_BIT_WIP) != 0 && retries < IS_MEM_READY_MAX_RETRIES);
+    } while ((status_value & QSPIF_STATUS_BIT_WIP) != 0 && retries < IS_MEM_READY_MAX_RETRIES);
 
-    if ((status_value[0] & QSPIF_STATUS_BIT_WIP) != 0) {
-        tr_error("_is_mem_ready FALSE: status value = 0x%x ", (int)status_value[0]);
+    if ((status_value & QSPIF_STATUS_BIT_WIP) != 0) {
+        tr_error("_is_mem_ready FALSE: status value = 0x%x ", status_value);
         mem_ready = false;
     }
     return mem_ready;
@@ -1192,7 +1163,7 @@ bool QSPIFBlockDevice::_is_mem_ready()
 int QSPIFBlockDevice::_set_write_enable()
 {
     // Check Status Register Busy Bit to Verify the Device isn't Busy
-    char status_value[QSPI_MAX_STATUS_REGISTER_SIZE];
+    uint8_t status_value = 0;
     int status = -1;
 
     do {
@@ -1206,85 +1177,22 @@ int QSPIFBlockDevice::_set_write_enable()
             break;
         }
 
-        memset(status_value, 0, QSPI_MAX_STATUS_REGISTER_SIZE);
-        if (QSPI_STATUS_OK != _qspi_send_general_command(QSPIF_RDSR, QSPI_NO_ADDRESS_COMMAND, NULL, 0, status_value,
-                                                         QSPI_MAX_STATUS_REGISTER_SIZE)) {   // store received values in status_value
-            tr_error("Reading Status Register failed");
+        if (QSPI_STATUS_OK != _qspi_send_general_command(QSPIF_INST_RSR1, QSPI_NO_ADDRESS_COMMAND,
+                                                         NULL, 0,
+                                                         (char *) &status_value, 1)) {
+            tr_error("Reading Status Register 1 failed");
             break;
         }
 
-        if ((status_value[0] & QSPIF_STATUS_BIT_WEL) == 0) {
-            tr_error("_set_write_enable failed");
+        if ((status_value & QSPIF_STATUS_BIT_WEL) == 0) {
+            tr_error("_set_write_enable failed - status register 1 value: %u", status_value);
             break;
         }
+
         status = 0;
     } while (false);
+
     return status;
-}
-
-int QSPIFBlockDevice::_enable_fast_mdoe()
-{
-    char status_reg[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
-    qspi_inst_t read_conf_register_inst = 0x15;
-    char status_reg_qer_setup[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
-
-    status_reg_qer_setup[2] = 0x2; // Bit 1 of config Reg 2
-
-    // Configure  BUS Mode to 1_1_1 for all commands other than Read
-    if (QSPI_STATUS_OK != _qspi_configure_format(QSPI_CFG_BUS_SINGLE, QSPI_CFG_BUS_SINGLE, QSPI_CFG_ADDR_SIZE_24, QSPI_CFG_BUS_SINGLE,
-                                                 0, QSPI_CFG_BUS_SINGLE, 0)) {
-        tr_error("_qspi_configure_format failed");
-        return QSPIF_BD_ERROR_DEVICE_ERROR;
-    }
-
-    // Read Status Register
-    if (QSPI_STATUS_OK == _qspi_send_general_command(read_conf_register_inst, QSPI_NO_ADDRESS_COMMAND, NULL, 0,
-                                                     &status_reg[1],
-                                                     QSPI_MAX_STATUS_REGISTER_SIZE - 1)) {  // store received values in status_value
-        tr_debug("Reading Config Register Success: value = 0x%x", (int)status_reg[2]);
-    } else {
-        tr_error("Reading Config Register failed");
-        return -1;
-    }
-
-    // Set Bits for Quad Enable
-    for (int i = 0; i < QSPI_MAX_STATUS_REGISTER_SIZE; i++) {
-        status_reg[i] |= status_reg_qer_setup[i];
-    }
-
-    // Write new Status Register Setup
-    if (_set_write_enable() != 0) {
-        tr_error("Write Enabe failed");
-        return -1;
-    }
-
-    if (QSPI_STATUS_OK == _qspi_send_general_command(_write_register_inst, QSPI_NO_ADDRESS_COMMAND, status_reg,
-                                                     QSPI_MAX_STATUS_REGISTER_SIZE, NULL,
-                                                     0)) {   // Write Fast mode bit to status_register
-        tr_debug("fast mode enable - Writing Config Register Success: value = 0x%x",
-                 (int)status_reg[2]);
-    } else {
-        tr_error("fast mode enable - Writing Config Register failed");
-        return -1;
-    }
-
-    if (false == _is_mem_ready()) {
-        tr_error("Device not ready after write, failed");
-        return -1;
-    }
-
-    // For Debug
-    memset(status_reg, 0, QSPI_MAX_STATUS_REGISTER_SIZE);
-    if (QSPI_STATUS_OK == _qspi_send_general_command(read_conf_register_inst, QSPI_NO_ADDRESS_COMMAND, NULL, 0,
-                                                     &status_reg[1],
-                                                     QSPI_MAX_STATUS_REGISTER_SIZE - 1)) {  // store received values in status_value
-        tr_debug("Verifying Config Register Success: value = 0x%x", (int)status_reg[2]);
-    } else {
-        tr_error("Verifying Config Register failed");
-        return -1;
-    }
-
-    return 0;
 }
 
 /*********************************************/
@@ -1421,6 +1329,92 @@ qspi_status_t QSPIFBlockDevice::_qspi_configure_format(qspi_bus_width_t inst_wid
     return status;
 }
 
+qspi_status_t QSPIFBlockDevice::_qspi_read_status_registers(uint8_t *reg_buffer)
+{
+    // Read Status Register 1
+    qspi_status_t status = _qspi_send_general_command(QSPIF_INST_RSR1, QSPI_NO_ADDRESS_COMMAND,
+                                        NULL, 0,
+                                        (char *) &reg_buffer[0], 1);
+    if (QSPI_STATUS_OK == status) {
+        tr_debug("Reading Status Register 1 Success: value = 0x%x", (int) reg_buffer[0]);
+    } else {
+        tr_error("Reading Status Register 1 failed");
+        return status;
+    }
+
+    // Read Status Register 2
+    status = _qspi_send_general_command(_read_status_reg_2_inst, QSPI_NO_ADDRESS_COMMAND,
+                                        NULL, 0,
+                                        (char *) &reg_buffer[1], 1);
+    if (QSPI_STATUS_OK == status) {
+        tr_debug("Reading Status Register 2 Success: value = 0x%x", (int) reg_buffer[1]);
+    } else {
+        tr_error("Reading Status Register 2 failed");
+        return status;
+    }
+
+    return QSPI_STATUS_OK;
+}
+
+qspi_status_t QSPIFBlockDevice::_qspi_write_status_registers(uint8_t *reg_buffer)
+{
+    qspi_status_t status;
+
+    if (_write_status_reg_2_inst == QSPI_NO_INST) {
+        // Status registers are written on different data bytes of the same command
+        if (_set_write_enable() != 0) {
+            tr_error("Write Enable failed");
+            return QSPI_STATUS_ERROR;
+        }
+        status = _qspi_send_general_command(QSPIF_INST_WSR1, QSPI_NO_ADDRESS_COMMAND,
+                                            (char *) reg_buffer, 2,
+                                            NULL, 0);
+        if (QSPI_STATUS_OK == status) {
+            tr_debug("Writing Status Registers Success: reg 1 value = 0x%x, reg 2 value = 0x%x",
+                     (int) reg_buffer[0], (int) reg_buffer[1]);
+        } else {
+            tr_error("Writing Status Registers failed");
+            return status;
+        }
+    } else {
+        // Status registers are written using different commands
+
+        // Write status register 1
+        if (_set_write_enable() != 0) {
+            tr_error("Write Enable failed");
+            return QSPI_STATUS_ERROR;
+        }
+        status = _qspi_send_general_command(QSPIF_INST_WSR1, QSPI_NO_ADDRESS_COMMAND,
+                                            (char *) &reg_buffer[0], 1,
+                                            NULL, 0);
+        if (QSPI_STATUS_OK == status) {
+            tr_debug("Writing Status Register 1 Success: value = 0x%x",
+                     (int) reg_buffer[0]);
+        } else {
+            tr_error("Writing Status Register 1 failed");
+            return status;
+        }
+
+        // Write status register 2
+        if (_set_write_enable() != 0) {
+            tr_error("Write Enable failed");
+            return QSPI_STATUS_ERROR;
+        }
+        status = _qspi_send_general_command(_write_status_reg_2_inst, QSPI_NO_ADDRESS_COMMAND,
+                                            (char *) &reg_buffer[0], 1,
+                                            NULL, 0);
+        if (QSPI_STATUS_OK == status) {
+            tr_debug("Writing Status Register 2 Success: value = 0x%x",
+                     (int) reg_buffer[1]);
+        } else {
+            tr_error("Writing Status Register 2 failed");
+            return status;
+        }
+    }
+
+    return QSPI_STATUS_OK;
+}
+ 
 /*********************************************/
 /************** Local Functions **************/
 /*********************************************/

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -38,7 +38,7 @@ using namespace mbed;
 #define QSPI_NO_ADDRESS_COMMAND UINT64_MAX
 #define QSPI_ALT_DEFAULT_VALUE  0
 // Status Register Bits
-#define QSPIF_STATUS_BIT_WIP        0x1 //Write In Progress
+#define QSPIF_STATUS_BIT_WIP        0x1 // Write In Progress
 #define QSPIF_STATUS_BIT_WEL        0x2 // Write Enable Latch
 
 /* SFDP Header Parsing */
@@ -64,14 +64,14 @@ using namespace mbed;
 #define QSPIF_BASIC_PARAM_TABLE_QER_BYTE 58
 #define QSPIF_BASIC_PARAM_TABLE_444_MODE_EN_SEQ_BYTE 56
 // Erase Types Params
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_1_BYTE 29
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_2_BYTE 31
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_3_BYTE 33
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_4_BYTE 35
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_1_SIZE_BYTE 28
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_2_SIZE_BYTE 30
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_3_SIZE_BYTE 32
-#define QSPIF_BASIC_PARAM_ERASE_TYPE_4_SIZE_BYTE 34
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_BYTE 29
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_2_BYTE 31
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_3_BYTE 33
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_4_BYTE 35
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_1_SIZE_BYTE 28
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_2_SIZE_BYTE 30
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_3_SIZE_BYTE 32
+#define QSPIF_BASIC_PARAM_TABLE_ERASE_TYPE_4_SIZE_BYTE 34
 #define QSPIF_BASIC_PARAM_4K_ERASE_TYPE_BYTE 1
 
 #define QSPIF_BASIC_PARAM_TABLE_SOFT_RESET_BYTE 61
@@ -183,7 +183,7 @@ int QSPIFBlockDevice::init()
         tr_debug("QSPIFBlockDevice csel: %d", (int)_csel);
     } else if (_unique_device_status == -1) {
         tr_error("QSPIFBlockDevice with the same csel(%d) already exists", (int)_csel);
-        return QSPIF_BD_ERROR_DEVICE_NOT_UNIQE;
+        return QSPIF_BD_ERROR_DEVICE_NOT_UNIQUE;
     } else {
         tr_error("Too many different QSPIFBlockDevice devices - max allowed: %d", QSPIF_MAX_ACTIVE_FLASH_DEVICES);
         return QSPIF_BD_ERROR_DEVICE_MAX_EXCEED;
@@ -223,7 +223,7 @@ int QSPIFBlockDevice::init()
         goto exit_point;
     }
 
-    //Synchronize Device
+    // Synchronize Device
     if (false == _is_mem_ready()) {
         tr_error("Init - _is_mem_ready Failed");
         status = QSPIF_BD_ERROR_READY_FAILED;
@@ -513,7 +513,6 @@ bd_size_t QSPIFBlockDevice::get_erase_size(bd_addr_t addr)
     int8_t type_mask = ERASE_BITMASK_TYPE1;
     int i_ind = 0;
 
-
     if (region != -1) {
         type_mask = 0x01;
 
@@ -627,10 +626,10 @@ int QSPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t &basic_table_addr, size_
     // Verify SFDP signature for sanity
     // Also check that major/minor version is acceptable
     if (!(memcmp(&sfdp_header[0], "SFDP", 4) == 0 && sfdp_header[5] == 1)) {
-        tr_error("Init - _verify SFDP signature and version Failed");
+        tr_error("Init - Verification of SFDP signature and version failed");
         return -1;
     } else {
-        tr_debug("Init - verified SFDP Signature and version Successfully");
+        tr_debug("Init - Verification of SFDP signature and version succeeded");
     }
 
     // Discover Number of Parameter Headers
@@ -641,7 +640,7 @@ int QSPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t &basic_table_addr, size_
     addr += QSPIF_SFDP_HEADER_SIZE;
     data_length = QSPIF_PARAM_HEADER_SIZE;
 
-    // Loop over Param Headers and parse them (currently supported Basic Param Table and Sector Region Map Table)
+    // Loop over Param Headers and parse them (currently supports Basic Param Table and Sector Region Map Table)
     for (int i_ind = 0; i_ind < number_of_param_headers; i_ind++) {
         status = _qspi_send_read_sfdp_command(addr, (char *) param_header, data_length);
         if (status != QSPI_STATUS_OK) {
@@ -662,20 +661,17 @@ int QSPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t &basic_table_addr, size_
             basic_table_addr = ((param_header[6] << 16) | (param_header[5] << 8) | (param_header[4]));
             // Supporting up to 64 Bytes Table (16 DWORDS)
             basic_table_size = ((param_header[3] * 4) < SFDP_DEFAULT_BASIC_PARAMS_TABLE_SIZE_BYTES) ? (param_header[3] * 4) : 64;
-
         } else if ((param_header[0] == 81) && (param_header[7] == 0xFF)) {
             // Found Sector Map Table: LSB=0x81, MSB=0xFF
             tr_debug("Found Sector Map Table at Table: %d", i_ind + 1);
             sector_map_table_addr = ((param_header[6] << 16) | (param_header[5] << 8) | (param_header[4]));
             sector_map_table_size = param_header[3] * 4;
-
         }
         addr += QSPIF_PARAM_HEADER_SIZE;
-
     }
+
     return 0;
 }
-
 
 int QSPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, size_t basic_table_size)
 {
@@ -694,11 +690,10 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, s
     }
 
     // Get device density (stored in bits - 1)
-    uint32_t density_bits = (
-                                (param_table[7] << 24) |
-                                (param_table[6] << 16) |
-                                (param_table[5] << 8) |
-                                param_table[4]);
+    uint32_t density_bits = ((param_table[7] << 24) |
+                             (param_table[6] << 16) |
+                             (param_table[5] << 8)  |
+                              param_table[4]);
     _device_size_bytes = (density_bits + 1) / 8;
 
     // Set Page Size (QSPI write must be done on Page limits)
@@ -778,7 +773,7 @@ int QSPIFBlockDevice::_sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr)
             tr_debug("Setting QE Bit, Bit 1 of Status Reg 2");
             break;
         default:
-            tr_warning("Unsuported QER configuration");
+            tr_warning("Unsupported QER configuration");
             return 0;
     }
 
@@ -856,7 +851,7 @@ int QSPIFBlockDevice::_sfdp_set_qpi_enabled(uint8_t *basic_param_table_ptr)
             break;
 
         default:
-            tr_warning("_sfdp_set_qpi_enabled - Unsuported En Seq 444 configuration");
+            tr_warning("_sfdp_set_qpi_enabled - Unsupported En Seq 444 configuration");
             break;
     }
     return 0;
@@ -1380,8 +1375,8 @@ qspi_status_t QSPIFBlockDevice::_qspi_update_4byte_ext_addr_reg(bd_addr_t addr)
     return status;
 }
 
-qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(qspi_inst_t read_inst, void *buffer, bd_addr_t addr,
-                                                        bd_size_t size)
+qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(qspi_inst_t read_inst, void *buffer,
+                                                        bd_addr_t addr, bd_size_t size)
 {
     tr_debug("Inst: 0x%xh, addr: %llu, size: %llu", read_inst, addr, size);
 
@@ -1421,8 +1416,8 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(qspi_inst_t read_inst, v
     return QSPI_STATUS_OK;
 }
 
-qspi_status_t QSPIFBlockDevice::_qspi_send_program_command(qspi_inst_t progInst, const void *buffer, bd_addr_t addr,
-                                                           bd_size_t *size)
+qspi_status_t QSPIFBlockDevice::_qspi_send_program_command(qspi_inst_t prog_inst, const void *buffer,
+                                                           bd_addr_t addr, bd_size_t *size)
 {
     tr_debug("Inst: 0x%xh, addr: %llu, size: %llu", prog_inst, addr, *size);
 
@@ -1466,8 +1461,8 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_erase_command(qspi_inst_t erase_inst,
 }
 
 qspi_status_t QSPIFBlockDevice::_qspi_send_general_command(qspi_inst_t instruction, bd_addr_t addr,
-                                                           const char *tx_buffer,
-                                                           mbed::bd_size_t tx_length, const char *rx_buffer, mbed::bd_size_t rx_length)
+                                                           const char *tx_buffer, bd_size_t tx_length,
+                                                           const char *rx_buffer, bd_size_t rx_length)
 {
     tr_debug("Inst: 0x%xh, addr: %llu, tx length: %llu, rx length: %llu", instruction, addr, tx_length, rx_length);
 

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -617,7 +617,7 @@ int QSPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t &basic_table_addr, size_
     size_t data_length = QSPIF_SFDP_HEADER_SIZE;
     bd_addr_t addr = 0x0;
 
-    qspi_status_t status = _qspi_send_read_sfdp_command(addr, (char*) sfdp_header, data_length);
+    qspi_status_t status = _qspi_send_read_sfdp_command(addr, (char *) sfdp_header, data_length);
     if (status != QSPI_STATUS_OK) {
         tr_error("Init - Read SFDP Failed");
         return -1;
@@ -677,7 +677,7 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, s
 {
     uint8_t param_table[SFDP_DEFAULT_BASIC_PARAMS_TABLE_SIZE_BYTES]; /* Up To 16 DWORDS = 64 Bytes */
 
-    qspi_status_t status = _qspi_send_read_sfdp_command(basic_table_addr, (char*) param_table, basic_table_size);
+    qspi_status_t status = _qspi_send_read_sfdp_command(basic_table_addr, (char *) param_table, basic_table_size);
     if (status != QSPI_STATUS_OK) {
         tr_error("Init - Read SFDP First Table Failed");
         return -1;
@@ -693,7 +693,7 @@ int QSPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, s
     uint32_t density_bits = ((param_table[7] << 24) |
                              (param_table[6] << 16) |
                              (param_table[5] << 8)  |
-                              param_table[4]);
+                             param_table[4]);
     _device_size_bytes = (density_bits + 1) / 8;
 
     // Set Page Size (QSPI write must be done on Page limits)
@@ -1108,7 +1108,7 @@ int QSPIFBlockDevice::_sfdp_detect_reset_protocol_and_reset(uint8_t *basic_param
         // Issue instruction 66h to enable resets on the device
         // Then issue instruction 99h to reset the device
         qspi_status_t qspi_status = _qspi_send_general_command(0x66, QSPI_NO_ADDRESS_COMMAND, // Send reset enable instruction
-                                                                NULL, 0, NULL, 0);
+                                                               NULL, 0, NULL, 0);
         if (qspi_status == QSPI_STATUS_OK) {
             qspi_status = _qspi_send_general_command(0x99, QSPI_NO_ADDRESS_COMMAND, // Send reset instruction
                                                      NULL, 0, NULL, 0);
@@ -1119,7 +1119,7 @@ int QSPIFBlockDevice::_sfdp_detect_reset_protocol_and_reset(uint8_t *basic_param
         status = QSPIF_BD_ERROR_PARSING_FAILED;
     }
 
-    if (status == QSPIF_BD_ERROR_OK){
+    if (status == QSPIF_BD_ERROR_OK) {
         if (false == _is_mem_ready()) {
             tr_error("Device not ready, reset failed");
             status = QSPIF_BD_ERROR_READY_FAILED;
@@ -1198,8 +1198,8 @@ int QSPIFBlockDevice::_clear_block_protection()
 
     /* Read Manufacturer ID (1byte), and Device ID (2bytes) */
     qspi_status_t status = _qspi_send_general_command(QSPIF_INST_RDID, QSPI_NO_ADDRESS_COMMAND,
-                                             NULL, 0,
-                                             (char *) vendor_device_ids, QSPI_RDID_DATA_LENGTH);
+                                                      NULL, 0,
+                                                      (char *) vendor_device_ids, QSPI_RDID_DATA_LENGTH);
     if (QSPI_STATUS_OK != status) {
         tr_error("Read Vendor ID Failed");
         return -1;
@@ -1523,8 +1523,8 @@ qspi_status_t QSPIFBlockDevice::_qspi_read_status_registers(uint8_t *reg_buffer)
 {
     // Read Status Register 1
     qspi_status_t status = _qspi_send_general_command(QSPIF_INST_RSR1, QSPI_NO_ADDRESS_COMMAND,
-                                        NULL, 0,
-                                        (char *) &reg_buffer[0], 1);
+                                                      NULL, 0,
+                                                      (char *) &reg_buffer[0], 1);
     if (QSPI_STATUS_OK == status) {
         tr_debug("Reading Status Register 1 Success: value = 0x%x", (int) reg_buffer[0]);
     } else {

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -248,10 +248,8 @@ private:
     qspi_status_t _qspi_send_general_command(mbed::qspi_inst_t instruction_int, mbed::bd_addr_t addr, const char *tx_buffer,
                                              mbed::bd_size_t tx_length, const char *rx_buffer, mbed::bd_size_t rx_length);
 
-    // Send Bus configure_format command to Driver
-    qspi_status_t _qspi_configure_format(qspi_bus_width_t inst_width, qspi_bus_width_t address_width,
-                                         qspi_address_size_t address_size, qspi_bus_width_t alt_width, qspi_alt_size_t alt_size, qspi_bus_width_t data_width,
-                                         int dummy_cycles);
+    // Send command to read from the SFDP table
+    qspi_status_t _qspi_send_read_sfdp_command(mbed::bd_addr_t addr, void *rx_buffer, mbed::bd_size_t rx_length);
 
     // Read the contents of status registers 1 and 2 into a buffer (buffer must have a length of 2)
     qspi_status_t _qspi_read_status_registers(uint8_t *reg_buffer);

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -253,6 +253,12 @@ private:
                                          qspi_address_size_t address_size, qspi_bus_width_t alt_width, qspi_alt_size_t alt_size, qspi_bus_width_t data_width,
                                          int dummy_cycles);
 
+    // Read the contents of status registers 1 and 2 into a buffer (buffer must have a length of 2)
+    qspi_status_t _qspi_read_status_registers(uint8_t *reg_buffer);
+
+    // Set the contents of status registers 1 and 2 from a buffer (buffer must have a length of 2)
+    qspi_status_t _qspi_write_status_registers(uint8_t *reg_buffer);
+
     // Send set_frequency command to Driver
     qspi_status_t _qspi_set_frequency(int freq);
 
@@ -267,9 +273,6 @@ private:
 
     // Wait on status register until write not-in-progress
     bool _is_mem_ready();
-
-    // Enable Fast Mode - for flash chips with low power default
-    int _enable_fast_mdoe();
 
     /****************************************/
     /* SFDP Detection and Parsing Functions */
@@ -335,8 +338,10 @@ private:
     mbed::qspi_inst_t _prog_instruction;
     mbed::qspi_inst_t _erase_instruction;
     mbed::qspi_inst_t _erase4k_inst;  // Legacy 4K erase instruction (default 0x20h)
-    mbed::qspi_inst_t _write_register_inst; // Write status/config register instruction may vary between chips
-    mbed::qspi_inst_t _read_register_inst; // Read status/config register instruction may vary between chips
+
+    // Status register write/read instructions
+    mbed::qspi_inst_t _write_status_reg_2_inst;
+    mbed::qspi_inst_t _read_status_reg_2_inst;
 
     // Up To 4 Erase Types are supported by SFDP (each with its own command Instruction and Size)
     mbed::qspi_inst_t _erase_type_inst_arr[MAX_NUM_OF_ERASE_TYPES];

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -268,6 +268,8 @@ private:
     /*********************************/
     /* Flash Configuration Functions */
     /*********************************/
+    // Clear the device's block protection
+    int _clear_block_protection();
 
     // Configure Write Enable in Status Register
     int _set_write_enable();

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -358,6 +358,8 @@ private:
     mbed::qspi_inst_t _write_status_reg_2_inst;
     mbed::qspi_inst_t _read_status_reg_2_inst; // If three registers, this instruction reads the latter two
 
+    // Attempt to enable 4-byte addressing. True by default, but may be disabled for some vendors
+    bool _attempt_4_byte_addressing;
     // 4-byte addressing extension register write instruction
     mbed::qspi_inst_t _4byte_msb_reg_write_inst;
 

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -354,8 +354,9 @@ private:
     mbed::qspi_inst_t _legacy_erase_instruction;
 
     // Status register write/read instructions
+    unsigned int _num_status_registers;
     mbed::qspi_inst_t _write_status_reg_2_inst;
-    mbed::qspi_inst_t _read_status_reg_2_inst;
+    mbed::qspi_inst_t _read_status_reg_2_inst; // If three registers, this instruction reads the latter two
 
     // 4-byte addressing extension register write instruction
     mbed::qspi_inst_t _4byte_msb_reg_write_inst;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -356,6 +356,10 @@ private:
     mbed::qspi_inst_t _erase_type_inst_arr[MAX_NUM_OF_ERASE_TYPES];
     unsigned int _erase_type_size_arr[MAX_NUM_OF_ERASE_TYPES];
 
+    // Quad mode enable status register and bit
+    int _quad_enable_register_idx;
+    int _quad_enable_bit;
+
     // Sector Regions Map
     int _regions_count; //number of regions
     int _region_size_bytes[QSPIF_MAX_REGIONS]; //regions size in bytes

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -275,6 +275,9 @@ private:
     // Wait on status register until write not-in-progress
     bool _is_mem_ready();
 
+    // Enable Fast Mode - for flash chips with low power default
+    int _enable_fast_mode();
+
     /****************************************/
     /* SFDP Detection and Parsing Functions */
     /****************************************/

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -27,11 +27,11 @@ enum qspif_bd_error {
     QSPIF_BD_ERROR_OK                    = 0,     /*!< no error */
     QSPIF_BD_ERROR_DEVICE_ERROR          = BD_ERROR_DEVICE_ERROR, /*!< device specific error -4001 */
     QSPIF_BD_ERROR_PARSING_FAILED        = -4002, /* SFDP Parsing failed */
-    QSPIF_BD_ERROR_READY_FAILED          = -4003, /* Wait for  Mem Ready failed */
+    QSPIF_BD_ERROR_READY_FAILED          = -4003, /* Wait for Mem Ready failed */
     QSPIF_BD_ERROR_WREN_FAILED           = -4004, /* Write Enable Failed */
     QSPIF_BD_ERROR_INVALID_ERASE_PARAMS  = -4005, /* Erase command not on sector aligned addresses or exceeds device size */
-    QSPIF_BD_ERROR_DEVICE_NOT_UNIQE      = -4006, /* Only one instance per csel is allowed */
-    QSPIF_BD_ERROR_DEVICE_MAX_EXCEED     = -4007 /* Max active QSPIF devices exceeded */
+    QSPIF_BD_ERROR_DEVICE_NOT_UNIQUE     = -4006, /* Only one instance per csel is allowed */
+    QSPIF_BD_ERROR_DEVICE_MAX_EXCEED     = -4007  /* Max active QSPIF devices exceeded */
 };
 
 /** Enum qspif polarity mode
@@ -285,7 +285,7 @@ private:
     // Parse and Detect required Basic Parameters from Table
     int _sfdp_parse_basic_param_table(uint32_t basic_table_addr, size_t basic_table_size);
 
-    // Parse and read information required by Regions Secotr Map
+    // Parse and read information required by Regions Sector Map
     int _sfdp_parse_sector_map_table(uint32_t sector_map_table_addr, size_t sector_map_table_size);
 
     // Detect the soft reset protocol and reset - returns error if soft reset is not supported
@@ -298,7 +298,7 @@ private:
     // Enable Quad mode if supported (1-1-4, 1-4-4, 4-4-4 bus modes)
     int _sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr);
 
-    // Enable QPI mode (4-4-4) is supported
+    // Enable QPI mode (4-4-4)
     int _sfdp_set_qpi_enabled(uint8_t *basic_param_table_ptr);
 
     // Set Page size for program

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -305,9 +305,7 @@ private:
     int _sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
     // Detect all supported erase types
-    int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-                                               mbed::qspi_inst_t &erase4k_inst,
-                                               mbed::qspi_inst_t *erase_type_inst_arr, unsigned int *erase_type_size_arr);
+    int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
     // Detect 4-byte addressing mode and enable it if supported
     int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);
@@ -343,8 +341,7 @@ private:
     // Command Instructions
     mbed::qspi_inst_t _read_instruction;
     mbed::qspi_inst_t _prog_instruction;
-    mbed::qspi_inst_t _erase_instruction;
-    mbed::qspi_inst_t _erase4k_inst;  // Legacy 4K erase instruction (default 0x20h)
+    mbed::qspi_inst_t _legacy_erase_instruction;
 
     // Status register write/read instructions
     mbed::qspi_inst_t _write_status_reg_2_inst;

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -292,8 +292,8 @@ private:
     int _sfdp_detect_reset_protocol_and_reset(uint8_t *basic_param_table_ptr);
 
     // Detect fastest read Bus mode supported by device
-    int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, bool &set_quad_enable,
-                                        bool &is_qpi_mode, mbed::qspi_inst_t &read_inst);
+    int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size,
+                                        bool &set_quad_enable, bool &is_qpi_mode);
 
     // Enable Quad mode if supported (1-1-4, 1-4-4, 4-4-4 bus modes)
     int _sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr);
@@ -340,7 +340,6 @@ private:
 
     // Command Instructions
     mbed::qspi_inst_t _read_instruction;
-    mbed::qspi_inst_t _prog_instruction;
     mbed::qspi_inst_t _legacy_erase_instruction;
 
     // Status register write/read instructions

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -313,6 +313,9 @@ private:
     // Detect 4-byte addressing mode and enable it if supported
     int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
+    // Query vendor ID and handle special behavior that isn't covered by SFDP data
+    int _handle_vendor_quirks();
+
     /***********************/
     /* Utilities Functions */
     /***********************/
@@ -324,6 +327,11 @@ private:
     int _utils_iterate_next_largest_erase_type(uint8_t &bitfield, int size, int offset, int boundry);
 
 private:
+    enum qspif_clear_protection_method_t {
+        QSPIF_BP_ULBPR,    // Issue global protection unlock instruction
+        QSPIF_BP_CLEAR_SR, // Clear protection bits in status register 1
+    };
+
     // QSPI Driver Object
     mbed::QSPI _qspi;
 
@@ -359,6 +367,9 @@ private:
     // Quad mode enable status register and bit
     int _quad_enable_register_idx;
     int _quad_enable_bit;
+
+    // Clear block protection
+    qspif_clear_protection_method_t _clear_protection_method;
 
     // Sector Regions Map
     int _regions_count; //number of regions

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -265,8 +265,6 @@ private:
     /*********************************/
     /* Flash Configuration Functions */
     /*********************************/
-    // Soft Reset Flash Memory
-    int _reset_flash_mem();
 
     // Configure Write Enable in Status Register
     int _set_write_enable();
@@ -286,6 +284,9 @@ private:
 
     // Parse and read information required by Regions Secotr Map
     int _sfdp_parse_sector_map_table(uint32_t sector_map_table_addr, size_t sector_map_table_size);
+
+    // Detect the soft reset protocol and reset - returns error if soft reset is not supported
+    int _sfdp_detect_reset_protocol_and_reset(uint8_t *basic_param_table_ptr);
 
     // Detect fastest read Bus mode supported by device
     int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, bool &set_quad_enable,

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -262,6 +262,9 @@ private:
     // Send set_frequency command to Driver
     qspi_status_t _qspi_set_frequency(int freq);
 
+    // Update the 4-byte addressing extension register with the MSB of the address if it is in use
+    qspi_status_t _qspi_update_4byte_ext_addr_reg(bd_addr_t addr);
+
     /*********************************/
     /* Flash Configuration Functions */
     /*********************************/
@@ -306,6 +309,9 @@ private:
                                                mbed::qspi_inst_t &erase4k_inst,
                                                mbed::qspi_inst_t *erase_type_inst_arr, unsigned int *erase_type_size_arr);
 
+    // Detect 4-byte addressing mode and enable it if supported
+    int _sfdp_detect_and_enable_4byte_addressing(uint8_t *basic_param_table_ptr, int basic_param_table_size);
+
     /***********************/
     /* Utilities Functions */
     /***********************/
@@ -343,6 +349,9 @@ private:
     // Status register write/read instructions
     mbed::qspi_inst_t _write_status_reg_2_inst;
     mbed::qspi_inst_t _read_status_reg_2_inst;
+
+    // 4-byte addressing extension register write instruction
+    mbed::qspi_inst_t _4byte_msb_reg_write_inst;
 
     // Up To 4 Erase Types are supported by SFDP (each with its own command Instruction and Size)
     mbed::qspi_inst_t _erase_type_inst_arr[MAX_NUM_OF_ERASE_TYPES];

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -369,6 +369,8 @@ private:
     int _quad_enable_register_idx;
     int _quad_enable_bit;
 
+    bool _needs_fast_mode;
+
     // Clear block protection
     qspif_clear_protection_method_t _clear_protection_method;
 

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -64,7 +64,7 @@ using namespace utest::v1;
 #define TEST_BLOCK_COUNT 10
 #define TEST_ERROR_MASK 16
 #define TEST_NUM_OF_THREADS 5
-#define TEST_THREAD_STACK_SIZE 1024
+#define TEST_THREAD_STACK_SIZE 1152
 
 uint8_t num_of_sectors = TEST_NUM_OF_THREADS * TEST_BLOCK_COUNT;
 uint32_t sectors_addr[TEST_NUM_OF_THREADS * TEST_BLOCK_COUNT] = {0};

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -30,8 +30,8 @@
 #include "utest.h"
 #include <stdlib.h>
 
-#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM) && !defined(TARGET_MCU_PSOC6)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6
 #else
 
 #define FSST_TEST_NUM_OF_THREADS 5

--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -66,9 +66,6 @@ static const char *kv_prefix[] = {"TDB_", "FS_", "SEC_"};
 
 static int kv_setup = TDBStoreSet;
 
-static const size_t ul_bd_size = 16 * 4096;
-static const size_t rbp_bd_size = 8 * 4096;
-
 static const int heap_alloc_threshold_size = 4096;
 
 /*----------------initialization------------------*/
@@ -77,6 +74,8 @@ static const int heap_alloc_threshold_size = 4096;
 static void kvstore_init()
 {
     int res;
+    size_t erase_size, ul_bd_size, rbp_bd_size;
+    BlockDevice *sec_bd;
 
     res = bd->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
@@ -105,14 +104,19 @@ static void kvstore_init()
 
 #if SECURESTORE_ENABLED
     if (kv_setup == SecStoreSet) {
+        sec_bd = bd;
         if (erase_val == -1) {
             flash_bd = new FlashSimBlockDevice(bd);
-            ul_bd = new SlicingBlockDevice(flash_bd, 0, ul_bd_size);
-            rbp_bd = new SlicingBlockDevice(flash_bd, ul_bd_size, ul_bd_size + rbp_bd_size);
-        } else {
-            ul_bd = new SlicingBlockDevice(bd, 0, ul_bd_size);
-            rbp_bd = new SlicingBlockDevice(bd, ul_bd_size, ul_bd_size + rbp_bd_size);
+            sec_bd = flash_bd;
         }
+
+        erase_size  = sec_bd->get_erase_size();
+        ul_bd_size  = erase_size * 4;
+        rbp_bd_size = erase_size * 2;
+
+        ul_bd = new SlicingBlockDevice(sec_bd, 0, ul_bd_size);
+        rbp_bd = new SlicingBlockDevice(sec_bd, ul_bd_size, ul_bd_size + rbp_bd_size);
+
         TDBStore *ul_kv = new TDBStore(ul_bd);
         TDBStore *rbp_kv = new TDBStore(rbp_bd);
         kvstore = new SecureStore(ul_kv, rbp_kv);

--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -32,8 +32,8 @@
 using namespace utest::v1;
 using namespace mbed;
 
-#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM) && !defined(TARGET_MCU_PSOC6)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6
 #else
 
 static const char   data[] = "data";

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -66,9 +66,6 @@ static const char *kv_prefix[] = {"TDB_", "FS_", "SEC_"};
 
 static int kv_setup = TDBStoreSet;
 
-static const size_t ul_bd_size = 16 * 4096;
-static const size_t rbp_bd_size = 8 * 4096;
-
 static const int heap_alloc_threshold_size = 4096;
 
 /*----------------initialization------------------*/
@@ -77,6 +74,8 @@ static const int heap_alloc_threshold_size = 4096;
 static void kvstore_init()
 {
     int res;
+    size_t erase_size, ul_bd_size, rbp_bd_size;
+    BlockDevice *sec_bd;
 
     res = bd->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
@@ -105,14 +104,19 @@ static void kvstore_init()
 
 #if SECURESTORE_ENABLED
     if (kv_setup == SecStoreSet) {
+        sec_bd = bd;
         if (erase_val == -1) {
             flash_bd = new FlashSimBlockDevice(bd);
-            ul_bd = new SlicingBlockDevice(flash_bd, 0, ul_bd_size);
-            rbp_bd = new SlicingBlockDevice(flash_bd, ul_bd_size, ul_bd_size + rbp_bd_size);
-        } else {
-            ul_bd = new SlicingBlockDevice(bd, 0, ul_bd_size);
-            rbp_bd = new SlicingBlockDevice(bd, ul_bd_size, ul_bd_size + rbp_bd_size);
+            sec_bd = flash_bd;
         }
+
+        erase_size  = sec_bd->get_erase_size();
+        ul_bd_size  = erase_size * 4;
+        rbp_bd_size = erase_size * 2;
+
+        ul_bd = new SlicingBlockDevice(sec_bd, 0, ul_bd_size);
+        rbp_bd = new SlicingBlockDevice(sec_bd, ul_bd_size, ul_bd_size + rbp_bd_size);
+
         TDBStore *ul_kv = new TDBStore(ul_bd);
         TDBStore *rbp_kv = new TDBStore(rbp_bd);
         kvstore = new SecureStore(ul_kv, rbp_kv);

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -32,8 +32,8 @@
 using namespace utest::v1;
 using namespace mbed;
 
-#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM)
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels
+#if !defined(TARGET_K64F) && !defined(TARGET_ARM_FM) && !defined(TARGET_MCU_PSOC6)
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6
 #else
 
 static const char   data[] = "data";

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -34,8 +34,8 @@
 #include <stdio.h>
 #include <algorithm>
 
-#if (!defined(TARGET_K64F) && !defined(TARGET_ARM_FM)) || !SECURESTORE_ENABLED
-#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices and Fastmodels. KVStore & SecureStore need to be enabled for this test
+#if (!defined(TARGET_K64F) && !defined(TARGET_ARM_FM)) && !defined(TARGET_MCU_PSOC6) || !SECURESTORE_ENABLED
+#error [NOT_SUPPORTED] Kvstore API tests run only on K64F devices, Fastmodels, and PSoC 6. KVStore & SecureStore need to be enabled for this test
 #else
 
 using namespace mbed;

--- a/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
@@ -92,8 +92,8 @@ static const char *const res_val2  = "This should surely not be saved as the res
 static void white_box_test()
 {
 
-#if !defined(TARGET_K64F)
-    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices");
+#if !defined(TARGET_K64F) && !defined(TARGET_MCU_PSOC6)
+    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices and PSoC 6");
 #endif
 
     bd_params_t bd_params[] = {
@@ -334,8 +334,8 @@ static void white_box_test()
 static void multi_set_test()
 {
 
-#if !defined(TARGET_K64F)
-    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices");
+#if !defined(TARGET_K64F) && !defined(TARGET_MCU_PSOC6)
+    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices and PSoC 6");
 #endif
 
     char *key;
@@ -458,8 +458,8 @@ static void multi_set_test()
 static void error_inject_test()
 {
 
-#if !defined(TARGET_K64F)
-    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices");
+#if !defined(TARGET_K64F) && !defined(TARGET_MCU_PSOC6)
+    TEST_SKIP_MESSAGE("Kvstore API tests run only on K64F devices and PSoC 6");
 #endif
 
     char *key;


### PR DESCRIPTION
### Description
Proposed fix for #11530 .

In several cases QSPIFBlockDevice does not conform to the SFDP standard [JESD216](https://www.jedec.org/system/files/docs/JESD216D-01.pdf).  These include:

 - Status register reading and writing
 - Soft resetting
 - Enabling of 4-byte addressing
 - Enabling of quad output mode
 - Use of the legacy erase instruction

In these cases QSPIFBlockDevice often assumes that certain instructions or methods are universal across flash devices when they are not.  This can cause issues in devices that do not match these assumptions.  This pull request resolves many of these issues and better aligns QSPIFBlockDevice with JESD216.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This PR is dependent on #11604 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
