### PR TITLE
QSPI: document use of QSPI_NO_INST

### DIFF
--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -151,7 +151,7 @@ public:
 
     /** Read from QSPI peripheral using custom read instruction, alt values
      *
-     *  @param instruction Instruction value to be used in instruction phase
+     *  @param instruction Instruction value to be used in instruction phase. Use QSPI_NO_INST to skip the instruction phase
      *  @param alt Alt value to be used in Alternate-byte phase. Use -1 for ignoring Alternate-byte phase
      *  @param address Address to be accessed in QSPI peripheral
      *  @param rx_buffer Buffer for data to be read from the peripheral
@@ -164,7 +164,7 @@ public:
 
     /** Write to QSPI peripheral using custom write instruction, alt values
      *
-     *  @param instruction Instruction value to be used in instruction phase
+     *  @param instruction Instruction value to be used in instruction phase. Use QSPI_NO_INST to skip the instruction phase
      *  @param alt Alt value to be used in Alternate-byte phase. Use -1 for ignoring Alternate-byte phase
      *  @param address Address to be accessed in QSPI peripheral
      *  @param tx_buffer Buffer containing data to be sent to peripheral
@@ -177,7 +177,7 @@ public:
 
     /** Perform a transaction to write to an address(a control register) and get the status results
      *
-     *  @param instruction Instruction value to be used in instruction phase
+     *  @param instruction Instruction value to be used in instruction phase. Use QSPI_NO_INST to skip the instruction phase
      *  @param address Some instruction might require address. Use -1 if no address
      *  @param tx_buffer Buffer containing data to be sent to peripheral
      *  @param tx_length Pointer to a variable containing the length of data to be transmitted, and on return this variable will be updated with the actual number of bytes written


### PR DESCRIPTION
### Description
Add comments to functions that can take a qspi_inst_t about the value that will cause the instruction phase to be skipped entirely.
This depends on #11604, which introduces the macro in question.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [x] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
