### PR TITLE
Fix for UBLOX_EVK_ODIN_W2 fails in emac test.

### DIFF
--- a/TESTS/network/emac/emac_test_multicast_filter.cpp
+++ b/TESTS/network/emac/emac_test_multicast_filter.cpp
@@ -29,7 +29,7 @@ using namespace utest::v1;
 void test_emac_multicast_filter_cb(int opt)
 {
     static bool multicasts_are_filtered = true;
-    unsigned char forward_addr[ETH_MAC_ADDR_LEN];
+    static unsigned char forward_addr[ETH_MAC_ADDR_LEN];
     static bool send_request = true;
     static bool receive = true;
     static int no_response_cnt = 0;
@@ -70,7 +70,6 @@ void test_emac_multicast_filter_cb(int opt)
                 }
                 receive = true;
                 break;
-
 
             case 3:
                 printf("STEP 3: set ipv4 multicast filter, test if input message is filtered\r\n\r\n");
@@ -145,7 +144,15 @@ void test_emac_multicast_filter_cb(int opt)
 
     if (next_step) {
         RESET_OUTGOING_MSG_DATA;
+#if (MBED_CONF_NETWORK_EMAC_NO_SUPPORT_FOR_IPV4_MULTICAST_FILTER == 1)
+        if (test_step == 2) {
+            test_step = 5;
+        } else {
+            test_step++;
+        }
+#else
         test_step++;
+#endif
         retries = 0;
         send_request = true;
     }

--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -72,7 +72,10 @@ Case cases[] = {
     Case("EMAC unicast frame length", test_emac_unicast_frame_len),
     Case("EMAC unicast burst", test_emac_unicast_burst),
     Case("EMAC unicast long", test_emac_unicast_long),
+#if !((MBED_CONF_NETWORK_EMAC_NO_SUPPORT_FOR_MULTICAST_FILTER == 1) && \
+    (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI))
     Case("EMAC multicast filter", test_emac_multicast_filter),
+#endif // !(MBED_CONF_NETWORK_EMAC_NO_SUPPORT_FOR_MULTICAST_FILTER == 1)
     Case("EMAC memory", test_emac_memory)
 };
 

--- a/TESTS/network/emac/mbed_lib.json
+++ b/TESTS/network/emac/mbed_lib.json
@@ -1,0 +1,24 @@
+{
+    "name": "network-emac",
+    "config": {
+        "NO_SUPPORT_FOR_MULTICAST_FILTER": false,
+        "NO_SUPPORT_FOR_IPV4_MULTICAST_FILTER": false
+    },
+    "target_overrides": {
+        "MTB_UBLOX_ODIN_W2": {
+            "NO_SUPPORT_FOR_MULTICAST_FILTER": true
+        },
+        "UBLOX_EVK_ODIN_W2": {
+            "NO_SUPPORT_FOR_MULTICAST_FILTER": true
+        },
+        "MTB_MXCHIP_EMW3166": {
+            "NO_SUPPORT_FOR_IPV4_MULTICAST_FILTER": true
+        },
+        "MTB_ADV_WISE_1530": {
+            "NO_SUPPORT_FOR_IPV4_MULTICAST_FILTER": true
+        },
+        "MTB_USI_WM_BN_BM_22": {
+            "NO_SUPPORT_FOR_IPV4_MULTICAST_FILTER": true
+        }
+    }
+}


### PR DESCRIPTION
UBLOX_EVK_ODIN_W2 and MTB_UBLOX_ODIN_W2 haven't multicast implementation so emac multicast test is disabled for those tests. 
Function without implementation:
- add_multicast_group
- remove_multicast_group
- set_all_multicast

For boards:
- MTB_MXCHIP_EMW3166
- MTB_ADV_WISE_1530
- MTB_USI_WM_BN_BM_22
Ipv4 multicast filtering is disable. All use WISE1530 module. Looks like multicast filtring adding is correct by calling mcast_list ioctl with pattern (01:00:5e:x:x:x for ipv4 and 33:33:x:x:x:x for ipv6) but for ipv4 doesn't work and it strongly suggest bug in firmware. 

 


### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
