### PR TITLE
Change imgtool lib import to relative import

### DIFF
--- a/tools/psa/tfm/bin_utils/imgtool.py
+++ b/tools/psa/tfm/bin_utils/imgtool.py
@@ -19,9 +19,9 @@ from __future__ import print_function
 import os
 import re
 import argparse
-from imgtool_lib import keys
-from imgtool_lib import image
-from imgtool_lib import version
+from .imgtool_lib import keys
+from .imgtool_lib import image
+from .imgtool_lib import version
 import sys
 
 def find_load_address(args):


### PR DESCRIPTION
### Description

Building for ARM_MUSCA_A1_NS with python 3 
```
python tools/psa/release.py -m ARM_MUSCA_A1_S
python -m mbed test --compile -j 8 -m ARM_MUSCA_A1_NS -t ARM --build-data BUILD/tests/build_data.json -DMBED_HEAP_STATS_ENABLED=1 -DMBED_STACK_STATS_ENABLED=1 -DMBED_TRAP_ERRORS_ENABLED=1 -DMBED_ALL_STATS_ENABLED -DSKIP_TIME_DRIFT_TESTS=1
```
shows that imgtool has an import problem.
```
  File "/home/juhpuu01/build_test/mbed-os/tools/psa/tfm/bin_utils/imgtool.py", line 22, in <module>
    from imgtool_lib import keys
ModuleNotFoundError: No module named 'imgtool_lib'
```
This is easily fixed by changing to a relative import.
Tested to be compatible for python 2.7.15 and 3.6.8

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
