### PR TITLE
USBMSD: implement MODE SENSE (10) command

### DIFF
--- a/drivers/USBMSD.h
+++ b/drivers/USBMSD.h
@@ -302,6 +302,7 @@ private:
     bool infoTransfer(void);
     void memoryRead(void);
     bool modeSense6(void);
+    bool modeSense10(void);
     void testUnitReady(void);
     bool requestSense(void);
     void memoryVerify(uint8_t *buf, uint16_t size);

--- a/drivers/source/usb/USBMSD.cpp
+++ b/drivers/source/usb/USBMSD.cpp
@@ -706,6 +706,15 @@ bool USBMSD::modeSense6(void)
     return true;
 }
 
+bool USBMSD::modeSense10(void)
+{
+    uint8_t sense10[] = { 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    if (!write(sense10, sizeof(sense10))) {
+        return false;
+    }
+    return true;
+}
+
 void USBMSD::sendCSW()
 {
     _csw.Signature = CSW_Signature;
@@ -825,6 +834,9 @@ void USBMSD::CBWDecode(uint8_t *buf, uint16_t size)
                         _csw.Status = CSW_PASSED;
                         sendCSW();
                         _media_removed = true;
+                        break;
+                    case MODE_SENSE10:
+                        modeSense10();
                         break;
                     default:
                         fail();


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

These changes resolve issue https://github.com/ARMmbed/mbed-os/issues/10342.

The mbed-os USB MSD stack was not responding the "MODE SENSE" command causing macOS not to mount the drive.

cc/ @facchinm 

##### Summary of change (*What the change is for and why*)

Implemented the MODE SENSE 10 USB MSD command which a response based on what CMSIS DAP sends: https://github.com/ARMmbed/DAPLink/blob/master/source/usb/msc/usbd_msc.c#L665-L699

This change allows macOS to successfully mount the mbed-os USB MSD.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
This was tested with a Arduino Nano 33 BLE board with macOS 10.14.6.   
 
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

USBMSD: implement MODE SENSE (10) command

##### Impact of changes

USBMSD

##### Migration actions required

N/A



