### PR TITLE
pinmap_peripheral function: update error code for easier debug

### DIFF
--- a/hal/mbed_pinmap_common.c
+++ b/hal/mbed_pinmap_common.c
@@ -74,7 +74,7 @@ uint32_t pinmap_peripheral(PinName pin, const PinMap *map)
     }
     peripheral = pinmap_find_peripheral(pin, map);
     if ((uint32_t)NC == peripheral) { // no mapping available
-        MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", peripheral);
+        MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", pin);
     }
     return peripheral;
 }
@@ -99,7 +99,7 @@ uint32_t pinmap_function(PinName pin, const PinMap *map)
     }
     function = pinmap_find_function(pin, map);
     if ((uint32_t)NC == function) { // no mapping available
-        MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", function);
+        MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", pin);
     }
     return function;
 }


### PR DESCRIPTION
### Description

Hi

Input parameter of pinmap_peripheral function is the PinName.
When application set the wrong pin value, error code displays the peripheral value, which doesn't help the developper.

Proposition is to display the function input parameter, i.e. pin value.

Thx

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes

