### PR TITLE
Fix the reset_reason host test in the CI

### DIFF
--- a/TESTS/host_tests/reset_reason.py
+++ b/TESTS/host_tests/reset_reason.py
@@ -16,7 +16,6 @@ limitations under the License.
 """
 import time
 from mbed_host_tests import BaseHostTest
-from mbed_host_tests.host_tests_runner.host_test_default import DefaultTestSelector
 
 DEFAULT_SYNC_DELAY = 4.0
 
@@ -32,6 +31,7 @@ MSG_KEY_RESET_REASON_RAW = 'reason_raw'
 MSG_KEY_RESET_REASON = 'reason'
 MSG_KEY_DEVICE_RESET = 'reset'
 MSG_KEY_SYNC = '__sync'
+MSG_KEY_RESET_COMPLETE = 'reset_complete'
 
 RESET_REASONS = {
     'POWER_ON': '0',
@@ -80,6 +80,7 @@ class ResetReasonTest(BaseHostTest):
         self.register_callback(MSG_KEY_RESET_REASON_RAW, self.cb_reset_reason_raw)
         self.register_callback(MSG_KEY_RESET_REASON, self.cb_reset_reason)
         self.register_callback(MSG_KEY_DEVICE_RESET, self.cb_reset_reason)
+        self.register_callback(MSG_KEY_RESET_COMPLETE, self.cb_reset_reason)
 
     def cb_device_ready(self, key, value, timestamp):
         """Request a raw value of the reset_reason register.
@@ -142,7 +143,10 @@ class ResetReasonTest(BaseHostTest):
         __ignored_clear_ack = yield
 
         # Reset the device using DAP.
-        self.reset_dut(DefaultTestSelector.RESET_TYPE_SW_RST)
+        self.reset()
+        __ignored_reset_ack = yield  # 'reset_complete'
+        time.sleep(self.sync_delay)
+        self.send_kv(MSG_KEY_SYNC, MSG_VALUE_DUMMY)
         reset_reason = yield
         raise_if_different(RESET_REASONS['PIN_RESET'], reset_reason, 'Wrong reset reason. ')
         self.send_kv(MSG_KEY_RESET_REASON, MSG_VALUE_RESET_REASON_CLEAR)


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Use a `BaseHostTestAbstract.reset()` method instead of `BaseHostTestAbstract.reset_dut()` for more consistent behavior with various platforms in the CI.

In contrast to a local setup, the `reset_dut()` method flashes the binary again after performing the reset in a remote setup (*RaaS*). This was not intentional in reset_reason tests. Moreover, this led to a different behavior (a different value of the `reset_reason_t` enum) for different flashing methods which are target specific.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->
@TuomoHautamaki, @OPpuolitaival, @jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
