### PR TITLE
Tests: USB: Move control endpoint buffers to heap

### DIFF
--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -40,6 +40,8 @@
 #define VENDOR_TEST_RW_RESTART          11
 #define VENDOR_TEST_ABORT_BUFF_CHECK    12
 
+#define CTRL_BUF_SIZE (2048)
+
 #define EVENT_READY (1 << 0)
 
 #define TEST_SIZE_EP_BULK_MAX   (64)
@@ -170,6 +172,7 @@ USBEndpointTester::USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t p
 
     queue = mbed::mbed_highprio_event_queue();
     configuration_desc(0);
+    ctrl_buf = new uint8_t[CTRL_BUF_SIZE];
     init();
     USBDevice::connect();
     flags.wait_any(EVENT_READY, osWaitForever, false);
@@ -183,6 +186,7 @@ USBEndpointTester::~USBEndpointTester()
         }
     }
     deinit();
+    delete[] ctrl_buf;
 }
 
 const char *USBEndpointTester::get_desc_string(const uint8_t *desc)
@@ -225,7 +229,7 @@ void USBEndpointTester::callback_request(const setup_packet_t *setup)
             case VENDOR_TEST_CTRL_IN:
                 result = Send;
                 data = ctrl_buf;
-                size = setup->wValue < sizeof(ctrl_buf) ? setup->wValue : sizeof(ctrl_buf);
+                size = setup->wValue < CTRL_BUF_SIZE ? setup->wValue : CTRL_BUF_SIZE;
                 break;
             case VENDOR_TEST_CTRL_OUT:
                 result = Receive;

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -23,12 +23,13 @@
 #include "USBDevice_Types.h"
 #include "EventQueue.h"
 #include "EventFlags.h"
+#include "platform/NonCopyable.h"
 
 #include "USBDevice.h"
 
 #define NUM_ENDPOINTS 6 // Not including CTRL OUT/IN
 
-class USBEndpointTester: public USBDevice {
+class USBEndpointTester: public USBDevice, private mbed::NonCopyable<USBEndpointTester> {
 
 public:
     USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release,
@@ -80,7 +81,7 @@ public:
 protected:
     events::EventQueue *queue;
     rtos::EventFlags flags;
-    uint8_t ctrl_buf[2048];
+    uint8_t *ctrl_buf;
 
     bool _abort_transfer_test;
     usb_ep_t _endpoints[NUM_ENDPOINTS];

--- a/TESTS/usb_device/basic/USBTester.cpp
+++ b/TESTS/usb_device/basic/USBTester.cpp
@@ -37,6 +37,8 @@
 #define MAX_EP_SIZE 64
 #define MIN_EP_SIZE 8
 
+#define CTRL_BUF_SIZE (2048)
+
 #define EVENT_READY (1 << 0)
 
 
@@ -57,7 +59,7 @@ USBTester::USBTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint1
     queue = mbed::mbed_highprio_event_queue();
 
     configuration_desc(0);
-
+    ctrl_buf = new uint8_t[CTRL_BUF_SIZE];
     init();
     USBDevice::connect();
     flags.wait_any(EVENT_READY, osWaitForever, false);
@@ -67,6 +69,7 @@ USBTester::USBTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint1
 USBTester::~USBTester()
 {
     deinit();
+    delete[] ctrl_buf;
 }
 
 
@@ -138,7 +141,7 @@ void USBTester::callback_request(const setup_packet_t *setup)
             case VENDOR_TEST_CTRL_IN:
                 result = Send;
                 data = ctrl_buf;
-                size = setup->wValue < sizeof(ctrl_buf) ? setup->wValue : sizeof(ctrl_buf);
+                size = setup->wValue < CTRL_BUF_SIZE ? setup->wValue : CTRL_BUF_SIZE;
                 break;
             case VENDOR_TEST_CTRL_OUT:
                 result = Receive;

--- a/TESTS/usb_device/basic/USBTester.h
+++ b/TESTS/usb_device/basic/USBTester.h
@@ -23,10 +23,11 @@
 #include "USBDevice_Types.h"
 #include "EventQueue.h"
 #include "EventFlags.h"
+#include "platform/NonCopyable.h"
 
 #include "USBDevice.h"
 
-class USBTester: public USBDevice {
+class USBTester: public USBDevice, private mbed::NonCopyable<USBTester> {
 public:
 
     /*
@@ -138,7 +139,7 @@ protected:
     virtual void epbulk_out_callback();
     virtual void epint_out_callback();
     virtual void callback_reset();
-    uint8_t ctrl_buf[2048];
+    uint8_t *ctrl_buf;
 
 };
 


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
This fixes a stack overflow error in the basic USB tests.

I updated the `ctrl_buf` member of the `USBTester` and `USBEndpointTester` test classes to be allocated on the heap. This saves 2 KB of a main stack.

---

The error was discovered on `DISCO_L475VG_IOT01A`. Bisecting showed that a regression occurred at 84e228a (PR #11136) which increased the size of the `USBDevice` by 240 B, from `584` to `824`. This in turn increased sizes of both test classes that inherit from the `USBDevice`; to 3048 (from 2808) in case of the `USBTester`, and 2980 (from 2740) in case of the `USBEndpointTester`.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@maciejbocianski, @jamesbeyond, @jeromecoutant 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
