### PR TITLE
USBDevice: add documentation on USB suspend/resume to enter deep sleep

### DIFF
--- a/drivers/internal/USBDevice.h
+++ b/drivers/internal/USBDevice.h
@@ -97,6 +97,11 @@ public:
      * Power down this instance
      *
      * Disable interrupts and stop sending events.
+     * This method can be used for temporary power-saving; This call can allow
+     * USB to be temporarily disabled to permit power saving.
+     * However, it is up to the user to make sure all the
+     * transfers have concluded (for example when USB power is lost).
+     * USBDevice::connect can be used to resume USB operation.
      */
     void deinit();
 
@@ -109,6 +114,8 @@ public:
 
     /**
     * Connect a device
+    * This method can also be used to resume USB operation when USB power is
+    * detected after it was suspended via USBDevice::deinit.
     */
     void connect();
 


### PR DESCRIPTION
### Description
It is now possible to temporarily suspend a USB Component and safely preserve its state. This functionality is needed to allow a device to enter deep sleep as a USBDevice instance prevents deep sleep.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@bulislaw @c1728p9 @evedon 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
