### PR TITLE
stm32f4xx_hal_pcd.c@346,22: unused variable 'ep'

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.c
@@ -343,7 +343,6 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
   uint32_t i = 0U, ep_intr = 0U, epint = 0U, epnum = 0U;
   uint32_t fifoemptymsk = 0U, temp = 0U;
-  USB_OTG_EPTypeDef *ep;
   uint32_t hclk = 180000000U;
   
   /* ensure that we are in device mode */


### PR DESCRIPTION
### Description

Compiler warning fix, trivial. One function has an unused
variable, delete that line.

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@ARMmbed/team-st-mcd  @adbridge 

### Release Notes
