### PR TITLE
Update examples testing scripts

### DIFF
--- a/tools/test/examples/README.md
+++ b/tools/test/examples/README.md
@@ -125,7 +125,7 @@ In the Mbed OS CI, we follow the below steps to compile and test Mbed OS example
 1. Create a symbolic link to `mbed-os` for every example. This step lets all the examples share a single `mbed-os` folder, rather than checking out the `mbed-os` folder many times. We highly recommend you pass an absolute path as the argument: 
 
    ```
-   python mbed-os/tools/test/examples/examples.py symlink $PWD/mbedos
+   python mbed-os/tools/test/examples/examples.py symlink $PWD/mbed-os
    ```
 
 1. Deploy other dependency libraries:

--- a/tools/test/examples/README.md
+++ b/tools/test/examples/README.md
@@ -1,38 +1,36 @@
 # Examples testing script
 
-The scripts in this folder are used for testing mbed-os official examples. it contains following files:
+The scripts in this folder are used for testing `mbed-os` official examples. It contains the following files:
 
-- `examples.py` the main script which serves as command line interface
-- `examples.json` the default configuration file for the script, which contains the information to the examples. if required, a customised configuration file can be pass as argument to the script
-- `examples_lib.py` the library file, which contains the main function of the testing scripts
+- `examples.py` - the main script that serves as the command-line interface.
+- `examples.json` - the default configuration file for the script, which contains the information to the examples. If required, you can pass a customized configuration file as an argument to the script.
+- `examples_lib.py` - the library file, which contains the main function of the testing scripts.
 
+## The scripts
 
-## The Scripts
+`examples.py` provides command-line interface and subcommands that makes easier to test examples. Included subcommands are:
 
-`examples.py` provide command line interface and sub commands that makes easier to test examples. included  sub commands  are:
+* **import** - imports each of the repos and its dependencies (.lib files) associated with the specific examples name from the .json configuration file. If there is already a clone of the repo, it will first be removed to ensure a clean, up-to-date cloning.
 
-* **import** - Imports each of the repos and its dependencies (.lib files) associated  with the specific examples name from the json configuration file. Note if there is already a clone of the repo then it will first be removed to  ensure a clean, up to date cloning.
+* **clone** - clones each of the repos associated with the specific examples name from the .json configuration file. If there is already a clone of the repo, it will first be removed to ensure a clean, up-to-date cloning.
 
-* **clone** - clones each of the repos associated with the specific examples name from the json configuration file. Note if there is already a clone of the repo then it will first be removed to ensure a clean, up to date cloning.
+* **deploy** - if the example directory exists as provided by the .json configuration file, pulls in the examples dependencies by using `mbed-cli deploy`.
 
-* **deploy** - If the example directory exists as provided by the json configuration file, pull in the examples dependencies by using `mbed-cli deploy`.
+* **update** - for each example repo identified in the config .json object, updates the version of `mbed-os` to that specified by the supplied GitHub tag. This function assumes that each example repo has already been cloned.
 
-* **update** - For each example repo identified in the config json object, update the version of mbed-os to that specified by the supplied GitHub tag. This function assumes that each example repo has already been cloned.
+* **compile** - compiles combinations of example programs, targets and compile chains.
 
-* **compile** - Compiles combinations of example programs, targets and compile chains.
+* **export** - exports and builds combinations of example programs, targets and IDEs.
 
-* **export** - Exports and builds combinations of example programs, targets and IDEs.
+* **list** - displays examples in a configuration file in a table.
 
-* **list** - display examples in configuration file in a table
+* **symlink** - creates a symbolic link to a given `mbed-os` PATH.
 
-* **symlink** - create symbolic link to given mbed-os PATH
+For more detailed options, please use `-h` or `--help`.
 
-for more detailed options, please use `-h` or `--help` 
+## The configuration file
 
-
-## The Configuration file
-
-here is the section of default configuration file:
+Here is the section of default configuration file:
 
  ```json
  {
@@ -89,61 +87,63 @@ here is the section of default configuration file:
 
 ### Fields
 
-* **name** - name of the example, should be the base name of the example repository address, will throw if not match
-* **github** - example github repository address
-* **sub-repo-example** specify if the example repository have sub folder for each examples
-* **subs** - array of sub examples names
-* **features** The features that must be in the features array of a target in targets.json
-* **baud_rate** example default baud rate
-* **compare_log**  array of log which is compared to command line output when testing, if example has many sub examples, the order of log should match with the order of sub examples. 
-* **targets** - list of mbed-os dev boards that runs this example. 
-* **targets** list of targeted development boards
-* **toolchains** toolchain to use for compile
-* **exporters** allowed exporters
-* **compile** enable compiling
-* **export** enable exporting
-* **test** enable testing
+* **name** - name of the example. It should be the base name of the example repository address and will throw if it doesn't match.
+* **github** - example GitHub repository address.
+* **sub-repo-example** - specifies if the example repository has a subfolder for each example.
+* **subs** - array of subexample names.
+* **features** - the features that must be in the features array of a target in `targets.json`.
+* **baud_rate** - example default baud rate.
+* **compare_log** - array of log compared to command-line output during testing. If the example has many subexamples, the order of log should match the order of subexamples. 
+* **targets** - list of `mbed-os` development boards that run this example. 
+* **targets** - list of targeted development boards.
+* **toolchains** - toolchain to use for compiling.
+* **exporters** - allowed exporters.
+* **compile** - enables compiling.
+* **export** - enables exporting.
+* **test** - enables testing.
 
 ### Values
 
-`[ ]` means all possible alternatives
+`[ ]` means all possible alternatives.
 
+## Typical use
 
+In the Mbed OS CI, we follow the below steps to compile and test Mbed OS examples.
 
-## Typical usage
+1. Clone `mbed-os` repository to the current folder:
 
-In mbed-OS CI, we usually following the bellow steps to compile and test  mbed-os-examples.
+   ```
+   git clone https://github.com/ARMmbed/mbed-os.git
+   ```
 
-1. Clone mbed-os repository to current folder 
+1. Clone the examples repo to the current folder. Users can pass an `-e` option to the script to filter out the rest of the examples, so the scripts only run on one particular example:
+
+   ```
+   python mbed-os/tools/test/examples/examples.py clone
+   ```
+
+1. Create a symbolic link to `mbed-os` for every example. This step lets all the examples share a single `mbed-os` folder, rather than checking out the `mbed-os` folder many times. We highly recommend you pass an absolute path as the argument: 
+
+   ```
+   python mbed-os/tools/test/examples/examples.py symlink $PWD/mbedos
+   ```
+
+1. Deploy other dependency libraries:
+
+   ```
+   python mbed-os/tools/test/examples/examples.py deploy
+   ```
+
+1. Compile the test for the examples on a specific target:
+
+   ```
+   python mbed-os/tools/test/examples/examples.py compile -m <target>
+   ```
+
+After the compile test finished, the scripts print the result table:
 
 ```
-git clone https://github.com/ARMmbed/mbed-os.git
-```
-
-2. Clone the examples repo to current folder , users can pass a `-e` option to the script to filter out rest of the exmpale and let the scripts only run on particular one 
-
-```
-python mbed-os/tools/test/examples/examples.py clone
-```
-
-3. Create symbolic link to mbed-os for every examples. this is step is to let the all the examples share a single mbed-os folder, rather that checkout the mbed-os folder many times . In bellow command pass an absolute path as the argument is highly recommended  
-
-```
-python mbed-os/tools/test/examples/examples.py symlink $PWD/mbedos
-```
-4. deploy mbed-os other dependency libraries
-
-```
-python mbed-os/tools/test/examples/examples.py deploy
-```
-5. compile test for the examples on a specific target
-```
-python mbed-os/tools/test/examples/examples.py compile -m <target>
-```
-once the compile test finished, the scripts will prints the result table as follows:
-
-```
-Passed Example Compilation:
+Passed example compilation:
 +---------------------------------+--------+-----------+----------+--------------+
 | EXAMPLE NAME                    | TARGET | TOOLCHAIN | TEST GEN | BUILD RESULT |
 +---------------------------------+--------+-----------+----------+--------------+
@@ -164,6 +164,4 @@ Passed Example Compilation:
 Number of failures = 0
 ```
 
-after the compilation stage, a `test_spec.json` file will be generated, later this file will be consumed by GreenTea tests, which is going to test the compiled example on hardware platform. 
-
-
+After the compilation stage, a `test_spec.json` file is generated. Later, Greentea tests will consume this file. They test the compiled example on hardware platform. 

--- a/tools/test/examples/README.md
+++ b/tools/test/examples/README.md
@@ -1,0 +1,169 @@
+# Examples testing script
+
+The scripts in this folder are used for testing mbed-os official examples. it contains following files:
+
+- `examples.py` the main script which serves as command line interface
+- `examples.json` the default configuration file for the script, which contains the information to the examples. if required, a customised configuration file can be pass as argument to the script
+- `examples_lib.py` the library file, which contains the main function of the testing scripts
+
+
+## The Scripts
+
+`examples.py` provide command line interface and sub commands that makes easier to test examples. included  sub commands  are:
+
+* **import** - Imports each of the repos and its dependencies (.lib files) associated  with the specific examples name from the json configuration file. Note if there is already a clone of the repo then it will first be removed to  ensure a clean, up to date cloning.
+
+* **clone** - clones each of the repos associated with the specific examples name from the json configuration file. Note if there is already a clone of the repo then it will first be removed to ensure a clean, up to date cloning.
+
+* **deploy** - If the example directory exists as provided by the json configuration file, pull in the examples dependencies by using `mbed-cli deploy`.
+
+* **update** - For each example repo identified in the config json object, update the version of mbed-os to that specified by the supplied GitHub tag. This function assumes that each example repo has already been cloned.
+
+* **compile** - Compiles combinations of example programs, targets and compile chains.
+
+* **export** - Exports and builds combinations of example programs, targets and IDEs.
+
+* **list** - display examples in configuration file in a table
+
+* **symlink** - create symbolic link to given mbed-os PATH
+
+for more detailed options, please use `-h` or `--help` 
+
+
+## The Configuration file
+
+here is the section of default configuration file:
+
+ ```json
+ {
+  "examples": [
+    {
+      "name": "mbed-os-example-blinky",
+      "github": "https://github.com/ARMmbed/mbed-os-example-blinky",
+      "sub-repo-example": false,
+      "subs": [],
+      "features" : [],
+      "targets" : [],
+      "toolchains" : [],
+      "exporters": [],
+      "compile" : true,
+      "export": true,
+      "test" : true,
+      "baud_rate": 9600,
+      "compare_log": ["mbed-os-example-blinky/tests/blinky.log"],
+      "auto-update" : true
+    },
+      
+    ...
+    
+    {
+      "name": "mbed-os-example-tls",
+      "github": "https://github.com/ARMmbed/mbed-os-example-tls",
+      "sub-repo-example": true,
+      "subs": [
+          "benchmark",
+          "tls-client",
+          "hashing",
+          "authcrypt"
+      ],
+      "features" : [],
+      "targets" : ["K66F", "NUCLEO_F429ZI"],
+      "toolchains" : ["GCC_ARM", "ARM"],
+      "exporters": [],
+      "compile" : false,
+      "export": false,
+      "test" : false,
+      "baud_rate": 9600,
+      "compare_log": [
+          "mbed-os-example-tls/tests/benchmark.log",
+          "mbed-os-example-tls/tests/tls-client.log",
+          "mbed-os-example-tls/tests/hashing.log",
+          "mbed-os-example-tls/tests/authcrypt.log"
+      ],
+      "auto-update" : true
+    }
+  ]
+}
+
+ ```
+
+### Fields
+
+* **name** - name of the example, should be the base name of the example repository address, will throw if not match
+* **github** - example github repository address
+* **sub-repo-example** specify if the example repository have sub folder for each examples
+* **subs** - array of sub examples names
+* **features** The features that must be in the features array of a target in targets.json
+* **baud_rate** example default baud rate
+* **compare_log**  array of log which is compared to command line output when testing, if example has many sub examples, the order of log should match with the order of sub examples. 
+* **targets** - list of mbed-os dev boards that runs this example. 
+* **targets** list of targeted development boards
+* **toolchains** toolchain to use for compile
+* **exporters** allowed exporters
+* **compile** enable compiling
+* **export** enable exporting
+* **test** enable testing
+
+### Values
+
+`[ ]` means all possible alternatives
+
+
+
+## Typical usage
+
+In mbed-OS CI, we usually following the bellow steps to compile and test  mbed-os-examples.
+
+1. Clone mbed-os repository to current folder 
+
+```
+git clone https://github.com/ARMmbed/mbed-os.git
+```
+
+2. Clone the examples repo to current folder , users can pass a `-e` option to the script to filter out rest of the exmpale and let the scripts only run on particular one 
+
+```
+python mbed-os/tools/test/examples/examples.py clone
+```
+
+3. Create symbolic link to mbed-os for every examples. this is step is to let the all the examples share a single mbed-os folder, rather that checkout the mbed-os folder many times . In bellow command pass an absolute path as the argument is highly recommended  
+
+```
+python mbed-os/tools/test/examples/examples.py symlink $PWD/mbedos
+```
+4. deploy mbed-os other dependency libraries
+
+```
+python mbed-os/tools/test/examples/examples.py deploy
+```
+5. compile test for the examples on a specific target
+```
+python mbed-os/tools/test/examples/examples.py compile -m <target>
+```
+once the compile test finished, the scripts will prints the result table as follows:
+
+```
+Passed Example Compilation:
++---------------------------------+--------+-----------+----------+--------------+
+| EXAMPLE NAME                    | TARGET | TOOLCHAIN | TEST GEN | BUILD RESULT |
++---------------------------------+--------+-----------+----------+--------------+
+| mbed-os-example-kvstore         |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-tls-socket      |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-blockdevice     |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-wifi            |  K64F  |  GCC_ARM  | TEST_OFF |    PASSED    |
+| mbed-os-example-error-handling  |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-sd-driver       |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-crash-reporting |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-filesystem      |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-blinky          |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-bootloader      |  K64F  |  GCC_ARM  | TEST_OFF |    PASSED    |
+| mbed-os-example-cpu-stats       |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-sys-info        |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
+| mbed-os-example-attestation     |  K64F  |  GCC_ARM  | TEST_ON  |    PASSED    |
++---------------------------------+--------+-----------+----------+--------------+
+Number of failures = 0
+```
+
+after the compilation stage, a `test_spec.json` file will be generated, later this file will be consumed by GreenTea tests, which is going to test the compiled example on hardware platform. 
+
+

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -31,6 +31,7 @@
       "exporters": ["iar", "make_armc5", "make_armc6", "make_gcc_arm", "make_iar"],
       "compile" : true,
       "export": true,
+      "test" : false,
       "auto-update" : true
     },
     {
@@ -79,6 +80,7 @@
       "exporters": [],
       "compile" : true,
       "export": false,
+      "test" : false,
       "auto-update" : true
     },
     {
@@ -127,6 +129,7 @@
       "exporters": [],
       "compile" : true,
       "export": true,
+      "test" : false,
       "auto-update" : true
     },
     {
@@ -140,6 +143,7 @@
       "exporters": [],
       "compile" : true,
       "export": true,
+      "test" : false,
       "auto-update" : true
     },
     {
@@ -153,6 +157,7 @@
       "exporters": [],
       "compile" : true,
       "export": true,
+      "test" : false,
       "auto-update" : true
     },
     {
@@ -166,6 +171,7 @@
         "exporters": [],
         "compile" : true,
         "export": false,
+        "test" : false,
         "auto-update" : true
     },
     {
@@ -330,6 +336,7 @@
         "exporters": [],
         "compile" : true,
         "export": true,
+        "test" : false,
         "auto-update" : true
     },
     {
@@ -345,6 +352,7 @@
         "exporters": [],
         "compile" : true,
         "export": true,
+        "test" : false,
         "auto-update" : true
     },
     {
@@ -376,6 +384,7 @@
         "exporters": [],
         "compile" : true,
         "export": true,
+        "test" : false,
         "auto-update" : true
     },
     {

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -370,8 +370,8 @@
         "targets" : ["NUCLEO_F401RE", "DISCO_L475VG_IOT01A"],
         "toolchains" : [],
         "exporters": [],
-        "compile" : true,
-        "export": true,
+        "compile" : false,
+        "export": false,
         "test" : false,
         "auto-update" : true
     },

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -44,8 +44,8 @@
       "targets" : ["K66F", "NUCLEO_F429ZI"],
       "toolchains" : ["GCC_ARM", "ARM"],
       "exporters": [],
-      "compile" : true,
-      "export": true,
+      "compile" : false,
+      "export": false,
       "test" : false,
       "baud_rate": 9600,
       "compare_log": [
@@ -74,7 +74,7 @@
       "targets" : ["NRF51_DK", "NRF52_DK", "K66F", "NUCLEO_F401RE"],
       "toolchains" : [],
       "exporters": [],
-      "compile" : true,
+      "compile" : false,
       "export": false,
       "test" : false,
       "auto-update" : true
@@ -351,9 +351,9 @@
         "targets" : ["K64F"],
         "toolchains" : [],
         "exporters": [],
-        "compile" : true,
-        "export": true,
-        "test" : true,
+        "compile" : false,
+        "export": false,
+        "test" : false,
         "baud_rate": 9600,
         "compare_log": ["mbed-os-example-mbed-crypto/tests/getting-started.log"],
         "auto-update" : true

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -3,10 +3,8 @@
     {
       "name": "mbed-os-example-blinky",
       "github": "https://github.com/ARMmbed/mbed-os-example-blinky",
-      "mbed": [
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-blinky"
-      ],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : [],
       "toolchains" : [],
@@ -21,10 +19,8 @@
     {
       "name": "mbed-os-example-blinky-baremetal",
       "github": "https://github.com/ARMmbed/mbed-os-example-blinky-baremetal",
-      "mbed": [
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-blinky-baremetal"
-      ],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : ["K66F", "NUCLEO_F429ZI", "ARCH_PRO", "LPC1768"],
       "toolchains" : [],
@@ -37,13 +33,13 @@
     {
       "name": "mbed-os-example-tls",
       "github": "https://github.com/ARMmbed/mbed-os-example-tls",
-      "mbed": [
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-benchmark",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-hashing",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt"
+      "sub-repo-example": true,
+      "subs": [
+          "benchmark",
+          "tls-client",
+          "hashing",
+          "authcrypt"
       ],
-      "test-repo-source": "mbed",
       "features" : [],
       "targets" : ["K66F", "NUCLEO_F429ZI"],
       "toolchains" : ["GCC_ARM", "ARM"],
@@ -63,17 +59,17 @@
     {
       "name": "mbed-os-example-ble",
       "github":"https://github.com/ARMmbed/mbed-os-example-ble",
-      "mbed": [
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-Beacon",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-HeartRate",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-Thermometer",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-LEDBlinker",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-LED",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-GAPButton",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-Button",
-          "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-BatteryLevel"
+      "sub-repo-example": true,
+      "subs": [
+          "BLE_Beacon",
+          "BLE_HeartRate",
+          "BLE_Thermometer",
+          "BLE_LEDBlinker",
+          "BLE_LED",
+          "BLE_GAPButton",
+          "BLE_Button",
+          "BLE_BatteryLevel"
       ],
-      "test-repo-source": "mbed",
       "features" : ["BLE"],
       "targets" : ["NRF51_DK", "NRF52_DK", "K66F", "NUCLEO_F401RE"],
       "toolchains" : [],
@@ -86,9 +82,8 @@
     {
       "name": "mbed-os-example-sockets",
       "github":"https://github.com/ARMmbed/mbed-os-example-sockets",
-      "mbed": [
-      ],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : ["K66F", "NUCLEO_F429ZI", "NUMAKER_PFM_NUC472", "FVP_MPS2_M3"],
       "toolchains" : [],
@@ -103,9 +98,8 @@
     {
       "name": "mbed-os-example-tls-socket",
       "github":"https://github.com/ARMmbed/mbed-os-example-tls-socket",
-      "mbed": [
-      ],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : ["K64F", "DISCO_F746NG"],
       "toolchains" : [],
@@ -120,9 +114,8 @@
     {
       "name": "mbed-os-example-wifi",
       "github":"https://github.com/ARMmbed/mbed-os-example-wifi",
-      "mbed": [
-      ],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : [],
       "toolchains" : [],
@@ -135,8 +128,8 @@
     {
       "name": "nanostack-border-router",
       "github":"https://github.com/ARMmbed/nanostack-border-router",
-      "mbed": [],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : ["K66F", "NUCLEO_F429ZI"],
       "toolchains" : [],
@@ -149,8 +142,8 @@
     {
       "name": "mbed-os-example-cellular",
       "github":"https://github.com/ARMmbed/mbed-os-example-cellular",
-      "mbed": [],
-      "test-repo-source": "github",
+      "sub-repo-example": false,
+      "subs": [],
       "features" : [],
       "targets" : ["MTS_DRAGONFLY_F411RE"],
       "toolchains" : [],
@@ -163,8 +156,8 @@
     {
         "name": "mbed-os-example-lorawan",
         "github":"https://github.com/ARMmbed/mbed-os-example-lorawan",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["DISCO_L072CZ_LRWAN1", "MTB_MTS_XDOT", "MTS_MDOT_F411RE"],
         "toolchains" : [],
@@ -177,8 +170,8 @@
     {
         "name": "mbed-os-example-nvstore",
         "github":"https://github.com/ARMmbed/mbed-os-example-nvstore",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K66F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -193,8 +186,8 @@
     {
         "name": "mbed-os-example-devicekey",
         "github":"https://github.com/ARMmbed/mbed-os-example-devicekey",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K66F"],
         "toolchains" : [],
@@ -209,8 +202,8 @@
     {
         "name": "mbed-os-example-thread-statistics",
         "github":"https://github.com/ARMmbed/mbed-os-example-thread-statistics",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K66F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -225,8 +218,8 @@
     {
         "name": "mbed-os-example-sys-info",
         "github":"https://github.com/ARMmbed/mbed-os-example-sys-info",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -241,8 +234,8 @@
     {
         "name": "mbed-os-example-cpu-usage",
         "github":"https://github.com/ARMmbed/mbed-os-example-cpu-usage",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K66F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -257,8 +250,8 @@
     {
         "name": "mbed-os-example-cpu-stats",
         "github":"https://github.com/ARMmbed/mbed-os-example-cpu-stats",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -273,8 +266,8 @@
     {
         "name": "mbed-os-example-socket-stats",
         "github":"https://github.com/ARMmbed/mbed-os-example-socket-stats",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K66F"],
         "toolchains" : [],
@@ -289,8 +282,8 @@
     {
         "name": "mbed-os-example-error-handling",
         "github":"https://github.com/ARMmbed/mbed-os-example-error-handling",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -305,10 +298,8 @@
     {
         "name": "mbed-os-example-filesystem",
         "github":"https://github.com/ARMmbed/mbed-os-example-filesystem",
-        "mbed": [
-            "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-filesystem"
-        ],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F","K82F"],
         "toolchains" : [],
@@ -323,10 +314,8 @@
     {
         "name": "mbed-os-example-mesh-minimal",
         "github":"https://github.com/ARMmbed/mbed-os-example-mesh-minimal",
-        "mbed": [
-            "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-mesh-minimal"
-        ],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["DISCO_F469NI", "DISCO_F746NG", "K66F",
                      "NUCLEO_F429ZI", "NUCLEO_F439ZI", "NUCLEO_F746ZG",
@@ -342,10 +331,8 @@
     {
         "name": "mbed-os-example-bootloader",
         "github":"https://github.com/ARMmbed/mbed-os-example-bootloader",
-        "mbed": [
-            "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-bootloader"
-        ],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F", "NUCLEO_F429ZI", "UBLOX_EVK_ODIN_W2"],
         "toolchains" : [],
@@ -358,8 +345,8 @@
     {
         "name": "mbed-os-example-mbed-crypto",
         "github":"https://github.com/ARMmbed/mbed-os-example-mbed-crypto",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": true,
+        "subs": ["getting-started"],
         "features" : [],
         "targets" : ["K64F"],
         "toolchains" : [],
@@ -374,10 +361,11 @@
     {
         "name": "mbed-os-example-nfc",
         "github": "https://github.com/ARMmbed/mbed-os-example-nfc",
-        "mbed": [
-            "https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-nfc-SmartPoster"
+        "sub-repo-example": true,
+        "subs": [
+            "NFC_EEPROM",
+            "NFC_SmartPoster"
         ],
-        "test-repo-source": "mbed",
         "features" : [],
         "targets" : ["NUCLEO_F401RE", "DISCO_L475VG_IOT01A"],
         "toolchains" : [],
@@ -390,8 +378,8 @@
     {
         "name": "mbed-os-example-blockdevice",
         "github":"https://github.com/armmbed/mbed-os-example-blockdevice",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F"],
         "toolchains" : [],
@@ -406,8 +394,8 @@
     {
         "name": "mbed-os-example-kvstore",
         "github":"https://github.com/ARMmbed/mbed-os-example-kvstore",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F", "FVP_MPS2_M3"],
         "toolchains" : [],
@@ -422,8 +410,8 @@
     {
         "name": "mbed-os-example-crash-reporting",
         "github":"https://github.com/ARMmbed/mbed-os-example-crash-reporting",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F", "DISCO_L475VG_IOT01A"],
         "toolchains" : [],
@@ -438,8 +426,8 @@
     {
         "name": "mbed-os-example-sd-driver",
         "github":"https://github.com/ARMmbed/mbed-os-example-sd-driver",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["K64F"],
         "toolchains" : [],
@@ -454,8 +442,8 @@
     {
         "name": "mbed-os-example-attestation",
         "github": "https://github.com/ARMmbed/mbed-os-example-attestation",
-        "mbed": [],
-        "test-repo-source": "github",
+        "sub-repo-example": false,
+        "subs": [],
         "features" : [],
         "targets" : ["CY8CKIT_062_WIFI_BT_PSA",
                      "K64F",

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -30,10 +30,6 @@ import json
 """ import and bulid a bunch of example programs """
 
 ROOT = abspath(dirname(dirname(dirname(dirname(__file__)))))
-DEFAULT_BUILD_PROFILES = [
-    "develop",
-    "mbed-os/tools/profiles/extensions/minimal-printf.json",
-]
 sys.path.insert(0, ROOT)
 
 from tools.utils import argparse_force_uppercase_type
@@ -87,10 +83,8 @@ def parse_args():
     compile_cmd.add_argument(
         "--profiles",
         nargs='+',
-        default=DEFAULT_BUILD_PROFILES,
         metavar="profile",
-        help="build profile file(s). default = {}".format(DEFAULT_BUILD_PROFILES)
-    )
+        help="build profile(s)")
     
     compile_cmd.add_argument("-j", "--jobs",
                              dest='jobs',

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -152,9 +152,7 @@ def do_deploy(_, config, examples):
 def do_compile(args, config, examples):
     """Do the compile step"""
     results = lib.compile_repos(config, args.toolchains, args.mcu, args.profile, args.verbose, examples, args.jobs)
-    lib.print_summary(results)
-    failures = lib.get_num_failures(results)
-    print("Number of failures = %d" % failures)
+    failures = lib.get_build_summary(results)
     return failures 
     
 def do_update(args, config, examples):

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -50,21 +50,21 @@ def main():
                         type=argparse_many(lambda x: x),
                         default=[])
     subparsers = parser.add_subparsers()
-    import_cmd = subparsers.add_parser("import")
+    import_cmd = subparsers.add_parser("import", help="import of examples in config file" )
     import_cmd.set_defaults(fn=do_import)
-    clone_cmd = subparsers.add_parser("clone")
+    clone_cmd  = subparsers.add_parser("clone",  help="clone examples in config file" )
     clone_cmd.set_defaults(fn=do_clone)
     list_cmd   = subparsers.add_parser("list",   help="list examples in config file in a table")
     list_cmd.set_defaults(fn=do_list)
     symlink_cmd = subparsers.add_parser("symlink", help="create symbolic link to given mbed-os PATH")
     symlink_cmd.add_argument("PATH", help=" path of mbed-os to be symlinked")
     symlink_cmd.set_defaults(fn=do_symlink)
-    deploy_cmd = subparsers.add_parser("deploy", help="mbed deploy" )
+    deploy_cmd = subparsers.add_parser("deploy", help="mbed deploy for examples in config file" )
     deploy_cmd.set_defaults(fn=do_deploy)
-    version_cmd = subparsers.add_parser("tag")
-    version_cmd.add_argument("tag")
-    version_cmd.set_defaults(fn=do_versionning)
-    compile_cmd = subparsers.add_parser("compile")
+    version_cmd = subparsers.add_parser("update", help="update mbed-os to sepcific tags")
+    version_cmd.add_argument("TAG", help=" tag of mbed-os")
+    version_cmd.set_defaults(fn=do_update)
+    compile_cmd = subparsers.add_parser("compile", help="compile of examples" )
     compile_cmd.set_defaults(fn=do_compile),
     compile_cmd.add_argument(
         "toolchains", nargs="*", default=SUPPORTED_TOOLCHAINS,
@@ -96,7 +96,7 @@ def main():
                              default=False,
                              help="Verbose diagnostic output")
 
-    export_cmd = subparsers.add_parser("export")
+    export_cmd = subparsers.add_parser("export", help="export of examples")
     export_cmd.set_defaults(fn=do_export),
     export_cmd.add_argument(
         "ide", nargs="*", default=SUPPORTED_IDES,
@@ -155,7 +155,7 @@ def do_compile(args, config, examples):
     print("Number of failures = %d" % failures)
     return failures 
     
-def do_versionning(args, config, examples):
+def do_update(args, config, examples):
     """ Test update the mbed-os to the version specified by the tag """
     return lib.update_mbedos_version(config, args.tag, examples)
 

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -157,7 +157,7 @@ def do_compile(args, config, examples):
     
 def do_update(args, config, examples):
     """ Test update the mbed-os to the version specified by the tag """
-    return lib.update_mbedos_version(config, args.tag, examples)
+    return lib.update_mbedos_version(config, args.TAG, examples)
 
 def do_list(_, config, examples):
     """List the examples in the config file"""
@@ -170,7 +170,7 @@ def do_list(_, config, examples):
     return 0
 
 def do_symlink(args, config, examples):
-    return lib.symlink_mbedos(config, args.path, examples)
+    return lib.symlink_mbedos(config, args.PATH, examples)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -19,6 +19,7 @@ limitations
 from argparse import ArgumentParser
 import os
 from os.path import dirname, abspath, basename
+from prettytable import PrettyTable
 import os.path
 import sys
 import subprocess
@@ -53,7 +54,12 @@ def main():
     import_cmd.set_defaults(fn=do_import)
     clone_cmd = subparsers.add_parser("clone")
     clone_cmd.set_defaults(fn=do_clone)
-    deploy_cmd = subparsers.add_parser("deploy")
+    list_cmd   = subparsers.add_parser("list",   help="list examples in config file in a table")
+    list_cmd.set_defaults(fn=do_list)
+    symlink_cmd = subparsers.add_parser("symlink", help="create symbolic link to given mbed-os PATH")
+    symlink_cmd.add_argument("PATH", help=" path of mbed-os to be symlinked")
+    symlink_cmd.set_defaults(fn=do_symlink)
+    deploy_cmd = subparsers.add_parser("deploy", help="mbed deploy" )
     deploy_cmd.set_defaults(fn=do_deploy)
     version_cmd = subparsers.add_parser("tag")
     version_cmd.add_argument("tag")
@@ -153,6 +159,18 @@ def do_versionning(args, config, examples):
     """ Test update the mbed-os to the version specified by the tag """
     return lib.update_mbedos_version(config, args.tag, examples)
 
+def do_list(_, config, examples):
+    """List the examples in the config file"""
+    exp_table = PrettyTable()
+    exp_table.hrules =  1
+    exp_table.field_names = ["Name", "Subs", "Feature", "Targets", "Compile", "Test"]
+    for example in config["examples"]:
+        exp_table.add_row([example['name'], '\n'.join(example['subs']),'\n'.join(example['features']),'\n'.join(example['targets']),example['compile'],example['test']])
+    print(exp_table)
+    return 0
+
+def do_symlink(args, config, examples):
+    return lib.symlink_mbedos(config, args.path, examples)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -116,19 +116,21 @@ def main():
 
     all_examples = []
     for example in config['examples']:
-        all_examples = all_examples + [basename(x['repo']) for x in lib.get_repo_list(example)]
-    examples = [x for x in all_examples if x in args.example] if args.example else all_examples
-    return args.fn(args, config, examples)
+        name = basename(example['github'])
+        if name != example['name']:
+            exit("ERROR : repo basename '%s' and example name '%s' not match " % (name, example['name']))
+        all_examples.append(name)
+
+    exp_filter = [x for x in all_examples if x in args.example] if args.example else all_examples
+
+    return args.fn(args, config, exp_filter)
 
 
 def do_export(args, config, examples):
     """Do export and build step"""
     results = {}
     results = lib.export_repos(config, args.ide, args.mcu, examples)
-
-    lib.print_summary(results, export=True)
-    failures = lib.get_num_failures(results, export=True)
-    print("Number of failures = %d" % failures)
+    failures = lib.get_export_summary(results)
     return failures
 
 


### PR DESCRIPTION
### Description

This PR is update the examples testing scripts.
This script is standalone script purely used by mbed CI test, So this will not change mbed-OS behaviours.

This including following changes:

- Add a `README` file to explain how this script is used in the CI
- Removed the dependency of Mercurial, This script will only use Github for check out code
- Add a function for the script to create symbolic links to mbed-os.
- Add a logging tool, allow the STDOUT to be easy to debug
- Update the output message, print a nicer result summary

However, because this scripts changed where to checkout examples, some of the examples will failed to build

- mbed-os-example-BLE
- mbed-os-example-tls
- mbed-os-example-crypto

So temporarily turn off the build tests for these examples. An update on the CI scripts will be raised soon. Once the CI update is in place will enable the build test for these examples ASAP.


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

@OPpuolitaival @evedon @adbridge @mark-edgeworth @AnotherButler 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
