### PR TITLE
Fix swapped BT pins on CYW943012P6EVB-01

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.c
@@ -936,30 +936,6 @@ const cy_stc_gpio_pin_config_t CYBSP_BT_REG_ON_config =
 		.channel_num = CYBSP_BT_REG_ON_PIN,
 	};
 #endif //defined (CY_USING_HAL)
-const cy_stc_gpio_pin_config_t CYBSP_BT_HOST_WAKE_config = 
-{
-	.outVal = 0,
-	.driveMode = CY_GPIO_DM_HIGHZ,
-	.hsiom = CYBSP_BT_HOST_WAKE_HSIOM,
-	.intEdge = CY_GPIO_INTR_DISABLE,
-	.intMask = 0UL,
-	.vtrip = CY_GPIO_VTRIP_CMOS,
-	.slewRate = CY_GPIO_SLEW_FAST,
-	.driveSel = CY_GPIO_DRIVE_1_2,
-	.vregEn = 0UL,
-	.ibufMode = 0UL,
-	.vtripSel = 0UL,
-	.vrefSel = 0UL,
-	.vohSel = 0UL,
-};
-#if defined (CY_USING_HAL)
-	const cyhal_resource_inst_t CYBSP_BT_HOST_WAKE_obj = 
-	{
-		.type = CYHAL_RSC_GPIO,
-		.block_num = CYBSP_BT_HOST_WAKE_PORT_NUM,
-		.channel_num = CYBSP_BT_HOST_WAKE_PIN,
-	};
-#endif //defined (CY_USING_HAL)
 const cy_stc_gpio_pin_config_t CYBSP_BT_DEVICE_WAKE_config = 
 {
 	.outVal = 0,
@@ -982,6 +958,30 @@ const cy_stc_gpio_pin_config_t CYBSP_BT_DEVICE_WAKE_config =
 		.type = CYHAL_RSC_GPIO,
 		.block_num = CYBSP_BT_DEVICE_WAKE_PORT_NUM,
 		.channel_num = CYBSP_BT_DEVICE_WAKE_PIN,
+	};
+#endif //defined (CY_USING_HAL)
+const cy_stc_gpio_pin_config_t CYBSP_BT_HOST_WAKE_config = 
+{
+	.outVal = 0,
+	.driveMode = CY_GPIO_DM_HIGHZ,
+	.hsiom = CYBSP_BT_HOST_WAKE_HSIOM,
+	.intEdge = CY_GPIO_INTR_DISABLE,
+	.intMask = 0UL,
+	.vtrip = CY_GPIO_VTRIP_CMOS,
+	.slewRate = CY_GPIO_SLEW_FAST,
+	.driveSel = CY_GPIO_DRIVE_1_2,
+	.vregEn = 0UL,
+	.ibufMode = 0UL,
+	.vtripSel = 0UL,
+	.vrefSel = 0UL,
+	.vohSel = 0UL,
+};
+#if defined (CY_USING_HAL)
+	const cyhal_resource_inst_t CYBSP_BT_HOST_WAKE_obj = 
+	{
+		.type = CYHAL_RSC_GPIO,
+		.block_num = CYBSP_BT_HOST_WAKE_PORT_NUM,
+		.channel_num = CYBSP_BT_HOST_WAKE_PIN,
 	};
 #endif //defined (CY_USING_HAL)
 const cy_stc_gpio_pin_config_t CYBSP_BT_RST_config = 

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/GeneratedSource/cycfg_pins.h
@@ -948,44 +948,20 @@ extern "C" {
 #if defined (CY_USING_HAL)
 	#define CYBSP_BT_REG_ON_HAL_DRIVEMODE CYHAL_GPIO_DRIVE_OPENDRAINDRIVESHIGH
 #endif //defined (CY_USING_HAL)
-#define CYBSP_BT_HOST_WAKE_ENABLED 1U
-#define CYBSP_BT_HOST_WAKE_PORT GPIO_PRT3
-#define CYBSP_BT_HOST_WAKE_PORT_NUM 3U
-#define CYBSP_BT_HOST_WAKE_PIN 5U
-#define CYBSP_BT_HOST_WAKE_NUM 5U
-#define CYBSP_BT_HOST_WAKE_DRIVEMODE CY_GPIO_DM_HIGHZ
-#define CYBSP_BT_HOST_WAKE_INIT_DRIVESTATE 0
+#define CYBSP_BT_DEVICE_WAKE_ENABLED 1U
+#define CYBSP_BT_DEVICE_WAKE_PORT GPIO_PRT3
+#define CYBSP_BT_DEVICE_WAKE_PORT_NUM 3U
+#define CYBSP_BT_DEVICE_WAKE_PIN 5U
+#define CYBSP_BT_DEVICE_WAKE_NUM 5U
+#define CYBSP_BT_DEVICE_WAKE_DRIVEMODE CY_GPIO_DM_STRONG_IN_OFF
+#define CYBSP_BT_DEVICE_WAKE_INIT_DRIVESTATE 0
 #ifndef ioss_0_port_3_pin_5_HSIOM
 	#define ioss_0_port_3_pin_5_HSIOM HSIOM_SEL_GPIO
 #endif
-#define CYBSP_BT_HOST_WAKE_HSIOM ioss_0_port_3_pin_5_HSIOM
-#define CYBSP_BT_HOST_WAKE_IRQ ioss_interrupts_gpio_3_IRQn
+#define CYBSP_BT_DEVICE_WAKE_HSIOM ioss_0_port_3_pin_5_HSIOM
+#define CYBSP_BT_DEVICE_WAKE_IRQ ioss_interrupts_gpio_3_IRQn
 #if defined (CY_USING_HAL)
-	#define CYBSP_BT_HOST_WAKE_HAL_PORT_PIN P3_5
-#endif //defined (CY_USING_HAL)
-#if defined (CY_USING_HAL)
-	#define CYBSP_BT_HOST_WAKE_HAL_IRQ CYHAL_GPIO_IRQ_NONE
-#endif //defined (CY_USING_HAL)
-#if defined (CY_USING_HAL)
-	#define CYBSP_BT_HOST_WAKE_HAL_DIR CYHAL_GPIO_DIR_INPUT 
-#endif //defined (CY_USING_HAL)
-#if defined (CY_USING_HAL)
-	#define CYBSP_BT_HOST_WAKE_HAL_DRIVEMODE CYHAL_GPIO_DRIVE_NONE
-#endif //defined (CY_USING_HAL)
-#define CYBSP_BT_DEVICE_WAKE_ENABLED 1U
-#define CYBSP_BT_DEVICE_WAKE_PORT GPIO_PRT4
-#define CYBSP_BT_DEVICE_WAKE_PORT_NUM 4U
-#define CYBSP_BT_DEVICE_WAKE_PIN 0U
-#define CYBSP_BT_DEVICE_WAKE_NUM 0U
-#define CYBSP_BT_DEVICE_WAKE_DRIVEMODE CY_GPIO_DM_STRONG_IN_OFF
-#define CYBSP_BT_DEVICE_WAKE_INIT_DRIVESTATE 0
-#ifndef ioss_0_port_4_pin_0_HSIOM
-	#define ioss_0_port_4_pin_0_HSIOM HSIOM_SEL_GPIO
-#endif
-#define CYBSP_BT_DEVICE_WAKE_HSIOM ioss_0_port_4_pin_0_HSIOM
-#define CYBSP_BT_DEVICE_WAKE_IRQ ioss_interrupts_gpio_4_IRQn
-#if defined (CY_USING_HAL)
-	#define CYBSP_BT_DEVICE_WAKE_HAL_PORT_PIN P4_0
+	#define CYBSP_BT_DEVICE_WAKE_HAL_PORT_PIN P3_5
 #endif //defined (CY_USING_HAL)
 #if defined (CY_USING_HAL)
 	#define CYBSP_BT_DEVICE_WAKE_HAL_IRQ CYHAL_GPIO_IRQ_NONE
@@ -995,6 +971,30 @@ extern "C" {
 #endif //defined (CY_USING_HAL)
 #if defined (CY_USING_HAL)
 	#define CYBSP_BT_DEVICE_WAKE_HAL_DRIVEMODE CYHAL_GPIO_DRIVE_STRONG
+#endif //defined (CY_USING_HAL)
+#define CYBSP_BT_HOST_WAKE_ENABLED 1U
+#define CYBSP_BT_HOST_WAKE_PORT GPIO_PRT4
+#define CYBSP_BT_HOST_WAKE_PORT_NUM 4U
+#define CYBSP_BT_HOST_WAKE_PIN 0U
+#define CYBSP_BT_HOST_WAKE_NUM 0U
+#define CYBSP_BT_HOST_WAKE_DRIVEMODE CY_GPIO_DM_HIGHZ
+#define CYBSP_BT_HOST_WAKE_INIT_DRIVESTATE 0
+#ifndef ioss_0_port_4_pin_0_HSIOM
+	#define ioss_0_port_4_pin_0_HSIOM HSIOM_SEL_GPIO
+#endif
+#define CYBSP_BT_HOST_WAKE_HSIOM ioss_0_port_4_pin_0_HSIOM
+#define CYBSP_BT_HOST_WAKE_IRQ ioss_interrupts_gpio_4_IRQn
+#if defined (CY_USING_HAL)
+	#define CYBSP_BT_HOST_WAKE_HAL_PORT_PIN P4_0
+#endif //defined (CY_USING_HAL)
+#if defined (CY_USING_HAL)
+	#define CYBSP_BT_HOST_WAKE_HAL_IRQ CYHAL_GPIO_IRQ_NONE
+#endif //defined (CY_USING_HAL)
+#if defined (CY_USING_HAL)
+	#define CYBSP_BT_HOST_WAKE_HAL_DIR CYHAL_GPIO_DIR_INPUT 
+#endif //defined (CY_USING_HAL)
+#if defined (CY_USING_HAL)
+	#define CYBSP_BT_HOST_WAKE_HAL_DRIVEMODE CYHAL_GPIO_DRIVE_NONE
 #endif //defined (CY_USING_HAL)
 #define CYBSP_BT_RST_ENABLED 1U
 #define CYBSP_BT_RST_PORT GPIO_PRT4
@@ -1653,13 +1653,13 @@ extern const cy_stc_gpio_pin_config_t CYBSP_BT_REG_ON_config;
 #if defined (CY_USING_HAL)
 	extern const cyhal_resource_inst_t CYBSP_BT_REG_ON_obj;
 #endif //defined (CY_USING_HAL)
-extern const cy_stc_gpio_pin_config_t CYBSP_BT_HOST_WAKE_config;
-#if defined (CY_USING_HAL)
-	extern const cyhal_resource_inst_t CYBSP_BT_HOST_WAKE_obj;
-#endif //defined (CY_USING_HAL)
 extern const cy_stc_gpio_pin_config_t CYBSP_BT_DEVICE_WAKE_config;
 #if defined (CY_USING_HAL)
 	extern const cyhal_resource_inst_t CYBSP_BT_DEVICE_WAKE_obj;
+#endif //defined (CY_USING_HAL)
+extern const cy_stc_gpio_pin_config_t CYBSP_BT_HOST_WAKE_config;
+#if defined (CY_USING_HAL)
+	extern const cyhal_resource_inst_t CYBSP_BT_HOST_WAKE_obj;
 #endif //defined (CY_USING_HAL)
 extern const cy_stc_gpio_pin_config_t CYBSP_BT_RST_config;
 #if defined (CY_USING_HAL)

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/design.modus
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/COMPONENT_BSP_DESIGN_MODUS/design.modus
@@ -424,8 +424,8 @@
                     <Param id="sioOutputBuffer" value="true"/>
                     <Param id="inFlash" value="true"/>
                 </Block>
-                <Block location="ioss[0].port[3].pin[5]" alias="CYBSP_BT_HOST_WAKE" template="mxs40pin" version="1.1">
-                    <Param id="DriveModes" value="CY_GPIO_DM_HIGHZ"/>
+                <Block location="ioss[0].port[3].pin[5]" alias="CYBSP_BT_DEVICE_WAKE" template="mxs40pin" version="1.1">
+                    <Param id="DriveModes" value="CY_GPIO_DM_STRONG_IN_OFF"/>
                     <Param id="initialState" value="0"/>
                     <Param id="vtrip" value="CY_GPIO_VTRIP_CMOS"/>
                     <Param id="isrTrigger" value="CY_GPIO_INTR_DISABLE"/>
@@ -434,8 +434,8 @@
                     <Param id="sioOutputBuffer" value="true"/>
                     <Param id="inFlash" value="true"/>
                 </Block>
-                <Block location="ioss[0].port[4].pin[0]" alias="CYBSP_BT_DEVICE_WAKE" template="mxs40pin" version="1.1">
-                    <Param id="DriveModes" value="CY_GPIO_DM_STRONG_IN_OFF"/>
+                <Block location="ioss[0].port[4].pin[0]" alias="CYBSP_BT_HOST_WAKE" template="mxs40pin" version="1.1">
+                    <Param id="DriveModes" value="CY_GPIO_DM_HIGHZ"/>
                     <Param id="initialState" value="0"/>
                     <Param id="vtrip" value="CY_GPIO_VTRIP_CMOS"/>
                     <Param id="isrTrigger" value="CY_GPIO_INTR_DISABLE"/>

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/cybsp_types.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CYW943012P6EVB_01/cybsp_types.h
@@ -127,10 +127,10 @@ extern "C" {
 
 /** Pin: BT Power */
 #define CYBSP_BT_POWER              (P3_4)
-/** Pin: BT Host Wakeup */
-#define CYBSP_BT_HOST_WAKE          (P3_5)
 /** Pin: BT Device Wakeup */
-#define CYBSP_BT_DEVICE_WAKE        (P4_0)
+#define CYBSP_BT_DEVICE_WAKE        (P3_5)
+/** Pin: BT Host Wakeup */
+#define CYBSP_BT_HOST_WAKE          (P4_0)
 
 /** Pin: UART RX */
 #define CYBSP_DEBUG_UART_RX         (P13_0)


### PR DESCRIPTION
### Description
The BT_DEVICE_WAKE and BT_HOST_WAKE pins were swapped relative to
how the chips are wired up on the board.
Greentea report: CYW943012P6EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3700607/CYW943012P6EVB_01-GCC_ARM.txt)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
