### PR TITLE
Fix memory leak on NetworkInterface destruction

### DIFF
--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -144,6 +144,7 @@ NetworkInterface::~NetworkInterface()
     ns_list_foreach_safe(iface_eventlist_entry_t, entry, event_list) {
         if (entry->iface == this) {
             ns_list_remove(event_list, entry);
+            delete entry;
         }
     }
 }


### PR DESCRIPTION
### Description

We dynamically allocate memory in [every add_event_listener()](https://github.com/ARMmbed/mbed-os/blob/ef4fe9852f0580adbcde72fbad6d52f9f7f5d544/features/netsocket/NetworkInterface.cpp#L122), but we [did not free it](https://github.com/ARMmbed/mbed-os/blob/ef4fe9852f0580adbcde72fbad6d52f9f7f5d544/features/netsocket/NetworkInterface.cpp#L146) on NetworkInterface destruction.

Found with the unittests update in https://github.com/ARMmbed/mbed-os/pull/11612

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 
@kjbracey-arm 
@SeppoTakalo 
@VeijoPesonen 