### PR TITLE
Check return of BlockDevice::init() in TDBStore.

### DIFF
--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -1019,7 +1019,10 @@ int TDBStore::init()
     _size = (size_t) -1;
 
     _buff_bd = new BufferedBlockDevice(_bd);
-    _buff_bd->init();
+    ret = _buff_bd->init();
+    if (ret) {
+        goto fail;
+    }
 
     // Underlying BD must have flash attributes, i.e. have an erase value
     if (_bd->get_erase_value() == -1) {
@@ -1138,6 +1141,19 @@ int TDBStore::init()
 
 end:
     _is_initialized = true;
+    _mutex.unlock();
+    return ret;
+fail:
+    delete[] ram_table;
+    delete _buff_bd;
+    delete[] _work_buf;
+    delete[] _key_buf;
+    delete reinterpret_cast<inc_set_handle_t *>(_inc_set_handle);
+    _ram_table = nullptr;
+    _buff_bd = nullptr;
+    _work_buf = nullptr;
+    _key_buf = nullptr;
+    _inc_set_handle = nullptr;
     _mutex.unlock();
     return ret;
 }

--- a/features/storage/kvstore/tdbstore/TDBStore.h
+++ b/features/storage/kvstore/tdbstore/TDBStore.h
@@ -61,8 +61,7 @@ public:
      *        the available data and clean corrupted and erroneous records.
      *
      * @returns MBED_SUCCESS                        Success.
-     *          MBED_ERROR_READ_FAILED              Unable to read from media.
-     *          MBED_ERROR_WRITE_FAILED             Unable to write to media.
+     * @returns Negative error code on failure.
      */
     virtual int init();
 


### PR DESCRIPTION
### Description

Return value was ignored, and TDBStore:init() ended up in a
MBED_ERROR() phase after that.

TDBStore API was limited to allow returning of only two separate
errors, which may end up hiding the actual return value. Change
the documentation slightly to allow returning of original error
code from the underlying block device.

Fixes #11591


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@VeijoPesonen 

### Release Notes

`TDBSTore::init()` is now allowed to return error codes from underlying BlockeDevice.
Previously the API was limited to return only `MBED_ERROR_READ_FAILED` or `MBED_ERROR_WRITE_FAILED` which might have hidden the actual error code from the device.
Now application will get the original return value passed from BlockDevice.

