### PR TITLE
Make devicekey remainder test more meaningful

### DIFF
--- a/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
+++ b/features/storage/TESTS/kvstore/direct_access_devicekey_test/main.cpp
@@ -50,7 +50,7 @@ static inline uint32_t align_down(uint64_t val, uint64_t size)
     return (((val) / size)) * size;
 }
 
-int  get_virtual_TDBStore_position(uint32_t conf_start_address, uint32_t conf_size, bool is_conf_tdb_internal,
+int  get_virtual_TDBStore_position(uint32_t conf_start_address, uint32_t conf_size,
                                    uint32_t *tdb_start_address, uint32_t *tdb_end_address)
 {
     uint32_t bd_final_size = conf_size;
@@ -117,14 +117,14 @@ int  get_virtual_TDBStore_position(uint32_t conf_start_address, uint32_t conf_si
 }
 
 
-void test_direct_access_to_devicekey_tdb_flashiap_remainder()
+void test_direct_access_to_devicekey_tdb_flashiap_default()
 {
-    utest_printf("Test Direct Access To DeviceKey Test Entire FlashIAP Remainder\n");
+    utest_printf("Test Direct Access To DeviceKey Test Entire FlashIAP Default Address\n");
 
     uint32_t flash_bd_start_address;
     uint32_t flash_bd_end_address;
 
-    int err = get_virtual_TDBStore_position(0, 0, true, &flash_bd_start_address, &flash_bd_end_address);
+    int err = get_virtual_TDBStore_position(MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS, MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE, &flash_bd_start_address, &flash_bd_end_address);
     TEST_SKIP_UNLESS_MESSAGE(err != -2, "Test skipped. Not enough available space on Internal FlashIAP");
     TEST_ASSERT_EQUAL(0, err);
     uint32_t flash_bd_size = flash_bd_end_address - flash_bd_start_address;
@@ -177,7 +177,7 @@ void test_direct_access_to_devicekey_tdb_last_two_sectors()
     uint32_t flash_bd_start_address;
     uint32_t flash_bd_end_address;
 
-    int err = get_virtual_TDBStore_position(0, 0, false, &flash_bd_start_address, &flash_bd_end_address);
+    int err = get_virtual_TDBStore_position(0, 0, &flash_bd_start_address, &flash_bd_end_address);
     TEST_SKIP_UNLESS_MESSAGE(err != -2, "Test skipped. Not enough available space on Internal FlashIAP");
     TEST_ASSERT_EQUAL(0, err);
 
@@ -258,7 +258,6 @@ void test_direct_access_to_device_inject_root()
     // Now use Direct Access To DeviceKey to retrieve it */
     uint32_t internal_start_address;
     uint32_t internal_rbp_size;
-    bool is_conf_tdb_internal = false;
     if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "FILESYSTEM") == 0) {
         internal_start_address =  MBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS;
         internal_rbp_size =  MBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE;
@@ -268,7 +267,6 @@ void test_direct_access_to_device_inject_root()
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_INTERNAL") == 0) {
         internal_start_address =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
         internal_rbp_size =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
-        is_conf_tdb_internal = true;
     } else if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "default") == 0) {
 #if COMPONENT_QSPIF || COMPONENT_SPIF || COMPONENT_DATAFLASH
         internal_start_address =  MBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS;
@@ -279,7 +277,6 @@ void test_direct_access_to_device_inject_root()
 #elif COMPONENT_FLASHIAP
         internal_start_address =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS;
         internal_rbp_size =  MBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE;
-        is_conf_tdb_internal = true;
 #else
         TEST_SKIP_UNLESS_MESSAGE(false, "Test skipped. No KVStore Internal");
 #endif
@@ -289,7 +286,7 @@ void test_direct_access_to_device_inject_root()
 
     uint32_t tdb_st_add = 0;
     uint32_t tdb_end_add = 0;
-    ret = get_virtual_TDBStore_position(internal_start_address, internal_rbp_size, is_conf_tdb_internal, &tdb_st_add, &tdb_end_add);
+    ret = get_virtual_TDBStore_position(internal_start_address, internal_rbp_size, &tdb_st_add, &tdb_end_add);
     TEST_SKIP_UNLESS_MESSAGE(ret != -2, "Test skipped. Not enough available space on Internal FlashIAP");
     TEST_ASSERT_EQUAL(0, ret);
 
@@ -329,7 +326,7 @@ utest::v1::status_t greentea_failure_handler(const Case *const source, const fai
 }
 
 Case cases[] = {
-    Case("Testing direct access to devicekey with tdb over flashiap remainder", test_direct_access_to_devicekey_tdb_flashiap_remainder, greentea_failure_handler),
+    Case("Testing direct access to devicekey with tdb over flashiap default placement", test_direct_access_to_devicekey_tdb_flashiap_default, greentea_failure_handler),
     Case("Testing direct access to devicekey with tdb over last two sectors", test_direct_access_to_devicekey_tdb_last_two_sectors, greentea_failure_handler),
     Case("Testing direct access to injected devicekey ", test_direct_access_to_device_inject_root, greentea_failure_handler),
 };


### PR DESCRIPTION
### Description
As of 722628be0250fbd09248d92e3e2720775ec0f84b, the "remainder" configuration also uses the default location near the end of flash. Which makes the two tests nearly identical with the exception that the "last two sectors" test correctly handles parts with a low (possibly 1:1) erase size to program size ratio.
Therefore, change the "remainder" test to instead be a "default" test that uses the tdb_internal_address/size values, so that it
a.) tests something meaningfully different
b.) tests using the custom TDB address/size values if they are provided.
c.) functions correctly on devices where the default sector-based size computation does not work (e.g. because of the low erase size to program size ratio) and therefore a custom location and size has been specified.
The is_conf_tdb_internal variable is unused and therefore removed.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
