### PR TITLE
Revert tickless on UBLOX_EVK_ODIN_W2

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4780,7 +4780,6 @@
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "supported_form_factors": ["ARDUINO"],
         "release_versions": ["5"],
-        "macros_add": ["MBED_TICKLESS"],
         "device_has_remove": [],
         "extra_labels_add": ["PSA"],
         "components_add": ["SD", "FLASHIAP"],


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Tickless mode was recently enabled on UBLOX_EVK_ODIN_W2 (PR #11480) but appears to cause crashes in WiFi tests (Issue #11557). This PR disables tickless mode on UBLOX_EVK_ODIN_W2 until the crashes related to WiFi are fixed.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
