### PR TITLE
modified Wi-SUN tasklet to return success when calling connect twice

### DIFF
--- a/features/nanostack/nanostack-interface/Nanostack.cpp
+++ b/features/nanostack/nanostack-interface/Nanostack.cpp
@@ -116,7 +116,7 @@ nsapi_error_t map_mesh_error(mesh_error_t err)
         case MESH_ERROR_PARAM:
             return NSAPI_ERROR_PARAMETER;
         case MESH_ERROR_STATE:
-            return NSAPI_ERROR_DEVICE_ERROR;
+            return NSAPI_ERROR_IS_CONNECTED;
         default:
             return NSAPI_ERROR_DEVICE_ERROR;
     }


### PR DESCRIPTION
### Description

If connect to be called multiple times it will return NSAPI_ERROR_IS_CONNECTED status.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [X] Breaking change

### Reviewers

@JarkkoPaso @artokin @SeppoTakalo @AnttiKauppila @teetak01 

### Release Notes

##### Summary of changes
As stated in Mesh API documentation, we should return the status NSAPI_ERROR_IS_CONNECTED if connect is called twice. This PR (11556) fixes it.

##### Impact of changes

If connect method is called twice then different status code is returned.

##### Migration actions required

Implementations that rely on NSAPI_ERROR_DEVICE_ERROR status code when calling connect twice as their recovery method needs to change the handling to the correct status NSAPI_ERROR_IS_CONNECTED.