### PR TITLE
Nanostack RF driver updates for Mbed OS 5.14.1

### DIFF
--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
@@ -550,10 +550,11 @@ static void rf_init_registers(void)
     rf_write_register_field(PCKTCTRL3, PCKT_FORMAT_FIELD, PCKT_FORMAT_802_15_4);
     rf_write_register_field(MOD2, MOD_TYPE_FIELD, MOD_2FSK);
     rf_write_register(PCKT_FLT_OPTIONS, 0);
-    rf_write_register_field(PCKTCTRL1, PCKT_CRCMODE_FIELD, PCKT_CRCMODE_0X1021);
+    rf_write_register_field(PCKTCTRL1, PCKT_CRCMODE_FIELD, PCKT_CRCMODE_0x04C11DB7);
     rf_write_register_field(PCKTCTRL1, PCKT_TXSOURCE_FIELD, PCKT_TXSOURCE_NORMAL);
     rf_write_register_field(PCKTCTRL1, PCKT_WHITENING_FIELD, PCKT_WHITENING_ENABLED);
     rf_write_register_field(PCKTCTRL2, PCKT_FIXVARLEN_FIELD, PCKT_VARIABLE_LEN);
+    rf_write_register_field(PCKTCTRL2, PCKT_FCS_TYPE_FIELD, PCKT_FCS_TYPE_4_OCTET);
     rf_write_register_field(PCKTCTRL3, PCKT_RXMODE_FIELD, PCKT_RXMODE_NORMAL);
     rf_write_register_field(PCKTCTRL3, PCKT_BYTE_SWAP_FIELD, PCKT_BYTE_SWAP_LSB);
     rf_write_register(PCKTCTRL5, PCKT_PREAMBLE_LEN);
@@ -999,6 +1000,7 @@ static void rf_receive(uint8_t rx_channel)
     rf_poll_state_change(S2LP_STATE_READY);
     rf_flush_rx_fifo();
     if (rf_update_config == true) {
+        rf_channel_multiplier = 1;
         rf_update_config = false;
         rf_set_channel_configuration_registers();
     }

--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
@@ -249,10 +249,14 @@ extern "C" {
 // PCKTCTRL2
 #define PCKT_FIXVARLEN_FIELD    0x01
 #define PCKT_VARIABLE_LEN       (1 << 0)
+#define PCKT_FCS_TYPE_FIELD     0x20
+#define PCKT_FCS_TYPE_4_OCTET   (0 << 5)
+#define PCKT_FCS_TYPE_2_OCTET   (1 << 5)
 
 // PCKTCTRL1
 #define PCKT_CRCMODE_FIELD      0xE0
 #define PCKT_CRCMODE_0X1021     (3 << 5)
+#define PCKT_CRCMODE_0x04C11DB7 (5 << 5)
 #define PCKT_TXSOURCE_FIELD     0x0C
 #define PCKT_TXSOURCE_NORMAL    (0 << 2)
 #define PCKT_WHITENING_FIELD    0x10


### PR DESCRIPTION
### Description

Nanostack RF driver updates for Mbed OS 5.14.1

S2-LP RF driver:

v1.0.0
- Fixed channel spacing configuration
- Changed to use 4-octet FCS
- Fixed configuration follows Wi-SUN and 802.15.4g specifications

Note: This is a breaking change because new RF configuration is not backward compatible.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [x] Breaking change

### Reviewers

@mikter @juhhei01 @artokin 

### Release Notes

#### Summary of changes:
 - 4-octet FCS which follows IEEE Std 802.15.4-2015
 - Bug fix related to channel spacing configuration

#### Impact of changes:
This release contains version of a S2-LP driver which is not inter-operable with previous versions of the driver.

####  Migration actions required:
To make previous version (Mbed OS 5.14.0) of the S2-LP driver inter-operable with this release, following changes are needed.
```
/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
@@ -553 +553 @@ static void rf_init_registers(void)
-    rf_write_register_field(PCKTCTRL1, PCKT_CRCMODE_FIELD, PCKT_CRCMODE_0X1021);
+    rf_write_register_field(PCKTCTRL1, PCKT_CRCMODE_FIELD, PCKT_CRCMODE_0x04C11DB7);
@@ -556,0 +557 @@ static void rf_init_registers(void)
+    rf_write_register_field(PCKTCTRL2, PCKT_FCS_TYPE_FIELD, PCKT_FCS_TYPE_4_OCTET);
@@ -1001,0 +1003 @@ static void rf_receive(uint8_t rx_channel)
+        rf_channel_multiplier = 1;
/components/802.15.4_RF/stm-s2lp-rf-driver/source/s2lpReg.h
@@ -251,0 +252,3 @@ extern "C" {
+#define PCKT_FCS_TYPE_FIELD     0x20
+#define PCKT_FCS_TYPE_4_OCTET   (0 << 5)
+#define PCKT_FCS_TYPE_2_OCTET   (1 << 5)
@@ -255,0 +259 @@ extern "C" {
+#define PCKT_CRCMODE_0x04C11DB7 (5 << 5)
```