### PR TITLE
Increase STM32 default deep sleep latency to 4ms

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1911,7 +1911,7 @@
             }
         },
         "overrides": {
-            "deep-sleep-latency": 3,
+            "deep-sleep-latency": 4,
             "init-us-ticker-at-boot": true
         },
         "device_has": [


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Recent measurements have shown that the total wake-up latency can be more
than the 3ms initially set. It was measured as 3,7ms on DISCO_L475VG_IOT01A
target and 3,1ms on NUCLEO_L073RZ target. So set it to 4ms to be on the
safe side.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
The change better reflects the reality of the actual latency and will allows mbed-os OS to schedule
more precisely the wake-up timings.

##### Documentation (*Details of any document updates required*)

No specific documentation update needed.

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Note that this patch actually will fix the initial issue raised in #11545 
 
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@jeromecoutant @ABOSTM @TuomoHautamaki @kjbracey-arm 
<!--
    Optional
    Request additional reviewers with @username
-->
