### PR TITLE
Add bootloader support for Seeed Arch-MAX

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/mbed_lib.json
@@ -171,6 +171,12 @@
             "SPI_MISO": "D12",
             "SPI_CLK": "D13",
             "SPI_CS": "D10"
+        },
+        "ARCH_MAX": {
+            "SPI_MOSI": "PC_3",
+            "SPI_MISO": "PC_2",
+            "SPI_CLK":  "PB_10",
+            "SPI_CS":   "PE_2"
         }
     }
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/device/TOOLCHAIN_GCC_ARM/STM32F407XG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/device/TOOLCHAIN_GCC_ARM/STM32F407XG.ld
@@ -1,5 +1,13 @@
 /* Linker script to configure memory regions. */
 
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x80000
+#endif
+
 #if !defined(MBED_BOOT_STACK_SIZE)
     #define MBED_BOOT_STACK_SIZE 0x400
 #endif
@@ -10,7 +18,7 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
   RAM (rwx) : ORIGIN = 0x20000188, LENGTH = 128k - 0x188 
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/device/TOOLCHAIN_IAR/stm32f407xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xE/device/TOOLCHAIN_IAR/stm32f407xx.icf
@@ -1,11 +1,13 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x80000; }
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = 0x08000000;
+define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
-define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x0807FFFF;
+define symbol __ICFEDIT_region_ROM_start__ = MBED_APP_START;
+define symbol __ICFEDIT_region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 define symbol __NVIC_start__          = 0x20000000;
 define symbol __NVIC_end__            = 0x20000187;
 define symbol __region_CRASH_DATA_RAM_start__  = 0x20000188;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3837,6 +3837,7 @@
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "program_cycle_s": 2,
+        "components_add": ["SD", "FLASHIAP"],
         "extra_labels_add": [
             "STM32F4",
             "STM32F407",
@@ -3859,9 +3860,10 @@
             }
         },
         "release_versions": ["2", "5"],
-        "overrides": {"lse_available": 0},
         "device_name": "STM32F407VETx",
+        "bootloader_supported": true,
         "overrides": {
+            "lse_available": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },


### PR DESCRIPTION
### Description
Add bootloader support for Seeed Arch-MAX
* Add flash sector info in the pack file
* Fix linker script for GCC and IAR toolchain
* Add SD and FLASHIAP component

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Test result

```
mbedgt: test suite report:
| target           | platform_name | test suite                                                                   | result | elapsed_time (sec) | copy_method |
|------------------|---------------|------------------------------------------------------------------------------|--------|--------------------|-------------|
| ARCH_MAX-GCC_ARM | ARCH_MAX      | components-storage-blockdevice-component_sd-tests-filesystem-dirs            | OK     | 136.24             | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | components-storage-blockdevice-component_sd-tests-filesystem-files           | OK     | 77.04              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | components-storage-blockdevice-component_sd-tests-filesystem-fopen           | OK     | 154.4              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | components-storage-blockdevice-component_sd-tests-filesystem-parallel        | OK     | 60.17              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | components-storage-blockdevice-component_sd-tests-filesystem-seek            | OK     | 83.37              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-device_key-tests-device_key-functionality                           | OK     | 62.18              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-basic_test                        | OK     | 29.39              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-basic_test_default                | OK     | 29.76              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-case_async_validate               | OK     | 30.68              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-case_control_async                | OK     | 37.69              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-case_control_repeat               | OK     | 31.21              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-case_selection                    | OK     | 29.3               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-case_setup_failure                | OK     | 30.24              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | OK     | 30.87              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-control_type                      | OK     | 30.15              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | OK     | 29.43              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | OK     | 31.75              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | OK     | 29.32              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | OK     | 29.28              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-test_setup_failure                | OK     | 28.59              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-frameworks-utest-tests-unit_tests-test_skip                         | OK     | 29.23              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-nvstore-tests-nvstore-functionality                         | OK     | 53.26              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-blockdevice-buffered_block_device                     | OK     | 29.91              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-blockdevice-flashsim_block_device                     | OK     | 30.12              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-blockdevice-general_block_device                      | OK     | 63.5               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-blockdevice-heap_block_device                         | OK     | 33.34              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-blockdevice-mbr_block_device                          | OK     | 30.43              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-blockdevice-util_block_device                         | OK     | 29.03              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-filesystem-general_filesystem                         | OK     | 115.68             | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-kvstore-direct_access_devicekey_test                  | OK     | 44.31              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-kvstore-static_tests                                  | OK     | 76.76              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | features-storage-tests-kvstore-tdbstore_whitebox                             | OK     | 29.02              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-events-queue                                                           | OK     | 39.04              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-events-timing                                                          | OK     | 90.29              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-c_strings                                                 | OK     | 30.85              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-crc                                                       | OK     | 30.94              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-dev_null                                                  | OK     | 31.87              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-echo                                                      | OK     | 30.26              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-flashiap                                                  | OK     | 47.75              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-generic_tests                                             | OK     | 29.98              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-race_test                                                 | OK     | 29.9               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-reset_reason                                              | OK     | 33.88              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-rtc                                                       | OK     | 43.58              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-sleep_lock                                                | OK     | 29.69              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-stl_features                                              | OK     | 29.25              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-ticker                                                    | OK     | 53.92              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-timeout                                                   | OK     | 67.92              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-timer                                                     | OK     | 37.06              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-timerevent                                                | OK     | 30.29              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-watchdog                                                  | OK     | 32.35              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_drivers-watchdog_reset                                            | OK     | 38.85              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_functional-callback                                               | OK     | 30.76              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_functional-callback_big                                           | OK     | 31.12              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_functional-callback_small                                         | OK     | 30.02              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_functional-functionpointer                                        | OK     | 28.98              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-common_tickers                                                | OK     | 31.47              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-common_tickers_freq                                           | OK     | 37.88              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-critical_section                                              | OK     | 29.42              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-flash                                                         | OK     | 33.31              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-gpio                                                          | OK     | 28.7               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-minimum_requirements                                          | OK     | 29.18              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-mpu                                                           | OK     | 30.92              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-pinmap                                                        | OK     | 29.41              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-reset_reason                                                  | OK     | 34.66              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-rtc                                                           | OK     | 63.4               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-rtc_reset                                                     | OK     | 35.01              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-rtc_time                                                      | OK     | 34.56              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-rtc_time_conv                                                 | OK     | 47.29              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-sleep                                                         | OK     | 30.34              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-sleep_manager                                                 | OK     | 30.51              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-sleep_manager_racecondition                                   | OK     | 41.36              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-stack_size_unification                                        | OK     | 28.34              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-ticker                                                        | OK     | 40.83              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-trng                                                          | OK     | 31.33              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-us_ticker                                                     | OK     | 27.9               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-watchdog                                                      | OK     | 35.53              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-watchdog_reset                                                | OK     | 36.04              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_hal-watchdog_timing                                               | OK     | 50.93              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-atomic                                                   | OK     | 40.47              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-circularbuffer                                           | OK     | 36.42              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-critical_section                                         | OK     | 30.24              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-error_handling                                           | OK     | 30.69              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-filehandle                                               | OK     | 31.19              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-minimal-printf                                           | OK     | 34.71              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-sharedptr                                                | OK     | 29.44              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-singletonptr                                             | OK     | 30.37              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-stream                                                   | OK     | 29.53              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-system_reset                                             | OK     | 29.62              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-transaction                                              | OK     | 31.47              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbed_platform-wait_ns                                                  | OK     | 30.18              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-mbed-attributes                                              | OK     | 31.22              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-mbed-call_before_main                                        | OK     | 28.76              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-mbed-cpp                                                     | OK     | 28.45              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-mbed-div                                                     | OK     | 27.96              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-mbed-static_assert                                           | OK     | 28.62              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-basic                                              | OK     | 43.25              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-condition_variable                                 | OK     | 29.49              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-event_flags                                        | OK     | 32.15              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-heap_and_stack                                     | OK     | 28.81              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-kernel_tick_count                                  | OK     | 31.02              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-mail                                               | OK     | 33.51              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-malloc                                             | OK     | 50.99              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-memorypool                                         | OK     | 36.87              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-mutex                                              | OK     | 33.13              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-queue                                              | OK     | 31.62              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-rtostimer                                          | OK     | 30.38              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-semaphore                                          | OK     | 33.24              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-signals                                            | OK     | 35.2               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-systimer                                           | OK     | 30.88              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedmicro-rtos-mbed-threads                                            | OK     | 40.31              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedtls-multi                                                          | OK     | 30.01              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-mbedtls-selftest                                                       | OK     | 33.1               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-netsocket-dns                                                          | OK     | 66.28              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-netsocket-tcp                                                          | OK     | 107.48             | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-netsocket-tls                                                          | OK     | 99.34              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-netsocket-udp                                                          | OK     | 57.4               | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-network-interface                                                      | OK     | 53.54              | default     |
| ARCH_MAX-GCC_ARM | ARCH_MAX      | tests-network-l3ip                                                           | OK     | 28.23              | default     |
mbedgt: test suite results: 118 OK
```
### Full test log file

[arch_max-gcc_arm.txt](https://github.com/ARMmbed/mbed-os/files/3736997/arch_max-gcc_arm.txt)
[arch_max-arm.txt](https://github.com/ARMmbed/mbed-os/files/3737048/arch_max-arm.txt)
[arch_max-iar.txt](https://github.com/ARMmbed/mbed-os/files/3737049/arch_max-iar.txt)


cc @ARMmbed/team-seeed  