### PR TITLE
Add support for nRF52 Watchdog

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/config/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/config/sdk_config.h
@@ -4451,6 +4451,18 @@
 #define NRFX_WDT_CONFIG_LOG_LEVEL 3
 #endif
 
+
+// <e> NRFX_WDT_CONFIG_NO_IRQ - Remove WDT IRQ handling from WDT driver.
+//==========================================================
+
+// <0=> Include WDT IRQ handling
+// <1=> Remove WDT IRQ handling
+
+#ifndef NRFX_WDT_CONFIG_NO_IRQ
+#define NRFX_WDT_CONFIG_NO_IRQ 1
+#endif
+
+
 // <o> NRFX_WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
  
 // <0=> Default 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Trampoline SRL
  * Copyright (c) 2019 Giampaolo Mancini <giampaolo@trampolineup.com>
+ * SPDX-License-Identifier: Apache-2.0 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
@@ -69,7 +69,7 @@ watchdog_status_t hal_watchdog_stop(void)
 uint32_t hal_watchdog_get_reload_value(void)
 {
     // Convert to milliseconds from 32768 Hz clock ticks.
-    return nrf_wdt_reload_value_get() / 32768U * 1000;
+    return (uint64_t)nrf_wdt_reload_value_get() / 32768U * 1000;
 }
 
 watchdog_features_t hal_watchdog_get_platform_features(void)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019 Trampoline SRL
+ * Copyright (c) 2019 Giampaolo Mancini <giampaolo@trampolineup.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "watchdog_api.h"
+#include "nrfx_wdt.h"
+
+#if DEVICE_WATCHDOG
+
+static void dummy(void) {
+}
+
+watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
+{
+    nrfx_err_t err_code;
+
+    // nRF would allow a 4294967295 ms refresh value but
+    // Mbed OS allows max UINT32_MAX ms rehfreses.
+    if ( config->timeout_ms < 15U && config->timeout_ms > 65535U ) {
+        return WATCHDOG_STATUS_INVALID_ARGUMENT;
+    }
+
+    nrfx_wdt_config_t nrf_cfg = NRFX_WDT_DEAFULT_CONFIG;
+
+    nrf_cfg.reload_value = config->timeout_ms;
+    nrf_cfg.behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP_HALT;
+
+    err_code = nrfx_wdt_init(&nrf_cfg, dummy);
+    if (err_code != NRFX_SUCCESS) {
+        return WATCHDOG_STATUS_INVALID_ARGUMENT;
+    }
+
+    nrfx_wdt_channel_id channel;
+    if (nrfx_wdt_channel_alloc(&channel) != NRF_SUCCESS) {
+        return WATCHDOG_STATUS_INVALID_ARGUMENT;
+    }
+    nrfx_wdt_enable();
+    nrfx_wdt_feed();
+
+    return WATCHDOG_STATUS_OK;
+}
+
+void hal_watchdog_kick(void)
+{
+    nrfx_wdt_feed();
+}
+
+watchdog_status_t hal_watchdog_stop(void)
+{
+    return WATCHDOG_STATUS_NOT_SUPPORTED;
+}
+
+uint32_t hal_watchdog_get_reload_value(void)
+{
+    // Convert to milliseconds from 32768 Hz clock ticks.
+    return nrf_wdt_reload_value_get() / 32768U * 1000;
+}
+
+watchdog_features_t hal_watchdog_get_platform_features(void)
+{
+    watchdog_features_t features;
+    features.max_timeout = 0xFFFF;
+    features.update_config = false;
+    features.disable_watchdog = false;
+    return features;
+}
+
+#endif // DEVICE_WATCHDOG

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
@@ -27,9 +27,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 {
     nrfx_err_t err_code;
 
-    // nRF would allow a 4294967295 ms refresh value but
-    // Mbed OS allows max UINT32_MAX ms rehfreses.
-    if ( config->timeout_ms < 15U && config->timeout_ms > 65535U ) {
+    // The nRF watchdogs accept a range from 0xF to maximum 0xFFFF_FFFF
+    // 32768 Hz ticks. (Plase, see
+    // https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v15.3.0%2Fstructnrfx__wdt__config__t.html)
+    // Min timeout values in ms range from 0x1 to (0xFFFFFFFF / 0x8000) * 1000
+    if ( config->timeout_ms < 0x1 && config->timeout_ms > 0x07CFFFFF ) {
         return WATCHDOG_STATUS_INVALID_ARGUMENT;
     }
 
@@ -72,7 +74,8 @@ uint32_t hal_watchdog_get_reload_value(void)
 watchdog_features_t hal_watchdog_get_platform_features(void)
 {
     watchdog_features_t features;
-    features.max_timeout = 0xFFFF;
+
+    features.max_timeout = 0x07CFFFFF;
     features.update_config = false;
     features.disable_watchdog = false;
     return features;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/watchdog_api.c
@@ -35,10 +35,11 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
         return WATCHDOG_STATUS_INVALID_ARGUMENT;
     }
 
-    nrfx_wdt_config_t nrf_cfg = NRFX_WDT_DEAFULT_CONFIG;
+    nrfx_wdt_config_t nrf_cfg;
 
     nrf_cfg.reload_value = config->timeout_ms;
     nrf_cfg.behaviour = NRF_WDT_BEHAVIOUR_RUN_SLEEP_HALT;
+    nrf_cfg.interrupt_priority = NRFX_WDT_CONFIG_NO_IRQ;
 
     err_code = nrfx_wdt_init(&nrf_cfg, dummy);
     if (err_code != NRFX_SUCCESS) {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_wdt.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/modules/nrfx/drivers/src/nrfx_wdt.c
@@ -90,7 +90,7 @@ nrfx_err_t nrfx_wdt_init(nrfx_wdt_config_t const * p_config,
 
     nrf_wdt_behaviour_set(p_config->behaviour);
 
-    nrf_wdt_reload_value_set((p_config->reload_value * 32768) / 1000);
+    nrf_wdt_reload_value_set(((uint64_t)p_config->reload_value * 32768) / 1000);
 
     NRFX_IRQ_PRIORITY_SET(WDT_IRQn, p_config->interrupt_priority);
     NRFX_IRQ_ENABLE(WDT_IRQn);


### PR DESCRIPTION
### Description

Add the Watchdog driver implementation for the nRF52 targets using the [nRF5 SDK WDT API](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.3.0/nrf_dev_wdt_example.html).

To enable the Watchdog driver for the nRF2 targets, you need to activate it adding the macro `NRFX_WDT_ENABLED=1` in the `macro` section of `mbed_app.json` configuration file and adding the `"WATCHDOG"` key to the list of the device's drivers. Example file:

```json
{
    "macros": [
        "MBED_HEAP_STATS_ENABLED=1",
        "MBED_STACK_STATS_ENABLED=1",
        "MBED_MEM_TRACING_ENABLED=1",
        "NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS=8",
        "NRFX_WDT_ENABLED=1"
    ],
    "target_overrides": {
        "*": {
        "platform.stdio-buffered-serial": true,
        "platform.stdio-baud-rate": 115200,
        "platform.default-serial-baud-rate": 115200
    },
    "ARDUINO_NANO33BLE": {
        "target.device_has_add": ["WATCHDOG"]
    }
}
```

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change


