### PR TITLE
Allow WhdAccessPoint scan results with extended parameters

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdAccessPoint.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdAccessPoint.cpp
@@ -1,0 +1,65 @@
+/* WHD Access Point Interface Implementation
+ * Copyright (c) 2018-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdlib>
+#include <utility>
+#include "WhdAccessPoint.h"
+
+WhdAccessPoint::WhdAccessPoint(nsapi_wifi_ap_t ap, whd_bss_type_t bss_type, uint8_t *ie_ptr, uint32_t ie_len) :
+    WiFiAccessPoint(ap), _bss_type(bss_type)
+{
+    _ie_ptr = (uint8_t *)malloc(ie_len * sizeof(uint8_t));
+    if (_ie_ptr != NULL) {
+        _ie_len = ie_len;
+        memcpy(_ie_ptr, ie_ptr, ie_len * sizeof(uint8_t));
+    }
+}
+
+WhdAccessPoint &WhdAccessPoint::operator=(WhdAccessPoint &&rhs)
+{
+    if (this != &rhs) {
+        WiFiAccessPoint::operator=(rhs);
+        _bss_type = rhs._bss_type;
+        _ie_ptr = rhs._ie_ptr;
+        _ie_len = rhs._ie_len;
+        rhs._ie_ptr = NULL;
+        rhs._ie_len = 0;
+    }
+    return *this;
+}
+
+whd_bss_type_t WhdAccessPoint::get_bss_type() const
+{
+    return _bss_type;
+}
+
+uint8_t *WhdAccessPoint::get_ie_data() const
+{
+    return _ie_ptr;
+}
+
+uint32_t WhdAccessPoint::get_ie_len() const
+{
+    return _ie_len;
+}
+
+WhdAccessPoint::~WhdAccessPoint()
+{
+    if (_ie_ptr != NULL) {
+        free(_ie_ptr);
+    }
+}

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdAccessPoint.h
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdAccessPoint.h
@@ -1,0 +1,74 @@
+/* WHD Access Point Interface
+ * Copyright (c) 2017-2019 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WHD_ACCESS_POINT_H
+#define WHD_ACCESS_POINT_H
+
+#include "netsocket/WiFiAccessPoint.h"
+#include "whd_types.h"
+
+/* Enum for scan result type */
+enum scan_result_type {
+    SRES_TYPE_WIFI_ACCESS_POINT,
+    SRES_TYPE_WHD_ACCESS_POINT
+};
+
+/** WhdAccessPoint class
+ *
+ *  Class that represents a Whd Access Point
+ *  which contains additional Whd specific information
+ */
+class WhdAccessPoint : public WiFiAccessPoint {
+public:
+    WhdAccessPoint() : WiFiAccessPoint() {};
+    WhdAccessPoint(nsapi_wifi_ap_t ap, whd_bss_type_t bss_type, uint8_t *ie_ptr, uint32_t ie_len);
+
+    /** Define move assignment and prevent copy-assignment
+     *
+     *  Due to IE element data could have large memory footprint,
+     *  only move assignment is allowed.
+     */
+    WhdAccessPoint &operator=(WhdAccessPoint &&rhs);
+    WhdAccessPoint &operator=(const WhdAccessPoint &rhs) = delete;
+
+    /** Get WHD access point's bss type
+     *
+     *  @return The whd_bss_type_t of the access point
+     */
+    whd_bss_type_t get_bss_type() const;
+
+    /** Get WHD access point's IE data
+     *
+     *  @return The pointer to ie data buffer
+     */
+    uint8_t *get_ie_data() const;
+
+    /** Get WHD access point's IE length
+     *
+     *  @return The ie data length
+     */
+    uint32_t get_ie_len() const;
+
+    virtual ~WhdAccessPoint();
+
+private:
+    whd_bss_type_t _bss_type;
+    uint8_t *_ie_ptr;          /**< Pointer to received Beacon/Probe Response IE(Information Element)         */
+    uint32_t _ie_len;          /**< Length of IE(Information Element)                                         */
+};
+
+#endif

--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSoftAPInterface.h
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSoftAPInterface.h
@@ -131,6 +131,21 @@ public:
      */
     int unregister_event_handler(void);
 
+    /** Set blocking status of interface. 
+     *  Nonblocking mode unsupported.
+     *
+     *  @param blocking true if connect is blocking
+     *  @return         0 on success, negative error code on failure
+     */
+    nsapi_error_t set_blocking(bool blocking)
+    {
+        if (blocking) {
+            _blocking = blocking;
+            return NSAPI_ERROR_OK;
+        } else {
+            return NSAPI_ERROR_UNSUPPORTED;
+        }
+    }
 
 protected:
     WHD_EMAC &_whd_emac;


### PR DESCRIPTION
Add WhdAccessPoint to include additional WHD scan info
- To save memory, only move assignment is supported for WhdAccessPoint
- Add scan_whd to scan for WhdAccessPoint with extended parameters such as BSS_TYPE, IE_DATA and IE_LEN 
- Set set_blocking(false) to unsupported by return NSAPI_ERROR_UNSUPPORTED

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
