### PR TITLE
Simplicy QSPIF target overrides for PSoC6

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -39,23 +39,7 @@
             "QSPI_MIN_READ_SIZE": "4",
             "QSPI_MIN_PROG_SIZE": "4"
         }, 
-        "CY8CKIT_062S2_43012": {
-            "QSPI_FREQ": "50000000",
-            "QSPI_MIN_PROG_SIZE": "512"
-        },
-        "CY8CPROTO_062_4343W": {
-            "QSPI_FREQ": "50000000",
-            "QSPI_MIN_PROG_SIZE": "512"
-        },
-        "CY8CKIT_062_WIFI_BT": {
-            "QSPI_FREQ": "50000000",
-            "QSPI_MIN_PROG_SIZE": "512"
-        },
-        "CY8CKIT_062_BLE": {
-            "QSPI_FREQ": "50000000",
-            "QSPI_MIN_PROG_SIZE": "512"
-        },
-        "CYW943012P6EVB_01": {
+        "MCU_PSOC6": {
             "QSPI_FREQ": "50000000",
             "QSPI_MIN_PROG_SIZE": "512"
         }


### PR DESCRIPTION
### Description
All current PSoC 6 targets support the same QSPI frequency and minimum
program size. So specify a single entry rather than duplicating for
each device.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
