### PR TITLE
Cleaned up Mbed LWIP configurations

### DIFF
--- a/features/lwipstack/lwip-sys/arch/cc.h
+++ b/features/lwipstack/lwip-sys/arch/cc.h
@@ -1,40 +1,41 @@
-/* 
- * Copyright (c) 2001-2003 Swedish Institute of Computer Science. 
- * All rights reserved.  
- *  
- * Redistribution and use in source and binary forms, with or without modification,  
- * are permitted provided that the following conditions are met: 
- * 
- * 1. Redistributions of source code must retain the above copyright notice, 
- *    this list of conditions and the following disclaimer. 
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
- *    and/or other materials provided with the distribution. 
- * 3. The name of the author may not be used to endorse or promote products 
- *    derived from this software without specific prior written permission.  
- * 
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED  
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF  
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT  
- * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,  
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT  
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS  
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN  
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING  
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY  
- * OF SUCH DAMAGE. 
- * 
- * This file is part of the lwIP TCP/IP stack. 
- *  
- * Author: Adam Dunkels <adam@sics.se> 
- * 
- */ 
-#ifndef __CC_H__ 
-#define __CC_H__ 
+/*
+ * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __CC_H__
+#define __CC_H__
 
 #include <stdint.h>
 #include <stddef.h> /* for size_t */
 #include "mbed_toolchain.h"
+#include "lwipopts.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,7 +61,7 @@ extern "C" {
     #define PACK_STRUCT_END
     #define PACK_STRUCT_FIELD(fld) fld
     #define ALIGNED(n)  __align(n)
-#elif defined (__IAR_SYSTEMS_ICC__) 
+#elif defined (__IAR_SYSTEMS_ICC__)
     /* IAR Embedded Workbench tools */
     #define PACK_STRUCT_BEGIN __packed
     #define PACK_STRUCT_STRUCT
@@ -68,14 +69,14 @@ extern "C" {
     #define PACK_STRUCT_FIELD(fld) fld
     #define IAR_STR(a) #a
     #define ALIGNED(n) _Pragma(IAR_STR(data_alignment= ## n ##))
-#else 
+#else
     /* GCC tools (CodeSourcery) */
     #define PACK_STRUCT_BEGIN
     #define PACK_STRUCT_STRUCT __attribute__ ((__packed__))
     #define PACK_STRUCT_END
     #define PACK_STRUCT_FIELD(fld) fld
     #define ALIGNED(n)  __attribute__((aligned (n)))
-#endif 
+#endif
 
 /* Provide Thumb-2 routines for GCC to improve performance */
 #if defined(TOOLCHAIN_GCC) && defined(__thumb2__)
@@ -117,7 +118,7 @@ MBED_NORETURN void assert_printf(const char *msg, int line, const char *file);
 #define LWIP_PLATFORM_DIAG(vars) printf vars
 #define LWIP_PLATFORM_ASSERT(flag) { assert_printf((flag), __LINE__, __FILE__); }
 #endif // MBED_CONF_LWIP_USE_MBED_TRACE
-#endif 
+#endif
 
 #if TRACE_TO_ASCII_HEX_DUMP
 #define TRACE_TO_ASCII_HEX_DUMPF(prefix, len, data) trace_to_ascii_hex_dump(prefix, len, data)
@@ -182,4 +183,4 @@ SET_MEMP_SECTION(memp_memory_TCPIP_MSG_API_base);
 }
 #endif
 
-#endif /* __CC_H__ */ 
+#endif /* __CC_H__ */

--- a/features/lwipstack/lwip-sys/arch/cc.h
+++ b/features/lwipstack/lwip-sys/arch/cc.h
@@ -48,8 +48,10 @@ extern "C" {
 #define BYTE_ORDER LITTLE_ENDIAN
 #endif
 
+#ifndef LWIP_PROVIDE_ERRNO
 /* Use LWIP error codes */
 #define LWIP_PROVIDE_ERRNO
+#endif
 
 #if defined(__arm__) && defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 6010050)
     /* Keil uVision4 tools */

--- a/features/lwipstack/lwip/src/include/lwip/lwip_errno.h
+++ b/features/lwipstack/lwip/src/include/lwip/lwip_errno.h
@@ -44,6 +44,7 @@ extern "C" {
 #endif
 
 #ifdef LWIP_PROVIDE_ERRNO
+#if LWIP_PROVIDE_ERRNO == 1
 
 #define  EPERM            1  /* Operation not permitted */
 #define  ENOENT           2  /* No such file or directory */
@@ -177,6 +178,7 @@ extern "C" {
 extern int errno;
 #endif
 
+#endif //LWIP_PROVIDE_ERRNO == 1
 #else /* LWIP_PROVIDE_ERRNO */
 
 /* Define LWIP_ERRNO_STDINCLUDE if you want to include <errno.h> here */

--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -71,7 +71,10 @@
 #error "Either IPv4 or IPv6 must be preferred."
 #endif
 
-#define LWIP_DEBUG                  MBED_CONF_LWIP_DEBUG_ENABLED
+#undef  LWIP_DEBUG
+#if MBED_CONF_LWIP_DEBUG_ENABLED
+#define LWIP_DEBUG                  1
+#endif
 
 #if NO_SYS == 0
 #include "cmsis_os2.h"

--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -25,22 +25,20 @@
 #include <sys/time.h>
 #endif
 #include "nsapi_types.h"
+#include "mbed_retarget.h"
+
 // Operating System
 #define NO_SYS                      0
 
-#if MBED_CONF_LWIP_IPV4_ENABLED
-#define LWIP_IPV4                   1
-#else
-#define LWIP_IPV4                   0
-#endif
-#if MBED_CONF_LWIP_IPV6_ENABLED
-#define LWIP_IPV6                   1
-#else
-#define LWIP_IPV6                   0
-#endif
 #if !MBED_CONF_LWIP_IPV4_ENABLED && !MBED_CONF_LWIP_IPV6_ENABLED
 #error "Either IPv4 or IPv6 must be enabled."
 #endif
+
+#define LWIP_IPV4                   MBED_CONF_LWIP_IPV4_ENABLED
+
+#define LWIP_IPV6                   MBED_CONF_LWIP_IPV6_ENABLED
+
+#define LWIP_PROVIDE_ERRNO 0
 
 // On dual stack configuration how long to wait for both or preferred stack
 // addresses before completing bring up.
@@ -57,32 +55,23 @@
 #define BOTH_ADDR_TIMEOUT           0
 #endif
 
-// Configurable DHCP timeout. DHCP timeout can be configured for specific usecase requirement.
-#ifdef MBED_CONF_LWIP_DHCP_TIMEOUT
-#define DHCP_TIMEOUT                (MBED_CONF_LWIP_DHCP_TIMEOUT)
-#else
-#define DHCP_TIMEOUT                60
-#endif
+
+#define DHCP_TIMEOUT                MBED_CONF_LWIP_DHCP_TIMEOUT
 
 #define LINK_TIMEOUT                60
 
 #define PREF_IPV4                   1
 #define PREF_IPV6                   2
 
-#if MBED_CONF_LWIP_IP_VER_PREF == 4
-#define IP_VERSION_PREF             PREF_IPV4
-#endif
 #if MBED_CONF_LWIP_IP_VER_PREF == 6
 #define IP_VERSION_PREF             PREF_IPV6
-#endif
-#ifndef IP_VERSION_PREF
+#elif MBED_CONF_LWIP_IP_VER_PREF == 4
+#define IP_VERSION_PREF             PREF_IPV4
+#else
 #error "Either IPv4 or IPv6 must be preferred."
 #endif
 
-#undef  LWIP_DEBUG
-#if MBED_CONF_LWIP_DEBUG_ENABLED
-#define LWIP_DEBUG                  1
-#endif
+#define LWIP_DEBUG                  MBED_CONF_LWIP_DEBUG_ENABLED
 
 #if NO_SYS == 0
 #include "cmsis_os2.h"
@@ -102,11 +91,6 @@
 // Thread stacks use 8-byte alignment
 #define LWIP_ALIGN_UP(pos, align) ((pos) % (align) ? (pos) +  ((align) - (pos) % (align)) : (pos))
 
-// Thread stack size for lwip tcpip thread
-#ifndef MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE
-#define MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE      1200
-#endif
-
 #ifdef LWIP_DEBUG
 // For LWIP debug, double the stack
 #define TCPIP_THREAD_STACKSIZE      LWIP_ALIGN_UP(MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE*2, 8)
@@ -119,11 +103,6 @@
 
 // Thread priority (osPriorityNormal by default)
 #define TCPIP_THREAD_PRIO           (MBED_CONF_LWIP_TCPIP_THREAD_PRIORITY)
-
-// Thread stack size for lwip system threads
-#ifndef MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE
-#define MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE    512
-#endif
 
 #ifdef LWIP_DEBUG
 #define DEFAULT_THREAD_STACKSIZE    LWIP_ALIGN_UP(MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE*2, 8)
@@ -143,43 +122,24 @@
 #define LWIP_RAM_HEAP_POINTER       lwip_ram_heap
 
 // Number of simultaneously queued TCP segments.
-#ifdef MBED_CONF_LWIP_MEMP_NUM_TCP_SEG
 #define MEMP_NUM_TCP_SEG            MBED_CONF_LWIP_MEMP_NUM_TCP_SEG
-#endif
 
 // TCP Maximum segment size.
-#ifdef MBED_CONF_LWIP_TCP_MSS
 #define TCP_MSS                     MBED_CONF_LWIP_TCP_MSS
-#endif
 
 // TCP sender buffer space (bytes).
-#ifdef MBED_CONF_LWIP_TCP_SND_BUF
 #define TCP_SND_BUF                 MBED_CONF_LWIP_TCP_SND_BUF
-#endif
 
 // TCP sender buffer space (bytes).
-#ifdef MBED_CONF_LWIP_TCP_WND
 #define TCP_WND                     MBED_CONF_LWIP_TCP_WND
-#endif
 
-#ifdef MBED_CONF_LWIP_TCP_MAXRTX
 #define TCP_MAXRTX                  MBED_CONF_LWIP_TCP_MAXRTX
-#endif
 
-#ifdef MBED_CONF_LWIP_TCP_SYNMAXRTX
 #define TCP_SYNMAXRTX               MBED_CONF_LWIP_TCP_SYNMAXRTX
-#endif
 
 // Number of pool pbufs.
 // Each requires 684 bytes of RAM (if MSS=536 and PBUF_POOL_BUFSIZE defaulting to be based on MSS)
-#ifdef MBED_CONF_LWIP_PBUF_POOL_SIZE
-#undef PBUF_POOL_SIZE
 #define PBUF_POOL_SIZE              MBED_CONF_LWIP_PBUF_POOL_SIZE
-#else
-#ifndef PBUF_POOL_SIZE
-#define PBUF_POOL_SIZE              5
-#endif
-#endif
 
 #ifdef MBED_CONF_LWIP_PBUF_POOL_BUFSIZE
 #undef PBUF_POOL_BUFSIZE
@@ -194,63 +154,38 @@
 #endif
 #endif
 
-#ifdef MBED_CONF_LWIP_MEM_SIZE
-#undef MEM_SIZE
 #define MEM_SIZE                    MBED_CONF_LWIP_MEM_SIZE
-#endif
 
 // One tcp_pcb_listen is needed for each TCPServer.
 // Each requires 72 bytes of RAM.
-#ifdef MBED_CONF_LWIP_TCP_SERVER_MAX
 #define MEMP_NUM_TCP_PCB_LISTEN     MBED_CONF_LWIP_TCP_SERVER_MAX
-#else
-#define MEMP_NUM_TCP_PCB_LISTEN     4
-#endif
 
 // One is tcp_pcb needed for each TCPSocket.
 // Each requires 196 bytes of RAM.
-#ifdef MBED_CONF_LWIP_TCP_SOCKET_MAX
 #define MEMP_NUM_TCP_PCB            MBED_CONF_LWIP_TCP_SOCKET_MAX
-#else
-#define MEMP_NUM_TCP_PCB            4
-#endif
 
 // One udp_pcb is needed for each UDPSocket.
 // Each requires 84 bytes of RAM (total rounded to multiple of 512).
-#ifdef MBED_CONF_LWIP_UDP_SOCKET_MAX
 #define MEMP_NUM_UDP_PCB            MBED_CONF_LWIP_UDP_SOCKET_MAX
-#else
-#define MEMP_NUM_UDP_PCB            4
-#endif
 
 // Number of non-pool pbufs.
 // Each requires 92 bytes of RAM.
-#ifndef MEMP_NUM_PBUF
-#define MEMP_NUM_PBUF               8
-#endif
+#define MEMP_NUM_PBUF               MBED_CONF_LWIP_NUM_PBUF
 
 // Each netbuf requires 64 bytes of RAM.
-#ifndef MEMP_NUM_NETBUF
-#define MEMP_NUM_NETBUF             8
-#endif
+#define MEMP_NUM_NETBUF             MBED_CONF_LWIP_NUM_NETBUF
 
 // One netconn is needed for each UDPSocket, TCPSocket or TCPServer.
 // Each requires 236 bytes of RAM (total rounded to multiple of 512).
-#ifdef MBED_CONF_LWIP_SOCKET_MAX
 #define MEMP_NUM_NETCONN            MBED_CONF_LWIP_SOCKET_MAX
-#else
-#define MEMP_NUM_NETCONN            4
-#endif
 
 #if MBED_CONF_LWIP_TCP_ENABLED
 #define LWIP_TCP                    1
 #define TCP_OVERSIZE                0
 #define LWIP_TCP_KEEPALIVE          1
-#ifdef MBED_CONF_TCP_CLOSE_TIMEOUT
-#define TCP_CLOSE_TIMEOUT            MBED_CONF_TCP_CLOSE_TIMEOUT
-#else
-#define TCP_CLOSE_TIMEOUT            1000
-#endif
+
+#define TCP_CLOSE_TIMEOUT            MBED_CONF_LWIP_TCP_CLOSE_TIMEOUT
+
 #else
 #define LWIP_TCP                    0
 #endif

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -21,6 +21,10 @@
             "help": "Address timeout mode; true: wait both stack's addresses; false: wait for preferred stack's address",
             "value": true
         },
+        "dhcp-timeout": {
+            "help": "DHCP timeout value",
+            "value": 60
+        },
         "ethernet-enabled": {
             "help": "Enable support for Ethernet interfaces",
             "value": true
@@ -74,28 +78,28 @@
             "value": 4
         },
         "memp-num-tcp-seg": {
-            "help": "Number of simultaneously queued TCP segments. Current default (used if null here) is set to 16 in opt.h, unless overridden by target Ethernet drivers.",
-            "value": null
+            "help": "Number of simultaneously queued TCP segments, see LWIP opt.h for more information. Current default is 16.",
+            "value": 16
         },
         "tcp-mss": {
-            "help": "TCP Maximum segment size. Current default (used if null here) is set to 536 in opt.h, unless overridden by target Ethernet drivers.",
-            "value": null
+            "help": "TCP Maximum segment size, see LWIP opt.h for more information. Current default is 536.",
+            "value": 536
         },
         "tcp-snd-buf": {
-            "help": "TCP sender buffer space (bytes). Current default (used if null here) is set to (2 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.",
-            "value": null
+            "help": "TCP sender buffer space (bytes), see LWIP's opt.h for more information. Current default is (2 * TCP_MSS).",
+            "value": "(2 * TCP_MSS)"
         },
         "tcp-wnd": {
-            "help": "TCP sender buffer space (bytes). Current default (used if null here) is set to (4 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.",
-            "value": null
+            "help": "TCP sender buffer space (bytes), see LWIP's opt.h for more information. Current default is (4 * TCP_MSS).",
+            "value": "(4 * TCP_MSS)"
         },
         "tcp-maxrtx": {
-            "help": "Maximum number of retransmissions of data segments.",
+            "help": "Maximum number of retransmissions of data segments, see LWIP's opt.h for more information. Current default is 6.",
             "value": 6
         },
         "tcp-synmaxrtx": {
-            "help": "Maximum number of retransmissions of SYN segments. Current default (used if null here) is set to 6 in opt.h",
-            "value": null
+            "help": "Maximum number of retransmissions of SYN segments, see LWIP's opt.h for more information. Current default is 6.",
+            "value": 6
         },
         "tcp-close-timeout": {
             "help": "Maximum timeout (ms) for TCP close handshaking timeout",
@@ -106,16 +110,16 @@
             "value": "osPriorityNormal"
         },
         "pbuf-pool-size": {
-            "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.",
-            "value": null
+            "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading, see LWIP's opt.h for more information. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default  is 5.",
+            "value": 5
         },
         "pbuf-pool-bufsize": {
-            "help": "Size of pbufs in pool. If set to null, lwIP will base the size on the TCP MSS, which is 536 unless overridden by the target",
+            "help": "Size of pbufs in pool, see LWIP's opt.h for more information.",
             "value": null
         },
         "mem-size": {
-            "help": "Size of heap (bytes) - used for outgoing packets, and also used by some drivers for reception. Current default (used if null here) is set to 1600 in opt.h, unless overridden by target Ethernet drivers.",
-            "value": null
+            "help": "Size of heap (bytes) - used for outgoing packets, and also used by some drivers for reception, see LWIP's opt.h for more information. Current default is 1600.",
+            "value": 1600
         },
         "tcpip-thread-stacksize": {
             "help": "Stack size for lwip TCPIP thread",
@@ -128,6 +132,14 @@
         "ppp-thread-stacksize": {
             "help": "Thread stack size for PPP (obsolete: use netsocket/ppp configuration instead)",
             "value": 768
+        },
+        "num-pbuf": {
+            "help": "Number of non-pool pbufs, each needs 92 bytes of RAM, see LWIP's opt.h for more information. Current default is 8.",
+            "value": 8
+        },
+        "num-netbuf": {
+            "help": "Number of netbufs, each netbuf requires 64 bytes of RAM, see LWIP's opt.h for more information. Current default is 8.",
+            "value": 8
         }
     },
     "target_overrides": {

--- a/features/netsocket/ppp/include/ppp_opts.h
+++ b/features/netsocket/ppp/include/ppp_opts.h
@@ -71,7 +71,9 @@
 #define PPP_DNS                           1
 
 // Used as maximum size for output buffer, to restrict the memory manager get_pool_alloc_unit()
+#ifndef PBUF_POOL_BUFSIZE
 #define PBUF_POOL_BUFSIZE                 536 + 40
+#endif
 
 #endif // PPP_SUPPORT
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Cleaned up LWIP configuration mechanism. Moved default settings into mbed_lib.json and updated "help" sections accordingly. This is not a breaking change, if some developers have overridden those values earlier, this change has no effect for them. 
Also as mbed_retarget.h defines `errno` values, there were warnings about duplicates because LWIP defined those as well by default. This has also been fixed in this PR.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@VeijoPesonen @kjbracey-arm @ARMmbed/mbed-os-ipcore 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
LWIP configuration mechanism has been updated to make it easier to control default values directly from mbed_lib.json. This is not a breaking change and existing applications should still work unmodified with this change. 
