### PR TITLE
Fix watchdog reset test

### DIFF
--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -195,17 +195,17 @@ void test_deepsleep_reset()
     // Phase 1. -- run the test code.
     Semaphore sem(0, 1);
     LowPowerTimeout lp_timeout;
-    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
+    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS + SERIAL_FLUSH_TIME_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
         return;
     }
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     Watchdog &watchdog = Watchdog::get_instance();
     TEST_ASSERT_FALSE(watchdog.is_running());
     TEST_ASSERT_TRUE(watchdog.start(TIMEOUT_MS));
     TEST_ASSERT_TRUE(watchdog.is_running());
     // Watchdog should fire before twice the timeout value.
     lp_timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (2 * TIMEOUT_MS));
-    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     if (!sleep_manager_can_deep_sleep()) {
         TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
     }

--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -178,7 +178,7 @@ void test_sleep_reset()
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 
-#if DEVICE_LOWPOWERTIMER
+#if DEVICE_LPTICKER
 void test_deepsleep_reset()
 {
     // Phase 2. -- verify the test results.
@@ -335,7 +335,7 @@ Case cases[] = {
     Case("Watchdog reset", case_setup, test_simple_reset),
 #if DEVICE_SLEEP
     Case("Watchdog reset in sleep mode", case_setup, test_sleep_reset),
-#if DEVICE_LOWPOWERTIMER
+#if DEVICE_LPTICKER
     Case("Watchdog reset in deepsleep mode", case_setup, test_deepsleep_reset),
 #endif
 #endif

--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -197,8 +197,12 @@ void test_deepsleep_reset()
     if (!sleep_manager_can_deep_sleep()) {
         TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
     }
-    // Watchdog should fire before twice the timeout value.
-    ThisThread::sleep_for(2 * TIMEOUT_MS); // Device reset expected.
+
+    // The Watchdog reset is allowed to be delayed up to twice the timeout
+    // value when the deepsleep mode is active.
+    // To make the test less sensitive to clock/wait accuracy, add 20% extra
+    // (making tha whole deepsleep wait equal to 2.2 * timeout).
+    ThisThread::sleep_for(220 * TIMEOUT_MS / 100); // Device reset expected.
 
     // Watchdog reset should have occurred during the deepsleep above.
 

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -85,6 +85,18 @@ void release_sem(Semaphore *sem)
 
 testcase_data current_case;
 
+Thread wdg_kicking_thread(osPriorityNormal, 768);
+Semaphore kick_wdg_during_test_teardown(0, 1);
+
+void wdg_kicking_thread_fun()
+{
+    kick_wdg_during_test_teardown.acquire();
+    while (true) {
+        hal_watchdog_kick();
+        wait_us(20000);
+    }
+}
+
 bool send_reset_notification(testcase_data *tcdata, uint32_t delay_ms)
 {
     char msg_value[12];
@@ -120,7 +132,7 @@ void test_simple_reset()
 
     // Watchdog reset should have occurred during wait_ms() above;
 
-    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 
@@ -155,7 +167,7 @@ void test_sleep_reset()
 
     // Watchdog reset should have occurred during sem.wait() (sleep) above;
 
-    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 
@@ -188,7 +200,7 @@ void test_deepsleep_reset()
 
     // Watchdog reset should have occurred during sem.wait() (deepsleep) above;
 
-    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 #endif
@@ -229,7 +241,7 @@ void test_restart_reset()
 
     // Watchdog reset should have occurred during that wait() above;
 
-    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 
@@ -260,7 +272,7 @@ void test_kick_reset()
 
     // Watchdog reset should have occurred during that wait() above;
 
-    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 
@@ -294,6 +306,10 @@ int testsuite_setup(const size_t number_of_cases)
         utest_printf("Invalid data received from host\n");
         return utest::v1::STATUS_ABORT;
     }
+
+    // The thread is started here, but feeding the watchdog will start
+    // when the semaphore is released during a test case teardown.
+    wdg_kicking_thread.start(mbed::callback(wdg_kicking_thread_fun));
 
     utest_printf("This test suite is composed of %i test cases. Starting at index %i.\n", number_of_cases,
                  current_case.start_index);

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -66,7 +66,11 @@
  * flushing the Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 ms.
  * To be on the safe side, set the wait time to 20 ms.
  */
-#define SERIAL_FLUSH_TIME_MS    20
+#define SERIAL_FLUSH_TIME_MS 20
+
+#define TIMEOUT_US (1000 * (TIMEOUT_MS))
+#define KICK_ADVANCE_US (1000 * (KICK_ADVANCE_MS))
+#define SERIAL_FLUSH_TIME_US (1000 * (SERIAL_FLUSH_TIME_MS))
 
 using utest::v1::Case;
 using utest::v1::Specification;
@@ -128,9 +132,9 @@ void test_simple_reset()
     }
     TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
     // Watchdog should fire before twice the timeout value.
-    wait_ms(2 * TIMEOUT_MS); // Device reset expected.
+    wait_us(2 * TIMEOUT_US); // Device reset expected.
 
-    // Watchdog reset should have occurred during wait_ms() above;
+    // Watchdog reset should have occurred during a wait above.
 
     kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
@@ -162,10 +166,10 @@ void test_sleep_reset()
         TEST_ASSERT_MESSAGE(0, "Deepsleep should be disallowed.");
         return;
     }
-    sem.wait(); // Device reset expected.
+    sem.acquire(); // Device reset expected.
     sleep_manager_unlock_deep_sleep();
 
-    // Watchdog reset should have occurred during sem.wait() (sleep) above;
+    // Watchdog reset should have occurred during sem.acquire() (sleep) above.
 
     kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
@@ -192,13 +196,13 @@ void test_deepsleep_reset()
     TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
     // Watchdog should fire before twice the timeout value.
     lp_timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (2 * TIMEOUT_MS));
-    wait_ms(SERIAL_FLUSH_TIME_MS); // Wait for the serial buffers to flush.
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     if (!sleep_manager_can_deep_sleep()) {
         TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
     }
-    sem.wait(); // Device reset expected.
+    sem.acquire(); // Device reset expected.
 
-    // Watchdog reset should have occurred during sem.wait() (deepsleep) above;
+    // Watchdog reset should have occurred during sem.acquire() (deepsleep) above.
 
     kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
@@ -224,12 +228,12 @@ void test_restart_reset()
     // Phase 1. -- run the test code.
     watchdog_config_t config = { TIMEOUT_MS };
     TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
-    wait_ms(TIMEOUT_MS / 2UL);
+    wait_us(TIMEOUT_US / 2);
     TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_stop());
     // Check that stopping the Watchdog prevents a device reset.
     // The watchdog should trigger at, or after the timeout value.
     // The watchdog should trigger before twice the timeout value.
-    wait_ms(TIMEOUT_MS / 2UL + TIMEOUT_MS);
+    wait_us(TIMEOUT_US / 2 + TIMEOUT_US);
 
     if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
@@ -237,9 +241,9 @@ void test_restart_reset()
     }
     TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
     // Watchdog should fire before twice the timeout value.
-    wait_ms(2 * TIMEOUT_MS); // Device reset expected.
+    wait_us(2 * TIMEOUT_US); // Device reset expected.
 
-    // Watchdog reset should have occurred during that wait() above;
+    // Watchdog reset should have occurred during a wait above.
 
     kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
@@ -260,7 +264,7 @@ void test_kick_reset()
     for (int i = 3; i; i--) {
         // The reset is prevented as long as the watchdog is kicked
         // anytime before the timeout.
-        wait_ms(TIMEOUT_MS - KICK_ADVANCE_MS);
+        wait_us(TIMEOUT_US - KICK_ADVANCE_US);
         hal_watchdog_kick();
     }
     if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
@@ -268,9 +272,9 @@ void test_kick_reset()
         return;
     }
     // Watchdog should fire before twice the timeout value.
-    wait_ms(2 * TIMEOUT_MS); // Device reset expected.
+    wait_us(2 * TIMEOUT_US); // Device reset expected.
 
-    // Watchdog reset should have occurred during that wait() above;
+    // Watchdog reset should have occurred during a wait above.
 
     kick_wdg_during_test_teardown.release(); // For testsuite failure handling.
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -188,8 +188,12 @@ void test_deepsleep_reset()
     if (!sleep_manager_can_deep_sleep()) {
         TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
     }
-    // Watchdog should fire before twice the timeout value.
-    ThisThread::sleep_for(2 * TIMEOUT_MS); // Device reset expected.
+
+    // The Watchdog reset is allowed to be delayed up to twice the timeout
+    // value when the deepsleep mode is active.
+    // To make the test less sensitive to clock/wait accuracy, add 20% extra
+    // (making tha whole deepsleep wait equal to 2.2 * timeout).
+    ThisThread::sleep_for(220 * TIMEOUT_MS / 100); // Device reset expected.
 
     // Watchdog reset should have occurred during the deepsleep above.
 

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -171,7 +171,7 @@ void test_sleep_reset()
     TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
 }
 
-#if DEVICE_LOWPOWERTIMER
+#if DEVICE_LPTICKER
 void test_deepsleep_reset()
 {
     // Phase 2. -- verify the test results.
@@ -320,7 +320,7 @@ Case cases[] = {
     Case("Watchdog reset", case_setup, test_simple_reset),
 #if DEVICE_SLEEP
     Case("Watchdog reset in sleep mode", case_setup, test_sleep_reset),
-#if DEVICE_LOWPOWERTIMER
+#if DEVICE_LPTICKER
     Case("Watchdog reset in deepsleep mode", case_setup, test_deepsleep_reset),
 #endif
 #endif

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -189,14 +189,14 @@ void test_deepsleep_reset()
     watchdog_config_t config = { TIMEOUT_MS };
     Semaphore sem(0, 1);
     LowPowerTimeout lp_timeout;
-    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
+    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS + SERIAL_FLUSH_TIME_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
         return;
     }
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
     // Watchdog should fire before twice the timeout value.
     lp_timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (2 * TIMEOUT_MS));
-    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     if (!sleep_manager_can_deep_sleep()) {
         TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
     }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/watchdog_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/watchdog_api.c
@@ -75,8 +75,8 @@ watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
   cfg.enableInterrupt = false;
   cfg.enableWindowMode = false;
   cfg.workMode.enableWait = true;
-  cfg.workMode.enableStop = false;
-  cfg.workMode.enableDebug = false;
+  cfg.workMode.enableStop = true;
+  cfg.workMode.enableDebug = true;
 
   const uint32_t prescaler = calculate_prescaler_value(config->timeout_ms);
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
I fixed the Watchdog reset tests (both HAL & drier) with the following:
* Added a watchdog-kicking thread, running in the background when the test suite is handling a failed assertion. This is to make sure all failures are processed correctly by greentea. This is especially important in case the watchdog reset is late and happens when the test suite teardown is doing its job.
* Fixed the LP ticker macro in the test, so the deepsleep test case is actually executed.
* Replaced deprecated API calls for wait/sleep with the current ones.
* Updated the Watchdog timing requirements for the deepsleep mode according to findings from #11774 -- allow doubled timeout for this mode.

Also fixed the `hal_watchdog_init()` for K64F -- enabled the Watchdog for `Debug` and `Stop` modes, as required by https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/porting/target/Watchdog.md#defined-behavior.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->
@0xc0170, @jamesbeyond 

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



