### PR TITLE
NRF52840_DK: enables FLASHIAP for the device

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7703,7 +7703,7 @@
     },
     "MCU_NRF52840": {
         "inherits": ["Target"],
-        "components_add": ["QSPIF"],
+        "components_add": ["QSPIF", "FLASHIAP"],
         "core": "Cortex-M4F",
         "macros": [
             "BOARD_PCA10056",


### PR DESCRIPTION
### Description
Enables FLASHIAP for the target.

```
mbedgt: test case report:
| target              | platform_name | test suite                                                  | test case                                                           | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|-------------------------------------------------------------|---------------------------------------------------------------------|--------|--------|--------|--------------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-nvstore-tests-nvstore-functionality        | NVStore: Basic functionality                                        | 1      | 0      | OK     | 0.57               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-nvstore-tests-nvstore-functionality        | NVStore: Multiple thread test                                       | 1      | 0      | OK     | 7.57               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-nvstore-tests-nvstore-functionality        | NVStore: Race test                                                  | 1      | 0      | OK     | 0.37               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-buffered_block_device    | BufferedBlockDevice functionality test                              | 1      | 0      | OK     | 0.29               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-flashsim_block_device    | FlashSimBlockDevice functionality test                              | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | DEFAULT Testing get type functionality                              | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing BlockDevice erase functionality                    | 1      | 0      | OK     | 0.6                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Deinit block device                                | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Init block device                                  | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing contiguous erase, write and read                   | 1      | 0      | OK     | 0.93               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing multi threads erase program read                   | 1      | 0      | OK     | 7.67               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing program read small data sizes                      | 1      | 0      | OK     | 0.72               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing read write random blocks                           | 1      | 0      | OK     | 1.73               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing unaligned erase blocks                             | 1      | 0      | OK     | 0.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing BlockDevice erase functionality                       | 1      | 0      | OK     | 0.51               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing Deinit block device                                   | 1      | 0      | OK     | 0.09               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing Init block device                                     | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing contiguous erase, write and read                      | 1      | 0      | OK     | 1.54               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing multi threads erase program read                      | 1      | 0      | OK     | 5.65               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing program read small data sizes                         | 1      | 0      | OK     | 0.44               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing read write random blocks                              | 1      | 0      | OK     | 1.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device     | QSPIF Testing unaligned erase blocks                                | 1      | 0      | OK     | 0.16               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-heap_block_device        | Testing get type functionality                                      | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-heap_block_device        | Testing read write random blocks                                    | 1      | 0      | OK     | 1.93               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-mbr_block_device         | Testing formatting of master boot record                            | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-mbr_block_device         | Testing mbr attributes                                              | 1      | 0      | OK     | 0.61               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-mbr_block_device         | Testing mbr read write                                              | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-util_block_device        | Testing chaining of block devices                                   | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-util_block_device        | Testing profiling of block devices                                  | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-util_block_device        | Testing slicing of a block device                                   | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over flashiap remainder | 1      | 0      | OK     | 0.51               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over last two sectors   | 1      | 0      | OK     | 0.41               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to injected devicekey                         | 1      | 0      | OK     | 0.46               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_buffer_null_size_not_zero                                       | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_buffer_size_bigger_than_data_real_size                          | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_buffer_size_is_zero                                             | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_buffer_size_smaller_than_data_real_size                         | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_existed_key                                                | 1      | 0      | OK     | 0.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_info_null                                                  | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_key_length_exceeds_max                                     | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_key_null                                                   | 1      | 0      | OK     | 0.04               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_non_existing_key                                           | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_overwritten_key                                            | 1      | 0      | OK     | 0.12               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_info_removed_key                                                | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_key_length_exceeds_max                                          | 1      | 0      | OK     | 0.0                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_key_null                                                        | 1      | 0      | OK     | 0.03               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_key_that_was_set_twice                                          | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_non_existing_key                                                | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_removed_key                                                     | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | get_several_keys_multithreaded                                      | 1      | 0      | OK     | 0.19               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_close_right_after_iterator_open                            | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list                                            | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list_keys_removed                               | 1      | 0      | OK     | 0.12               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list_non_matching_prefix                        | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_full_list                                             | 1      | 0      | OK     | 0.13               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_key_size_zero                                         | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_one_key_list                                          | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_path_check                                            | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_remove_while_iterating                                | 1      | 0      | OK     | 0.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_next_several_overwritten_keys                              | 1      | 0      | OK     | 0.12               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | iterator_open_it_null                                               | 1      | 0      | OK     | 0.04               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | kvstore_init                                                        | 1      | 0      | OK     | 0.48               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | remove_existed_key                                                  | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | remove_key_length_exceeds_max                                       | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | remove_key_null                                                     | 1      | 0      | OK     | 0.04               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | remove_non_existing_key                                             | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | remove_removed_key                                                  | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_buffer_null_size_not_zero                                       | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_buffer_size_is_zero                                             | 1      | 0      | OK     | 0.09               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_length_exceeds_max                                          | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_null                                                        | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_value_fifteen_byte_size                                     | 1      | 0      | OK     | 0.09               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_value_five_byte_size                                        | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_value_one_byte_size                                         | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_value_seventeen_byte_size                                   | 1      | 0      | OK     | 0.09               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_key_value_two_byte_size                                         | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_same_key_several_time                                           | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_several_key_value_sizes                                         | 1      | 0      | OK     | 0.96               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_several_keys_multithreaded                                      | 1      | 0      | OK     | 0.13               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_several_unvalid_key_names                                       | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_write_once_flag_try_remove                                      | 1      | 0      | OK     | 0.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                 | set_write_once_flag_try_set_twice                                   | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: Error inject test                                         | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: Multiple set test                                         | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: White box test                                            | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-flashiap                                 | FlashIAP - init                                                     | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-flashiap                                 | FlashIAP - program                                                  | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-flashiap                                 | FlashIAP - program across sectors                                   | 1      | 0      | OK     | 0.28               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-flashiap                                 | FlashIAP - program errors                                           | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-flashiap                                 | FlashIAP - timing                                                   | 1      | 0      | OK     | 1.42               |
mbedgt: test case results: 90 OK
mbedgt: completed in 284.88 sec
```

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@AnttiKauppila 
@kivaisan 
@JammuKekkonen 
@0xc0170 


### Release Notes
