### PR TITLE
Introduce qspi_inst_t type for QSPI instructions

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -1375,7 +1375,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_erase_command(qspi_inst_t erase_inst,
 
 qspi_status_t QSPIFBlockDevice::_qspi_send_general_command(qspi_inst_t instruction, bd_addr_t addr,
                                                            const char *tx_buffer,
-                                                           size_t tx_length, const char *rx_buffer, size_t rx_length)
+                                                           mbed::bd_size_t tx_length, const char *rx_buffer, mbed::bd_size_t rx_length)
 {
     // Send a general command Instruction to driver
     qspi_status_t status = _qspi.command_transfer(instruction, (int)addr, tx_buffer, tx_length, rx_buffer, rx_length);

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.cpp
@@ -381,7 +381,7 @@ int QSPIFBlockDevice::erase(bd_addr_t addr, bd_size_t in_size)
     int type = 0;
     uint32_t offset = 0;
     uint32_t chunk = 4096;
-    unsigned int cur_erase_inst = _erase_instruction;
+    qspi_inst_t cur_erase_inst = _erase_instruction;
     int size = (int)in_size;
     bool erase_failed = false;
     int status = QSPIF_BD_ERROR_OK;
@@ -955,8 +955,8 @@ int QSPIFBlockDevice::_sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int
 }
 
 int QSPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-                                                             unsigned int &erase4k_inst,
-                                                             unsigned int *erase_type_inst_arr, unsigned int *erase_type_size_arr)
+                                                             qspi_inst_t &erase4k_inst,
+                                                             qspi_inst_t *erase_type_inst_arr, unsigned int *erase_type_size_arr)
 {
     erase4k_inst = 0xff;
     bool found_4Kerase_type = false;
@@ -1009,7 +1009,7 @@ int QSPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_para
 
 int QSPIFBlockDevice::_sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size,
                                                       bool &set_quad_enable,
-                                                      bool &is_qpi_mode, unsigned int &read_inst)
+                                                      bool &is_qpi_mode, qspi_inst_t &read_inst)
 {
     set_quad_enable = false;
     is_qpi_mode = false;
@@ -1205,7 +1205,7 @@ int QSPIFBlockDevice::_set_write_enable()
 int QSPIFBlockDevice::_enable_fast_mdoe()
 {
     char status_reg[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
-    unsigned int read_conf_register_inst = 0x15;
+    qspi_inst_t read_conf_register_inst = 0x15;
     char status_reg_qer_setup[QSPI_MAX_STATUS_REGISTER_SIZE] = {0};
 
     status_reg_qer_setup[2] = 0x2; // Bit 1 of config Reg 2
@@ -1322,7 +1322,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_set_frequency(int freq)
     return _qspi.set_frequency(freq);
 }
 
-qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(unsigned int read_inst, void *buffer, bd_addr_t addr,
+qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(qspi_inst_t read_inst, void *buffer, bd_addr_t addr,
                                                         bd_size_t size)
 {
     // Send Read command to device driver
@@ -1337,7 +1337,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_read_command(unsigned int read_inst, 
 
 }
 
-qspi_status_t QSPIFBlockDevice::_qspi_send_program_command(unsigned int progInst, const void *buffer, bd_addr_t addr,
+qspi_status_t QSPIFBlockDevice::_qspi_send_program_command(qspi_inst_t progInst, const void *buffer, bd_addr_t addr,
                                                            bd_size_t *size)
 {
     // Send Program (write) command to device driver
@@ -1351,7 +1351,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_program_command(unsigned int progInst
     return result;
 }
 
-qspi_status_t QSPIFBlockDevice::_qspi_send_erase_command(unsigned int erase_inst, bd_addr_t addr, bd_size_t size)
+qspi_status_t QSPIFBlockDevice::_qspi_send_erase_command(qspi_inst_t erase_inst, bd_addr_t addr, bd_size_t size)
 {
     // Send Erase Instruction command to driver
     qspi_status_t result = QSPI_STATUS_OK;
@@ -1373,7 +1373,7 @@ qspi_status_t QSPIFBlockDevice::_qspi_send_erase_command(unsigned int erase_inst
 
 }
 
-qspi_status_t QSPIFBlockDevice::_qspi_send_general_command(unsigned int instruction, bd_addr_t addr,
+qspi_status_t QSPIFBlockDevice::_qspi_send_general_command(qspi_inst_t instruction, bd_addr_t addr,
                                                            const char *tx_buffer,
                                                            size_t tx_length, const char *rx_buffer, size_t rx_length)
 {

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -234,19 +234,19 @@ private:
     /********************************/
     /*   Calls to QSPI Driver APIs  */
     /********************************/
-    // Send Program => Write command to Driver
-    qspi_status_t _qspi_send_program_command(unsigned int prog_instruction, const void *buffer, mbed::bd_addr_t addr,
-                                             mbed::bd_size_t *size);
+    // Send Program/Write command to Driver
+    qspi_status_t _qspi_send_program_command(mbed::qspi_inst_t prog_instruction, const void *buffer,
+                                             mbed::bd_addr_t addr, mbed::bd_size_t *size);
 
     // Send Read command to Driver
-    qspi_status_t _qspi_send_read_command(unsigned int read_instruction, void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
+    qspi_status_t _qspi_send_read_command(mbed::qspi_inst_t read_instruction, void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Erase Instruction using command_transfer command to Driver
-    qspi_status_t _qspi_send_erase_command(unsigned int erase_instruction, mbed::bd_addr_t addr, mbed::bd_size_t size);
+    qspi_status_t _qspi_send_erase_command(mbed::qspi_inst_t erase_instruction, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Generic command_transfer command to Driver
-    qspi_status_t _qspi_send_general_command(unsigned int instruction_int, mbed::bd_addr_t addr, const char *tx_buffer,
-                                             size_t tx_length, const char *rx_buffer, size_t rx_length);
+    qspi_status_t _qspi_send_general_command(mbed::qspi_inst_t instruction_int, mbed::bd_addr_t addr, const char *tx_buffer,
+                                             mbed::bd_size_t tx_length, const char *rx_buffer, mbed::bd_size_t rx_length);
 
     // Send Bus configure_format command to Driver
     qspi_status_t _qspi_configure_format(qspi_bus_width_t inst_width, qspi_bus_width_t address_width,
@@ -331,15 +331,15 @@ private:
     PlatformMutex _mutex;
 
     // Command Instructions
-    unsigned int _read_instruction;
-    unsigned int _prog_instruction;
-    unsigned int _erase_instruction;
-    unsigned int _erase4k_inst;  // Legacy 4K erase instruction (default 0x20h)
-    unsigned int _write_register_inst; // Write status/config register instruction may vary between chips
-    unsigned int _read_register_inst; // Read status/config register instruction may vary between chips
+    mbed::qspi_inst_t _read_instruction;
+    mbed::qspi_inst_t _prog_instruction;
+    mbed::qspi_inst_t _erase_instruction;
+    mbed::qspi_inst_t _erase4k_inst;  // Legacy 4K erase instruction (default 0x20h)
+    mbed::qspi_inst_t _write_register_inst; // Write status/config register instruction may vary between chips
+    mned::qspi_inst_t _read_register_inst; // Read status/config register instruction may vary between chips
 
     // Up To 4 Erase Types are supported by SFDP (each with its own command Instruction and Size)
-    unsigned int _erase_type_inst_arr[MAX_NUM_OF_ERASE_TYPES];
+    mbed::qspi_inst_t _erase_type_inst_arr[MAX_NUM_OF_ERASE_TYPES];
     unsigned int _erase_type_size_arr[MAX_NUM_OF_ERASE_TYPES];
 
     // Sector Regions Map

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -336,7 +336,7 @@ private:
     mbed::qspi_inst_t _erase_instruction;
     mbed::qspi_inst_t _erase4k_inst;  // Legacy 4K erase instruction (default 0x20h)
     mbed::qspi_inst_t _write_register_inst; // Write status/config register instruction may vary between chips
-    mned::qspi_inst_t _read_register_inst; // Read status/config register instruction may vary between chips
+    mbed::qspi_inst_t _read_register_inst; // Read status/config register instruction may vary between chips
 
     // Up To 4 Erase Types are supported by SFDP (each with its own command Instruction and Size)
     mbed::qspi_inst_t _erase_type_inst_arr[MAX_NUM_OF_ERASE_TYPES];

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -286,7 +286,7 @@ private:
 
     // Detect fastest read Bus mode supported by device
     int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, bool &set_quad_enable,
-                                        bool &is_qpi_mode, unsigned int &read_inst);
+                                        bool &is_qpi_mode, mbed::qspi_inst_t &read_inst);
 
     // Enable Quad mode if supported (1-1-4, 1-4-4, 4-4-4 bus modes)
     int _sfdp_set_quad_enabled(uint8_t *basic_param_table_ptr);
@@ -299,8 +299,8 @@ private:
 
     // Detect all supported erase types
     int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-                                               unsigned int &erase4k_inst,
-                                               unsigned int *erase_type_inst_arr, unsigned int *erase_type_size_arr);
+                                               mbed::qspi_inst_t &erase4k_inst,
+                                               mbed::qspi_inst_t *erase_type_inst_arr, unsigned int *erase_type_size_arr);
 
     /***********************/
     /* Utilities Functions */

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -28,7 +28,7 @@
 
 #define ONE_MHZ     1000000
 
-#define QSPI_NO_INST 0x00
+#define QSPI_NO_INST (-1)
 
 namespace mbed {
 /** \defgroup drivers-public-api-spi SPI
@@ -43,7 +43,7 @@ namespace mbed {
 
 /** Type representing a QSPI instruction
  */
-typedef char qspi_inst_t;
+typedef int qspi_inst_t;
 
 /** A QSPI Driver, used for communicating with QSPI slave devices
  *

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -28,6 +28,8 @@
 
 #define ONE_MHZ     1000000
 
+#define QSPI_NO_INST 0x00
+
 namespace mbed {
 /** \defgroup drivers-public-api-spi SPI
  * \ingroup drivers-public-api
@@ -38,6 +40,10 @@ namespace mbed {
  * \ingroup drivers-public-api-spi
  * @{
  */
+
+/** Type representing a QSPI instruction
+ */
+typedef char qspi_inst_t;
 
 /** A QSPI Driver, used for communicating with QSPI slave devices
  *
@@ -160,7 +166,7 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t read(int instruction, int alt, int address, char *rx_buffer, size_t *rx_length);
+    qspi_status_t read(qspi_inst_t instruction, int alt, int address, char *rx_buffer, size_t *rx_length);
 
     /** Write to QSPI peripheral using custom write instruction, alt values
      *
@@ -173,7 +179,7 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t write(int instruction, int alt, int address, const char *tx_buffer, size_t *tx_length);
+    qspi_status_t write(qspi_inst_t instruction, int alt, int address, const char *tx_buffer, size_t *tx_length);
 
     /** Perform a transaction to write to an address(a control register) and get the status results
      *
@@ -187,7 +193,7 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t command_transfer(int instruction, int address, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length);
+    qspi_status_t command_transfer(qspi_inst_t instruction, int address, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length);
 
 #if !defined(DOXYGEN_ONLY)
 protected:
@@ -227,7 +233,7 @@ private:
     /*
      * This function builds the qspi command struct to be send to Hal
      */
-    inline void _build_qspi_command(int instruction, int address, int alt);
+    inline void _build_qspi_command(qspi_inst_t instruction, int address, int alt);
 #endif
 };
 

--- a/drivers/source/QSPI.cpp
+++ b/drivers/source/QSPI.cpp
@@ -122,7 +122,7 @@ qspi_status_t QSPI::read(int address, char *rx_buffer, size_t *rx_length)
             if (*rx_length != 0) {
                 lock();
                 if (true == _acquire()) {
-                    _build_qspi_command(-1, address, -1);
+                    _build_qspi_command(QSPI_NO_INST, address, -1);
                     if (QSPI_STATUS_OK == qspi_read(&_qspi, &_qspi_command, rx_buffer, rx_length)) {
                         ret_status = QSPI_STATUS_OK;
                     }
@@ -146,7 +146,7 @@ qspi_status_t QSPI::write(int address, const char *tx_buffer, size_t *tx_length)
             if (*tx_length != 0) {
                 lock();
                 if (true == _acquire()) {
-                    _build_qspi_command(-1, address, -1);
+                    _build_qspi_command(QSPI_NO_INST, address, -1);
                     if (QSPI_STATUS_OK == qspi_write(&_qspi, &_qspi_command, tx_buffer, tx_length)) {
                         ret_status = QSPI_STATUS_OK;
                     }
@@ -161,7 +161,7 @@ qspi_status_t QSPI::write(int address, const char *tx_buffer, size_t *tx_length)
     return ret_status;
 }
 
-qspi_status_t QSPI::read(int instruction, int alt, int address, char *rx_buffer, size_t *rx_length)
+qspi_status_t QSPI::read(qspi_inst_t instruction, int alt, int address, char *rx_buffer, size_t *rx_length)
 {
     qspi_status_t ret_status = QSPI_STATUS_ERROR;
 
@@ -185,7 +185,7 @@ qspi_status_t QSPI::read(int instruction, int alt, int address, char *rx_buffer,
     return ret_status;
 }
 
-qspi_status_t QSPI::write(int instruction, int alt, int address, const char *tx_buffer, size_t *tx_length)
+qspi_status_t QSPI::write(qspi_inst_t instruction, int alt, int address, const char *tx_buffer, size_t *tx_length)
 {
     qspi_status_t ret_status = QSPI_STATUS_ERROR;
 
@@ -209,7 +209,7 @@ qspi_status_t QSPI::write(int instruction, int alt, int address, const char *tx_
     return ret_status;
 }
 
-qspi_status_t QSPI::command_transfer(int instruction, int address, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length)
+qspi_status_t QSPI::command_transfer(qspi_inst_t instruction, int address, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length)
 {
     qspi_status_t ret_status = QSPI_STATUS_ERROR;
 
@@ -267,12 +267,12 @@ bool QSPI::_acquire()
     return _initialized;
 }
 
-void QSPI::_build_qspi_command(int instruction, int address, int alt)
+void QSPI::_build_qspi_command(qspi_inst_t instruction, int address, int alt)
 {
     memset(&_qspi_command, 0,  sizeof(qspi_command_t));
     //Set up instruction phase parameters
     _qspi_command.instruction.bus_width = _inst_width;
-    if (instruction != -1) {
+    if (instruction != QSPI_NO_INST) {
         _qspi_command.instruction.value = instruction;
         _qspi_command.instruction.disabled = false;
     } else {


### PR DESCRIPTION
### Description
Encourage the usage of consistent types (there are currently  a mix of `int` and `unsigned int` used for qspi instructions)
QSPI commands are limited to 8 bits, to this is a typdef to uint8_t

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
