### PR TITLE
report error if attempt to pad data fails

### DIFF
--- a/tools/regions.py
+++ b/tools/regions.py
@@ -166,8 +166,11 @@ def merge_region_list(
         _, begin = merged.segments()[0]
         for start, stop in merged.segments()[1:]:
             pad_size = start - begin
-            merged.puts(begin, padding * pad_size)
-            begin = stop + 1
+            try:
+                merged.puts(begin, padding * pad_size)
+                begin = stop + 1
+            except: 				
+                notify.info("Error while attempting to fill gaps in data for output binary")
 
     if not exists(dirname(destination)):
         makedirs(dirname(destination))


### PR DESCRIPTION
### Description

Partial fix for https://github.com/ARMmbed/mbed-os/issues/11576.  Notifies the user if there was a problem instead of letting Python crash.  

Tested with Python 2.7 and 3.7.  


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/mbed-os-tools 

### Release Notes

