### PR TITLE
minimal_printf: Fix high level C functions that print to the console

### DIFF
--- a/platform/source/minimal-printf/mbed_printf_armlink_overrides.c
+++ b/platform/source/minimal-printf/mbed_printf_armlink_overrides.c
@@ -40,7 +40,7 @@ int $Sub$$__2printf(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;
@@ -70,7 +70,7 @@ int $Sub$$__2vprintf(char *buffer, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;


### PR DESCRIPTION
### Description

Ensure the file descriptor stdout is passed to `fputc` when the high
level C functions to print to the console are referenced.
This issue fixed only affected binaries built with the ARM toolchain.

To reproduce the bug.
1. Build `mbed-os-example-blinky` and program your target with the following command
  ```bash
  $ mbed compile -t ARM -m <TARGET> --profile develop --profile mbed-os/tools/profile/extension/minimal_printf.json -f
  ```
2. Open a terminal to view the serial output of the target. It should display an incorrect out similar to:
  ```bash
  =============================== SYSTEM INFO ================================
  Parameter err� 
  ``` 

With the fix the output is similar to:
```bash
=============================== SYSTEM INFO  ================================
Mbed OS Version: 999999 
CPU ID: 0x410fc241 
Compiler ID: 2 
Compiler Version: 80200 
RAM0: Start 0x20000000 Size: 0x30000 
RAM1: Start 0x1fff0000 Size: 0x10000 
ROM0: Start 0x0 Size: 0x100000 
================= CPU STATS =================
Idle: 4%% Usage: 96%% 
================ HEAP STATS =================
Current heap: 1216
Max heap size: 1216
================ THREAD STATS ===============
ID: 0x20000e50 
Name: main 
State: 2 
Priority: 24 
Stack Size: 4096 
Stack Space: 3476 
ID: 0x20000fa0 
Name: rtx_idle 
State: 1 
Priority: 1 
Stack Size: 512 
Stack Space: 272 
ID: 0x20000f5c 
Name: rtx_timer 
State: 3 
Priority: 40 
Stack Size: 768 
Stack Space: 664 
```

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
