### PR TITLE
Fixes IPv6 multicast join issue

### DIFF
--- a/features/lwipstack/LWIPStack.cpp
+++ b/features/lwipstack/LWIPStack.cpp
@@ -560,13 +560,14 @@ nsapi_error_t LWIP::setsockopt(nsapi_socket_t handle, int level, int optname, co
                 return NSAPI_ERROR_PARAMETER;
             }
 
-            /* Convert the interface address, or make sure it's the correct sort of "any" */
             if (imr->imr_interface.version != NSAPI_UNSPEC) {
+                /* Convert the interface address */
                 if (!convert_mbed_addr_to_lwip(&if_addr, &imr->imr_interface)) {
                     return NSAPI_ERROR_PARAMETER;
                 }
             } else {
-                ip_addr_set_any(IP_IS_V6(&if_addr), &if_addr);
+                /* Set interface address to "any", matching the group address type */
+                ip_addr_set_any(IP_IS_V6(&multi_addr), &if_addr);
             }
 
             igmp_err = ERR_USE; // Maps to NSAPI_ERROR_UNSUPPORTED


### PR DESCRIPTION
### Description
Fixes IPv6 multicast join issue

Problem Statement:
During multicast join sequence, InternetSocket::join_multicast_group() calls InternetSocket::modify_multicast_group(). modify_multicast_group() sets up the multicast group address (i.e., mreq.imr_multiaddr) to be joined and the interface address (i.e., mreq.imr_interface) to be used for the multicast join request. The interface address is initialized with the default value, which sets the version of interface address to NSAPI_UNSPEC. This results in LWIP::setsockopt() API to attempt IPv6 multicast join on the IPv4 interface address, hence IPv6 multicast join always fails with the protocol error.

Fix:
Initialize interface address version based on the multicast address version in LWIP::setsockopt(), before attempting multicast join operation.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AnttiKauppila 

### Release Notes
