### PR TITLE
Cellular: Fix resolving of DNS server IPv4/6 address

### DIFF
--- a/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
+++ b/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
@@ -184,60 +184,54 @@ TEST_F(Testutil, separate_ip_addresses)
     char ip[64] = {0};
     char subnet[64] = {0};
 
-    strncpy(s, "32.1.20.187.1.112.139.245.251.136.232.110.123.51.230.138.0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15\0", 95);
+    // IP address representations formats are for IPv6 or IPv4 address, with and without mask, in dotted or colon (IPv6 only) notation
+
+    // IPv6 with a mask in dotted notation
+    strncpy(s, "32.1.20.187.1.112.139.245.251.136.232.110.123.51.230.138.0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15\0",
+            sizeof("32.1.20.187.1.112.139.245.251.136.232.110.123.51.230.138.0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15\0"));
     separate_ip_addresses(NULL, ip, sizeof(ip), subnet, sizeof(subnet));
 
     separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
     EXPECT_STREQ("2001:14BB:170:8BF5:FB88:E86E:7B33:E68A", ip);
     EXPECT_STREQ("001:203:405:607:809:A0B:C0D:E0F", subnet);
 
-    strncpy(s, "32:1:20:187:1:112:139:245:251:136:232:110:123:51:230:138 0:1:2:3:4:5:6:7:8:9:10:11:12:13:14:15\0", 95);
+    // IPv6 with mask in colon notation
+    strncpy(s, "32:1:20:187:1:112:139:1245 0:1:2:3:4:5:6:7\0", sizeof("32:1:20:187:1:112:139:1245 0:1:2:3:4:5:6:7\0"));
     separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("32:1:20:187:1:112:139:245:251:136:232:110:123:51:230:138", ip);
-    EXPECT_STREQ("0:1:2:3:4:5:6:7:8:9:10:11:12:13:14:15", subnet);
+    EXPECT_STREQ("32:1:20:187:1:112:139:1245", ip);
+    EXPECT_STREQ("0:1:2:3:4:5:6:7", subnet);
 
     ip[0] = '\0';
     subnet[0] = '\0';
-    strncpy(s, "1.2.3.4\0", 8);
+    // IPv6 without mask in dotted notation
+    strncpy(s, "0.2.3.4.5.6.7.8.90.100.11.12.13.14.15.16\0", sizeof("0.2.3.4.5.6.7.8.90.100.11.12.13.14.15.16\0"));
     separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("1.2.3.4", ip);
+    EXPECT_STREQ("002:304:506:708:5A64:B0C:D0E:F10", ip);
     EXPECT_STREQ("", subnet);
 
     ip[0] = '\0';
     subnet[0] = '\0';
-    strncpy(s, "1.2.3.4.5.6.7.8\0", 16);
+    // IPv6 without mask in colon notation
+    strncpy(s, "0032:1:20:187:0:112:139:245f\0", sizeof("0032:1:20:187:0:112:139:245f\0"));
     separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("1.2.3.4", ip);
-    EXPECT_STREQ("5.6.7.8", subnet);
-
-    ip[0] = '\0';
-    subnet[0] = '\0';
-    strncpy(s, "1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16\0", 39);
-    separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("102:304:506:708:90A:B0C:D0E:F10", ip);
+    EXPECT_STREQ("0032:1:20:187:0:112:139:245f", ip);
     EXPECT_STREQ("", subnet);
 
     ip[0] = '\0';
     subnet[0] = '\0';
-    strncpy(s, "32:1:20:187:1:112:139:245:251:136:232:110:123:51:230:138\0", 57);
+    // IPv4 with mask
+    strncpy(s, "100.0.3.40.255.6.7.80\0", sizeof("100.0.3.40.255.6.7.80\0"));
     separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("32:1:20:187:1:112:139:245:251:136:232:110:123:51:230:138", ip);
+    EXPECT_STREQ("100.0.3.40", ip);
+    EXPECT_STREQ("255.6.7.80", subnet);
+
+    ip[0] = '\0';
+    subnet[0] = '\0';
+    // IPv4 without mask
+    strncpy(s, "1.255.3.0\0", sizeof("1.255.3.0\0"));
+    separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
+    EXPECT_STREQ("1.255.3.0", ip);
     EXPECT_STREQ("", subnet);
-
-    ip[0] = '\0';
-    subnet[0] = '\0';
-    strncpy(s, "1.2.3.4 32:1:20:187:1:112:139:245:251:136:232:110:123:51:230:138\0", 65);
-    separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("1.2.3.4", ip);
-    EXPECT_STREQ("32:1:20:187:1:112:139:245:251:136:232:110:123:51:230:138", subnet);
-
-    ip[0] = '\0';
-    subnet[0] = '\0';
-    strncpy(s, "1.2.3.4 5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20\0", 51);
-    separate_ip_addresses(s, ip, sizeof(ip), subnet, sizeof(subnet));
-    EXPECT_STREQ("1.2.3.4", ip);
-    EXPECT_STREQ("506:708:90A:B0C:D0E:F10:1112:1314", subnet);
-    EXPECT_STREQ("1.2.3.4 5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20", s);
 }
 
 TEST_F(Testutil, get_dynamic_ip_port)

--- a/UNITTESTS/stubs/CellularUtil_stub.cpp
+++ b/UNITTESTS/stubs/CellularUtil_stub.cpp
@@ -69,9 +69,11 @@ void separate_ip4like_addresses(char *orig, char *ip, size_t ip_size, char *ip2,
                strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx]));
         ip[strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx])] = '\0';
         CellularUtil_stub::table_idx--;
-        memcpy(ip2, CellularUtil_stub::char_table[CellularUtil_stub::table_idx],
-               strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx]));
-        ip2[strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx])] = '\0';
+        if (ip2) {
+            memcpy(ip2, CellularUtil_stub::char_table[CellularUtil_stub::table_idx],
+                   strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx]));
+            ip2[strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx])] = '\0';
+        }
     }
 }
 
@@ -83,9 +85,11 @@ void separate_ip_addresses(char *orig, char *ip, size_t ip_size, char *ip2, size
                strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx]));
         ip[strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx])] = '\0';
         CellularUtil_stub::table_idx--;
-        memcpy(ip2, CellularUtil_stub::char_table[CellularUtil_stub::table_idx],
-               strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx]));
-        ip2[strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx])] = '\0';
+        if (ip2) {
+            memcpy(ip2, CellularUtil_stub::char_table[CellularUtil_stub::table_idx],
+                   strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx]));
+            ip2[strlen(CellularUtil_stub::char_table[CellularUtil_stub::table_idx])] = '\0';
+        }
     }
 }
 

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -816,9 +816,7 @@ nsapi_error_t AT_CellularContext::get_rate_control(
 nsapi_error_t AT_CellularContext::get_pdpcontext_params(pdpContextList_t &params_list)
 {
     const int ipv6_subnet_size = 128;
-    const int max_ipv6_size = 64;
     char *ipv6_and_subnetmask = new char[ipv6_subnet_size];
-    char *temp = new char[max_ipv6_size];
 
     _at.lock();
 
@@ -834,38 +832,28 @@ nsapi_error_t AT_CellularContext::get_pdpcontext_params(pdpContextList_t &params
 
         // rest are optional params
         ipv6_and_subnetmask[0] = '\0';
-        temp[0] = '\0';
         _at.read_string(ipv6_and_subnetmask, ipv6_subnet_size);
         separate_ip_addresses(ipv6_and_subnetmask, params->local_addr, sizeof(params->local_addr), params->local_subnet_mask, sizeof(params->local_subnet_mask));
         ipv6_and_subnetmask[0] = '\0';
 
         _at.read_string(ipv6_and_subnetmask, ipv6_subnet_size);
-        separate_ip_addresses(ipv6_and_subnetmask, params->gateway_addr, sizeof(params->gateway_addr), temp, max_ipv6_size);
-        prefer_ipv6(params->gateway_addr, sizeof(params->gateway_addr), temp, max_ipv6_size);
+        separate_ip_addresses(ipv6_and_subnetmask, params->gateway_addr, sizeof(params->gateway_addr), NULL, 0);
         ipv6_and_subnetmask[0] = '\0';
-        temp[0] = '\0';
 
         _at.read_string(ipv6_and_subnetmask, ipv6_subnet_size);
-        separate_ip_addresses(ipv6_and_subnetmask, params->dns_primary_addr, sizeof(params->dns_primary_addr), temp, max_ipv6_size);
-        prefer_ipv6(params->dns_primary_addr, sizeof(params->dns_primary_addr), temp, max_ipv6_size);
+        separate_ip_addresses(ipv6_and_subnetmask, params->dns_primary_addr, sizeof(params->dns_primary_addr), NULL, 0);
         ipv6_and_subnetmask[0] = '\0';
-        temp[0] = '\0';
 
         _at.read_string(ipv6_and_subnetmask, ipv6_subnet_size);
-        separate_ip_addresses(ipv6_and_subnetmask, params->dns_secondary_addr, sizeof(params->dns_secondary_addr), temp, max_ipv6_size);
-        prefer_ipv6(params->dns_secondary_addr, sizeof(params->dns_secondary_addr), temp, max_ipv6_size);
+        separate_ip_addresses(ipv6_and_subnetmask, params->dns_secondary_addr, sizeof(params->dns_secondary_addr), NULL, 0);
         ipv6_and_subnetmask[0] = '\0';
-        temp[0] = '\0';
 
         _at.read_string(ipv6_and_subnetmask, ipv6_subnet_size);
-        separate_ip_addresses(ipv6_and_subnetmask, params->p_cscf_prim_addr, sizeof(params->p_cscf_prim_addr), temp, max_ipv6_size);
-        prefer_ipv6(params->p_cscf_prim_addr, sizeof(params->p_cscf_prim_addr), temp, max_ipv6_size);
+        separate_ip_addresses(ipv6_and_subnetmask, params->p_cscf_prim_addr, sizeof(params->p_cscf_prim_addr), NULL, 0);
         ipv6_and_subnetmask[0] = '\0';
-        temp[0] = '\0';
 
         _at.read_string(ipv6_and_subnetmask, ipv6_subnet_size);
-        separate_ip_addresses(ipv6_and_subnetmask, params->p_cscf_sec_addr, sizeof(params->p_cscf_sec_addr), temp, max_ipv6_size);
-        prefer_ipv6(params->p_cscf_sec_addr, sizeof(params->p_cscf_sec_addr), temp, max_ipv6_size);
+        separate_ip_addresses(ipv6_and_subnetmask, params->p_cscf_sec_addr, sizeof(params->p_cscf_sec_addr), NULL, 0);
 
         params->im_signalling_flag = _at.read_int();
         params->lipa_indication = _at.read_int();
@@ -877,7 +865,6 @@ nsapi_error_t AT_CellularContext::get_pdpcontext_params(pdpContextList_t &params
     }
     _at.resp_stop();
 
-    delete [] temp;
     delete [] ipv6_and_subnetmask;
 
     return _at.unlock_return_error();

--- a/features/cellular/framework/common/CellularUtil.cpp
+++ b/features/cellular/framework/common/CellularUtil.cpp
@@ -205,16 +205,7 @@ void separate_ip_addresses(char *orig, char *ip, size_t ip_size, char *ip2, size
             }
         }
     } else {
-        temp = strstr(orig, " ");
-        // found space as separator and it wasn't in beginning --> contains 2 ip addresses
-        if (temp && temp != orig) {
-            separate_ip4like_addresses(temp++, ip2, ip2_size, NULL, 0);
-            orig[temp - orig - 1] = '\0';
-            separate_ip4like_addresses(orig, ip, ip_size, NULL, 0);
-            orig[temp - orig - 1] = ' '; // put space back to keep orig as original
-        } else {
-            separate_ip4like_addresses(orig, ip, ip_size, ip2, ip2_size);
-        }
+        separate_ip4like_addresses(orig, ip, ip_size, ip2, ip2_size);
     }
 }
 


### PR DESCRIPTION
### Description

Fix resolving of DNS server IPv4/6 address, if a network returns just IPv4 local address but both IPv4 and IPv6 addresses for DNS.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@mirelachirica 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
