### PR TITLE
Fix enum type to align with psa-arch-tests

### DIFF
--- a/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/test_a001.c
+++ b/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/test_a001.c
@@ -29,7 +29,7 @@ client_test_t test_a001_attestation_list[] = {
 
 static int         g_test_count = 1;
 
-int32_t psa_initial_attestation_get_token_test(security_t caller)
+int32_t psa_initial_attestation_get_token_test(caller_security_t caller)
 {
     int         num_checks = sizeof(check1)/sizeof(check1[0]);
     uint32_t    i, status, token_size;
@@ -75,7 +75,7 @@ int32_t psa_initial_attestation_get_token_test(security_t caller)
     return VAL_STATUS_SUCCESS;
 }
 
-int32_t psa_initial_attestation_get_token_size_test(security_t caller)
+int32_t psa_initial_attestation_get_token_size_test(caller_security_t caller)
 {
     int         num_checks = sizeof(check2)/sizeof(check2[0]);
     uint32_t    i, status, token_size;

--- a/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/test_a001.h
+++ b/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/test_a001.h
@@ -28,6 +28,6 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_a001_attestation_list[];
 
-int32_t psa_initial_attestation_get_token_test(security_t caller);
-int32_t psa_initial_attestation_get_token_size_test(security_t caller);
+int32_t psa_initial_attestation_get_token_test(caller_security_t caller);
+int32_t psa_initial_attestation_get_token_size_test(caller_security_t caller);
 #endif /* _TEST_A001_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s001/test_s001.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s001/test_s001.c
@@ -141,7 +141,7 @@ static int32_t sst_remove_stray_uid(psa_sst_uid_t p_uid)
     return VAL_STATUS_SUCCESS;
 }
 
-int32_t psa_sst_uid_not_found(security_t caller)
+int32_t psa_sst_uid_not_found(caller_security_t caller)
 {
     int32_t test_status;
     psa_sst_uid_t uid = UID_BASE_VALUE + 6;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s001/test_s001.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s001/test_s001.h
@@ -31,5 +31,5 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s001_sst_list[];
 
-int32_t psa_sst_uid_not_found(security_t caller);
+int32_t psa_sst_uid_not_found(caller_security_t caller);
 #endif /* _TEST_S001_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s002/test_s002.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s002/test_s002.c
@@ -35,7 +35,7 @@ client_test_t test_s002_sst_list[] = {
     NULL,
 };
 
-int32_t psa_sst_update_write_once_flag_after_create(security_t caller)
+int32_t psa_sst_update_write_once_flag_after_create(caller_security_t caller)
 {
     uint32_t status;
     psa_sst_uid_t uid = UID_WRITE_ONCE_1;
@@ -84,7 +84,7 @@ int32_t psa_sst_update_write_once_flag_after_create(security_t caller)
 }
 
 
-int32_t psa_sst_create_with_write_once_flag(security_t caller)
+int32_t psa_sst_create_with_write_once_flag(caller_security_t caller)
 {
     uint32_t status;
     psa_sst_uid_t uid = UID_WRITE_ONCE_2;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s002/test_s002.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s002/test_s002.h
@@ -31,6 +31,6 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s002_sst_list[];
 
-int32_t psa_sst_update_write_once_flag_after_create(security_t caller);
-int32_t psa_sst_create_with_write_once_flag(security_t caller);
+int32_t psa_sst_update_write_once_flag_after_create(caller_security_t caller);
+int32_t psa_sst_create_with_write_once_flag(caller_security_t caller);
 #endif /* _TEST_S002_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s003/test_s003.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s003/test_s003.c
@@ -39,7 +39,7 @@ static char test_desc[2][80] = {
                                 "Overload storage space\n",
                                 "Overload storage again to verify all previous UID removed\n"};
 
-int32_t psa_sst_insufficient_space(security_t caller)
+int32_t psa_sst_insufficient_space(caller_security_t caller)
 {
     uint32_t status = PSA_SST_SUCCESS;
     psa_sst_uid_t uid;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s003/test_s003.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s003/test_s003.h
@@ -31,5 +31,5 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s003_sst_list[];
 
-int32_t psa_sst_insufficient_space(security_t caller);
+int32_t psa_sst_insufficient_space(caller_security_t caller);
 #endif /* _TEST_S003_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s004/test_s004.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s004/test_s004.c
@@ -37,7 +37,7 @@ static uint8_t read_buff[TEST_BUFF_SIZE] = {0};
 static uint8_t write_buff[TEST_BUFF_SIZE] = {0x99, 0x01, 0x30, 0x50, 0x04, 0x23, 0xF6, 0x07, 0x08, \
                                   0x0D, 0x70, 0xA1, 0xFF, 0xFF, 0x14, 0x73, 0x46, 0x97, 0xE8, 0xDD};
 
-int32_t psa_sst_get_data_check(security_t caller)
+int32_t psa_sst_get_data_check(caller_security_t caller)
 {
     uint32_t status,j;
 

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s004/test_s004.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s004/test_s004.h
@@ -31,5 +31,5 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s004_sst_list[];
 
-int32_t psa_sst_get_data_check(security_t caller);
+int32_t psa_sst_get_data_check(caller_security_t caller);
 #endif /* _TEST_S004_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s005/test_s005.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s005/test_s005.c
@@ -64,7 +64,7 @@ static int32_t psa_sst_apis_check(psa_sst_uid_t uid, uint32_t data_len,
     return VAL_STATUS_SUCCESS;
 }
 
-int32_t psa_sst_apis_check_success_case(security_t caller)
+int32_t psa_sst_apis_check_success_case(caller_security_t caller)
 {
    psa_sst_uid_t uid = UID_BASE_VALUE + 4;
    uint32_t data_len = 0, status = VAL_STATUS_SUCCESS;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s005/test_s005.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s005/test_s005.h
@@ -31,6 +31,6 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s005_sst_list[];
 
-int32_t psa_sst_apis_check_success_case(security_t caller);
+int32_t psa_sst_apis_check_success_case(caller_security_t caller);
 
 #endif /* _TEST_S005_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s006/test_s006.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s006/test_s006.c
@@ -53,7 +53,7 @@ static int32_t psa_sst_remove_api(psa_sst_uid_t uid, uint32_t data_len,
     return VAL_STATUS_SUCCESS;
 }
 
-int32_t psa_sst_flags_not_supported(security_t caller)
+int32_t psa_sst_flags_not_supported(caller_security_t caller)
 {
    psa_sst_create_flags_t flag = 0x80000000;
    uint32_t status = VAL_STATUS_SUCCESS;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s006/test_s006.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s006/test_s006.h
@@ -31,6 +31,6 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s006_sst_list[];
 
-int32_t psa_sst_flags_not_supported(security_t caller);
+int32_t psa_sst_flags_not_supported(caller_security_t caller);
 
 #endif /* _TEST_S006_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s007/test_s007.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s007/test_s007.c
@@ -37,7 +37,7 @@ static uint8_t write_buff[TEST_BUFF_SIZE] = {
   0x70, 0xA1, 0xFF, 0xFF, 0x14, 0x73, 0x46, 0x97, 0xE8, 0xDD, 0xCA, 0x0B, 0x3C, 0x0D, 0x2E};
 static uint8_t read_buff[TEST_BUFF_SIZE];
 
-int32_t psa_sst_get_incorrect_size(security_t caller)
+int32_t psa_sst_get_incorrect_size(caller_security_t caller)
 {
     psa_sst_uid_t uid = UID_BASE_VALUE + 5;
     uint32_t status = VAL_STATUS_SUCCESS;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s007/test_s007.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s007/test_s007.h
@@ -31,6 +31,6 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s007_sst_list[];
 
-int32_t psa_sst_get_incorrect_size(security_t caller);
+int32_t psa_sst_get_incorrect_size(caller_security_t caller);
 
 #endif /* _TEST_S007_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s008/test_s008.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s008/test_s008.c
@@ -39,7 +39,7 @@ static uint8_t read_buff[TEST_BUFF_SIZE];
 static uint8_t write_buff[TEST_BUFF_SIZE] = {0x99, 0x01, 0x02, 0x03, 0x04, 0x23, 0xF6, 0x07, 0x08, \
                                   0x0D, 0x70, 0xA1, 0xFF, 0xFF, 0x14, 0x73, 0x46, 0x97, 0xE8, 0xDD};
 
-int32_t psa_sst_invalid_offset_failure(security_t caller)
+int32_t psa_sst_invalid_offset_failure(caller_security_t caller)
 {
     uint32_t status, j;
 
@@ -80,7 +80,7 @@ int32_t psa_sst_invalid_offset_failure(security_t caller)
     return VAL_STATUS_SUCCESS;
 }
 
-int32_t psa_sst_valid_offset_success(security_t caller)
+int32_t psa_sst_valid_offset_success(caller_security_t caller)
 {
     uint32_t status, data_len, offset = TEST_BUFF_SIZE;
 

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s008/test_s008.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s008/test_s008.h
@@ -31,7 +31,7 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s008_sst_list[];
 
-int32_t psa_sst_valid_offset_success(security_t caller);
-int32_t psa_sst_invalid_offset_failure(security_t caller);
+int32_t psa_sst_valid_offset_success(caller_security_t caller);
+int32_t psa_sst_invalid_offset_failure(caller_security_t caller);
 
 #endif /* _TEST_S008_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s009/test_s009.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s009/test_s009.c
@@ -36,7 +36,7 @@ static psa_sst_uid_t uid = UID_BASE_VALUE + 5;
 static uint8_t write_buff[TEST_BUFF_SIZE] = {0x99, 0x01, 0x02, 0x03, 0x04, 0x23, 0xF6, 0x07, 0x08, \
                                   0x0D, 0x70, 0xA1, 0xFF, 0xFF, 0x14, 0x73, 0x46, 0x97, 0xE8, 0xDD};
 
-int32_t psa_sst_zero_length_check(security_t caller)
+int32_t psa_sst_zero_length_check(caller_security_t caller)
 {
     uint32_t status;
 

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s009/test_s009.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s009/test_s009.h
@@ -31,6 +31,6 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s009_sst_list[];
 
-int32_t psa_sst_zero_length_check(security_t caller);
+int32_t psa_sst_zero_length_check(caller_security_t caller);
 
 #endif /* _TEST_S009_CLIENT_TESTS_H_ */

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s010/test_s010.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s010/test_s010.c
@@ -34,7 +34,7 @@ client_test_t test_s010_sst_list[] = {
 
 static uint8_t write_buff[TEST_BUFF_SIZE] = {0xFF};
 
-int32_t psa_sst_uid_value_zero_check(security_t caller)
+int32_t psa_sst_uid_value_zero_check(caller_security_t caller)
 {
     int32_t status;
     psa_sst_uid_t uid = 0;

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s010/test_s010.h
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s010/test_s010.h
@@ -31,5 +31,5 @@ extern val_api_t *val;
 extern psa_api_t *psa;
 extern client_test_t test_s010_sst_list[];
 
-int32_t psa_sst_uid_value_zero_check(security_t caller);
+int32_t psa_sst_uid_value_zero_check(caller_security_t caller);
 #endif /* _TEST_S010_CLIENT_TESTS_H_ */

--- a/features/frameworks/TARGET_PSA/val.h
+++ b/features/frameworks/TARGET_PSA/val.h
@@ -169,9 +169,9 @@
 
 /* enums */
 typedef enum {
-    NONSECURE = 0x0,
-    SECURE    = 0x1,
-} security_t;
+    CALLER_NONSECURE = 0x0,
+    CALLER_SECURE    = 0x1,
+} caller_security_t;
 
 typedef enum {
     TEST_ISOLATION_L1      = 0x1,
@@ -272,6 +272,6 @@ typedef struct {
     uint8_t  status;
 } test_status_buffer_t;
 
-typedef int32_t (*client_test_t)(security_t caller);
+typedef int32_t (*client_test_t)(caller_security_t caller);
 typedef int32_t (*server_test_t)(void);
 #endif /* VAL_COMMON_H */

--- a/features/frameworks/TARGET_PSA/val_greentea.cpp
+++ b/features/frameworks/TARGET_PSA/val_greentea.cpp
@@ -88,7 +88,7 @@ val_status_t mbed_val_execute_non_secure_tests(uint32_t test_num, client_test_t 
         }
 
         /* Execute client tests */
-        test_status = tests_list[i](NONSECURE);
+        test_status = tests_list[i](CALLER_NONSECURE);
 
         if (server_hs == TRUE)
         {


### PR DESCRIPTION
This is related to https://github.com/ARMmbed/mbed-os/issues/11256
When TARGET_PSA is enabled on Cortex-A boards, the SECURE
is redeclared. So to minimize the impact we can redeclare this in
val.h which is used only by Mbed. And `security_t` itself is used in
mbed-os\components\TARGET_PSA\TESTS, but the SECURE string is not used.
