### PR TITLE
DeviceKey: Fix random key doesn't generate with custom entropy source

### DIFF
--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "DeviceKey.h"
+#include "mbedtls/config.h"
 #include "utest/utest.h"
 #include "mbed_error.h"
 #include "unity/unity.h"
@@ -51,7 +52,7 @@ void generate_derived_key_consistency_32_byte_key_long_consistency_test(char *ke
  */
 int inject_dummy_rot_key()
 {
-#if !DEVICE_TRNG
+#if !DEVICE_TRNG && !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
     uint32_t key[DEVICE_KEY_16BYTE / sizeof(uint32_t)];
 
     memcpy(key, "1234567812345678", DEVICE_KEY_16BYTE);

--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -271,7 +271,7 @@ int DeviceKey::generate_key_by_random(uint32_t *output, size_t size)
         return DEVICEKEY_INVALID_PARAM;
     }
 
-#if defined(DEVICE_TRNG) || defined(MBEDTLS_ENTROPY_NV_SEED)
+#if defined(DEVICE_TRNG) || defined(MBEDTLS_ENTROPY_NV_SEED) || defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
     uint32_t test_buff[DEVICE_KEY_32BYTE / sizeof(int)];
     mbedtls_entropy_context *entropy = new mbedtls_entropy_context;
     mbedtls_entropy_init(entropy);


### PR DESCRIPTION
### Description

This PR tries to fix random key doesn't generate with custom entropy source in `device_key`. Originally, when `DEVICE_TRNG` is defined, `MBEDTLS_ENTROPY_HARDWARE_ALT` will also be defined accordingly to provide entropy source. This is fine for targets supporting TRNG. However, for targets without TRNG, it is also possible to provide non-TRNG entropy source solution via the define `MBEDTLS_ENTROPY_HARDWARE_ALT`. Related discussion can be found at #11680

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
