### PR TITLE
Add FLASHIAP component to DISCO_H747

### DIFF
--- a/features/storage/kvstore/conf/global/mbed_lib.json
+++ b/features/storage/kvstore/conf/global/mbed_lib.json
@@ -20,6 +20,9 @@
         "NUCLEO_F429ZI": {
             "storage_type": "TDB_INTERNAL"
         },
+        "DISCO_H747I": {
+            "storage_type": "TDB_INTERNAL"
+        },
         "UBLOX_EVK_ODIN_W2": {
             "storage_type": "TDB_INTERNAL"
         },

--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -15,6 +15,10 @@
             "internal_size": "0x8000",
             "internal_base_address": "0x00028000"
         },
+        "DISCO_H747I": {
+            "internal_size": "256*1024",
+            "internal_base_address": "0x080C0000"
+        },
        "ARM_MUSCA_A1_S": {
             "internal_size": "0x8000",
             "internal_base_address": "0x00420000"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3315,6 +3315,7 @@
     "DISCO_H747I": {
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M7FD",
+        "components_add": ["FLASHIAP"],
         "extra_labels_add": [
             "STM32H7",
             "STM32H747xI",


### PR DESCRIPTION
### Description

FLASHIAP component/capability is needed for DeviceKey functionality
and also for Pelion enablement - firmware update uses this feature, too.

Related to issue [11617](https://github.com/ARMmbed/mbed-os/issues/11617).


    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/team-st-mcd  @jeromecoutant @adbridge 

### Release Notes

Enable FLASHIAP component on ST DISCO_H747I.
