### PR TITLE
Fixed issue with integer overflow when converting time units

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/include/cyabs_rtos.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/include/cyabs_rtos.h
@@ -167,7 +167,8 @@ extern cy_rtos_error_t cy_rtos_last_error();
  * @param[in]  entry_function Function pointer which points to the main function for the new thread
  * @param[in]  name           String thread name used for a debugger
  * @param[in]  stack          The buffer to use for the thread stack. This must be aligned to
-                              CY_RTOS_ALIGNMENT with a size of at least CY_RTOS_MIN_STACK_SIZE
+ *                            CY_RTOS_ALIGNMENT with a size of at least CY_RTOS_MIN_STACK_SIZE.
+ *                            If stack is null, cy_rtos_create_thread will allocate a stack from the heap.
  * @param[in]  stack_size     The size of the thread stack in bytes
  * @param[in]  priority       The priority of the thread. Values are operating system specific, but some
  *                            common priority levels are defined:

--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/source/COMPONENT_RTX/cyabs_rtos_rtxv5.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/abstraction/rtos/source/COMPONENT_RTX/cyabs_rtos_rtxv5.c
@@ -803,7 +803,7 @@ cy_rslt_t cy_rtos_get_time(cy_time_t *tval)
 
         /* Convert ticks count to time in milliseconds */
         if (tick_freq != 0)
-            *tval = ((osKernelGetTickCount() * 1000) / tick_freq);
+            *tval = (cy_time_t)((osKernelGetTickCount() * 1000LL) / tick_freq);
         else
             status = CY_RTOS_GENERAL_ERROR;
     }


### PR DESCRIPTION
### Description

- Fixed a potential integer overflow when converting from one time format to another.
- Updated a comment to better describe what happens when null is provided.

### Pull request type
    [x] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
