### PR TITLE
Slightly optimise GCC static destruction

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -2,7 +2,7 @@
     "GCC_ARM": {
         "common": ["-c", "-Wall", "-Wextra",
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
-                   "-fmessage-length=0", "-fno-exceptions",
+                   "-fmessage-length=0", "-fno-exceptions", "-fno-use-cxa-atexit",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
                    "-fomit-frame-pointer", "-Og", "-g3", "-DMBED_DEBUG",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -2,7 +2,7 @@
     "GCC_ARM": {
         "common": ["-c", "-Wall", "-Wextra",
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
-                   "-fmessage-length=0", "-fno-exceptions",
+                   "-fmessage-length=0", "-fno-exceptions", "-fno-use-cxa-atexit",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
                    "-fomit-frame-pointer", "-Os", "-g", "-DMBED_TRAP_ERRORS_ENABLED=1"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -2,7 +2,7 @@
     "GCC_ARM": {
         "common": ["-c", "-Wall", "-Wextra",
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
-                   "-fmessage-length=0", "-fno-exceptions",
+                   "-fmessage-length=0", "-fno-exceptions", "-fno-use-cxa-atexit",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
                    "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g"],


### PR DESCRIPTION
### Description

Static destruction code may still end up in a GCC image despite our efforts. Use of `SingletonPtr` will eliminate most, but references can still occur.

For IAR and ARM toolchains they can be totally eliminated in the compiler (see #11726 for ARM). As the Clang attributes have been submitted for C++ standardisation (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1247r0.html), it seems likely that one day GCC will also support this, so it seems not worthwhile to create a `NotDestroyed<T>` template wrapper as a workaround, as I was originally intending.

In the meantime, GCC is inserting calls to `__eabi_atexit`. That is stubbed out, so whatever it attempts to register will not be called. We can't stop it putting the calls in, but we can transparently slightly
reduce code size by telling it to use `atexit` instead. It needs to pass fewer parameters for us to ignore, so the callsites become a little smaller.


### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@pan-, @bulislaw, @0xc0170 
