### PR TITLE
EFM32GG11_STK3701: add QSPIF component config

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -58,6 +58,10 @@
         "CYW943012P6EVB_01": {
             "QSPI_FREQ": "50000000",
             "QSPI_MIN_PROG_SIZE": "512"
+        },
+        "EFM32GG11_STK3701": {
+            "QSPI_MIN_READ_SIZE": "4",
+            "QSPI_MIN_PROG_SIZE": "4"
         }
     }
 }


### PR DESCRIPTION
### Description
fix for https://github.com/ARMmbed/mbed-os/issues/11633


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/team-silabs
@ARMmbed/mbed-os-storage
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
