### PR TITLE
USB-Cypress: Lock sleep when USB is initialized

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_usb_phy.cpp
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_usb_phy.cpp
@@ -17,6 +17,7 @@
 
 #include "cy_usb_phy_hw.h"
 #include "mbed_assert.h"
+#include "mbed_power_mgmt.h"
 
 #if defined(DEVICE_USBDEVICE)
 
@@ -63,6 +64,10 @@ void USBPhyHw::init(USBPhyEvents *events)
 
     // Initialize instance to access class data
     instance = this;
+
+    if (this->events == NULL) {
+        sleep_manager_lock_deep_sleep();
+    }
 
     // Store events
     instance->events = events;
@@ -176,6 +181,12 @@ void USBPhyHw::usb_dev_execute_ep_callbacks(void)
 void USBPhyHw::deinit()
 {
     cyhal_usb_dev_free(&obj);
+
+    if (events != NULL) {
+        sleep_manager_unlock_deep_sleep();
+    }
+
+    events = NULL;
 }
 
 bool USBPhyHw::powered()


### PR DESCRIPTION
### Description

None of the USB drivers currently support entering deep sleep mode
while USB is active. To protect USB from malfunctioning lock deep
sleep in USBPhyHw::init.This is done for similar

This was done for all other implementations as part of
https://github.com/ARMmbed/mbed-os/commit/8ffbe5c6033

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @c1728p9 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
