### PR TITLE
Fix for missing os_cb_section

### DIFF
--- a/platform/source/mbed_sdk_boot.c
+++ b/platform/source/mbed_sdk_boot.c
@@ -87,6 +87,9 @@ void _platform_post_stackheap_init(void)
     us_ticker_init();
 #endif
 }
+//Define an empty os_cb_sections to remove a RTX warning when building with no RTOS due 
+//to the --keep=os_cb_sections linker option
+const uint32_t os_cb_sections[] __attribute__((section(".rodata"))) = {};
 
 #elif defined (__GNUC__)
 

--- a/platform/source/mbed_sdk_boot.c
+++ b/platform/source/mbed_sdk_boot.c
@@ -87,7 +87,7 @@ void _platform_post_stackheap_init(void)
     us_ticker_init();
 #endif
 }
-//Define an empty os_cb_sections to remove a RTX warning when building with no RTOS due 
+//Define an empty os_cb_sections to remove a RTX warning when building with no RTOS due
 //to the --keep=os_cb_sections linker option
 const uint32_t os_cb_sections[] __attribute__((section(".rodata"))) = {};
 


### PR DESCRIPTION
 -Added the os_cb_section stub to remove the warnings

### Description
Procedure to reproduce the issue:
1.Clone the blinky bare metal from https://github.com/ARMmbed/mbed-os-example-blinky-baremetal.git 
2. Compile the blinky bare metal with "mbed compile -t ARMC6 -m target --profile release"
3.End of the compilation you will notice "[Warning] @0,0: L6320W: Ignoring --keep command. Cannot find argument 'os_cb_sections'." warning.

Reason for the issue:
1. In release profile, ARMC6 compiler have extra optional argument --keep=os_cb_sections but os_cb_section defined inside RTX RTOS(refer mbed-os/rtos) 
2.For bare metal build we dont have RTX RTOS.

Fix for the issue:
1. Added the osc_cb_section stub to remove the warnings.
 
This fixes #11565

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @hugueskamba 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
