### PR TITLE
FlashIAP: Get erase value from HAL instead of hardcoding it

### DIFF
--- a/TESTS/mbed_drivers/flashiap/main.cpp
+++ b/TESTS/mbed_drivers/flashiap/main.cpp
@@ -143,6 +143,7 @@ void flashiap_cross_sector_program_test()
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
     uint32_t page_size = flash_device.get_page_size();
+    uint8_t erase_value = flash_device.get_erase_value();
 
     // Erase last two sectors
     uint32_t address = flash_device.get_flash_start() + flash_device.get_flash_size();
@@ -170,7 +171,7 @@ void flashiap_cross_sector_program_test()
         data[i] = rand() % 256;
     }
     for (uint32_t i = prog_size; i < aligned_prog_size; i++) {
-        data[i] = 0xFF;
+        data[i] = erase_value;
     }
 
     ret = flash_device.program(data, address, prog_size);

--- a/drivers/source/FlashIAP.cpp
+++ b/drivers/source/FlashIAP.cpp
@@ -99,6 +99,7 @@ int FlashIAP::program(const void *buffer, uint32_t addr, uint32_t size)
     uint32_t page_size = get_page_size();
     uint32_t flash_size = flash_get_size(&_flash);
     uint32_t flash_start_addr = flash_get_start_address(&_flash);
+    uint8_t flash_erase_value = flash_get_erase_value(&_flash);
     uint32_t chunk, prog_size;
     const uint8_t *buf = (uint8_t *) buffer;
     const uint8_t *prog_buf;
@@ -123,7 +124,7 @@ int FlashIAP::program(const void *buffer, uint32_t addr, uint32_t size)
             chunk = std::min(chunk, page_size);
             memcpy(_page_buf, buf, chunk);
             if (chunk < page_size) {
-                memset(_page_buf + chunk, 0xFF, page_size - chunk);
+                memset(_page_buf + chunk, flash_erase_value, page_size - chunk);
             }
             prog_buf = _page_buf;
             prog_size = page_size;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

When programming flash, if the chunk size to program is less than the page size, the buffer is padded with the erase value.  The erase value is hardcoded as `0xFF`.  However, since #8589, the HAL provides a `flash_get_erase_value()` function.

This PR replaces the hardcoded `0xFF` with the value returned by `flash_get_erase_value()`.  That value will be `0xFF` for all existing targets.  Removing the hardcoded assumption of `0xFF` allows for MBed to support a target with a different erase value, which is the spirit of #8589.

##### Documentation (*Details of any document updates required*)

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
