### PR TITLE
Cellular: Handle SEND FAIL and ERROR response

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -300,12 +300,17 @@ nsapi_size_or_error_t QUECTEL_BG96_CellularStack::socket_sendto_impl(CellularSoc
     _at.write_bytes((uint8_t *)data, size);
     _at.resp_start();
     _at.set_stop_tag("\r\n");
+    // Possible responses are SEND OK, SEND FAIL or ERROR.
+    char response[16];
+    response[0] = '\0';
+    _at.read_string(response, sizeof(response));
     _at.resp_stop();
+    if (strcmp(response, "SEND OK") != 0) {
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
 
     // Get the sent count after sending
-
     nsapi_size_or_error_t err = _at.at_cmd_int("+QISEND", "=", sent_len_after, "%d%d", socket->id, 0);
-
     if (err == NSAPI_ERROR_OK) {
         sent_len = sent_len_after - sent_len_before;
         return sent_len;

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26_CellularStack.cpp
@@ -440,7 +440,14 @@ nsapi_size_or_error_t QUECTEL_M26_CellularStack::socket_sendto_impl(CellularSock
     _at.write_bytes((uint8_t *)data, sent_len);
     _at.resp_start();
     _at.set_stop_tag("\r\n");
+    // Possible responses are SEND OK, SEND FAIL or ERROR.
+    char response[16];
+    response[0] = '\0';
+    _at.read_string(response, sizeof(response));
     _at.resp_stop();
+    if (strcmp(response, "SEND OK") != 0) {
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
 
     if (_at.get_last_error() != NSAPI_ERROR_OK) {
         tr_error("QUECTEL_M26_CellularStack:%s:%u:[NSAPI_ERROR_DEVICE_ERROR]", __FUNCTION__, __LINE__);


### PR DESCRIPTION
### Description

QISEND command can respond either SEND OK, SEND FAIL or ERROR.
If response is not SEND OK, sent bytes should not be checked but error should be reported.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@AriParkkila @mirelachirica @tz-arm 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
