### PR TITLE
TEST: change integration fs test format and mount order

### DIFF
--- a/TESTS/integration/fs-single/main.cpp
+++ b/TESTS/integration/fs-single/main.cpp
@@ -66,11 +66,11 @@ LittleFileSystem fs("sd");
 
 static control_t test_format(const size_t call_count)
 {
+    int format_err = fs.format(&sd);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, format_err, "could not format block device");
+
     int mount_err = fs.mount(&sd);
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, mount_err, "could not mount block device");
-
-    int format_err = fs.reformat(&sd);
-    TEST_ASSERT_EQUAL_INT_MESSAGE(0, format_err, "could not format block device");
 
     return CaseNext;
 }


### PR DESCRIPTION
### Description

This test case failed when using the fresh new sd card. it failed to mount.
Changed the setup order to format -> mount in the setup stage. So this is aligned with `fs-threaded` test, and make sure test case working with a new sd card.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@MarceloSalazar 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
