### PR TITLE
GREENTEA: init trace if trace is enabled in json

### DIFF
--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -23,7 +23,7 @@
 #include "greentea-client/test_env.h"
 #include "greentea-client/greentea_serial.h"
 #include "greentea-client/greentea_metrics.h"
-
+#include "mbed_trace.h"
 
 /**
  *   Generic test suite transport protocol keys
@@ -83,6 +83,10 @@ void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char 
             break;
         }
     }
+
+#ifdef MBED_CONF_MBED_TRACE_ENABLE
+    mbed_trace_init();
+#endif
 
     greentea_notify_version();
     greentea_notify_timeout(timeout);


### PR DESCRIPTION
### Description

Hi

I was interested to enable mbed trace feature.

I can read that someone has to call the trace initialization function.
https://github.com/ARMmbed/mbed-os/blame/master/features/frameworks/mbed-trace/README.md#L56

Proposition is to init trace within GREENTEA_SETUP call.

Thx



Example of mbed_app.json:

````
{
    "target_overrides": {
        "*": {
            "mbed-trace.enable": "1",
            "mbed-trace.max-level": "TRACE_LEVEL_INFO"
        },
    }
}
````

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

### Release Notes
