### PR TITLE
Fix failure of building non-RTOS for GR-PEACH, GR-LYCHEE and VK-RZ/A1H

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
@@ -22,27 +22,24 @@
  * limitations under the License.
  */
 
-#ifdef MBED_CONF_RTOS_PRESENT
-
-#include "os_tick.h"
 #include "irq_ctrl.h"
 #include "cmsis.h"
 #include "mbed_drv_cfg.h"
 
+// Define OS Timer channel and interrupt number
+#define OSTM                        (OSTM0)
+#define OSTM_IRQn                   ((IRQn_ID_t)OSTMI0TINT_IRQn)
+
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "os_tick.h"
 
 // Define OS TImer interrupt priority
 #ifndef OSTM_IRQ_PRIORITY
 #define OSTM_IRQ_PRIORITY           0xFFU
 #endif
 
-// Define OS Timer channel and interrupt number
-#define OSTM                        (OSTM0)
-#define OSTM_IRQn                   ((IRQn_ID_t)OSTMI0TINT_IRQn)
-
-
 static uint32_t OSTM_Clock;         // Timer tick frequency
 static uint8_t  OSTM_PendIRQ;       // Timer interrupt pending flag
-
 
 // Setup OS Tick.
 int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler)
@@ -190,10 +187,10 @@ uint32_t OS_Tick_GetOverflow (void)
 {
   return (IRQ_GetPending(OSTM_IRQn));
 }
+#endif
 
 // Get Cortex-A9 OS Timer interrupt number
 IRQn_ID_t mbed_get_a9_tick_irqn(){
   return OSTM_IRQn;
 }
-#endif
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
@@ -22,27 +22,24 @@
  * limitations under the License.
  */
 
-#ifdef MBED_CONF_RTOS_PRESENT
-
-#include "os_tick.h"
 #include "irq_ctrl.h"
 #include "cmsis.h"
 #include "mbed_drv_cfg.h"
 
+// Define OS Timer channel and interrupt number
+#define OSTM                        (OSTM0)
+#define OSTM_IRQn                   ((IRQn_ID_t)OSTMI0TINT_IRQn)
+
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "os_tick.h"
 
 // Define OS TImer interrupt priority
 #ifndef OSTM_IRQ_PRIORITY
 #define OSTM_IRQ_PRIORITY           0xFFU
 #endif
 
-// Define OS Timer channel and interrupt number
-#define OSTM                        (OSTM0)
-#define OSTM_IRQn                   ((IRQn_ID_t)OSTMI0TINT_IRQn)
-
-
 static uint32_t OSTM_Clock;         // Timer tick frequency
 static uint8_t  OSTM_PendIRQ;       // Timer interrupt pending flag
-
 
 // Setup OS Tick.
 int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler)
@@ -190,10 +187,10 @@ uint32_t OS_Tick_GetOverflow (void)
 {
   return (IRQ_GetPending(OSTM_IRQn));
 }
+#endif
 
 // Get Cortex-A9 OS Timer interrupt number
 IRQn_ID_t mbed_get_a9_tick_irqn(){
   return OSTM_IRQn;
 }
-#endif
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/os_tick_ostm.c
@@ -22,27 +22,24 @@
  * limitations under the License.
  */
 
-#ifdef MBED_CONF_RTOS_PRESENT
-
-#include "os_tick.h"
 #include "irq_ctrl.h"
 #include "cmsis.h"
 #include "mbed_drv_cfg.h"
 
+// Define OS Timer channel and interrupt number
+#define OSTM                        (OSTM0)
+#define OSTM_IRQn                   ((IRQn_ID_t)OSTMI0TINT_IRQn)
+
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "os_tick.h"
 
 // Define OS TImer interrupt priority
 #ifndef OSTM_IRQ_PRIORITY
 #define OSTM_IRQ_PRIORITY           0xFFU
 #endif
 
-// Define OS Timer channel and interrupt number
-#define OSTM                        (OSTM0)
-#define OSTM_IRQn                   ((IRQn_ID_t)OSTMI0TINT_IRQn)
-
-
 static uint32_t OSTM_Clock;         // Timer tick frequency
 static uint8_t  OSTM_PendIRQ;       // Timer interrupt pending flag
-
 
 // Setup OS Tick.
 int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler)
@@ -190,11 +187,10 @@ uint32_t OS_Tick_GetOverflow (void)
 {
   return (IRQ_GetPending(OSTM_IRQn));
 }
+#endif
 
 // Get Cortex-A9 OS Timer interrupt number
 IRQn_ID_t mbed_get_a9_tick_irqn(){
   return OSTM_IRQn;
 }
-
-#endif
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/serial_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/serial_api.c
@@ -592,7 +592,6 @@ void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->serial.uart->SCFTDR = c;
     serial_put_done(obj);
-    while ((obj->serial.uart->SCFSR & 0x40) == 0); // Wait TEND = 1
 }
 
 static void serial_put_done(serial_t *obj)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/serial_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/serial_api.c
@@ -592,6 +592,7 @@ void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->serial.uart->SCFTDR = c;
     serial_put_done(obj);
+    while ((obj->serial.uart->SCFSR & 0x40) == 0); // Wait TEND = 1
 }
 
 static void serial_put_done(serial_t *obj)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/sleep.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/sleep.c
@@ -128,6 +128,17 @@ void hal_deepsleep(void) {
     wk_CPGSTBCR13 = CPGSTBCR13;
 #endif
 
+    /* Waits for the serial transmission to complete */
+    const struct st_scif *SCIF[SCIF_COUNT] = SCIF_ADDRESS_LIST;
+
+    for (int uart = 0; uart < SCIF_COUNT; uart++) {
+        if ((wk_CPGSTBCR4 & (1 << (7 - uart))) == 0) {     // Is the power turned on?
+            if ((SCIF[uart]->SCSCR & 0x00A0) == 0x00A0) {  // Is transmission enabled? (TE = 1, TIE = 1)
+                while ((SCIF[uart]->SCFSR & 0x0040) == 0); // Waits for the transmission to complete (TEND = 1)
+            }
+        }
+    }
+
     /* MTU2 (for low power ticker) */
     CPGSTBCR3  |= ~(CPG_STBCR3_BIT_MSTP33);
     dummy_8    = CPGSTBCR3;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
Fix for issue https://github.com/ARMmbed/mbed-os-example-blinky-baremetal/issues/20  
I confirmed that ``mbed-os-example-blinky-baremetal`` can be built and blinky works properly.    
The following is the GR-PEACH build log. GR-LYCHEE and VK-RZ / A1H will build successfully as well.  
```
Building project mbed-os-example-blinky-baremetal (RZ_A1H, GCC_ARM)
Scan: mbed-os-example-blinky-baremetal
Link: mbed-os-example-blinky-baremetal
Elf2Bin: mbed-os-example-blinky-baremetal
| Module           |     .text |    .data |     .bss |
|------------------|-----------|----------|----------|
| [fill]           |    12(+0) |    6(+0) |   25(+0) |
| [lib]\c.a        | 16348(+0) | 2472(+0) |   89(+0) |
| [lib]\gcc.a      |  1008(+0) |    0(+0) |    0(+0) |
| [lib]\misc       |   252(+0) |    4(+0) |   28(+0) |
| [misc]           |     0(+0) |    0(+0) |    0(+0) |
| main.o           |   104(+0) |    0(+0) |   24(+0) |
| mbed-os\cmsis    |   896(+0) |    0(+0) | 4084(+0) |
| mbed-os\drivers  |   284(+0) |    0(+0) |    0(+0) |
| mbed-os\hal      |  2356(+0) |    8(+0) |  131(+0) |
| mbed-os\platform |  4528(+0) |  260(+0) |  188(+0) |
| mbed-os\targets  |  6524(+0) |    2(+0) |  723(+0) |
| Subtotals        | 32312(+0) | 2752(+0) | 5292(+0) |
Total Static RAM memory (data + bss): 8044(+0) bytes
Total Flash memory (text + data): 35064(+0) bytes

Image: .\BUILD\RZ_A1H\GCC_ARM\mbed-os-example-blinky-baremetal.bin
```
  
There was no problem when using RTOS (removed ``"requires": ["bare-metal"]`` in ``mbed_app.json``).
```
Building project mbed-os-example-blinky-baremetal (RZ_A1H, GCC_ARM)
Scan: mbed-os-example-blinky-baremetal
Link: mbed-os-example-blinky-baremetal
Elf2Bin: mbed-os-example-blinky-baremetal
| Module           |     .text |    .data |      .bss |
|------------------|-----------|----------|-----------|
| [fill]           |    24(+0) |   13(+0) |    28(+0) |
| [lib]\c.a        | 16348(+0) | 2472(+0) |    89(+0) |
| [lib]\gcc.a      |  1008(+0) |    0(+0) |     0(+0) |
| [lib]\misc       |   252(+0) |    4(+0) |    28(+0) |
| [misc]           |     0(+0) |    0(+0) |     0(+0) |
| main.o           |   104(+0) |    0(+0) |    24(+0) |
| mbed-os\cmsis    |  1292(+0) |    0(+0) |  4084(+0) |
| mbed-os\drivers  |   128(+0) |    0(+0) |     0(+0) |
| mbed-os\hal      |  2040(+0) |    4(+0) |    67(+0) |
| mbed-os\platform |  3624(+0) |  260(+0) |   136(+0) |
| mbed-os\rtos     | 11120(+0) |  173(+0) |  5972(+0) |
| mbed-os\targets  |  6420(+0) |    2(+0) |   720(+0) |
| Subtotals        | 42360(+0) | 2928(+0) | 11148(+0) |
Total Static RAM memory (data + bss): 14076(+0) bytes
Total Flash memory (text + data): 45288(+0) bytes

Image: .\BUILD\RZ_A1H\GCC_ARM\mbed-os-example-blinky-baremetal.bin
```
##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@toyowata 
<!--
    Optional
    Request additional reviewers with @username
-->

