### PR TITLE
nrf5x - add missing gpio_set implementation

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/gpio_api.c
@@ -159,6 +159,18 @@ static void gpio_apply_config(uint8_t pin)
     }
 }
 
+uint32_t gpio_set(PinName pin)
+{
+    MBED_ASSERT(pin != (PinName)NC);
+    m_gpio_cfg[pin].used_as_gpio = true;
+    m_gpio_cfg[pin].direction = PIN_INPUT;
+    m_gpio_cfg[pin].pull = PullNone;
+    m_gpio_cfg[pin].used_as_irq = false;
+    m_gpio_cfg[pin].irq_fall = false;
+    m_gpio_cfg[pin].irq_rise = false;
+
+    return (uint32_t)(1UL << pin);
+}
 
 void gpio_mode(gpio_t *obj, PinMode mode)
 {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/gpio_api.c
@@ -160,6 +160,18 @@ static void gpio_apply_config(uint8_t pin)
     }
 }
 
+uint32_t gpio_set(PinName pin)
+{
+    MBED_ASSERT(pin != (PinName)NC);
+    m_gpio_cfg[pin].used_as_gpio = true;
+    m_gpio_cfg[pin].direction = PIN_INPUT;
+    m_gpio_cfg[pin].pull = PullNone;
+    m_gpio_cfg[pin].used_as_irq = false;
+    m_gpio_cfg[pin].irq_fall = false;
+    m_gpio_cfg[pin].irq_rise = false;
+
+    return (uint32_t)(1UL << pin);
+}
 
 void gpio_mode(gpio_t *obj, PinMode mode)
 {


### PR DESCRIPTION
### Description

add missing `gpio_set` implementation to Nordic NRF51/NRF52

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
 