### PR TITLE
Cellular: Change visibility of _is_connected as protected

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -47,7 +47,7 @@ using namespace mbed;
 using namespace rtos;
 
 AT_CellularContext::AT_CellularContext(ATHandler &at, CellularDevice *device, const char *apn, bool cp_req, bool nonip_req) :
-    AT_CellularBase(at), _is_connected(false), _current_op(OP_INVALID), _fh(0), _cp_req(cp_req)
+    AT_CellularBase(at), _current_op(OP_INVALID), _fh(0), _cp_req(cp_req), _is_connected(false)
 {
     tr_info("New CellularContext %s (%p)", apn ? apn : "", this);
     _nonip_req = nonip_req;

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -121,7 +121,6 @@ private:
     void do_disconnect();
     void set_cid(int cid);
 private:
-    bool _is_connected;
     ContextOperation  _current_op;
     FileHandle *_fh;
     rtos::Semaphore _semaphore;
@@ -131,6 +130,7 @@ protected:
     char _found_apn[MAX_APN_LENGTH];
     // flag indicating if CP was requested to be setup
     bool _cp_req;
+    bool _is_connected;
 };
 
 } // namespace mbed


### PR DESCRIPTION
### Description

`AT_CellularContext::do_connect()` is a virtual API and therefore can be overwritten in
inherited class. The problem was that it sets `AT_CellularContext::_is_connected` flag but
earlier it was set as private member making it impossible to set in overwritten `do_connect()`
method.

This commit fixes the problem by changing `_is_connected` as protected enabling its use
in inherited class.

This is a fix for issue #11606.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

@AriParkkila @mudassar-ublox 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
