### PR TITLE
Explicitly set tdb internal flash size for PSoC6 Targets

### DIFF
--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -22,6 +22,9 @@
         "FVP_MPS2": {
             "internal_size": "0x200000",
             "internal_base_address": "0x00200000"
+        },
+        "MCU_PSOC6": {
+            "internal_size": "7168"
         }
     }
 }


### PR DESCRIPTION
### Description
The default computation comes up with a size that is too small on PSoC 6 devices. This is a similar change to #11298, but for PSoC 6 boards which implement TDB in internal storage.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies`
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type
@ARMmbed/team-cypress
<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
