### PR TITLE
AT_CellularDevice.cpp - unused variable err warning

### DIFF
--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -203,7 +203,9 @@ nsapi_error_t AT_CellularDevice::get_sim_state(SimState &state)
     _at->flush();
     nsapi_error_t error = _at->at_cmd_str("+CPIN", "?", simstr, sizeof(simstr));
     ssize_t len = strlen(simstr);
+#if MBED_CONF_MBED_TRACE_ENABLE
     device_err_t err = _at->get_last_device_error();
+#endif
     _at->unlock();
 
     if (len != -1) {


### PR DESCRIPTION
We get this compiler warning;

```
Compile [  7.9%]: AT_CellularDevice.cpp
[Warning] AT_CellularDevice.cpp@206,18: variable 'err' set but not used [-Wunused-but-set-variable]
```

Due to the fact, that the code that would actually use this variable
is behind trace flags. Moving the definition to be behind that same
flag resolves the issue.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@kivaisan  @AnttiKauppila @0xc0170 

### Release Notes

Remove compiler warning due unused variable in `AT_CellularDevice.cpp`.

