### PR TITLE
LWIP::get_ipv6_addr for link-local only

### DIFF
--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -227,7 +227,13 @@ void LWIP::Interface::netif_status_irq(struct netif *netif)
 
         if (interface->has_addr_state & HAS_ANY_ADDR) {
             interface->connected = NSAPI_STATUS_GLOBAL_UP;
+#if LWIP_IPV6
+            if (ip_addr_islinklocal(get_ipv6_addr(netif))) {
+                interface->connected = NSAPI_STATUS_LOCAL_UP;
+            }
+#endif
         }
+
     } else if (!netif_is_up(&interface->netif) && netif_is_link_up(&interface->netif)) {
         interface->connected = NSAPI_STATUS_DISCONNECTED;
     }

--- a/features/lwipstack/lwip_tools.cpp
+++ b/features/lwipstack/lwip_tools.cpp
@@ -92,6 +92,12 @@ const ip_addr_t *LWIP::get_ipv6_addr(const struct netif *netif)
             return netif_ip_addr6(netif, i);
         }
     }
+
+    for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+        if (ip6_addr_isvalid(netif_ip6_addr_state(netif, i))) {
+            return netif_ip_addr6(netif, i);
+        }
+    }
 #endif
     return NULL;
 }


### PR DESCRIPTION
 LWIP::get_ipv6_addr is modified to avoid netif NULL return if only link-local adress
exists. 
Second netifs loop iteration is added. 
On original  pass  global IP is preffered if it fails also netifs for link-local are considered on second loop.
This can avoid to return NULL if  local adress exists.


Initial IPV6 issue  https://github.com/ARMmbed/mbed-os/issues/11442


### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@SeppoTakalo 
@mikaleppanen 
@kjbracey-arm 
@michalpasztamobica 

### Release Notes

