### PR TITLE
Add option to use CCMRAM on F303xE.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_ARM_STD/stm32f303xe.sct
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_ARM_STD/stm32f303xe.sct
@@ -42,7 +42,7 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-; STM32F303RE: 512KB FLASH (0x80000) + 64KB SRAM (0x10000)
+; STM32F303RE: 512KB FLASH (0x80000) + 64KB SRAM (0x10000) + 16KB CCMRAM (0x4000)
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
   ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
@@ -57,6 +57,10 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   }
 
   ARM_LIB_STACK (0x20000000+0x10000) EMPTY -Stack_Size { ; stack
+  }
+
+  CCMRAM (0x10000000) (0x4000)  {
+   .ANY (CCMRAM)
   }
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_GCC_ARM/STM32F303XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_GCC_ARM/STM32F303XE.ld
@@ -168,5 +168,12 @@ SECTIONS
     
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+    .CCMRAM (NOLOAD):
+    {
+        Image$$RW_IRAM2$$Base = . ;
+        *(CCMRAM)
+        Image$$RW_IRAM2$$ZI$$Limit = .;
+    } > CCM
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_IAR/stm32f303xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_IAR/stm32f303xe.icf
@@ -33,8 +33,10 @@ define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
+do not initialize  { section CCMRAM };
 
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
 place in RAM_region   { readwrite, block STACKHEAP };
+place in CCMRAM_region    { section CCMRAM };


### PR DESCRIPTION
### Description (*required*)
Add option to place data to ccm ram on STM32F303xE. Similar functionality exists already for at least STM32F437xG target.

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@anttiylitokola @teetak01 

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

##### Summary of changes

##### Impact of changes

##### Migration actions required
