### PR TITLE
LWIP: make MEMP_NUM_NETBUF and MEMP_NUM_PBUF configurable

### DIFF
--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -226,13 +226,23 @@
 
 // Number of non-pool pbufs.
 // Each requires 92 bytes of RAM.
+#ifdef MBED_CONF_LWIP_PBUF_NUM
+#undef MEMP_NUM_PBUF
+#define MEMP_NUM_PBUF               MBED_CONF_LWIP_PBUF_NUM
+#else
 #ifndef MEMP_NUM_PBUF
 #define MEMP_NUM_PBUF               8
 #endif
+#endif
 
 // Each netbuf requires 64 bytes of RAM.
+#ifdef MBED_CONF_LWIP_NETBUF_NUM
+#undef MEMP_NUM_NETBUF
+#define MEMP_NUM_NETBUF             MBED_CONF_LWIP_NETBUF_NUM
+#else
 #ifndef MEMP_NUM_NETBUF
 #define MEMP_NUM_NETBUF             8
+#endif
 #endif
 
 // One netconn is needed for each UDPSocket, TCPSocket or TCPServer.

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -144,6 +144,14 @@
         "ppp-thread-stacksize": {
             "help": "Thread stack size for PPP (obsolete: use netsocket/ppp configuration instead)",
             "value": 768
+        },
+        "pbuf-num": {
+            "help": "Number of pbufs in MEMP_PBUF pool",
+            "value": null
+        },
+        "netbuf-num": {
+            "help": "Number of netbufs in MEMP_NETBUF pool",
+            "value": null
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Description

This change makes the MEMP_NUM_NETBUF and MEMP_NUM_PBUF values of lwIP stack configurable to let the applications to operate correctly on higher network loads.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change