### PR TITLE
Remove target dependency in ublox cellular APIs

### DIFF
--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -20,14 +20,36 @@
 using namespace mbed;
 using namespace events;
 
-#ifdef TARGET_UBLOX_C030_R41XM
+#ifdef UBX_MDM_SARA_R41XM
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeDisable,// C_EREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_REG
     0,  // AT_CGSN_WITH_TYPE
+    0,  // AT_CGDATA
+    0,  // AT_CGAUTH
+    1,  // AT_CNMI
+    1,  // AT_CSMP
+    1,  // AT_CMGF
+    0,  // AT_CSDH
+    1,  // PROPERTY_IPV4_STACK
+    0,  // PROPERTY_IPV6_STACK
+    0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
+};
+#elif defined(UBX_MDM_SARA_U2XX) || defined(UBX_MDM_SARA_G3XX)
+static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
+    AT_CellularNetwork::RegistrationModeDisable,// C_EREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
+#ifdef UBX_MDM_SARA_G3XX
+    0,  // AT_CGSN_WITH_TYPE
+#else
+    1,  // AT_CGSN_WITH_TYPE
+#endif
     1,  // AT_CGDATA
-    1,  // AT_CGAUTH
+    0,  // AT_CGAUTH
     1,  // AT_CNMI
     1,  // AT_CSMP
     1,  // AT_CMGF
@@ -39,23 +61,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_AT_CGEREP
 };
 #else
-static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
-    AT_CellularNetwork::RegistrationModeDisable,// C_EREG
-    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
-    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
-    1,  // AT_CGSN_WITH_TYPE
-    1,  // AT_CGDATA
-    1,  // AT_CGAUTH
-    1,  // AT_CNMI
-    1,  // AT_CSMP
-    1,  // AT_CMGF
-    1,  // AT_CSDH
-    1,  // PROPERTY_IPV4_STACK
-    0,  // PROPERTY_IPV6_STACK
-    0,  // PROPERTY_IPV4V6_STACK
-    0,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
-};
+#error This modem is currently not supported.
 #endif
 
 UBLOX_AT::UBLOX_AT(FileHandle *fh) : AT_CellularDevice(fh)
@@ -98,7 +104,7 @@ nsapi_error_t UBLOX_AT::init()
 
     nsapi_error_t err = NSAPI_ERROR_OK;
 
-#ifdef TARGET_UBLOX_C027
+#ifdef UBX_MDM_SARA_G3XX
     err = _at->at_cmd_discard("+CFUN", "=0");
 
     if (err == NSAPI_ERROR_OK) {
@@ -107,7 +113,7 @@ nsapi_error_t UBLOX_AT::init()
         config_authentication_parameters();
         err = _at->at_cmd_discard("+CFUN", "=1"); // set full functionality
     }
-#else
+#elif defined(UBX_MDM_SARA_U2XX) || defined(UBX_MDM_SARA_R41XM)
     err = _at->at_cmd_discard("+CFUN", "=4");
     if (err == NSAPI_ERROR_OK) {
         _at->at_cmd_discard("E0", ""); // echo off
@@ -115,6 +121,8 @@ nsapi_error_t UBLOX_AT::init()
         config_authentication_parameters();
         err = _at->at_cmd_discard("+CFUN", "=1"); // set full functionality
     }
+#else
+#error This modem is currently not supported.
 #endif
 
     return _at->unlock_return_error();
@@ -155,7 +163,7 @@ nsapi_error_t UBLOX_AT::set_authentication_parameters(const char *apn,
     nsapi_error_t err = _at->at_cmd_discard("+CGDCONT", "=", "%d%s%s", 1, "IP", apn);
 
     if (err == NSAPI_ERROR_OK) {
-#ifdef TARGET_UBLOX_C030_R41XM
+#ifdef UBX_MDM_SARA_R41XM
         if (modem_security == CellularContext::CHAP) {
             err = _at->at_cmd_discard("+UAUTHREQ", "=", "%d%d%s%s", 1, modem_security, password, username);
         } else if (modem_security == CellularContext::NOAUTH) {

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -61,7 +61,23 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_AT_CGEREP
 };
 #else
-#error This modem is currently not supported.
+static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
+    0,  // C_EREG
+    0,  // C_GREG
+    0,  // C_REG
+    0,  // AT_CGSN_WITH_TYPE
+    0,  // AT_CGDATA
+    0,  // AT_CGAUTH
+    0,  // AT_CNMI
+    0,  // AT_CSMP
+    0,  // AT_CMGF
+    0,  // AT_CSDH
+    0,  // PROPERTY_IPV4_STACK
+    0,  // PROPERTY_IPV6_STACK
+    0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    0,  // PROPERTY_AT_CGEREP
+};
 #endif
 
 UBLOX_AT::UBLOX_AT(FileHandle *fh) : AT_CellularDevice(fh)
@@ -122,7 +138,8 @@ nsapi_error_t UBLOX_AT::init()
         err = _at->at_cmd_discard("+CFUN", "=1"); // set full functionality
     }
 #else
-#error This modem is currently not supported.
+    _at->unlock();
+    return NSAPI_ERROR_UNSUPPORTED;
 #endif
 
     return _at->unlock_return_error();

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.cpp
@@ -18,7 +18,6 @@
 #include "UBLOX_AT_CellularStack.h"
 #include "APN_db.h"
 #include "CellularLog.h"
-
 #include "rtos/ThisThread.h"
 
 namespace mbed {
@@ -53,9 +52,9 @@ void UBLOX_AT_CellularContext::do_connect()
     _cb_data.error = NSAPI_ERROR_NO_CONNECTION;
 
     // Attempt to establish a connection
-#ifndef TARGET_UBLOX_C030_R41XM
+#ifndef UBX_MDM_SARA_R41XM
     _cb_data.error = define_context();
-#elif TARGET_UBLOX_C030_R410M
+#elif UBX_MDM_SARA_R410M
     _at.cmd_start_stop("+CGACT", "?");
     _at.resp_start("+CGACT:");
     _cid = _at.read_int();
@@ -66,7 +65,7 @@ void UBLOX_AT_CellularContext::do_connect()
     _is_context_active = true;
     _is_context_activated = true;
     _cb_data.error = NSAPI_ERROR_OK;
-#elif TARGET_UBLOX_C030_R412M
+#elif UBX_MDM_SARA_R412M
     CellularNetwork::RadioAccessTechnology rat = read_radio_technology();
     if (rat == CellularNetwork::RadioAccessTechnology::RAT_EGPRS) {
         if (!_is_context_active) {
@@ -115,7 +114,7 @@ void UBLOX_AT_CellularContext::do_connect()
     }
 }
 
-#ifndef TARGET_UBLOX_C030_R41XM
+#ifndef UBX_MDM_SARA_R41XM
 nsapi_error_t UBLOX_AT_CellularContext::define_context()
 {
     bool success = false;
@@ -249,7 +248,7 @@ int UBLOX_AT_CellularContext::nsapi_security_to_modem_security(AuthenticationTyp
         case CHAP:
             modem_security = 2;
             break;
-#ifndef TARGET_UBLOX_C030_R41XM
+#ifndef UBX_MDM_SARA_R41XM
         case AUTOMATIC:
             modem_security = 3;
             break;
@@ -324,7 +323,7 @@ CellularContext::AuthenticationType UBLOX_AT_CellularContext::get_auth()
     return _authentication_type;
 }
 
-#ifdef TARGET_UBLOX_C030_R412M
+#ifdef UBX_MDM_SARA_R412M
 CellularNetwork::RadioAccessTechnology UBLOX_AT_CellularContext::read_radio_technology()
 {
     int act;
@@ -358,6 +357,6 @@ CellularNetwork::RadioAccessTechnology UBLOX_AT_CellularContext::read_radio_tech
 
     return rat;
 }
-#endif // #ifdef TARGET_UBLOX_C030_R412M
+#endif // #ifdef UBX_MDM_SARA_R412M
 
 } /* namespace mbed */

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.h
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularContext.h
@@ -45,7 +45,7 @@ public:
     /** Get the next set of credentials from the database.
      */
     void get_next_credentials(char **config);
-#ifdef TARGET_UBLOX_C030_R412M
+#ifdef UBX_MDM_SARA_R412M
     CellularNetwork::RadioAccessTechnology read_radio_technology(void);
 #endif
 protected:
@@ -55,7 +55,7 @@ protected:
      *
      * @return      True if successful, otherwise false.
      */
-#ifndef TARGET_UBLOX_C030_R41XM
+#ifndef UBX_MDM_SARA_R41XM
     nsapi_error_t define_context();
 #endif
 
@@ -79,7 +79,7 @@ private:
      *                 CHAP or AUTOMATIC).
      * @return         True if successful, otherwise false.
      */
-#ifndef TARGET_UBLOX_C030_R41XM
+#ifndef UBX_MDM_SARA_R41XM
     bool activate_profile(const char *apn, const char *username, const char *password, AuthenticationType auth);
 #endif
 

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "UBLOX_AT_CellularNetwork.h"
-
 #include "rtos/ThisThread.h"
 
 using namespace mbed;
@@ -47,11 +46,11 @@ nsapi_error_t UBLOX_AT_CellularNetwork::set_access_technology_impl(RadioAccessTe
     _at.lock();
     switch (opRat) {
         case RAT_EGPRS:
-#if defined (TARGET_UBLOX_C030_R412M)
+#if defined (UBX_MDM_SARA_R412M)
             _at.at_cmd_discard("+URAT", "=", "%d%d", 9, 8);
             break;
 #endif
-#if defined(TARGET_UBLOX_C030_U201)
+#if defined(UBX_MDM_SARA_U201)
         case RAT_GSM:
             _at.at_cmd_discard("+URAT", "=", "%d%d", 0, 0);
             break;
@@ -61,7 +60,7 @@ nsapi_error_t UBLOX_AT_CellularNetwork::set_access_technology_impl(RadioAccessTe
         case RAT_HSDPA_HSUPA:
             _at.at_cmd_discard("+URAT", "=", "%d%d", 2, 2);
             break;
-#elif defined(TARGET_UBLOX_C030_R41XM)
+#elif defined(UBX_MDM_SARA_R41XM)
         case RAT_CATM1:
             _at.at_cmd_discard("+URAT", "=", "%d%d", 7, 8);
             break;

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -447,7 +447,7 @@ nsapi_error_t UBLOX_AT_CellularStack::gethostbyname(const char *host, SocketAddr
     if (address->set_ip_address(host)) {
         err = NSAPI_ERROR_OK;
     } else {
-#ifdef TARGET_UBLOX_C030_R41XM
+#ifdef UBX_MDM_SARA_R41XM
         _at.set_at_timeout(70000);
 #else
         _at.set_at_timeout(120000);

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -21,14 +21,36 @@
 using namespace mbed;
 using namespace events;
 
-#ifdef TARGET_UBLOX_C027
+#ifdef UBX_MDM_SARA_R41XM
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeDisable,// C_EREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
     AT_CellularNetwork::RegistrationModeLAC,    // C_REG
     0,  // AT_CGSN_WITH_TYPE
+    0,  // AT_CGDATA
+    0,  // AT_CGAUTH
+    1,  // AT_CNMI
+    1,  // AT_CSMP
+    1,  // AT_CMGF
+    0,  // AT_CSDH
+    1,  // PROPERTY_IPV4_STACK
+    0,  // PROPERTY_IPV6_STACK
+    0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    1,  // PROPERTY_AT_CGEREP
+};
+#elif defined(UBX_MDM_SARA_U2XX) || defined(UBX_MDM_SARA_G3XX)
+static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
+    AT_CellularNetwork::RegistrationModeDisable,// C_EREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
+    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
+#ifdef UBX_MDM_SARA_G3XX
+    0,  // AT_CGSN_WITH_TYPE
+#else
+    1,  // AT_CGSN_WITH_TYPE
+#endif
     1,  // AT_CGDATA
-    1,  // AT_CGAUTH
+    0,  // AT_CGAUTH
     1,  // AT_CNMI
     1,  // AT_CSMP
     1,  // AT_CMGF
@@ -40,23 +62,7 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_AT_CGEREP
 };
 #else
-static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
-    AT_CellularNetwork::RegistrationModeDisable,// C_EREG
-    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
-    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
-    1,  // AT_CGSN_WITH_TYPE
-    1,  // AT_CGDATA
-    1,  // AT_CGAUTH
-    1,  // AT_CNMI
-    1,  // AT_CSMP
-    1,  // AT_CMGF
-    1,  // AT_CSDH
-    1,  // PROPERTY_IPV4_STACK
-    0,  // PROPERTY_IPV6_STACK
-    0,  // PROPERTY_IPV4V6_STACK
-    0,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
-};
+#error This modem is currently not supported.
 #endif
 
 UBLOX_PPP::UBLOX_PPP(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -62,7 +62,23 @@ static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     1,  // PROPERTY_AT_CGEREP
 };
 #else
-#error This modem is currently not supported.
+static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
+    0,  // C_EREG
+    0,  // C_GREG
+    0,  // C_REG
+    0,  // AT_CGSN_WITH_TYPE
+    0,  // AT_CGDATA
+    0,  // AT_CGAUTH
+    0,  // AT_CNMI
+    0,  // AT_CSMP
+    0,  // AT_CMGF
+    0,  // AT_CSDH
+    0,  // PROPERTY_IPV4_STACK
+    0,  // PROPERTY_IPV6_STACK
+    0,  // PROPERTY_IPV4V6_STACK
+    0,  // PROPERTY_NON_IP_PDP_TYPE
+    0,  // PROPERTY_AT_CGEREP
+};
 #endif
 
 UBLOX_PPP::UBLOX_PPP(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/UBLOX/README.md
+++ b/features/cellular/framework/targets/UBLOX/README.md
@@ -1,0 +1,27 @@
+## Configuring Ublox Cellular Modems for custom targets
+
+In order to use cellular APIs with custom targets, user needs to define ublox modem macros in `mbed_app.json` configuration file:
+```
+"target_overrides": {
+    "*": {
+        "mbed-trace.enable": true,
+        "platform.stdio-convert-newlines": true,
+        "platform.stdio-baud-rate": 115200,
+        "platform.default-serial-baud-rate": 115200
+    },
+    "K64F": {
+        "target.macros_add": ["UBX_MDM_SARA_R41XM", "UBX_MDM_SARA_R412M"]
+    }
+}
+```
+
+
+List of supported ublox modems and their respective macros are as follow:
+
+| Ublox mbed board  | Modem Name    | Family Macro         | Modem Macro          |
+| -----------       | :-----------: | :-------------:      | :-------------:      |
+| UBLOX_C027        | SARA-G350     | `UBX_MDM_SARA_G3XX`  | `UBX_MDM_SARA_G350`  |
+| UBLOX_C030_N211   | SARA-N211     | `UBX_MDM_SARA_N2XX`  | `UBX_MDM_SARA_N211`  |
+| UBLOX_C030_U201   | SARA-U201     | `UBX_MDM_SARA_U2XX`  | `UBX_MDM_SARA_U201`  |
+| UBLOX_C030_R410M  | SARA-R410M    | `UBX_MDM_SARA_R41XM` | `UBX_MDM_SARA_R410M` |
+| UBLOX_C030_R412M  | SARA-R412M    | `UBX_MDM_SARA_R41XM` | `UBX_MDM_SARA_R412M` |

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -707,7 +707,7 @@
                 "macro_name": "MODEM_ON_BOARD_UART"
             }
         },
-        "macros": ["TARGET_LPC1768"],
+        "macros": ["TARGET_LPC1768", "UBX_MDM_SARA_G3XX", "UBX_MDM_SARA_G350"],
         "inherits": ["LPCTarget"],
         "device_has": [
             "USTICKER",
@@ -4997,23 +4997,28 @@
     "UBLOX_C030_U201": {
         "inherits": ["UBLOX_C030"],
         "components_add": ["SD", "FLASHIAP"],
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "macros_add": ["UBX_MDM_SARA_U2XX", "UBX_MDM_SARA_U201"]
     },
     "UBLOX_C030_N211": {
         "inherits": ["UBLOX_C030"],
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "macros_add": ["UBX_MDM_SARA_N2XX", "UBX_MDM_SARA_N211"]
     },
     "UBLOX_C030_R41XM": {
         "inherits": ["UBLOX_C030"],
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "public": false
     },
     "UBLOX_C030_R410M": {
         "inherits": ["UBLOX_C030_R41XM"],
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "macros_add": ["UBX_MDM_SARA_R41XM", "UBX_MDM_SARA_R410M"]
     },
     "UBLOX_C030_R412M": {
         "inherits": ["UBLOX_C030_R41XM"],
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "macros_add": ["UBX_MDM_SARA_R41XM", "UBX_MDM_SARA_R412M"]
     },
     "NZ32_SC151": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
### Description
The intention of this PR is to allow ublox cellular APIs to be used with custom targets. 
When using ublox modem with a different MCU, user only has to define correct modem macros in their mbed_app.json like this:
 `        "K64F": {
            "target.macros_add": ["UBX_MDM_SARA_R41XM", "UBX_MDM_SARA_R412M"]
        }` 

Previously, as discussed in #11505 #11170, the APIs were tied to ublox mbed boards so it was troublesome to use the with a different MCU or a custom board.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@fahim-ublox @RobMeades @mudassar-ublox @pilotak 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
