### PR TITLE
Dns unittest preparation

### DIFF
--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -639,6 +639,8 @@ void nsapi_dns_call_in_set(call_in_callback_cb_t callback)
 void nsapi_dns_reset()
 {
     nsapi_dns_cache_reset();
+    dns_message_id = 1;
+    dns_unique_id = 1;
 }
 
 nsapi_error_t nsapi_dns_call_in(call_in_callback_cb_t cb, int delay, mbed::Callback<void()> func)
@@ -843,7 +845,7 @@ static void nsapi_dns_query_async_timeout(void)
     dns_mutex->unlock();
 }
 
-nsapi_error_t nsapi_dns_query_async_cancel(intptr_t id)
+nsapi_error_t nsapi_dns_query_async_cancel(nsapi_size_or_error_t id)
 {
     dns_mutex->lock();
 

--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include "mbed_shared_queues.h"
 #include "events/EventQueue.h"
 #include "OnboardNetworkStack.h"
@@ -63,7 +64,7 @@ enum dns_state {
 };
 
 struct DNS_QUERY {
-    int unique_id;
+    intptr_t unique_id;
     nsapi_error_t status;
     NetworkStack *stack;
     char *host;
@@ -94,7 +95,7 @@ static void nsapi_dns_cache_reset();
 static nsapi_error_t nsapi_dns_get_server_addr(NetworkStack *stack, uint8_t *index, uint8_t *total_attempts, uint8_t *send_success, SocketAddress *dns_addr, const char *interface_name);
 
 static void nsapi_dns_query_async_create(void *ptr);
-static nsapi_error_t nsapi_dns_query_async_delete(int unique_id);
+static nsapi_error_t nsapi_dns_query_async_delete(intptr_t unique_id);
 static void nsapi_dns_query_async_send(void *ptr);
 static void nsapi_dns_query_async_timeout(void);
 static void nsapi_dns_query_async_resp(DNS_QUERY *query, nsapi_error_t status, SocketAddress *address);
@@ -122,7 +123,7 @@ static SingletonPtr<PlatformMutex> dns_cache_mutex;
 #endif
 
 static uint16_t dns_message_id = 1;
-static int dns_unique_id = 1;
+static intptr_t dns_unique_id = 1;
 static DNS_QUERY *dns_query_queue[DNS_QUERY_QUEUE_SIZE];
 // Protects from several threads running asynchronous DNS
 static SingletonPtr<PlatformMutex> dns_mutex;
@@ -765,7 +766,7 @@ nsapi_value_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const
 
 static void nsapi_dns_query_async_initiate_next(void)
 {
-    int id = INT32_MAX;
+    intptr_t id = INTPTR_MAX;
     DNS_QUERY *query = NULL;
 
     // Trigger next query to start, find one that has been on queue longest
@@ -842,7 +843,7 @@ static void nsapi_dns_query_async_timeout(void)
     dns_mutex->unlock();
 }
 
-nsapi_error_t nsapi_dns_query_async_cancel(int id)
+nsapi_error_t nsapi_dns_query_async_cancel(intptr_t id)
 {
     dns_mutex->lock();
 
@@ -874,7 +875,7 @@ static void nsapi_dns_query_async_create(void *ptr)
 {
     dns_mutex->lock();
 
-    int unique_id = reinterpret_cast<int>(ptr);
+    intptr_t unique_id = reinterpret_cast<intptr_t>(ptr);
 
     DNS_QUERY *query = NULL;
 
@@ -940,7 +941,7 @@ static void nsapi_dns_query_async_create(void *ptr)
 
 }
 
-static nsapi_error_t nsapi_dns_query_async_delete(int unique_id)
+static nsapi_error_t nsapi_dns_query_async_delete(intptr_t unique_id)
 {
     int index = -1;
     DNS_QUERY *query = NULL;
@@ -1000,7 +1001,7 @@ static void nsapi_dns_query_async_send(void *ptr)
 {
     dns_mutex->lock();
 
-    int unique_id = reinterpret_cast<int>(ptr);
+    intptr_t unique_id = reinterpret_cast<intptr_t>(ptr);
 
     DNS_QUERY *query = NULL;
 
@@ -1162,7 +1163,7 @@ static void nsapi_dns_query_async_response(void *ptr)
 {
     dns_mutex->lock();
 
-    int unique_id = reinterpret_cast<int>(ptr);
+    intptr_t unique_id = reinterpret_cast<intptr_t>(ptr);
 
     DNS_QUERY *query = NULL;
 

--- a/features/netsocket/nsapi_dns.h
+++ b/features/netsocket/nsapi_dns.h
@@ -216,7 +216,7 @@ nsapi_size_or_error_t nsapi_dns_query_multiple(S *stack, const char *host,
   *  @param id       Unique id of the hostname translation operation
   *  @return         0 on success, negative error code on failure
   */
-nsapi_error_t nsapi_dns_query_async_cancel(nsapi_error_t id);
+nsapi_error_t nsapi_dns_query_async_cancel(nsapi_size_or_error_t id);
 
 /** Set a call in callback
  *


### PR DESCRIPTION
### Description

While working on unittests for `nsapi_dns` I noticed two things:
1) `unique_id` is cast from `int` to `void *` type and is always assumed to be 32-bit. This may be true for microcontrollers, but unittests are running on 64-bit machines (checked this with INFRA team). I therefore changed the type of `unique_id` to a more arch-independent `intptr_t`. This will still be a 32-bit variable for microcontrollers.
2) `nsapi_dns_query_async_cancel` had a different definition and implementation. Once the function was put to use the linker was unable to connect the two and gave errors. Unifying the header fixes the issue.

The unittests themselves will be put into a separate PR, in order not to mix code fixes and test updates.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

@AnttiKauppila 
@tymoteuszblochmobica 
