### PR TITLE
Updated targets.json file to go along with pr-11770

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9115,7 +9115,7 @@
     },
     "MCU_PSOC6_M4": {
         "inherits": ["MCU_PSOC6"],
-        "components_add": ["FLASHIAP", "QSPIF", "BSP_DESIGN_MODUS"],
+        "components_add": ["FLASHIAP", "QSPIF", "BSP_DESIGN_MODUS", "CM0P_SLEEP"],
         "macros_add": ["MCU_PSOC6_M4", "CY_RTOS_AWARE", "CY_USING_HAL", "MBED_TICKLESS"],
         "public": false
     },
@@ -9126,7 +9126,6 @@
         "extra_labels_add": [
             "PSOC6_02",
             "MXCRYPTO_02",
-            "CM0P_SLEEP",
             "WHD",
             "4343W",
             "CYW43XXX",
@@ -9145,7 +9144,6 @@
         "extra_labels_add": [
             "PSOC6_02",
             "MXCRYPTO_02",
-            "CM0P_SLEEP",
             "WHD",
             "43012",
             "CYW43XXX",
@@ -9166,7 +9164,6 @@
         "extra_labels_add": [
             "PSOC6_02",
             "MXCRYPTO_02",
-            "CM0P_SLEEP",
             "WHD",
             "4343W",
             "CYW43XXX",
@@ -9190,7 +9187,6 @@
         "extra_labels_add": [
             "PSOC6_01",
             "MXCRYPTO_01",
-            "CM0P_SLEEP",
             "WHD",
             "4343W",
             "CYW43XXX",
@@ -9231,8 +9227,7 @@
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": [
             "PSOC6_01",
-            "MXCRYPTO_01",
-            "CM0P_SLEEP"
+            "MXCRYPTO_01"
         ],
         "macros_add": ["CY8C6347BZI_BLD53"],
         "detect_code": ["1902"],
@@ -9248,8 +9243,7 @@
         "device_has_remove": ["USBDEVICE", "QSPI"],
         "extra_labels_add": [
             "PSOC6_01",
-            "MXCRYPTO_01",
-            "CM0P_SLEEP"
+            "MXCRYPTO_01"
         ],
         "macros_add": ["CYBLE_416045_02"],
         "detect_code": ["1904"],
@@ -9282,7 +9276,6 @@
         "extra_labels_add": [
             "PSOC6_01",
             "MXCRYPTO_01",
-            "CM0P_SLEEP",
             "WHD",
             "43012",
             "CYW43XXX",
@@ -9305,7 +9298,6 @@
         "macros_remove": ["MBEDTLS_CONFIG_HW_SUPPORT"],
         "extra_labels_add": [
             "PSOC6_01",
-            "CM0P_SLEEP",
             "WHD",
             "43012",
             "CYW43XXX",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Added changes to targets.json that got missed in PR-11770. This is required for the changes in PR-11770 to work properly.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

Updated targets.json file to convert CM0P_SLEEP from a label into a component so the files can be picked up properly.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
[GT_FT_KIT_062_BLE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3811103/GT_FT_KIT_062_BLE_GCC.txt)
[GT_FT_KIT_062_WIFI_BT_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3811104/GT_FT_KIT_062_WIFI_BT_GCC.txt)
[GT_FT_PROTO_062_4343W_GCC.txt](https://github.com/ARMmbed/mbed-os/files/3811105/GT_FT_PROTO_062_4343W_GCC.txt)
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->
@dgreen-arm @maclobdell @0xc0170 