### PR TITLE
Fix dropped bytes on spi write

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
@@ -130,12 +130,11 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     struct spi_s *spi = cy_get_spi(obj);
-    uint32_t received;
-    if (CY_RSLT_SUCCESS != cyhal_spi_send(&(spi->hal_spi), (uint32_t)value)) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_spi_send");
-    }
-    if (CY_RSLT_SUCCESS != cyhal_spi_recv(&(spi->hal_spi), &received)) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_spi_recv");
+    uint8_t received;
+    uint8_t value_byte = (uint8_t)value;
+
+    if (CY_RSLT_SUCCESS != cyhal_spi_transfer(&(spi->hal_spi), &value_byte, 1, &received, 1, 0xff)) {
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_spi_transfer");
     }
     return (int)received;
 }

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_spi_api.c
@@ -130,13 +130,12 @@ void spi_frequency(spi_t *obj, int hz)
 int spi_master_write(spi_t *obj, int value)
 {
     struct spi_s *spi = cy_get_spi(obj);
-    uint8_t received;
-    uint8_t value_byte = (uint8_t)value;
+    int received;
 
-    if (CY_RSLT_SUCCESS != cyhal_spi_transfer(&(spi->hal_spi), &value_byte, 1, &received, 1, 0xff)) {
+    if (CY_RSLT_SUCCESS != cyhal_spi_transfer(&(spi->hal_spi), (const uint8_t *)&value, 1, (uint8_t *)&received, 1, 0xff)) {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER_SPI, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_spi_transfer");
     }
-    return (int)received;
+    return received;
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill)


### PR DESCRIPTION
### Description
The cyhal_spi_send api was changed to read and discard a byte on every
send operation (at the protocol level all SPI transfers are bidirectional).
This means that to achieve a truly bidirectional transfer, the
cyhal_spi_transfer API must be called (as opposed to a write followed
by a read).
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


[GreenTea_CY8CKIT_062S2_43012_GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3708558/GreenTea_CY8CKIT_062S2_43012_GCC_ARM.txt)
[GreenTea_CY8CPROTO_062_4343W_GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3708559/GreenTea_CY8CPROTO_062_4343W_GCC_ARM.txt)


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
