### PR TITLE
Cypress: fix GPIO mode NONE

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/PinNamesTypes.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/PinNamesTypes.h
@@ -23,7 +23,7 @@
 #include "cybsp_types.h"
 
 // Pin Modes
-#define PullNone CYHAL_GPIO_DRIVE_STRONG
+#define PullNone CYHAL_GPIO_DRIVE_PULL_NONE
 #define PullDefault CYHAL_GPIO_DRIVE_NONE
 #define PullDown CYHAL_GPIO_DRIVE_PULLDOWN
 #define PullUp CYHAL_GPIO_DRIVE_PULLUP

--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/include/cyhal_gpio.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/include/cyhal_gpio.h
@@ -79,6 +79,7 @@ typedef enum {
     CYHAL_GPIO_DRIVE_OPENDRAINDRIVESHIGH, /**< Open-drain, Drives High */
     CYHAL_GPIO_DRIVE_STRONG,              /**< Strong output */
     CYHAL_GPIO_DRIVE_PULLUPDOWN,          /**< Pull-up and pull-down resistors */
+    CYHAL_GPIO_DRIVE_PULL_NONE,           /**< No Pull-up or pull-down resistors */
 } cyhal_gpio_drive_mode_t;
 
 /** GPIO callback function type */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/src/cyhal_gpio.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/src/cyhal_gpio.c
@@ -105,6 +105,16 @@ static uint32_t cyhal_gpio_convert_drive_mode(cyhal_gpio_drive_mode_t drive_mode
         case CYHAL_GPIO_DRIVE_PULLUPDOWN:
             drvMode = CY_GPIO_DM_PULLUP_DOWN;
             break;
+        case CYHAL_GPIO_DRIVE_PULL_NONE:
+            if (direction == CYHAL_GPIO_DIR_OUTPUT || direction == CYHAL_GPIO_DIR_BIDIRECTIONAL)
+            {
+                drvMode = CY_GPIO_DM_STRONG;
+            }
+            else
+            {
+                drvMode = CY_GPIO_DM_HIGHZ;
+            }
+            break;
         default:
             CY_ASSERT(false);
             drvMode = CY_GPIO_DM_HIGHZ;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
Provide fix for (arm-issue-11643).
https://github.com/ARMmbed/mbed-os/issues/11643
Cypress GPIO pull mode tests fail on CY8CKIT_062_WIFI_B

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
When PullNone mode, change from CYHAL_GPIO_DRIVE_STRONG -> CYHAL_GPIO_DRIVE_PULL_NONE. Fron now CYHAL_GPIO_DRIVE_PULL_NONE drives CY_GPIO_DM_STRONG when bidirectional or output, CY_GPIO_DM_HIGHZ - when direction is input.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->



