### PR TITLE
STM32F767ZI - I2C FastModePlus not properly enabled

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -381,25 +381,33 @@ void i2c_frequency(i2c_t *obj, int hz)
 
     // Enable the Fast Mode Plus capability
     if (hz == 1000000) {
-#if defined(I2C1_BASE) && defined (I2C_FASTMODEPLUS_I2C1)
+#if defined(I2C1_BASE) && defined(I2C_FASTMODEPLUS_I2C1)  // sometimes I2C_FASTMODEPLUS_I2Cx is define even if not supported by the chip
+#if defined(SYSCFG_CFGR1_I2C_FMP_I2C1) || defined(SYSCFG_CFGR1_I2C1_FMP) || defined(SYSCFG_PMC_I2C1_FMP) || defined(SYSCFG_PMCR_I2C1_FMP) || defined(SYSCFG_CFGR2_I2C1_FMP)
         if (obj_s->i2c == I2C_1) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C1);
         }
 #endif
-#if defined(I2C2_BASE) && defined (I2C_FASTMODEPLUS_I2C2)
+#endif
+#if defined(I2C2_BASE) && defined(I2C_FASTMODEPLUS_I2C2)  // sometimes I2C_FASTMODEPLUS_I2Cx is define even if not supported by the chip
+#if defined(SYSCFG_CFGR1_I2C_FMP_I2C2) || defined(SYSCFG_CFGR1_I2C2_FMP) || defined(SYSCFG_PMC_I2C2_FMP) || defined(SYSCFG_PMCR_I2C2_FMP) || defined(SYSCFG_CFGR2_I2C2_FMP)
         if (obj_s->i2c == I2C_2) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C2);
         }
 #endif
-#if defined(I2C3_BASE) && defined (I2C_FASTMODEPLUS_I2C3)
+#endif
+#if defined(I2C3_BASE) && defined (I2C_FASTMODEPLUS_I2C3)  // sometimes I2C_FASTMODEPLUS_I2Cx is define even if not supported by the chip
+#if defined(SYSCFG_CFGR1_I2C_FMP_I2C3) || defined(SYSCFG_CFGR1_I2C3_FMP) || defined(SYSCFG_PMC_I2C3_FMP) || defined(SYSCFG_PMCR_I2C3_FMP) || defined(SYSCFG_CFGR2_I2C3_FMP)
         if (obj_s->i2c == I2C_3) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C3);
         }
 #endif
-#if defined(I2C4_BASE) && defined (I2C_FASTMODEPLUS_I2C4)
+#endif
+#if defined(I2C4_BASE) && defined (I2C_FASTMODEPLUS_I2C4)  // sometimes I2C_FASTMODEPLUS_I2Cx is define even if not supported by the chip
+#if defined(SYSCFG_CFGR1_I2C_FMP_I2C4) || defined(SYSCFG_CFGR1_I2C4_FMP) || defined(SYSCFG_PMC_I2C4_FMP) || defined(SYSCFG_PMCR_I2C4_FMP) || defined(SYSCFG_CFGR2_I2C4_FMP)
         if (obj_s->i2c == I2C_4) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C4);
         }
+#endif
 #endif
     }
 #endif //I2C_IP_VERSION_V2

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -381,22 +381,22 @@ void i2c_frequency(i2c_t *obj, int hz)
 
     // Enable the Fast Mode Plus capability
     if (hz == 1000000) {
-#if defined(I2C1_BASE) && defined(__HAL_SYSCFG_FASTMODEPLUS_ENABLE) && defined (I2C_FASTMODEPLUS_I2C1)
+#if defined(I2C1_BASE) && defined (I2C_FASTMODEPLUS_I2C1)
         if (obj_s->i2c == I2C_1) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C1);
         }
 #endif
-#if defined(I2C2_BASE) && defined(__HAL_SYSCFG_FASTMODEPLUS_ENABLE) && defined (I2C_FASTMODEPLUS_I2C2)
+#if defined(I2C2_BASE) && defined (I2C_FASTMODEPLUS_I2C2)
         if (obj_s->i2c == I2C_2) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C2);
         }
 #endif
-#if defined(I2C3_BASE) && defined(__HAL_SYSCFG_FASTMODEPLUS_ENABLE) && defined (I2C_FASTMODEPLUS_I2C3)
+#if defined(I2C3_BASE) && defined (I2C_FASTMODEPLUS_I2C3)
         if (obj_s->i2c == I2C_3) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C3);
         }
 #endif
-#if defined(I2C4_BASE) && defined(__HAL_SYSCFG_FASTMODEPLUS_ENABLE) && defined (I2C_FASTMODEPLUS_I2C4)
+#if defined(I2C4_BASE) && defined (I2C_FASTMODEPLUS_I2C4)
         if (obj_s->i2c == I2C_4) {
             HAL_I2CEx_EnableFastModePlus(I2C_FASTMODEPLUS_I2C4);
         }


### PR DESCRIPTION
# Description

STM32F767ZI - I2C FastModePlus not properly enabled
Fixes #11659
Tests I2C ci-shield PASSED

### Pull request type

   [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

###

mbedgt: test suite report:
| target              | platform_name | test suite            | result | elapsed_time (sec) | copy_method |
|---------------------|---------------|-----------------------|--------|--------------------|-------------|
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | OK     | 18.97              | default     |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-assumptions-i2c | OK     | 15.84              | default     |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | OK     | 19.64              | default     |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-assumptions-i2c | OK     | 16.41              | default     |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | OK     | 18.72              | default     |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-assumptions-i2c | OK     | 15.52              | default     |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | OK     | 19.19              | default     |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-assumptions-i2c | OK     | 15.98              | default     |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | OK     | 17.97              | default     |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-assumptions-i2c | OK     | 15.14              | default     |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | OK     | 18.23              | default     |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-assumptions-i2c | OK     | 15.47              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | OK     | 18.88              | default     |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-assumptions-i2c | OK     | 15.42              | default     |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | OK     | 21.67              | default     |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-assumptions-i2c | OK     | 18.11              | default     |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | OK     | 18.91              | default     |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-assumptions-i2c | OK     | 15.88              | default     |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | OK     | 18.88              | default     |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-assumptions-i2c | OK     | 15.91              | default     |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | OK     | 18.05              | default     |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-assumptions-i2c | OK     | 15.25              | default     |
mbedgt: test suite results: 22 OK
mbedgt: test case report:
| target              | platform_name | test suite            | test case                          | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|-----------------------|------------------------------------|--------|--------|--------|--------------------|
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.1                |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-ARMC6 | NUCLEO_F091RC | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.08               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.07               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.04               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.07               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARMC6 | NUCLEO_F103RB | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.07               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.1                |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.07               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.08               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARMC6 | NUCLEO_F207ZG | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.08               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.08               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.06               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.07               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.07               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F303ZE-ARMC6 | NUCLEO_F303ZE | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.07               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.09               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.08               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.08               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.07               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446RE-ARMC6 | NUCLEO_F446RE | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.07               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.09               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.07               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.07               |
| NUCLEO_F767ZI-ARMC6 | NUCLEO_F767ZI | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.05               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.07               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.93               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.08               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.07               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.07               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_H743ZI-ARMC6 | NUCLEO_H743ZI | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.1                |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.07               |
| NUCLEO_L073RZ-ARMC6 | NUCLEO_L073RZ | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.05               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.08               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.07               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.07               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARMC6 | NUCLEO_L152RE | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.07               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.08               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.09               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.07               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.07               |
| NUCLEO_L476RG-ARMC6 | NUCLEO_L476RG | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.05               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm 2nd WR 10  Bytes     | 1      | 0      | OK     | 0.06               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm 2nd WR 100 Bytes     | 1      | 0      | OK     | 0.07               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm 2nd WR 2 Bytes       | 1      | 0      | OK     | 0.07               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm 2nd WR Single Byte   | 1      | 0      | OK     | 0.06               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.07               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-api-i2c         | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-assumptions-i2c | I2C - is SCL connected?            | 1      | 0      | OK     | 0.07               |
| NUCLEO_WB55RG-ARMC6 | NUCLEO_WB55RG | tests-assumptions-i2c | I2C - is SDA connected?            | 1      | 0      | OK     | 0.06               |
mbedgt: test case results: 132 OK