### PR TITLE
nxp LPC55S69: fix i2c pin mapping

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_LPCXpresso/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_LPCXpresso/PinNames.h
@@ -177,8 +177,8 @@ typedef enum {
     A1 = P0_23,
     A2 = P0_0,
     A3 = P1_31,
-    A4 = P0_14,
-    A5 = P0_13,
+    A4 = P0_13,
+    A5 = P0_14,
 
     //SPI Pins configuration
     SPI_MOSI    = D11,


### PR DESCRIPTION
### Description

Fix LPC55S69 I2C pin mapping on arduino A5/A4 pins

Target page also needs to be updated (https://os.mbed.com/platforms/LPCXpresso55S69/)


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 
@ARMmbed/team-nxp 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
