### PR TITLE
Cellular: Fix setting of PDP context ID (cid)

### DIFF
--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -279,6 +279,10 @@ void AT_CellularContext::set_disconnect()
 {
 }
 
+void AT_CellularContext::set_cid(int cid)
+{
+}
+
 void AT_CellularContext::do_connect_with_retry()
 {
 

--- a/UNITTESTS/stubs/AT_CellularStack_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularStack_stub.cpp
@@ -94,3 +94,6 @@ void AT_CellularStack::socket_attach(nsapi_socket_t handle, void (*callback)(voi
 {
 }
 
+void AT_CellularStack::set_cid(int cid)
+{
+}

--- a/UNITTESTS/target_h/myCellularContext.h
+++ b/UNITTESTS/target_h/myCellularContext.h
@@ -216,6 +216,10 @@ public:
     {
     };
 
+    void set_cid(int cid)
+    {
+    };
+
     void do_connect_with_retry()
     {
     };

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -119,6 +119,7 @@ private:
     void ciot_opt_cb(mbed::CellularNetwork::CIoT_Supported_Opt ciot_opt);
     virtual void do_connect_with_retry();
     void do_disconnect();
+    void set_cid(int cid);
 private:
     bool _is_connected;
     ContextOperation  _current_op;

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -98,6 +98,11 @@ const char *AT_CellularStack::get_ip_address()
     return (ipv4 || ipv6) ? _ip : NULL;
 }
 
+void AT_CellularStack::set_cid(int cid)
+{
+    _cid = cid;
+}
+
 nsapi_error_t AT_CellularStack::socket_stack_init()
 {
     return NSAPI_ERROR_OK;

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -44,6 +44,14 @@ public:
 public: // NetworkStack
 
     virtual const char *get_ip_address();
+
+    /**
+     * Set PDP context ID for this stack
+     *
+     *  @param cid value from AT+CGDCONT, where -1 is undefined
+     */
+    void set_cid(int cid);
+
 protected: // NetworkStack
 
     /**


### PR DESCRIPTION
### Description

Fix setting of PDP context ID to `CellularStack` after reconnecting, and also clear CID when disconnect is network initiated.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@kivaisan 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
