### PR TITLE
Travis CI: Fixed issue where jobs are getting stalled/timing out

### DIFF
--- a/tools/test/travis-ci/functions.sh
+++ b/tools/test/travis-ci/functions.sh
@@ -93,6 +93,9 @@ _fetch_deps()
 {
   local pkg="${1}"
   local dep_list="${2}"
+  local pid_list=""
+
+  local PID;
 
   info "Fetching '${pkg}' archives"
 
@@ -103,9 +106,17 @@ _fetch_deps()
       || die "Download failed ('${dep}')" \
       && info "Fetched ${deps_url}/${dep}.deb" &
 
+    PID=$!
+    pid_list="${pid_list} ${PID}"
+
   done <<< "${dep_list}"
 
-  wait
+  # Ignoring shellcheck warning, since we need to allow parameter expansion to
+  #  turn the list string into parametesr.
+  # shellcheck disable=SC2086
+  wait ${pid_list}
+
+  info "Fetch completed."
 }
 
 


### PR DESCRIPTION
### Description

Something on Travis CI's side has changed such that invoking the 'wait' command within a script attempts to wait on some other jobs in addition to those spawned within the CI job.

Workaround is to explicitly collect the PIDs for processes spawned within the script and only wait on those.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
