### PR TITLE
Baremetal: Fix the bare_metal configuration for NRF52840_DK

### DIFF
--- a/platform/bare_metal/mbed_lib.json
+++ b/platform/bare_metal/mbed_lib.json
@@ -1,4 +1,4 @@
 {
   "name": "bare-metal",
-  "requires": ["platform", "drivers"]
+  "requires": ["platform", "drivers", "mbedtls"]
 }


### PR DESCRIPTION
### Description

The NRF52840_DK target relies on the mbedtls library to compile
successfully.

Steps to reproduce failure (without the change(s) in this PR):

1. Clone mbed-os-example-blinky-baremetal
2. Change the current working directory to `mbed-os-example-blinky-baremetal`
3. Run `mbed deploy`
4. Change the current working directory to `mbed-os-example-blinky-baremetal/mbed-os`
5. Run `git checkout master`
6. Change the current working directory to `mbed-os-example-blinky-baremetal`
7. Run `mbed compile -t <ARM or GCC_ARM> -m NRF52840_DK`

Expected result: Build completes suyccessfully
Actual result: Build fails with the following error

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @0xc0170 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
