### PR TITLE
IOTBTOOL-407 Fix microbit to use Arm C5

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -5318,7 +5318,8 @@
         "inherits": ["MCU_NRF51_16K_S110"],
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "release_versions": ["2"],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "supported_toolchains": ["ARMC5", "GCC_ARM"]
     },
     "NRF51_MICROBIT_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT_S110"],


### PR DESCRIPTION
### Description

Earlier changes introduced a change to default Arm C6, which does not compile the micro library which is based on Mbed 2. This change fixes the compiler version for NRF51_MICROBIT devices.

https://jira.arm.com/browse/IOTBTOOL-407

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
