### PR TITLE
Disable C++ static destructors in ARMC6 compiler

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -24,7 +24,7 @@
                    "-DMBED_DEBUG", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
-        "cxx": ["-fno-rtti", "-std=gnu++14"],
+        "cxx": ["-fno-rtti", "-fno-c++-static-destructors", "-std=gnu++14"],
         "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign",
                "--any_contingency", "--keep=os_cb_sections"]
     },

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -23,7 +23,7 @@
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
-        "cxx": ["-fno-rtti", "-std=gnu++14"],
+        "cxx": ["-fno-rtti", "-fno-c++-static-destructors", "-std=gnu++14"],
         "ld": ["--show_full_path", "--legacyalign", "--any_contingency",
                "--keep=os_cb_sections"]
     },

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -23,7 +23,7 @@
                    "-DNDEBUG"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu11"],
-        "cxx": ["-fno-rtti", "-std=gnu++14"],
+        "cxx": ["-fno-rtti", "-fno-c++-static-destructors", "-std=gnu++14"],
         "ld": ["--show_full_path", "--legacyalign", "--any_contingency",
                "--keep=os_cb_sections"]
     },


### PR DESCRIPTION
### Description

We disable C++ static destructors as best as possible in the various toolchains, trying to eliminate unwanted destructor code. We don't want to waste RAM or ROM on the C++-standard-specified behaviour of running all statically-constructed objects' destructors in reverse order on exit; we're never going to perform an orderly exit.

Techniques used include:

* `SingletonPtr` - makes an object be "lazily constructed" on first use,  and also eliminates its destructor. Lazy construction adds ROM+RAM overhead.
* `__eabi_atexit` is stubbed out, preventing RAM usage by run-time registration of static destructors.
* GCC has `exit` wrapped to kill shutdown code
* IAR has static destructors disabled in the compiler flags

Killing static destructors in the compiler is the optimum; if we only stub out `__eabi_atexit`, the compiler is still inserting calls to it, and referencing the destructors in those call.

Clang 8 added the compiler option `-fno-c++-static-destructors` (and the object attributes `[[clang::no_destroy]]` and `[[clang::always_destroy]]` for fine control).

We can hence enable that option in ARMC6 tool profiles, matching IAR.

**This option appears to exist in ARM Compiler 6.11, but generates an apparently spurious linker error about `EthernetInterface`. It works in ARM Compiler 6.13, so this PR needs to wait until the compiler is updated.**



### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan-, @bulislaw, @0xc0170 

