### PR TITLE
Adjustment of netsocket tests to the lossy mesh network limitation.

### DIFF
--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -32,6 +32,7 @@
 #include "nsapi_dns.h"
 #include "events/EventQueue.h"
 #include "dns_tests.h"
+#include "ip6string.h"
 
 using namespace utest::v1;
 
@@ -165,7 +166,16 @@ static void net_bringup()
     net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    tr_info("MBED: IP address is '%s'", net->get_ip_address() ? net->get_ip_address() : "null");
+    const char *address = net->get_ip_address();
+
+#define MESH 3
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    printf("Waiting for GLOBAL_UP\n");
+    while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
+        ThisThread::sleep_for(500);
+    }
+#endif
+    printf("MBED: IP address is '%s'\n", address ? address : "null");
 }
 
 static void net_bringdown()

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -31,6 +31,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "tcp_tests.h"
+#include "ip6string.h"
 
 #ifndef ECHO_SERVER_ADDR
 #error [NOT_SUPPORTED] Requires parameters for echo server
@@ -76,7 +77,16 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    tr_info("MBED: TCPClient IP address is '%s'", net->get_ip_address() ? net->get_ip_address() : "null");
+    const char *address = net->get_ip_address();
+
+#define MESH 3
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    printf("Waiting for GLOBAL_UP\n");
+    while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
+        ThisThread::sleep_for(500);
+    }
+#endif
+    printf("MBED: TCPClient IP address is '%s'\n", address ? address : "null");
 }
 
 static void _ifdown()

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -32,6 +32,7 @@
 #include "tls_tests.h"
 #include "cert.h"
 #include "CellularDevice.h"
+#include "ip6string.h"
 
 #ifndef ECHO_SERVER_ADDR
 #error [NOT_SUPPORTED] Requires parameters for echo server
@@ -70,7 +71,16 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    tr_info("MBED: TLSClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
+    const char *address = net->get_ip_address();
+
+#define MESH 3
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    printf("Waiting for GLOBAL_UP\n");
+    while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
+        ThisThread::sleep_for(500);
+    }
+#endif
+    printf("MBED: TLSClient address is '%s'\n", address ? address : "null");
 }
 
 static void _ifdown()

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -31,6 +31,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "udp_tests.h"
+#include "ip6string.h"
 
 #ifndef ECHO_SERVER_ADDR
 #error [NOT_SUPPORTED] Requires parameters for echo server
@@ -63,7 +64,16 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    tr_info("MBED: UDPClient IP address is '%s'", net->get_ip_address() ? net->get_ip_address() : "null");
+    const char *address = net->get_ip_address();
+
+#define MESH 3
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+    printf("Waiting for GLOBAL_UP\n");
+    while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
+        ThisThread::sleep_for(500);
+    }
+#endif
+    printf("MBED: UDPClient IP address is '%s'\n", address ? address : "null");
 }
 
 static void _ifdown()


### PR DESCRIPTION
### Description
Netsocket tests are modified  according to loosy mesh network environment.   
Some tests are skipped.
The failures need to be investigated by the infra team. 
Local network setup, passes all tests

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@mikter 
@SeppoTakalo 
@michalpasztamobica 

### Release Notes


