### PR TITLE
STMOD_CELLULAR: remove flow control support for DISCO_L4R9I

### DIFF
--- a/components/cellular/COMPONENT_STMOD_CELLULAR/README.md
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/README.md
@@ -43,7 +43,6 @@ Here is the used mbed_app.json:
    },
     "target_overrides": {
         "DISCO_L496AG": {
-            "target.macros_add": ["CELLULAR_DEVICE=STModCellular"],
             "target.components_add": ["STMOD_CELLULAR"],
             "stmod_cellular.provide-default": "true"
         }
@@ -70,3 +69,33 @@ mbed compile -t GCC_ARM -m DISCO_L496AG --flash
 ````
 
 Then check the serial console (serial baudrate set to 115200 bit/s)
+
+## Board with STMOD+ Connector
+
+### DISCO_L496AG
+
+https://os.mbed.com/platforms/ST-Discovery-L496AG/
+
+Default HW configuration:
+- STMOD pins 1, 2, 3 and 4 are mapped to UART CTS/TX/RX/RTS
+
+BG96 expansion board is fully compatible.
+
+### DISCO_L4R9I
+
+https://os.mbed.com/platforms/DISCO-L4R9I/
+
+Default HW configuration:
+- STMOD pins 1 and 2 are mapped to SPI
+- STMOD pins 2 and 3 are mapped to UART TX/RX
+
+BG96 expansion board can be used but without flow control.
+
+### DISCO_H747I
+
+https://os.mbed.com/platforms/ST-Discovery-H747I/
+
+Default HW configuration:
+- STMOD pins 1, 2, 3 and 4 are mapped to SPI
+
+BG96 expansion board can not be used without solder bridges update

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/STModCellular.cpp
@@ -109,7 +109,6 @@ nsapi_error_t STModCellular::soft_power_on()
 
     tr_debug("Modem %sready to receive AT commands\r\n", rdy ? "" : "NOT ");
 
-#if DEVICE_SERIAL_FC
     if ((MBED_CONF_STMOD_CELLULAR_CTS != NC) && (MBED_CONF_STMOD_CELLULAR_RTS != NC)) {
         tr_debug("Enable flow control\r\n");
 
@@ -131,7 +130,6 @@ nsapi_error_t STModCellular::soft_power_on()
             tr_error("Failed to enable hw flow control\r\n");
         }
     }
-#endif
 
     rtos::ThisThread::sleep_for(500);
 
@@ -163,10 +161,10 @@ CellularDevice *CellularDevice::get_default_instance()
     tr_debug("MODEM default instance\r\n");
 
     static UARTSerial serial(MBED_CONF_STMOD_CELLULAR_TX, MBED_CONF_STMOD_CELLULAR_RX, MBED_CONF_STMOD_CELLULAR_BAUDRATE);
-#if defined (MBED_CONF_STMOD_CELLULAR_RTS) && defined(MBED_CONF_STMOD_CELLULAR_CTS)
-    tr_debug("STMOD_CELLULAR flow control: RTS %d CTS %d\r\n", MBED_CONF_STMOD_CELLULAR_RTS, MBED_CONF_STMOD_CELLULAR_CTS);
-    serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_STMOD_CELLULAR_RTS, MBED_CONF_STMOD_CELLULAR_CTS);
-#endif
+    if ((MBED_CONF_STMOD_CELLULAR_CTS != NC) && (MBED_CONF_STMOD_CELLULAR_RTS != NC)) {
+        tr_debug("STMOD_CELLULAR flow control: RTS %d CTS %d\r\n", MBED_CONF_STMOD_CELLULAR_RTS, MBED_CONF_STMOD_CELLULAR_CTS);
+        serial.set_flow_control(SerialBase::RTSCTS, MBED_CONF_STMOD_CELLULAR_RTS, MBED_CONF_STMOD_CELLULAR_CTS);
+    }
     static STModCellular device(&serial);
     return &device;
 }

--- a/components/cellular/COMPONENT_STMOD_CELLULAR/mbed_lib.json
+++ b/components/cellular/COMPONENT_STMOD_CELLULAR/mbed_lib.json
@@ -65,5 +65,10 @@
             "help": "Provide as default CellularDevice [true/false]",
             "value": false
         }
+    },
+    "target_overrides": {
+        "DISCO_L4R9I": {
+            "rts": "NC"
+        }
     }
 }


### PR DESCRIPTION
### Description

This gives the possibility to disable flow control when there is no HW available.

For ex, DISCO_L4R9I doesn't give any RTS pin with default HW configuration on STMOD+ connector.
See #11626 

@LMESTM 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


### Release Notes
