### PR TITLE
M2351: Change base target name 'NU_PFM_M2351_CM' to 'NU_PFM_M2351'

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8791,7 +8791,7 @@
         "macros_add": ["CMSDK_CM7"],
         "device_has_add": ["MPU"]
     },
-    "NU_PFM_M2351_CM": {
+    "NU_PFM_M2351": {
         "default_toolchain": "ARMC6",
         "extra_labels": [
             "NUVOTON",
@@ -8866,7 +8866,7 @@
         "public": false
     },
     "NU_PFM_M2351_NPSA_NS": {
-        "inherits": ["NU_PFM_M2351_CM"],
+        "inherits": ["NU_PFM_M2351"],
         "core": "Cortex-M23-NS",
         "trustzone": true,
         "extra_labels_add": [
@@ -8885,7 +8885,7 @@
         "mbed_ram_size"         : "0x10000"
     },
     "NU_PFM_M2351_NPSA_S": {
-        "inherits": ["NU_PFM_M2351_CM"],
+        "inherits": ["NU_PFM_M2351"],
         "core": "Cortex-M23",
         "trustzone": true,
         "extra_labels_add": [


### PR DESCRIPTION
### Description

This PR changes M2351 base target name from `NU_PFM_M2351_CM` to `NU_PFM_M2351` in `targets.json`. This is to meet platform name `NU_PFM_M2351` registered in [mbed-os-tools](https://github.com/ARMmbed/mbed-os-tools/blob/1bbbe70884e98d4f72d503094d709f5f29f74a36/src/mbed_os_tools/detect/platform_database.py#L229). This tool uses the platform name as a key to search platform related properties in `targets.json`. For example, the property `forced_reset_timeout` is for sync between host and DUT in Greentea test.

#### Known impact

[NUSD driver](https://github.com/OpenNuvoton/NuMaker-mbed-SD-driver) needs modification to support `NU_PFM_M2351` target name, like [the update](https://github.com/OpenNuvoton/NuMaker-mbed-SD-driver/blob/f9f81fcba836a651e57fa3b3ed31ba5954142306/NuSDBlockDevice.cpp#L62).
### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
