### PR TITLE
Missing errno.h include

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -749,8 +749,7 @@ int32_t ATHandler::read_int()
     }
 
     errno = 0;
-    char *endptr;
-    long result = std::strtol(buff, &endptr, 10);
+    long result = std::strtol(buff, NULL, 10);
     if ((result == LONG_MIN || result == LONG_MAX) && errno == ERANGE) {
         return -1; // overflow/underflow
     }

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <limits.h>
+#include <errno.h>
 #include "ATHandler.h"
 #include "mbed_poll.h"
 #include "FileHandle.h"


### PR DESCRIPTION
### Description
- include of errno.h header is needed for Mac OS X: unititests failing to compile otherwise
- removed usage of "endptr" from strtol() since its value is not used
### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change