### PR TITLE
STMOD_CELLULAR: set CTS with PullDown

### DIFF
--- a/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
@@ -113,6 +113,8 @@ nsapi_error_t STModCellular::soft_power_on()
     if ((MBED_CONF_STMOD_CELLULAR_CTS != NC) && (MBED_CONF_STMOD_CELLULAR_RTS != NC)) {
         tr_debug("Enable flow control\r\n");
 
+        pin_mode(MBED_CONF_STMOD_CELLULAR_CTS, PullDown);
+
         _at->lock();
         // enable CTS/RTS flowcontrol
         _at->set_stop_tag(mbed::OK);


### PR DESCRIPTION
### Description

Fix #11413 

We need to set CTS pin with pull down.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@JRubis
@LMESTM 

### Release Notes

