### PR TITLE
Nuvoton: Add implementations of HAL API i2c_free and analogin_free

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/i2c_api.c
@@ -147,6 +147,37 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     i2c_modinit_mask |= 1 << i;
 }
 
+void i2c_free(i2c_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->i2c.i2c, i2c_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->i2c.i2c);
+
+    /* Disable I2C interrupt */
+    NVIC_DisableIRQ(modinit->irq_n);
+
+    I2C_T *i2c_base = (I2C_T *) NU_MODBASE(obj->i2c.i2c);
+
+    /* Disable I2C module */
+    I2C_Close(i2c_base);
+
+    /* Disable IP clock
+     *
+     * NOTE: We must call secure version (from non-secure domain) because SYS/CLK regions are secure.
+     */
+    CLK_DisableModuleClock_S(modinit->clkidx);
+
+    // Mark this module to be deinited.
+    int i = modinit - i2c_modinit_tab;
+    i2c_modinit_mask &= ~(1 << i);
+
+    /* Free up pins */
+    gpio_set(obj->i2c.pin_sda);
+    gpio_set(obj->i2c.pin_scl);
+    obj->i2c.pin_sda = NC;
+    obj->i2c.pin_scl = NC;
+}
+
 int i2c_start(i2c_t *obj)
 {
     return i2c_do_trsn(obj, I2C_CTL0_STA_Msk | I2C_CTL0_SI_Msk, 1);

--- a/targets/TARGET_NUVOTON/TARGET_M251/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/analogin_api.c
@@ -93,6 +93,37 @@ void analogin_init(analogin_t *obj, PinName pin)
     eadc_modinit_mask |= 1 << chn;
 }
 
+void analogin_free(analogin_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->adc, adc_modinit_tab);
+    MBED_ASSERT(modinit->modname == (int) obj->adc);
+
+    /* Module subindex (aka channel) */
+    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+
+    EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);
+
+    /* Channel-level windup from here */
+
+    /* Mark channel free */
+    eadc_modinit_mask &= ~(1 << chn);
+
+    /* Module-level windup from here */
+
+    /* See analogin_init() for reason */
+    if (! eadc_modinit_mask) {
+        /* Disable EADC module */
+        EADC_Close(eadc_base);
+
+        /* Disable IP clock */
+        CLK_DisableModuleClock(modinit->clkidx);
+    }
+    
+    /* Free up pins */
+    gpio_set(obj->pin);
+    obj->pin = NC;
+}
+
 uint16_t analogin_read_u16(analogin_t *obj)
 {
     EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);

--- a/targets/TARGET_NUVOTON/TARGET_M251/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M251/i2c_api.c
@@ -137,6 +137,34 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     i2c_modinit_mask |= 1 << i;
 }
 
+void i2c_free(i2c_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->i2c.i2c, i2c_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->i2c.i2c);
+
+    /* Disable I2C interrupt */
+    NVIC_DisableIRQ(modinit->irq_n);
+
+    I2C_T *i2c_base = (I2C_T *) NU_MODBASE(obj->i2c.i2c);
+
+    /* Disable I2C module */
+    I2C_Close(i2c_base);
+
+    /* Disable IP clock */
+    CLK_DisableModuleClock(modinit->clkidx);
+
+    // Mark this module to be deinited.
+    int i = modinit - i2c_modinit_tab;
+    i2c_modinit_mask &= ~(1 << i);
+
+    /* Free up pins */
+    gpio_set(obj->i2c.pin_sda);
+    gpio_set(obj->i2c.pin_scl);
+    obj->i2c.pin_sda = NC;
+    obj->i2c.pin_scl = NC;
+}
+
 int i2c_start(i2c_t *obj)
 {
     return i2c_do_trsn(obj, I2C_CTL0_STA_Msk | I2C_CTL0_SI_Msk, 1);

--- a/targets/TARGET_NUVOTON/TARGET_M261/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/analogin_api.c
@@ -84,6 +84,37 @@ void analogin_init(analogin_t *obj, PinName pin)
     eadc_modinit_mask |= 1 << chn;
 }
 
+void analogin_free(analogin_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->adc, adc_modinit_tab);
+    MBED_ASSERT(modinit->modname == (int) obj->adc);
+
+    /* Module subindex (aka channel) */
+    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+
+    EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);
+
+    /* Channel-level windup from here */
+
+    /* Mark channel free */
+    eadc_modinit_mask &= ~(1 << chn);
+
+    /* Module-level windup from here */
+
+    /* See analogin_init() for reason */
+    if (! eadc_modinit_mask) {
+        /* Disable EADC module */
+        EADC_Close(eadc_base);
+
+        /* Disable IP clock */
+        CLK_DisableModuleClock(modinit->clkidx);
+    }
+    
+    /* Free up pins */
+    gpio_set(obj->pin);
+    obj->pin = NC;
+}
+
 uint16_t analogin_read_u16(analogin_t *obj)
 {
     EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);

--- a/targets/TARGET_NUVOTON/TARGET_M261/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M261/i2c_api.c
@@ -142,6 +142,34 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     i2c_modinit_mask |= 1 << i;
 }
 
+void i2c_free(i2c_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->i2c.i2c, i2c_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->i2c.i2c);
+
+    /* Disable I2C interrupt */
+    NVIC_DisableIRQ(modinit->irq_n);
+
+    I2C_T *i2c_base = (I2C_T *) NU_MODBASE(obj->i2c.i2c);
+
+    /* Disable I2C module */
+    I2C_Close(i2c_base);
+
+    /* Disable IP clock */
+    CLK_DisableModuleClock(modinit->clkidx);
+
+    // Mark this module to be deinited.
+    int i = modinit - i2c_modinit_tab;
+    i2c_modinit_mask &= ~(1 << i);
+
+    /* Free up pins */
+    gpio_set(obj->i2c.pin_sda);
+    gpio_set(obj->i2c.pin_scl);
+    obj->i2c.pin_sda = NC;
+    obj->i2c.pin_scl = NC;
+}
+
 int i2c_start(i2c_t *obj)
 {
     return i2c_do_trsn(obj, I2C_CTL0_STA_Msk | I2C_CTL0_SI_Msk, 1);

--- a/targets/TARGET_NUVOTON/TARGET_M451/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/analogin_api.c
@@ -84,6 +84,37 @@ void analogin_init(analogin_t *obj, PinName pin)
     eadc_modinit_mask |= 1 << chn;
 }
 
+void analogin_free(analogin_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->adc, adc_modinit_tab);
+    MBED_ASSERT(modinit->modname == (int) obj->adc);
+
+    /* Module subindex (aka channel) */
+    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+
+    EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);
+
+    /* Channel-level windup from here */
+
+    /* Mark channel free */
+    eadc_modinit_mask &= ~(1 << chn);
+
+    /* Module-level windup from here */
+
+    /* See analogin_init() for reason */
+    if (! eadc_modinit_mask) {
+        /* Disable EADC module */
+        EADC_Close(eadc_base);
+
+        /* Disable IP clock */
+        CLK_DisableModuleClock(modinit->clkidx);
+    }
+    
+    /* Free up pins */
+    gpio_set(obj->pin);
+    obj->pin = NC;
+}
+
 uint16_t analogin_read_u16(analogin_t *obj)
 {
     EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);

--- a/targets/TARGET_NUVOTON/TARGET_M451/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/i2c_api.c
@@ -150,6 +150,34 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     i2c_modinit_mask |= 1 << i;
 }
 
+void i2c_free(i2c_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->i2c.i2c, i2c_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->i2c.i2c);
+
+    /* Disable I2C interrupt */
+    NVIC_DisableIRQ(modinit->irq_n);
+
+    I2C_T *i2c_base = (I2C_T *) NU_MODBASE(obj->i2c.i2c);
+
+    /* Disable I2C module */
+    I2C_Close(i2c_base);
+
+    /* Disable IP clock */
+    CLK_DisableModuleClock(modinit->clkidx);
+
+    // Mark this module to be deinited.
+    int i = modinit - i2c_modinit_tab;
+    i2c_modinit_mask &= ~(1 << i);
+
+    /* Free up pins */
+    gpio_set(obj->i2c.pin_sda);
+    gpio_set(obj->i2c.pin_scl);
+    obj->i2c.pin_sda = NC;
+    obj->i2c.pin_scl = NC;
+}
+
 int i2c_start(i2c_t *obj)
 {
     return i2c_do_trsn(obj, I2C_CTL_STA_Msk | I2C_CTL_SI_Msk, 1);

--- a/targets/TARGET_NUVOTON/TARGET_M480/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/analogin_api.c
@@ -83,6 +83,37 @@ void analogin_init(analogin_t *obj, PinName pin)
     eadc_modinit_mask |= 1 << chn;
 }
 
+void analogin_free(analogin_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->adc, adc_modinit_tab);
+    MBED_ASSERT(modinit->modname == (int) obj->adc);
+
+    /* Module subindex (aka channel) */
+    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+
+    EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);
+
+    /* Channel-level windup from here */
+
+    /* Mark channel free */
+    eadc_modinit_mask &= ~(1 << chn);
+
+    /* Module-level windup from here */
+
+    /* See analogin_init() for reason */
+    if (! eadc_modinit_mask) {
+        /* Disable EADC module */
+        EADC_Close(eadc_base);
+
+        /* Disable IP clock */
+        CLK_DisableModuleClock(modinit->clkidx);
+    }
+    
+    /* Free up pins */
+    gpio_set(obj->pin);
+    obj->pin = NC;
+}
+
 uint16_t analogin_read_u16(analogin_t *obj)
 {
     EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);

--- a/targets/TARGET_NUVOTON/TARGET_M480/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/i2c_api.c
@@ -141,6 +141,34 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     i2c_modinit_mask |= 1 << i;
 }
 
+void i2c_free(i2c_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->i2c.i2c, i2c_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->i2c.i2c);
+
+    /* Disable I2C interrupt */
+    NVIC_DisableIRQ(modinit->irq_n);
+
+    I2C_T *i2c_base = (I2C_T *) NU_MODBASE(obj->i2c.i2c);
+
+    /* Disable I2C module */
+    I2C_Close(i2c_base);
+
+    /* Disable IP clock */
+    CLK_DisableModuleClock(modinit->clkidx);
+
+    // Mark this module to be deinited.
+    int i = modinit - i2c_modinit_tab;
+    i2c_modinit_mask &= ~(1 << i);
+
+    /* Free up pins */
+    gpio_set(obj->i2c.pin_sda);
+    gpio_set(obj->i2c.pin_scl);
+    obj->i2c.pin_sda = NC;
+    obj->i2c.pin_scl = NC;
+}
+
 int i2c_start(i2c_t *obj)
 {
     return i2c_do_trsn(obj, I2C_CTL0_STA_Msk | I2C_CTL0_SI_Msk, 1);

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/analogin_api.c
@@ -25,7 +25,6 @@
 #include "nu_modutil.h"
 
 static uint32_t adc_modinit_mask = 0;
-volatile int adc_busy_flag = 0;
 
 static const struct nu_modinit_s adc_modinit_tab[] = {
     {ADC_0_0, ADC_MODULE, CLK_CLKSEL1_ADC_S_HIRC, CLK_ADC_CLK_DIVIDER(1), ADC_RST, ADC_IRQn, NULL},
@@ -58,13 +57,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     ADC_T *adc_base = (ADC_T *) NU_MODBASE(obj->adc);
     uint32_t chn =  NU_MODSUBINDEX(obj->adc);
-    
-    // Wait for ADC is not busy, due to all ADC channels share the same module
-    while (adc_busy_flag != 0) {
-        wait_us(100);
-    }
-    adc_busy_flag = 1;
-    
+
     // NOTE: All channels (identified by ADCName) share a ADC module. This reset will also affect other channels of the same ADC module.
     if (! adc_modinit_mask) {
         // Select clock source of paired channels
@@ -88,10 +81,8 @@ void analogin_init(analogin_t *obj, PinName pin)
         // Just enable channel N
         adc_base->CHEN |= 1 << chn;
     }
-    
+
     adc_modinit_mask |= 1 << chn;
-    
-    adc_busy_flag = 0;
 }
 
 void analogin_free(analogin_t *obj)
@@ -103,12 +94,6 @@ void analogin_free(analogin_t *obj)
     uint32_t chn =  NU_MODSUBINDEX(obj->adc);
 
     ADC_T *adc_base = (ADC_T *) NU_MODBASE(obj->adc);
-
-    // Wait for ADC is not busy, due to all ADC channels share the same module
-    while (adc_busy_flag != 0) {
-        wait_us(100);
-    }
-    adc_busy_flag = 1;
 
     /* Channel-level windup from here */
 
@@ -132,8 +117,6 @@ void analogin_free(analogin_t *obj)
         CLK_DisableModuleClock(modinit->clkidx);
     }
 
-    adc_busy_flag = 0;
-
     /* Free up pins */
     gpio_set(obj->pin);
     obj->pin = NC;
@@ -143,27 +126,19 @@ uint16_t analogin_read_u16(analogin_t *obj)
 {
     ADC_T *adc_base = (ADC_T *) NU_MODBASE(obj->adc);
     uint32_t chn =  NU_MODSUBINDEX(obj->adc);
-    
-    // Wait for ADC is not busy, due to all ADC channels share the same module
-    while (adc_busy_flag != 0) {
-        wait_us(100);
-    }
-    adc_busy_flag = 1;
-    
+
     // Start the A/D conversion
     adc_base->CR |= ADC_CR_ADST_Msk;
     // Wait for conversion finish
     while (! ADC_GET_INT_FLAG(adc_base, ADC_ADF_INT) & ADC_ADF_INT) ;
     ADC_CLR_INT_FLAG(ADC, ADC_ADF_INT);
     uint16_t conv_res_12 = ADC_GET_CONVERSION_DATA(adc_base, chn);
-    
-    adc_busy_flag = 0;
-    
+
     // Just 12 bits are effective. Convert to 16 bits.
     // conv_res_12: 0000 b11b10b9b8 b7b6b5b4 b3b2b1b0
     // conv_res_16: b11b10b9b8 b7b6b5b4 b3b2b1b0 b11b10b9b8
     uint16_t conv_res_16 = (conv_res_12 << 4) | (conv_res_12 >> 8);
-    
+
     return conv_res_16;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/analogin_api.c
@@ -85,6 +85,37 @@ void analogin_init(analogin_t *obj, PinName pin)
     eadc_modinit_mask |= 1 << smp_mod;
 }
 
+void analogin_free(analogin_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->adc, adc_modinit_tab);
+    MBED_ASSERT(modinit->modname == (int) obj->adc);
+
+    /* Module subindex (aka channel) */
+    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+
+    EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);
+
+    /* Channel-level windup from here */
+
+    /* Mark channel free */
+    eadc_modinit_mask &= ~(1 << chn);
+
+    /* Module-level windup from here */
+
+    /* See analogin_init() for reason */
+    if (! eadc_modinit_mask) {
+        /* Disable EADC module */
+        EADC_Close(eadc_base);
+
+        /* Disable IP clock */
+        CLK_DisableModuleClock(modinit->clkidx);
+    }
+    
+    /* Free up pins */
+    gpio_set(obj->pin);
+    obj->pin = NC;
+}
+
 uint16_t analogin_read_u16(analogin_t *obj)
 {
     EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/i2c_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/i2c_api.c
@@ -172,6 +172,34 @@ int i2c_start(i2c_t *obj)
     return i2c_do_trsn(obj, I2C_CTL_STA_Msk | I2C_CTL_SI_Msk, 1);
 }
 
+void i2c_free(i2c_t *obj)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->i2c.i2c, i2c_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->i2c.i2c);
+
+    /* Disable I2C interrupt */
+    NVIC_DisableIRQ(modinit->irq_n);
+
+    I2C_T *i2c_base = (I2C_T *) NU_MODBASE(obj->i2c.i2c);
+
+    /* Disable I2C module */
+    I2C_Close(i2c_base);
+
+    /* Disable IP clock */
+    CLK_DisableModuleClock(modinit->clkidx);
+
+    // Mark this module to be deinited.
+    int i = modinit - i2c_modinit_tab;
+    i2c_modinit_mask &= ~(1 << i);
+
+    /* Free up pins */
+    gpio_set(obj->i2c.pin_sda);
+    gpio_set(obj->i2c.pin_scl);
+    obj->i2c.pin_sda = NC;
+    obj->i2c.pin_scl = NC;
+}
+
 int i2c_stop(i2c_t *obj)
 {
     return i2c_do_trsn(obj, I2C_CTL_STO_Msk | I2C_CTL_SI_Msk, 1);


### PR DESCRIPTION
# Description (*required*)

Follow-up of https://github.com/ARMmbed/mbed-os/issues/11746#issuecomment-547798707, this PR adds implementations of HAL API `i2c_free(...)` and `analogin_free(...)` for FPGA CI test shield tests on Nuvoton targets:

- NUMAKER_PFM_NANO130
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487/NUMAKER_IOT_M487
- NU_PFM_M2351_NPSA_NS
- NUMAKER_IOT_M263A
- NUMAKER_M252KG


----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
### Reviewers

@mprse 

