### PR TITLE
Add synchronization and switching between WhdSoftAPInterface and WhdSTAInterfaces

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/CyDhcpServer.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/CyDhcpServer.cpp
@@ -346,6 +346,9 @@ void CyDhcpServer::runServer(void)
 
     /* Create receive DHCP socket */
     _socket.open(_nstack);
+    char iface_name[8] = {0};
+    _niface->get_interface_name(iface_name);
+    _socket.setsockopt(NSAPI_SOCKET, NSAPI_BIND_TO_DEVICE, iface_name, strlen(iface_name));
     _socket.bind((uint16_t)IP_PORT_DHCP_SERVER);
 
     /* Save the current netmask to be sent in DHCP packets as the 'subnet mask option' */

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSTAInterface.h
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSTAInterface.h
@@ -22,6 +22,7 @@
 #include "netsocket/EMACInterface.h"
 #include "netsocket/OnboardNetworkStack.h"
 #include "whd_emac.h"
+#include "whd_interface.h"
 #include "whd_types_int.h"
 
 struct ol_desc;
@@ -58,7 +59,8 @@ public:
     WhdSTAInterface(
         WHD_EMAC &emac = WHD_EMAC::get_instance(),
         OnboardNetworkStack &stack = OnboardNetworkStack::get_default_instance(),
-        OlmInterface &olm = OlmInterface::get_default_instance());
+        OlmInterface &olm = OlmInterface::get_default_instance(),
+        whd_interface_shared_info_t &shared = whd_iface_shared);
 
     static WhdSTAInterface *get_default_instance();
 
@@ -215,6 +217,7 @@ private:
     nsapi_security_t _security;
     WHD_EMAC &_whd_emac;
     OlmInterface *_olm;
+    whd_interface_shared_info_t &_iface_shared;
 };
 
 #endif

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSoftAPInterface.h
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSoftAPInterface.h
@@ -23,6 +23,7 @@
 #include "netsocket/OnboardNetworkStack.h"
 #include "whd_emac.h"
 #include "CyDhcpServer.h"
+#include "whd_interface.h"
 #include <memory>
 
 /**
@@ -47,7 +48,8 @@ public:
      *  @return  pointer to default WhdSoftAPInterface instance
      */
     WhdSoftAPInterface(WHD_EMAC &emac = WHD_EMAC::get_instance(WHD_AP_ROLE),
-                       OnboardNetworkStack &stack = OnboardNetworkStack::get_default_instance());
+                       OnboardNetworkStack &stack = OnboardNetworkStack::get_default_instance(),
+                       whd_interface_shared_info_t &shared = whd_iface_shared);
 
     /** Get the default WhdSoftAPInterface instance.
      *  @return  pointer to default WhdSoftAPInterface instance
@@ -135,6 +137,7 @@ public:
 protected:
     WHD_EMAC &_whd_emac;
     std::unique_ptr<CyDhcpServer> _dhcp_server;
+    whd_interface_shared_info_t &_iface_shared;
 };
 
 #endif

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/whd_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/whd_emac.cpp
@@ -109,7 +109,13 @@ bool WHD_EMAC::power_up()
             // wifi driver and turns on the wifi chip.
             res = cybsp_wifi_init_secondary(&ifp /* Out */, &unicast_addr);
         } else {
-            res = cybsp_wifi_init_primary(&ifp /* OUT */);
+            WHD_EMAC &emac_other = WHD_EMAC::get_instance(interface_type == WHD_STA_ROLE ? WHD_AP_ROLE :
+                                                          WHD_STA_ROLE);
+            if (!emac_other.powered_up) {
+                res = cybsp_wifi_init_primary(&ifp /* OUT */);
+            } else {
+                ifp = emac_other.ifp;
+            }
         }
 
         if (CY_RSLT_SUCCESS == res) {

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/whd_interface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/whd_interface.cpp
@@ -17,6 +17,9 @@
 
 #include "WhdSTAInterface.h"
 #include "WhdSoftAPInterface.h"
+#include "whd_interface.h"
+
+whd_interface_shared_info_t whd_iface_shared;
 
 WiFiInterface *WiFiInterface::get_target_default_instance()
 {

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/whd_interface.h
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/whd_interface.h
@@ -1,0 +1,51 @@
+/* WHD implementation of NetworkInterfaceAPI
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WHD_INTERFACE_H
+#define WHD_INTERFACE_H
+
+#include "rtos/Mutex.h"
+#include "OnboardNetworkStack.h"
+
+/** WhdSTAInterface class
+ *  Shared information 
+ */
+#define IF_STATUS_ALL_IF_DOWN   0x0
+#define IF_STATUS_STA_UP        0x1
+#define IF_STATUS_SOFT_AP_UP    0x2
+
+enum whd_default_interface_config 
+{
+    DEFAULT_IF_NOT_SET,
+    DEFAULT_IF_STA,
+    DEFAULT_IF_SOFT_AP
+};
+
+struct whd_interface_shared_info_t {
+    rtos::Mutex mutex;
+    whd_default_interface_config default_if_cfg;
+    uint32_t if_status_flags;
+    OnboardNetworkStack::Interface *iface_sta;
+    OnboardNetworkStack::Interface *iface_softap;
+    whd_interface_shared_info_t() : default_if_cfg(DEFAULT_IF_NOT_SET), if_status_flags(IF_STATUS_ALL_IF_DOWN),
+                                    iface_sta(NULL), iface_softap(NULL)
+    {}
+};
+
+extern whd_interface_shared_info_t whd_iface_shared;
+
+#endif


### PR DESCRIPTION
### Description
Currently, there is no synchronization between STA and SoftAP interfaces which shares the same underlying WHD device. Synchronization mechanism using lock_guard is added to serialize operations including
- SoftAP: start, stop
- STA: scan, connect, disconnect

Also resolved switching issue between SoftAP and STA mode for primary interface
  - Avoid reinit primary interface by getting mapping the current interface to the other one which is already on
  - In concurrent mode, STA is the default if it is up, otherwise SoftAP is set as default.
  - For non-concurrent mode, the most recent started interface is set as default.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
