### PR TITLE
Fix for issue #11769 (Cypress: PWM FPGA test wrong assert)

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_pwmout_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_pwmout_api.c
@@ -50,7 +50,7 @@ void pwmout_write(pwmout_t *obj, float percent)
 
 float pwmout_read(pwmout_t *obj)
 {
-    return 100.0f * obj->width_us / obj->period_us;
+    return ((float)(obj->width_us) / obj->period_us);
 }
 
 void pwmout_period(pwmout_t *obj, float seconds)


### PR DESCRIPTION
### Description

Implementation of `pwmout_read()` is not consistent with the requirements.
This function should return the current float-point output duty-cycle in range `<0.0f, 1.0f>`.
Currently it returns decimal percentage value.

##### Summary of change

Bug fix.

### Pull request type

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

@yarbcy @0xc0170 

----------------------------------------------------------------------------------------------------------------



