### PR TITLE
Display full path of generated coverage output from unittests.

### DIFF
--- a/UNITTESTS/unit_test/coverage.py
+++ b/UNITTESTS/unit_test/coverage.py
@@ -137,6 +137,9 @@ class CoverageAPI(object):
                 coverage_path = os.path.join(build_path, "coverage")
                 if not os.path.exists(coverage_path):
                     os.mkdir(coverage_path)
+                coverage_output = os.path.join(coverage_path, "index.html")
+            else:
+                coverage_output = os.path.join(build_path, "coverage.xml")
 
             # Generate the command
             args = self._gen_cmd(output, excludes, filter_regex)
@@ -145,4 +148,4 @@ class CoverageAPI(object):
             execute_program(
                 args,
                 "%s code coverage report generation failed." % output.upper(),
-                "%s code coverage report created." % output.upper())
+                "%s code coverage report created in %s" % (output.upper(), coverage_output))


### PR DESCRIPTION
### Description (*required*)

When running unittests with `--coverage` option, it only tells you that `code coverage report created.` but without specifying where it went.

This small change makes it verbose to show where the coverage output was generated. Easier for end user to find it.

##### Summary of change (*What the change is for and why*)

Display full path of generated coverage output from unittests.

### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
```
$ mbed test --unittest --coverage both

...

100% tests passed, 0 tests failed out of 47

Total Test time (real) =   0.51 sec




HTML code coverage report created in /Users/seppo/src/mbed-os/BUILD/unittests/coverage/index.html


XML code coverage report created in /Users/seppo/src/mbed-os/BUILD/unittests/coverage.xml
```    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->
@ARMmbed/mbed-os-test 




