### PR TITLE
Fix Quectel M26 context hang

### DIFF
--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
@@ -54,6 +54,7 @@ nsapi_error_t QUECTEL_M26::get_sim_state(SimState &state)
     _at->lock();
     nsapi_error_t err = _at->at_cmd_str("+CPIN", "?", buf, 13);
     tr_debug("CPIN: %s", buf);
+    _at->unlock();
 
     if (memcmp(buf, "READY", 5) == 0) {
         state = SimStateReady;


### PR DESCRIPTION
### Description
Fix Quectel M26 hang on connect(). 

_at.lock() is acquired but not released in `QUECTEL_M26::get_sim_state(SimState &state)`

Tested with custom Quectel MC60, which uses Quectel M26 driver

### Pull request type


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
