### PR TITLE
nrf52 - fix i2c/twi driver

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_twi.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_twi.c
@@ -82,7 +82,7 @@
                                         NRF_GPIO_PIN_S0D1,          \
                                         NRF_GPIO_PIN_NOSENSE)
 
-#define HW_TIMEOUT      10000
+#define HW_TIMEOUT      100000
 
 // Control block - driver instance local data.
 typedef struct
@@ -93,13 +93,13 @@ typedef struct
     nrfx_twi_xfer_desc_t    xfer_desc;
     uint32_t                flags;
     uint8_t *               p_curr_buf;
-    uint8_t                 curr_length;
+    size_t                  curr_length;
     bool                    curr_no_stop;
     nrfx_drv_state_t        state;
     bool                    error;
     volatile bool           busy;
     bool                    repeated;
-    uint8_t                 bytes_transferred;
+    size_t                  bytes_transferred;
     bool                    hold_bus_uninit;
 } twi_control_block_t;
 
@@ -254,8 +254,8 @@ void nrfx_twi_disable(nrfx_twi_t const * p_instance)
 
 static bool twi_send_byte(NRF_TWI_Type  * p_twi,
                           uint8_t const * p_data,
-                          uint8_t         length,
-                          uint8_t       * p_bytes_transferred,
+                          size_t          length,
+                          size_t        * p_bytes_transferred,
                           bool            no_stop)
 {
     if (*p_bytes_transferred < length)
@@ -280,8 +280,8 @@ static bool twi_send_byte(NRF_TWI_Type  * p_twi,
 
 static void twi_receive_byte(NRF_TWI_Type * p_twi,
                              uint8_t      * p_data,
-                             uint8_t        length,
-                             uint8_t      * p_bytes_transferred)
+                             size_t         length,
+                             size_t       * p_bytes_transferred)
 {
     if (*p_bytes_transferred < length)
     {
@@ -304,9 +304,9 @@ static void twi_receive_byte(NRF_TWI_Type * p_twi,
 
 static bool twi_transfer(NRF_TWI_Type  * p_twi,
                          bool          * p_error,
-                         uint8_t       * p_bytes_transferred,
+                         size_t        * p_bytes_transferred,
                          uint8_t       * p_data,
-                         uint8_t         length,
+                         size_t          length,
                          bool            no_stop)
 {
     bool do_stop_check = ((*p_error) || ((*p_bytes_transferred) == length));
@@ -376,7 +376,7 @@ static bool twi_transfer(NRF_TWI_Type  * p_twi,
 static nrfx_err_t twi_tx_start_transfer(twi_control_block_t * p_cb,
                                         NRF_TWI_Type *        p_twi,
                                         uint8_t const *       p_data,
-                                        uint8_t               length,
+                                        size_t                length,
                                         bool                  no_stop)
 {
     nrfx_err_t ret_code = NRFX_SUCCESS;
@@ -444,7 +444,7 @@ static nrfx_err_t twi_tx_start_transfer(twi_control_block_t * p_cb,
 static nrfx_err_t twi_rx_start_transfer(twi_control_block_t * p_cb,
                                         NRF_TWI_Type *        p_twi,
                                         uint8_t const *       p_data,
-                                        uint8_t               length)
+                                        size_t                length)
 {
     nrfx_err_t ret_code = NRFX_SUCCESS;
     volatile int32_t hw_timeout;


### PR DESCRIPTION
Sync TWI driver to sdk version 15.3.0 to get rid of data length limitation

### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
