### PR TITLE
ESP8266 "busy s..." fix (ONME-4352)

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -469,6 +469,7 @@ private:
     void _oob_tcp_data_hdlr();
     void _oob_ready();
     void _oob_scan_results();
+    void _oob_ok_received();
 
     // OOB state variables
     int _connect_error;
@@ -479,6 +480,7 @@ private:
     bool _error;
     bool _busy;
     bool _reset_done;
+    bool _ok_received;
 
     // Modem's address info
     char _ip_buffer[16];

--- a/platform/ATCmdParser.h
+++ b/platform/ATCmdParser.h
@@ -312,6 +312,12 @@ public:
     void oob(const char *prefix, mbed::Callback<void()> func);
 
     /**
+     * @brief remove_oob Removes oob callback handler
+     * @param prefix Prefix to identify oob to be removed.
+     */
+    void remove_oob(const char *prefix);
+
+    /**
      * Flushes the underlying stream
      */
     void flush();

--- a/platform/source/ATCmdParser.cpp
+++ b/platform/source/ATCmdParser.cpp
@@ -362,6 +362,25 @@ void ATCmdParser::oob(const char *prefix, Callback<void()> cb)
     _oobs = oob;
 }
 
+void ATCmdParser::remove_oob(const char *prefix)
+{
+    struct oob *prev = NULL;
+    struct oob *oob = _oobs;
+    while (oob) {
+        if (memcmp(oob->prefix, prefix, strlen(prefix)) == 0) {
+            if (prev) {
+                prev->next = oob->next;
+            } else {
+                _oobs = oob->next;
+            }
+            delete oob;
+            return;
+        }
+        prev = oob;
+        oob = oob->next;
+    }
+}
+
 void ATCmdParser::abort()
 {
     _aborted = true;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
ESP8266 modem might return "busy s..." when application tries to send. That means modem is still busy sending some previous data. ESP specification is not 100% accurate how this scenario should be treated, but we found some information that we should wait until we receive "SEND OK" from modem and then try again. This PR tries to do that.
This is not easy to reproduce so we will need approval from different stakeholders before we can merge this in. -> "do not merge" label added for now. 

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    [X] Manual/Custom testing needed
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@ARMmbed/mbed-os-ipcore @teetak01 @anttiylitokola 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes
Fix for https://jira.arm.com/browse/ONME-4352

##### Impact of changes

##### Migration actions required



