### PR TITLE
Allow OS_THREAD_LIBSPACE_NUM as a macro

### DIFF
--- a/rtos/source/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/source/TARGET_CORTEX/mbed_rtx_conf.h
@@ -82,7 +82,9 @@
 // Provide Mbed-specific instead.
 #define RTX_NO_MULTITHREAD_CLIB
 // LIBSPACE default value set for ARMCC
+#ifndef OS_THREAD_LIBSPACE_NUM
 #define OS_THREAD_LIBSPACE_NUM      4
+#endif
 
 #define OS_IDLE_THREAD_NAME         "rtx_idle"
 #define OS_TIMER_THREAD_NAME        "rtx_timer"

--- a/rtos/source/TARGET_CORTEX/rtx5/RTX/Config/RTX_Config.h
+++ b/rtos/source/TARGET_CORTEX/rtx5/RTX/Config/RTX_Config.h
@@ -568,7 +568,9 @@
 // Number of Threads which use standard C/C++ library libspace
 // (when thread specific memory allocation is not used).
 #if (OS_THREAD_OBJ_MEM == 0)
+#ifndef OS_THREAD_LIBSPACE_NUM
 #define OS_THREAD_LIBSPACE_NUM      4
+#endif
 #else
 #define OS_THREAD_LIBSPACE_NUM      OS_THREAD_NUM
 #endif

--- a/tools/test_configs/CellularInterface.json
+++ b/tools/test_configs/CellularInterface.json
@@ -1,4 +1,7 @@
 {
+    "macros": [
+        "OS_THREAD_LIBSPACE_NUM=5"
+    ],
     "config": {
         "echo-server-addr" : {
             "help" : "IP address of echo server",


### PR DESCRIPTION
### Description

`OS_THREAD_LIBSPACE_NUM` is defined to 4, which is not a good default in all cases. This change makes it possible to give `OS_THREAD_LIBSPACE_NUM` also as a macro.

Mbed netsocket tests over cellular require `OS_THREAD_LIBSPACE_NUM` to be 5.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kivaisan 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
