### PR TITLE
ATCmdParser doxygen header's documentation update for scanf

### DIFF
--- a/platform/ATCmdParser.h
+++ b/platform/ATCmdParser.h
@@ -271,6 +271,9 @@ public:
 
     /**
      * Direct scanf on underlying stream
+     * This function does not itself match whitespace in its format string, so \n is not significant to it.
+     * It should be used only when certain string is needed or format ends with certain character, otherwise
+     * it will fill the output with one character.
      * @see scanf
      *
      * @param format Format string to pass to scanf

--- a/platform/source/ATCmdParser.cpp
+++ b/platform/source/ATCmdParser.cpp
@@ -309,7 +309,6 @@ restart:
             if (whole_line_wanted && c != '\n') {
                 // Don't attempt scanning until we get delimiter if they included it in format
                 // This allows recv("Foo: %s\n") to work, and not match with just the first character of a string
-                // (scanf does not itself match whitespace in its format string, so \n is not significant to it)
             } else if (response) {
                 sscanf(_buffer + offset, _buffer, &count);
             }


### PR DESCRIPTION
### Description

Added doxygen documentation about `ATCmdParser::scanf()` limitations. 
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [x] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@VeijoPesonen 
@michalpasztamobica 
@AnttiKauppila 
@SeppoTakalo 
### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
