### PR TITLE
fpga i2c test: limit tested peripherals

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/i2c/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/i2c/main.cpp
@@ -437,11 +437,11 @@ void i2c_test_byte_read(PinName sda, PinName scl)
 }
 
 Case cases[] = {
-    Case("i2c - init/free test all pins", all_ports<I2CPort, DefaultFormFactor, test_i2c_init_free>),
-    Case("i2c - test write i2c API", all_peripherals<I2CPort, DefaultFormFactor, i2c_test_write>),
-    Case("i2c - test read i2c API", all_peripherals<I2CPort, DefaultFormFactor, i2c_test_read>),
-    Case("i2c - test single byte write i2c API", all_peripherals<I2CPort, DefaultFormFactor, i2c_test_byte_write>),
-    Case("i2c - test single byte read i2c API", all_peripherals<I2CPort, DefaultFormFactor, i2c_test_byte_read>)
+    Case("i2c - init/free test all pins", one_peripheral<I2CPort, DefaultFormFactor, test_i2c_init_free>),
+    Case("i2c - test write i2c API", one_peripheral<I2CPort, DefaultFormFactor, i2c_test_write>),
+    Case("i2c - test read i2c API", one_peripheral<I2CPort, DefaultFormFactor, i2c_test_read>),
+    Case("i2c - test single byte write i2c API", one_peripheral<I2CPort, DefaultFormFactor, i2c_test_byte_write>),
+    Case("i2c - test single byte read i2c API", one_peripheral<I2CPort, DefaultFormFactor, i2c_test_byte_read>)
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)


### PR DESCRIPTION
Due to lack of i2c_free function switching between peripherals cause i2c tests failures on some targets. Limit testing to single peripheral until `i2c_free` is implemented.


### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

@jamesbeyond 

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
