### PR TITLE
DISCO_L4R9I: update default STMOD+ pin

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/TARGET_DISCO_L4R9I/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R9xI/TARGET_DISCO_L4R9I/PinNames.h
@@ -362,8 +362,8 @@ typedef enum {
 
     /**** STMOD+ pins ****/
     STMOD_1  = PA_6,
-    STMOD_2  = PB_15,
-    STMOD_3  = PB_14,
+    STMOD_2  = PB_10,
+    STMOD_3  = PB_11,
     STMOD_4  = PB_13,
 //  STMOD_5 is connected to GND
 //  STMOD_6 is connected to +5V


### PR DESCRIPTION
### Description

Tested with Quectel BG96 expansion board on STMOD+ connector of L4R9I DISCO board.

NB: mbed_app.json:
````
    "target_overrides": {
        "DISCO_L4R9I": {
            "stmod_cellular.provide-default": "true", 
            "target.components_add": [
                "STMOD_CELLULAR"
            ]
        }, 
````

| target            | platform_name | test suite                                       | result | elapsed_time (sec) | copy_method |
|-------------------|---------------|--------------------------------------------------|--------|--------------------|-------------|
| DISCO_L4R9I-ARMC6 | DISCO_L4R9I   | features-cellular-tests-api-cellular_device      | OK     | 50.26              | default     |
| DISCO_L4R9I-ARMC6 | DISCO_L4R9I   | features-cellular-tests-api-cellular_information | OK     | 24.05              | default     |
| DISCO_L4R9I-ARMC6 | DISCO_L4R9I   | features-cellular-tests-api-cellular_network     | OK     | 66.38              | default     |
| DISCO_L4R9I-ARMC6 | DISCO_L4R9I   | features-cellular-tests-api-cellular_sms         | OK     | 33.77              | default     |
| DISCO_L4R9I-ARMC6 | DISCO_L4R9I   | features-cellular-tests-socket-udp               | OK     | 32.84              | default     |




### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@LMESTM 

### Release Notes

