### PR TITLE
Qspi frequency test fix

### DIFF
--- a/TESTS/mbed_hal/qspi/flash_configs/SiliconLabs/EFM32GG11_STK3701/flash_config.h
+++ b/TESTS/mbed_hal/qspi/flash_configs/SiliconLabs/EFM32GG11_STK3701/flash_config.h
@@ -23,4 +23,6 @@
 #define QSPI_SECTOR_COUNT                       1024 // for MX25R3235F
 #endif
 
+#define QSPI_MIN_FREQUENCY  2000000
+
 #endif // MBED_QSPI_FLASH_CONFIG_H

--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -42,7 +42,9 @@ using namespace utest::v1;
 
 
 
+#ifndef QSPI_MIN_FREQUENCY
 #define QSPI_MIN_FREQUENCY  1000000
+#endif
 
 // max write size is usually page size
 #define DATA_SIZE_256  (QSPI_PAGE_SIZE)

--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -344,18 +344,17 @@ void qspi_frequency_test(void)
     ret = qspi_init(&qspi.handle, QPIN_0, QPIN_1, QPIN_2, QPIN_3, QSCK, QCSN, freq, 0);
     TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
 
-    do {
+    while (ret == QSPI_STATUS_OK && freq >= QSPI_MIN_FREQUENCY) {
         // check if the memory is working properly
         qspi.cmd.configure(MODE_1_1_1, ADDR_SIZE_24, ALT_SIZE_8);
-
+        ret = qspi_frequency(&qspi.handle, freq);
         flash_init(qspi);
         _qspi_write_read_test(qspi, WRITE_1_1_1, ADDR_SIZE_24, ALT_SIZE_8, WRITE_SINGLE, READ_1_1_1, ADDR_SIZE_24, ALT_SIZE_8, READ_SINGLE, TEST_REPEAT_SINGLE, DATA_SIZE_256, TEST_FLASH_ADDRESS);
 
         utest_printf("frequency setting %d [Hz] - OK\r\n", freq);
 
         freq /= 2;
-        ret = qspi_frequency(&qspi.handle, freq);
-    } while (ret == QSPI_STATUS_OK && freq >= QSPI_MIN_FREQUENCY);
+    }
 
     qspi_free(&qspi.handle);
 }


### PR DESCRIPTION
### Description

- fix `qspi_frequency_test`: prevent setting frequency below QSPI_MIN_FREQUENCY
- adjust min frequency for EFM32GG11 target for hal qspi test

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
 