### PR TITLE
Cypress Cordio BT Driver setting Host MCU active during Host Wake assert

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.cpp
@@ -34,6 +34,7 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
     dev_wake_irq_event(dev_wake_irq)
 {
     enabled_powersave = true;
+    bt_host_wake_active = false;
 }
 
 CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, PinName rts, int baud) :
@@ -46,6 +47,7 @@ CyH4TransportDriver::CyH4TransportDriver(PinName tx, PinName rx, PinName cts, Pi
     bt_device_wake(bt_device_wake_name)
 {
     enabled_powersave = false;
+    bt_host_wake_active = false;
     sleep_manager_lock_deep_sleep();
     holding_deep_sleep_lock = true;
 }

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/CyH4TransportDriver.h
@@ -64,7 +64,8 @@ public:
      */
     virtual uint16_t write(uint8_t type, uint16_t len, uint8_t *pData);
 
-    void bt_host_wake_irq_handler();
+    void bt_host_wake_rise_irq_handler();
+    void bt_host_wake_fall_irq_handler();
 
 #if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
     void on_host_stack_inactivity();
@@ -93,6 +94,7 @@ private:
 
     DigitalInOut bt_host_wake;
     DigitalInOut bt_device_wake;
+    bool bt_host_wake_active;
 
     bool     enabled_powersave;
     uint8_t  host_wake_irq_event;

--- a/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/HCIDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Cypress/TARGET_CYW43XXX/HCIDriver.cpp
@@ -171,6 +171,7 @@ public:
                 // Note: Reset is handled by ack_service_pack.
                 case HCI_VS_CMD_SET_SLEEP_MODE:
                     HciWriteLeHostSupport();
+                    sleep_manager_unlock_deep_sleep();
                     break;
 
                 case HCI_OPCODE_WRITE_LE_HOST_SUPPORT:
@@ -318,13 +319,6 @@ public:
         }
     }
 
-#if (defined(MBED_TICKLESS) && DEVICE_SLEEP && DEVICE_LPTICKER)
-    virtual void on_host_stack_inactivity(void)
-    {
-        cy_transport_driver.on_host_stack_inactivity();
-    }
-#endif
-
 private:
 
     // send pre_brcm_patchram_buf issue hci reset and update baud rate on 43012
@@ -390,7 +384,6 @@ private:
 #else /* BT_UART_NO_3M_SUPPORT */
         set_sleep_mode();
 #endif /* BT_UART_NO_3M_SUPPORT */
-        sleep_manager_unlock_deep_sleep();
     }
 
     void send_service_pack_command(void)
@@ -463,7 +456,7 @@ private:
             }
     }
 
-    //	0x18, 0xFC, 0x06, 0x00, 0x00, 0xC0, 0xC6, 0x2D, 0x00,   //update uart baudrate 3 mbp
+    // 0x18, 0xFC, 0x06, 0x00, 0x00, 0xC0, 0xC6, 0x2D, 0x00,   //update uart baudrate 3 mbp
     void HciUpdateUartBaudRate()
     {
             uint8_t *pBuf;


### PR DESCRIPTION


### Description
Update Target Cypress Specific Cordio BT Driver to keep Host MCU active for the duration BT device asserts HOST WAKE. This change fixes race condition in Cypress Cordio driver.

Change Description:
    1) Added Rising and falling edge interrupt for Host Wake Pin
    2) Keep Host MCU active for the duration of Host Wake Pin Asserted
    3) Remove Cordio inactivity virtual functions

Tested with mbed os BT applications:
    1) mbed-os-example-ble-LED
    2) mbed-os-example-ble-Beacon


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
