### PR TITLE
Tests: USB: Fix Python 3 compatibility

### DIFF
--- a/TESTS/host_tests/pyusb_basic.py
+++ b/TESTS/host_tests/pyusb_basic.py
@@ -1376,7 +1376,7 @@ def ep_test_abort(dev, log, verbose=False):
             payload_size = (NUM_PACKETS_UNTIL_ABORT + NUM_PACKETS_AFTER_ABORT) * ep_out.wMaxPacketSize
             num_bytes_written = 0
             while num_bytes_written < payload_size:
-                payload_out = array.array('B', (num_bytes_written/ep_out.wMaxPacketSize
+                payload_out = array.array('B', (num_bytes_written//ep_out.wMaxPacketSize
                                                 for _ in range(ep_out.wMaxPacketSize)))
                 try:
                     num_bytes_written += ep_out.write(payload_out)

--- a/TESTS/host_tests/usb_device_serial.py
+++ b/TESTS/host_tests/usb_device_serial.py
@@ -24,6 +24,7 @@ import uuid
 import sys
 import serial
 import serial.tools.list_ports as stlp
+import six
 import mbed_host_tests
 
 
@@ -268,7 +269,7 @@ class USBSerialTest(mbed_host_tests.BaseHostTest):
         mbed_serial.reset_output_buffer()
         mbed_serial.dtr = True
         try:
-            payload = mbed_serial.read(LINE_CODING_STRLEN)
+            payload = six.ensure_str(mbed_serial.read(LINE_CODING_STRLEN))
             while len(payload) == LINE_CODING_STRLEN:
                 baud, bits, parity, stop = (int(i) for i in payload.split(','))
                 new_line_coding = {
@@ -277,7 +278,7 @@ class USBSerialTest(mbed_host_tests.BaseHostTest):
                     'parity': self._PARITIES[parity],
                     'stopbits': self._STOPBITS[stop]}
                 mbed_serial.apply_settings(new_line_coding)
-                payload = mbed_serial.read(LINE_CODING_STRLEN)
+                payload = six.ensure_str(mbed_serial.read(LINE_CODING_STRLEN))
         except serial.SerialException as exc:
             self.log('TEST ERROR: {}'.format(exc))
             self.notify_complete(False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ junit-xml==1.8
 pyyaml==4.2b1
 jsonschema==2.6.0
 future==0.16.0
-six==1.11.0
+six==1.12.0
 mbed-cloud-sdk>=2.0.6,<2.1
 requests>=2.20,<2.21
 idna>=2,<2.8


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
This is a follow-up to #11520.

Use integer division explicitly in basic test.
Convert bytes to str for Python 3 in serial test.

**After the update, this patch also bumps the version of `six` module to 1.12.0.**

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@OPpuolitaival @madchutney 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
