### PR TITLE
Ensure modem echo is off before sending other AT commands

### DIFF
--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -454,10 +454,12 @@ nsapi_error_t AT_CellularDevice::init()
         _at->clear_error();
         _at->flush();
         _at->at_cmd_discard("E0", "");
-        _at->at_cmd_discard("+CMEE", "=1");
-        _at->at_cmd_discard("+CFUN", "=1");
         if (_at->get_last_error() == NSAPI_ERROR_OK) {
-            break;
+            _at->at_cmd_discard("+CMEE", "=1");
+            _at->at_cmd_discard("+CFUN", "=1");
+            if (_at->get_last_error() == NSAPI_ERROR_OK) {
+                break;
+            }
         }
         tr_debug("Wait 100ms to init modem");
         rtos::ThisThread::sleep_for(100); // let modem have time to get ready


### PR DESCRIPTION
### Description
Currently three AT commands are sent together and response for OK is checked only for last command. This means that there can be a case where modem echo remains on as it sent OK to AT+CFUN=1 command but did not receive first two commands (reason being not fully powered up yet).
This can affect the functionality of cellular APIs and test cases. It is better to first ensure that modem is responding to ATE0 command and then send other commands.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
