### PR TITLE
STM32H7 FLASH API issue with M4 core

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/flash_api.c
@@ -85,8 +85,17 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
         status = -1;
     }
 
+#if defined(DUAL_CORE)
+#if defined(CORE_CM7)
     SCB_CleanInvalidateDCache_by_Addr((uint32_t *)GetSectorBase(EraseInitStruct.Sector, EraseInitStruct.Banks), GetSectorSize(EraseInitStruct.Sector));
     SCB_InvalidateICache();
+#endif /* CORE_CM7 */
+#else /* DUAL_CORE */
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)GetSectorBase(EraseInitStruct.Sector, EraseInitStruct.Banks), GetSectorSize(EraseInitStruct.Sector));
+    SCB_InvalidateICache();
+#endif /* DUAL_CORE */
+
+
 
     HAL_FLASH_Lock();
 #if defined(DUAL_CORE)
@@ -133,8 +142,15 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data,
         }
     }
 
+#if defined(DUAL_CORE)
+#if defined(CORE_CM7)
     SCB_CleanInvalidateDCache_by_Addr((uint32_t *)StartAddress, FullSize);
     SCB_InvalidateICache();
+#endif /* CORE_CM7 */
+#else /* DUAL_CORE */
+    SCB_CleanInvalidateDCache_by_Addr((uint32_t *)StartAddress, FullSize);
+    SCB_InvalidateICache();
+#endif /* DUAL_CORE */
 
     HAL_FLASH_Lock();
 #if defined(DUAL_CORE)


### PR DESCRIPTION
### Description (*required*)

Compilation is failing for DISCO_H747I_CM4

##### Summary of change (*What the change is for and why*)

SCB cache functions are only available for M7 core, not M4

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@0xc0170 why CI didn't catch the issue before ?


----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)


##### Summary of changes

##### Impact of changes

##### Migration actions required



