### PR TITLE
ARM toolchain: heap setup micro-optimisation

### DIFF
--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -927,7 +927,6 @@ __asm(".global __use_no_semihosting\n\t");
 // Through weak-reference, we can check if ARM_LIB_HEAP is defined at run-time.
 // If ARM_LIB_HEAP is defined, we can fix heap allocation.
 extern MBED_WEAK uint32_t   Image$$ARM_LIB_HEAP$$ZI$$Base[];
-extern MBED_WEAK uint32_t   Image$$ARM_LIB_HEAP$$ZI$$Length[];
 extern MBED_WEAK uint32_t   Image$$ARM_LIB_HEAP$$ZI$$Limit[];
 
 // Heap here is considered starting after ZI ends to Stack start
@@ -942,7 +941,7 @@ extern "C" MBED_WEAK __value_in_regs struct __initial_stackheap _mbed_user_setup
     struct __initial_stackheap r;
 
     // Fix heap if ARM_LIB_HEAP is defined
-    if (Image$$ARM_LIB_HEAP$$ZI$$Length) {
+    if (Image$$ARM_LIB_HEAP$$ZI$$Base != Image$$ARM_LIB_HEAP$$ZI$$Limit) {
         heap_base = (uint32_t) Image$$ARM_LIB_HEAP$$ZI$$Base;
         heap_limit = (uint32_t) Image$$ARM_LIB_HEAP$$ZI$$Limit;
     }
@@ -965,7 +964,7 @@ extern "C" __value_in_regs struct __argc_argv $Sub$$__rt_lib_init(unsigned heapb
     uint32_t heap_limit = (uint32_t)Image$$ARM_LIB_STACK$$ZI$$Base;
 
     // Fix heap if ARM_LIB_HEAP is defined
-    if (Image$$ARM_LIB_HEAP$$ZI$$Length) {
+    if (Image$$ARM_LIB_HEAP$$ZI$$Base != Image$$ARM_LIB_HEAP$$ZI$$Limit) {
         heap_base = (uint32_t) Image$$ARM_LIB_HEAP$$ZI$$Base;
         heap_limit = (uint32_t) Image$$ARM_LIB_HEAP$$ZI$$Limit;
     }


### PR DESCRIPTION
### Description

Locating and checking the length of the `ARM_LIB_HEAP` region is an extra task, when we're just interested in the base and limit. Looking at only those saves 8 bytes of ROM.

More space could be saved if we ensured all targets had `ARM_LIB_HEAP`, removing the need for this run-time fallback code.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
