### PR TITLE
SecureStore: Add member initializers for inc_handle_t

### DIFF
--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -52,19 +52,19 @@ static const uint32_t security_flags = KVStore::REQUIRE_CONFIDENTIALITY_FLAG | K
 namespace {
 
 typedef struct {
-    uint16_t metadata_size;
-    uint16_t revision;
-    uint32_t data_size;
-    uint32_t create_flags;
-    uint8_t  iv[iv_size];
+    uint16_t metadata_size = 0u;
+    uint16_t revision = 0u;
+    uint32_t data_size = 0u;
+    uint32_t create_flags = 0u;
+    uint8_t  iv[iv_size] = { 0u };
 } record_metadata_t;
 
 // incremental set handle
 typedef struct {
     record_metadata_t metadata;
-    char *key;
-    uint32_t offset_in_data;
-    uint8_t ctr_buf[enc_block_size];
+    char *key = nullptr;
+    uint32_t offset_in_data = 0u;
+    uint8_t ctr_buf[enc_block_size] = { 0u };
     mbedtls_aes_context enc_ctx;
     mbedtls_cipher_context_t auth_ctx;
     KVStore::set_handle_t underlying_handle;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
_inc_set_handle is new'd in SecureStore::init(), then its members are referenced in various functions without being explicitly initialized first. These pre-existing values can confuse the SecureStore's internal state and cause various undesired behaviors.

Note: At least on the ARM GCC versions that I've tested with (6.3.1 and 7.2.1), the default initialization is also achieved by using `new inc_set_handle_t();` instead of `new inc_set_handle_t;` (note the added parentheses). I chose to add explicit initializers instead because a.) it is hard to tell whether this behavior is guaranteed by spec or just how GCC happens to be implemented and b.) the explicit initializers make it more clear what is going on (and are not prone to failure if a future change forgets to use parentheses with new).

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
Fix use of uninitialized memory contents in SecureStore.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

A full Greentea test log will be uploaded soon (probably tomorrow).
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@ARMMbed/team-cypress
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



