### PR TITLE
STM32L4 TRNG clock configuration

### DIFF
--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -42,18 +42,17 @@ void trng_init(trng_t *obj)
         error("Only 1 RNG instance supported\r\n");
     }
 
-#if !defined(TARGET_STM32WB)
-    /*  Because M0 core of WB also needs RG RNG is already clocked by default */
-#if defined(RCC_PERIPHCLK_RNG)
+#if defined(RCC_PERIPHCLK_RNG) /* STM32L4 / STM32H7 / STM32WB */
+
+#if defined(TARGET_STM32WB)
+    /*  No need to reconfigure RngClockSelection as RNG is already clocked by M0 */
+
+#elif defined(TARGET_STM32H7)
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
 
     /*Select PLLQ output as RNG clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RNG;
-#if ((CLOCK_SOURCE) & USE_PLL_MSI)
-    PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_MSI;
-#else
     PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_PLL;
-#endif
 #if defined(DUAL_CORE)
     uint32_t timeout = HSEM_TIMEOUT;
     while (LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID) && (--timeout != 0)) {
@@ -65,8 +64,33 @@ void trng_init(trng_t *obj)
 #if defined(DUAL_CORE)
     LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, HSEM_CR_COREID_CURRENT);
 #endif /* DUAL_CORE */
+
+#elif defined(TARGET_STM32L4)
+    /* RNG and USB clocks have the same source, so the common source selection could be already done by USB */
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RNG;
+
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY)) {
+        /* MSI clock is enabled, MSI selected as RNG clock source if not alredy done */
+        if (__HAL_RCC_GET_RNG_SOURCE() != RCC_RNGCLKSOURCE_MSI) {
+            PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_MSI;
+            if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
+                error("RNG clock configuration error\n");
+            }
+        }
+    } else {
+        /* MSI clock is not enabled, PLL selected as RNG clock source */
+        PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_PLL;
+        if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
+            error("RNG clock configuration error\n");
+        }
+    }
+
+#else
+#error("RNG clock not configured");
 #endif
-#endif //!defined(TARGET_STM32WB)
+#endif /* defined(RCC_PERIPHCLK_RNG) */
 
     /* RNG Peripheral clock enable */
     __HAL_RCC_RNG_CLK_ENABLE();


### PR DESCRIPTION
### Description

Fixes #11674 

In some cases, mainly STM32L4, STM targets that have TRNG will use RCC_RNGCLKSOURCE_PLL even if the CLOCK_SOURCE is defined to be USE_PLL_MSI and TRNG should use RCC_RNGCLKSOURCE_MSI instead.
USE_PLL_MSI was defined in the system_clock.c and isn't seen in the trng_api.c thus evaluating to 0 when preprocessing

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jarlamsa 

### Release Notes


