### PR TITLE
minimal-printf: Fix handling of the two character sequence %%

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -404,6 +404,21 @@ static control_t test_printf_x(const size_t call_count)
     return CaseNext;
 }
 
+static control_t test_printf_percent(const size_t call_count)
+{
+    int result_baseline;
+    int result_minimal;
+    int result_file;
+
+    result_minimal = mbed_printf("%% \r\n");
+    result_file = mbed_fprintf(stderr, "%% \r\n");
+    result_baseline = printf("%% \r\n");
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
+
+    return CaseNext;
+}
+
 /******************************************************************************/
 /*                                                                            */
 /* SNPRINTF                                                                   */
@@ -721,6 +736,34 @@ static control_t test_snprintf_x(const size_t call_count)
     return CaseNext;
 }
 
+static control_t test_snprintf_percent(const size_t call_count)
+{
+    char buffer_baseline[100];
+    char buffer_minimal[100];
+    int result_baseline;
+    int result_minimal;
+
+    result_minimal = mbed_snprintf(buffer_minimal, sizeof(buffer_minimal), "%% \r\n");
+    result_baseline = snprintf(buffer_baseline, sizeof(buffer_baseline), "%% \r\n");
+    TEST_ASSERT_EQUAL_STRING(buffer_baseline, buffer_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+
+    return CaseNext;
+}
+
+static control_t test_snprintf_unsupported_specifier(const size_t call_count)
+{
+    char buffer_minimal[100];
+
+    TEST_ASSERT_NOT_EQUAL(
+        0,
+        mbed_snprintf(buffer_minimal, sizeof(buffer_minimal), "%a \r\n", 5)
+    );
+    TEST_ASSERT_EQUAL_STRING("%a \r\n", buffer_minimal);
+
+    return CaseNext;
+}
+
 #if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FLOATING_POINT
 static control_t test_printf_f(const size_t call_count)
 {
@@ -902,6 +945,9 @@ Case cases[] = {
     Case("snprintf %u", test_snprintf_u),
     Case("printf %x", test_printf_x),
     Case("snprintf %x", test_snprintf_x),
+    Case("printf %%", test_printf_percent),
+    Case("snprintf %%", test_snprintf_percent),
+    Case("snprintf unsupported specifier", test_snprintf_unsupported_specifier),
 #if MBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FLOATING_POINT
     Case("printf %f", test_printf_f),
     Case("snprintf %f", test_snprintf_f),

--- a/platform/source/minimal-printf/mbed_printf_implementation.c
+++ b/platform/source/minimal-printf/mbed_printf_implementation.c
@@ -626,19 +626,14 @@ int mbed_minimal_formatted_string(char *buffer, size_t length, const char *forma
 
                     mbed_minimal_formatted_string_void_pointer(buffer, length, &result, value, stream);
                 } else {
-                    /* write all characters between format beginning and unrecognied modifier */
-                    while (index < next_index) {
-                        mbed_minimal_formatted_string_character(buffer, length, &result, format[index], stream);
-                        index++;
+                    // Unrecognised, or `%%`. Print the `%` that led us in.
+                    mbed_minimal_formatted_string_character(buffer, length, &result, '%', stream);
+                    if (next == '%') {
+                        // Continue printing loop after `%%`
+                        index = next_index;
                     }
-
-                    /* if this is not the end of the string, write unrecognized modifier */
-                    if (next != '\0') {
-                        mbed_minimal_formatted_string_character(buffer, length, &result, format[index], stream);
-                    } else {
-                        /* break out of for loop */
-                        break;
-                    }
+                    // Otherwise we continue the printing loop after the leading `%`, so an
+                    // unrecognised thing like "Blah = %a" will just come out as "Blah = %a"
                 }
             } else
                 /* not a format specifier */


### PR DESCRIPTION
### Description

The two character sequence `%%` is used in standard implementations of
`printf` to print a single %. This is because `%` is essentially `printf`'s
escape character for format specifiers and as `\%` cannot work `printf`
uses `%%`.
Therefore to be compatible with string buffers containing
`%%`, minimal-printf also needs to only print a single `%`.

To reproduce the bug.
1. Build `mbed-os-example-blinky` and program your target with the following command
  ```bash
  $ mbed compile -t ARM -m <TARGET> --profile develop --profile mbed-os/tools/profile/extension/minimal_printf.json -f
  ```
2. Open a terminal to view the serial output of the target. It should display an incorrect out similar to:
  ```bash
  =============================== SYSTEM INFO ================================
  Mbed OS Version: 999999 
  CPU ID: 0x410fc241 
  Compiler ID: 2 
  Compiler Version: 80200 
  RAM0: Start 0x20000000 Size: 0x30000 
  RAM1: Start 0x1fff0000 Size: 0x10000 
  ROM0: Start 0x0 Size: 0x100000 
  ================= CPU STATS =================
  Idle: 4%% Usage: 96%% 
  ================ HEAP STATS =================
  Current heap: 1216
  Max heap size: 1216
  ================ THREAD STATS ===============
  ID: 0x20000e50 
  Name: main 
  State: 2 
  Priority: 24 
  Stack Size: 4096 
  Stack Space: 3476 
  ID: 0x20000fa0 
  Name: rtx_idle 
  State: 1 
  Priority: 1 
  Stack Size: 512 
  Stack Space: 272 
  ID: 0x20000f5c 
  Name: rtx_timer 
  State: 3 
  Priority: 40 
  Stack Size: 768 
  Stack Space: 664
  ``` 

With the fix the output is similar to:
```bash
=============================== SYSTEM INFO  ================================
Mbed OS Version: 999999 
CPU ID: 0x410fc241 
Compiler ID: 2 
Compiler Version: 80200 
RAM0: Start 0x20000000 Size: 0x30000 
RAM1: Start 0x1fff0000 Size: 0x10000 
ROM0: Start 0x0 Size: 0x100000 
================= CPU STATS =================
Idle: 4% Usage: 96%
================ HEAP STATS =================
Current heap: 1216
Max heap size: 1216
================ THREAD STATS ===============
ID: 0x20000e50 
Name: main 
State: 2 
Priority: 24 
Stack Size: 4096 
Stack Space: 3476 
ID: 0x20000fa0 
Name: rtx_idle 
State: 1 
Priority: 1 
Stack Size: 512 
Stack Space: 272 
ID: 0x20000f5c 
Name: rtx_timer 
State: 3 
Priority: 40 
Stack Size: 768 
Stack Space: 664 
```

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@evedon @kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
