### PR TITLE
DNS tests modification for ESP8266-specific scenario

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns_timeouts.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_timeouts.cpp
@@ -65,7 +65,7 @@ void ASYNCHRONOUS_DNS_TIMEOUTS()
     TEST_ASSERT(result_exp_timeout > 0);
 
     // Give event queue time to finalise before destructors
-    ThisThread::sleep_for(2000);
+    ThisThread::sleep_for(12000);
 
     nsapi_dns_call_in_set(0);
 }

--- a/TESTS/netsocket/dns/dns_tests.h
+++ b/TESTS/netsocket/dns/dns_tests.h
@@ -71,7 +71,7 @@ namespace dns_global {
 #ifdef MBED_GREENTEA_TEST_DNSSOCKET_TIMEOUT_S
 static const int TESTS_TIMEOUT = MBED_GREENTEA_TEST_DNSSOCKET_TIMEOUT_S;
 #else
-static const int TESTS_TIMEOUT = 10 * 60;
+static const int TESTS_TIMEOUT = 14 * 60;
 #endif
 }
 


### PR DESCRIPTION
### Description

The `ASYNCHRONOUS_DNS_TIMEOUTS` test floods the device with UDP requests (it skips the 100 ms delay to simulate instant timeout). `ESP8266` starts responding with "busy p..." message. It needs more time to process the requests and recover for subsequent tests.

I have also increased the total suite timeout, not only to cover the delay I've just added, but also to allow larger time buffer as we've seen the tests have come really close to the borderline and they have a large variation, dependent on the network status.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 
@AriParkkila 
@tymoteuszblochmobica 
@SeppoTakalo 
@VeijoPesonen 
