### PR TITLE
Handle legacy process event first on connection complete

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericGap.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.tpp
@@ -1887,6 +1887,19 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
         address = _pal_gap.get_random_address();
     }
 
+    // legacy process event
+    processConnectionEvent(
+        e.connection_handle,
+        e.role.value() == e.role.CENTRAL ? LegacyGap::CENTRAL : LegacyGap::PERIPHERAL,
+        e.peer_address_type,
+        e.peer_address.data(),
+        _address_type,
+        address.data(),
+        &connection_params,
+        e.local_resolvable_private_address.data(),
+        e.peer_resolvable_private_address.data()
+    );
+
     // new process event
     if (_eventHandler) {
         _eventHandler->onConnectionComplete(
@@ -1905,19 +1918,6 @@ void GenericGap<PalGapImpl, PalSecurityManager, ConnectionEventMonitorEventHandl
             )
         );
     }
-
-    // legacy process event
-    processConnectionEvent(
-        e.connection_handle,
-        e.role.value() == e.role.CENTRAL ? LegacyGap::CENTRAL : LegacyGap::PERIPHERAL,
-        e.peer_address_type,
-        e.peer_address.data(),
-        _address_type,
-        address.data(),
-        &connection_params,
-        e.local_resolvable_private_address.data(),
-        e.peer_resolvable_private_address.data()
-    );
 
 #if BLE_FEATURE_SECURITY
     // Now starts pairing or authentication procedures if required


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

This is a proposed fix for [mbed-os-example-ble issue 257](https://github.com/ARMmbed/mbed-os-example-ble/issues/257).

SM control block doesn't get ready when calling user-defined on_connection_complete process event, so I move the legacy process event forward.

Tested with BLE_SM/BLE_GAP/BLE_Battery/BLE_GattServer on NRF52840_DK.

**Updated:**
This PR only fix `Error during SM::setLinkSecurity 4.`
To make BLE SM example work, `onAdvertisingEnd()` should care if the connection is established, like this [mbed-os-example-ble#265](https://github.com/ARMmbed/mbed-os-example-ble/pull/265/commits/637fc1c94f56e37a4f9c54964520e8dd77d4dfb3#diff-a234aea72d2757529d51354dc1e700e1L261) does.

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
