### PR TITLE
Clearing UART TC Flag prevents deep sleep, so do not clear it

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -569,13 +569,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -683,9 +676,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -443,13 +443,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -554,9 +547,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -526,13 +526,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -637,9 +630,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -228,7 +228,6 @@ void serial_clear(serial_t *obj)
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
-    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
     __HAL_UART_SEND_REQ(huart, UART_RXDATA_FLUSH_REQUEST);
 }
 
@@ -486,13 +485,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -600,9 +592,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -571,13 +571,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -682,9 +675,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -524,13 +524,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -638,9 +631,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_IT(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32H7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/serial_device.c
@@ -537,13 +537,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -651,9 +644,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_IT(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -480,13 +480,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
-    }
-}
-
 /**
  * The asynchronous TX and RX handler.
  *
@@ -587,9 +580,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -479,13 +479,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -590,9 +583,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -503,13 +503,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -614,9 +607,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32WB/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/serial_device.c
@@ -428,13 +428,6 @@ uint8_t serial_rx_active(serial_t *obj)
     return (((HAL_UART_GetState(huart) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) ? 1 : 0);
 }
 
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
-{
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    }
-}
-
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
@@ -539,9 +532,6 @@ void serial_tx_abort_asynch(serial_t *obj)
 
     __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
-
-    // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
     // reset states
     huart->TxXferCount = 0;


### PR DESCRIPTION
### Description

Fix to address #11361

The TC flag is used in function serial_is_tx_ongoing to check if there is
an ongoing serial transmission. So this Flag must not be cleared at the
end of the transmission, otherwise, serial_is_tx_ongoing will notify that
TX is ongoing.

The impact is that it may prevent deep sleep to be entered.

Also there is no need to clear this flag at the end of the transaction
because it will be cleared automatically by HW when a new transmission
starts.


<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jeromecoutant   please review
@ua1arn  please verify if that fixes your issue
 

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

Note that the issue has been reproduced using the Serial Async API. 
The fix solves the issues reusing the similar test case as provided in the issue description.

I am not sure if there is an automated test that can be used to make sure there is no regression around Serial Async API.

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
