### PR TITLE
Fix spurious link up/down when AP IP address range change

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSTAInterface.cpp
+++ b/features/netsocket/emac-drivers/TARGET_WHD/interface/WhdSTAInterface.cpp
@@ -162,13 +162,21 @@ static void *whd_wifi_link_state_change_handler(whd_interface_t ifp,
         return NULL;
     }
 
-    if (event_header->event_type == WLC_E_DEAUTH_IND ||
-            event_header->event_type == WLC_E_DISASSOC_IND) {
+    if ((event_header->event_type == WLC_E_DEAUTH_IND) ||
+            (event_header->event_type == WLC_E_DISASSOC_IND) ||
+            ((event_header->event_type == WLC_E_PSK_SUP) &&
+            (event_header->status == WLC_SUP_KEYED) &&
+            (event_header->reason == WLC_E_SUP_DEAUTH))) {
         whd_emac_wifi_link_state_changed(ifp, WHD_FALSE);
+        return handler_user_data;
     }
 
-    if (whd_wifi_is_ready_to_transceive(ifp) == WHD_SUCCESS) {
+    if (((event_header->event_type == WLC_E_PSK_SUP) &&
+            (event_header->status == WLC_SUP_KEYED) &&
+            (event_header->reason == WLC_E_SUP_OTHER)) ||
+            (whd_wifi_is_ready_to_transceive(ifp) == WHD_SUCCESS)) {
         whd_emac_wifi_link_state_changed(ifp, WHD_TRUE);
+        return handler_user_data;
     }
 
     return handler_user_data;


### PR DESCRIPTION
### Description
Fixed additional link notification in whd_wifi_link_state_change_handler by checking additional conditions during the link state transition.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
