### PR TITLE
IPCore unittests improvements

### DIFF
--- a/UNITTESTS/features/netsocket/DTLSSocket/test_DTLSSocket.cpp
+++ b/UNITTESTS/features/netsocket/DTLSSocket/test_DTLSSocket.cpp
@@ -54,6 +54,12 @@ TEST_F(TestDTLSSocket, constructor)
     EXPECT_TRUE(socket);
 }
 
+TEST_F(TestDTLSSocket, connect_no_socket)
+{
+    EXPECT_TRUE(socket);
+    EXPECT_EQ(socket->connect("127.0.0.1", 1024), NSAPI_ERROR_NO_SOCKET);
+}
+
 /* connect */
 
 TEST_F(TestDTLSSocket, connect)

--- a/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
+++ b/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
@@ -162,7 +162,10 @@ TEST_F(TestInternetSocket, close_during_read)
     socket->add_reader();
     // The reader will be removed after we attempt to close the socket.
     auto delay = std::chrono::milliseconds(2);
-    auto fut = std::async(std::launch::async, [&](){std::this_thread::sleep_for(delay); socket->rem_reader();});
+    auto fut = std::async(std::launch::async, [&]() {
+        std::this_thread::sleep_for(delay);
+        socket->rem_reader();
+    });
 
     // close() will block until the other thread calls rem_reader()
     auto start = std::chrono::system_clock::now();

--- a/UNITTESTS/features/netsocket/NetworkInterface/test_NetworkInterface.cpp
+++ b/UNITTESTS/features/netsocket/NetworkInterface/test_NetworkInterface.cpp
@@ -64,6 +64,7 @@ protected:
 TEST_F(TestNetworkInterface, constructor)
 {
     EXPECT_TRUE(iface);
+    iface->set_as_default(); //Empty function. Just trigger it, so it doesn't obscure coverage reports.
 }
 
 // get_default_instance is tested along with the implementations of NetworkInterface.
@@ -90,6 +91,12 @@ TEST_F(TestNetworkInterface, get_gateway)
 {
     char *n = 0;
     EXPECT_EQ(iface->get_gateway(), n);
+}
+
+TEST_F(TestNetworkInterface, get_interface_name)
+{
+    char *n = 0;
+    EXPECT_EQ(iface->get_interface_name(n), n);
 }
 
 TEST_F(TestNetworkInterface, set_network)
@@ -168,7 +175,7 @@ TEST_F(TestNetworkInterface, add_event_listener)
 
 TEST_F(TestNetworkInterface, remove_event_listener)
 {
-    // Add two callback and check that both are called
+    // Add two callbacks and check that both are called
     callback_is_called = false;
     second_callback_called = false;
     iface->add_event_listener(my_iface_callback);
@@ -215,7 +222,6 @@ TEST_F(TestNetworkInterface, correct_event_listener_per_interface)
     EXPECT_EQ(second_callback_called, true);
 
     iface->remove_event_listener(my_iface_callback);
-    iface2->remove_event_listener(my_iface_callback2);
-
+    // Do not call iface2->remove_event_listener, so the destructor can take care of this.
     delete iface2;
 }

--- a/UNITTESTS/features/netsocket/SocketAddress/test_SocketAddress.cpp
+++ b/UNITTESTS/features/netsocket/SocketAddress/test_SocketAddress.cpp
@@ -162,5 +162,9 @@ TEST_F(TestSocketAddress, bool_operator_ip6_true)
     EXPECT_TRUE(addr ? true : false);
 }
 
-
+TEST_F(TestSocketAddress, bool_operator_ip6_false)
+{
+    SocketAddress addr("0:0:0:0:0:0:0:0",80);
+    EXPECT_FALSE(addr ? true : false);
+}
 

--- a/UNITTESTS/features/netsocket/SocketAddress/test_SocketAddress.cpp
+++ b/UNITTESTS/features/netsocket/SocketAddress/test_SocketAddress.cpp
@@ -164,7 +164,7 @@ TEST_F(TestSocketAddress, bool_operator_ip6_true)
 
 TEST_F(TestSocketAddress, bool_operator_ip6_false)
 {
-    SocketAddress addr("0:0:0:0:0:0:0:0",80);
+    SocketAddress addr("0:0:0:0:0:0:0:0", 80);
     EXPECT_FALSE(addr ? true : false);
 }
 

--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -77,7 +77,7 @@ TEST_F(TestTCPSocket, connect)
     stack.return_value = NSAPI_ERROR_OK;
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
-    EXPECT_EQ(socket->setsockopt(NSAPI_SOCKET,NSAPI_BIND_TO_DEVICE, "12345", 5), NSAPI_ERROR_UNSUPPORTED);
+    EXPECT_EQ(socket->setsockopt(NSAPI_SOCKET, NSAPI_BIND_TO_DEVICE, "12345", 5), NSAPI_ERROR_UNSUPPORTED);
     EXPECT_EQ(socket->connect("127.0.0.1", 1024), NSAPI_ERROR_OK);
 }
 

--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -77,6 +77,8 @@ TEST_F(TestTCPSocket, connect)
     stack.return_value = NSAPI_ERROR_OK;
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->setsockopt(NSAPI_SOCKET,NSAPI_BIND_TO_DEVICE, "12345", 5), NSAPI_ERROR_UNSUPPORTED);
+    EXPECT_EQ(socket->connect("127.0.0.1", 1024), NSAPI_ERROR_OK);
 }
 
 TEST_F(TestTCPSocket, connect_no_open)

--- a/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
+++ b/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
@@ -74,6 +74,9 @@ TEST_F(TestUDPSocket, sendto_addr_port)
 
     stack.return_value = NSAPI_ERROR_OK;
     EXPECT_EQ(socket->sendto("127.0.0.1", 0, 0, 0), 0);
+
+    EXPECT_EQ(socket->setsockopt(NSAPI_SOCKET,NSAPI_BIND_TO_DEVICE,"12324",5), NSAPI_ERROR_UNSUPPORTED);
+    EXPECT_EQ(socket->sendto("127.0.0.1", 0, 0, 0), 0);
 }
 
 TEST_F(TestUDPSocket, connect)

--- a/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
+++ b/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
@@ -75,7 +75,7 @@ TEST_F(TestUDPSocket, sendto_addr_port)
     stack.return_value = NSAPI_ERROR_OK;
     EXPECT_EQ(socket->sendto("127.0.0.1", 0, 0, 0), 0);
 
-    EXPECT_EQ(socket->setsockopt(NSAPI_SOCKET,NSAPI_BIND_TO_DEVICE,"12324",5), NSAPI_ERROR_UNSUPPORTED);
+    EXPECT_EQ(socket->setsockopt(NSAPI_SOCKET, NSAPI_BIND_TO_DEVICE, "12324", 5), NSAPI_ERROR_UNSUPPORTED);
     EXPECT_EQ(socket->sendto("127.0.0.1", 0, 0, 0), 0);
 }
 


### PR DESCRIPTION
### Description

A result of a short revisit to the unittests of socket classes:
* implemented proper `InternetSocket::close()` tests which asynchronously block the closing when there is an active reader or writer (_using C++11's async and chrono, which were enabled recently_)
* added tests for some newly added functions (`get_interface_name()` etc.)
* some more tests extensions added wherever it was reasonable and possible

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 
@SeppoTakalo 
@VeijoPesonen 

### Release Notes
