### PR TITLE
mbed_rtc_time.h lacks an include guard

### DIFF
--- a/platform/mbed_rtc_time.h
+++ b/platform/mbed_rtc_time.h
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#ifndef __MBED_RTC_TIME_H__
+#define __MBED_RTC_TIME_H__
+
 #include <time.h>
 
 #ifdef __cplusplus
@@ -129,3 +132,5 @@ int settimeofday(const struct timeval *tv, const struct timezone *tz);
 
 /** @}*/
 /** @}*/
+
+#endif /* __MBED_RTC_TIME_H__ */


### PR DESCRIPTION
Adds a missing include guard

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
