### PR TITLE
STM32 QSPI: Use defines for setting address size

### DIFF
--- a/targets/TARGET_STM/qspi_api.c
+++ b/targets/TARGET_STM/qspi_api.c
@@ -262,28 +262,42 @@ qspi_status_t qspi_prepare_command(const qspi_command_t *command, QSPI_CommandTy
     st_command->DdrMode = QSPI_DDR_MODE_DISABLE;
     st_command->DdrHoldHalfCycle = QSPI_DDR_HHC_ANALOG_DELAY;
 
-    switch (command->address.bus_width) {
-        case QSPI_CFG_BUS_SINGLE:
-            st_command->AddressMode = QSPI_ADDRESS_1_LINE;
-            break;
-        case QSPI_CFG_BUS_DUAL:
-            st_command->AddressMode = QSPI_ADDRESS_2_LINES;
-            break;
-        case QSPI_CFG_BUS_QUAD:
-            st_command->AddressMode = QSPI_ADDRESS_4_LINES;
-            break;
-        default:
-            st_command->AddressMode = QSPI_ADDRESS_NONE;
-            break;
-    }
-
     if (command->address.disabled == true) {
         st_command->AddressMode = QSPI_ADDRESS_NONE;
         st_command->AddressSize = 0;
     } else {
         st_command->Address = command->address.value;
-        /* command->address.size needs to be shifted by QUADSPI_CCR_ADSIZE_Pos */
-        st_command->AddressSize = (command->address.size << QUADSPI_CCR_ADSIZE_Pos) & QUADSPI_CCR_ADSIZE_Msk;
+        switch (command->address.bus_width) {
+            case QSPI_CFG_BUS_SINGLE:
+                st_command->AddressMode = QSPI_ADDRESS_1_LINE;
+                break;
+            case QSPI_CFG_BUS_DUAL:
+                st_command->AddressMode = QSPI_ADDRESS_2_LINES;
+                break;
+            case QSPI_CFG_BUS_QUAD:
+                st_command->AddressMode = QSPI_ADDRESS_4_LINES;
+                break;
+            default:
+                error("Command param error: wrong address size\n");
+                return QSPI_STATUS_ERROR;
+        }
+        switch (command->address.size) {
+            case QSPI_CFG_ADDR_SIZE_8:
+                st_command->AddressSize = QSPI_ADDRESS_8_BITS;
+                break;
+            case QSPI_CFG_ADDR_SIZE_16:
+                st_command->AddressSize = QSPI_ADDRESS_16_BITS;
+                break;
+            case QSPI_CFG_ADDR_SIZE_24:
+                st_command->AddressSize = QSPI_ADDRESS_24_BITS;
+                break;
+            case QSPI_CFG_ADDR_SIZE_32:
+                st_command->AddressSize = QSPI_ADDRESS_32_BITS;
+                break;
+            default:
+                error("Command param error: wrong address size\n");
+                return QSPI_STATUS_ERROR;
+        }
     }
 
     uint8_t alt_lines = 0;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

A small clean-up Pull Request, to align with rest of the code following recent changes in QSPI.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

The change follows recent updates and can be considered a cosmetic change but should be future proof for any new STM32 devices with QSPI.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

Tested fine on DISCO_L475VG_IOT01A
```
+-----------------------------+---------------------+---------------------+--------+--------------------+-------------+
| target                      | platform_name       | test suite          | result | elapsed_time (sec) | copy_method |
+-----------------------------+---------------------+---------------------+--------+--------------------+-------------+
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-qspi | OK     | 37.78              | default     |
+-----------------------------+---------------------+---------------------+--------+--------------------+-------------+
```

```
+-----------------------------+---------------------+---------------------------------------------------------+--------+--------------------+-------------+
| target                      | platform_name       | test suite                                              | result | elapsed_time (sec) | copy_method |
+-----------------------------+---------------------+---------------------------------------------------------+--------+--------------------+-------------+
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-general_block_device | OK     | 38.42              | default     |
+-----------------------------+---------------------+---------------------------------------------------------+--------+--------------------+-------------+
```

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@jeromecoutant 
<!--
    Optional
    Request additional reviewers with @username
-->
