### PR TITLE
Update the internal kvstore flash reservation size to from 7k to 65K for Cypress Devices

### DIFF
--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -24,7 +24,7 @@
             "internal_base_address": "0x00200000"
         },
         "MCU_PSOC6": {
-            "internal_size": "7168"
+            "internal_size": "0x10000"
         }
     }
 }


### PR DESCRIPTION
### Description
Updated the internal flash available for kvstore from 7K to 65K. 
This fixes the features-storage-tests-kvstore-static_tests failure for Cypress devices that do not have external flash capability (QSPIF). The 7K initially allocated is not enough for the devices that use the internal flash for kvstore.
For example, The test fails in the GT reports attached to the PR, https://github.com/ARMmbed/mbed-os/pull/11561
GT test report after fix,
[GT_FT_PROTO_063_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3769562/GT_FT_PROTO_063_BLE_GCC.txt)

This change should only impact Cypress devices with no external flash.

GT test reports for other devices,
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3769569/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3769570/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_KIT_062S2_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3769571/GT_FT_KIT_062S2_43012_GCC.txt)
[GT_FT_KIT_EVB_43012_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3769572/GT_FT_KIT_EVB_43012_GCC.txt)
[GT_FT_PROTO_062_4343W_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3769573/GT_FT_PROTO_062_4343W_GCC.txt)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers
@ARMmbed/team-cypress 
<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
