### PR TITLE
Adding baud rate setting to TLS and UDP echo burst tests

### DIFF
--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -28,6 +28,7 @@
 #include "utest/utest_stack_trace.h"
 #include "tls_tests.h"
 #include "cert.h"
+#include "CellularDevice.h"
 
 #ifndef ECHO_SERVER_ADDR
 #error [NOT_SUPPORTED] Requires parameters for echo server
@@ -150,6 +151,11 @@ utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(tls_global::TESTS_TIMEOUT, "default_auto");
     _ifup();
+
+#ifdef MBED_CONF_APP_BAUD_RATE
+    CellularDevice::get_default_instance()->set_baud_rate(MBED_CONF_APP_BAUD_RATE);
+#endif
+
     tc_bucket.start();
     return greentea_test_setup_handler(number_of_cases);
 }

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -21,6 +21,7 @@
 #include "unity/unity.h"
 #include "utest.h"
 #include "udp_tests.h"
+#include "CellularDevice.h"
 
 using namespace utest::v1;
 
@@ -70,6 +71,10 @@ static void _sigio_handler(osThreadId id)
 
 void UDPSOCKET_ECHOTEST_BURST()
 {
+#ifdef MBED_CONF_APP_BAUD_RATE
+    CellularDevice::get_default_instance()->set_baud_rate(MBED_CONF_APP_BAUD_RATE);
+#endif
+
     SocketAddress udp_addr;
     NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(ECHO_SERVER_PORT);
@@ -153,6 +158,10 @@ void UDPSOCKET_ECHOTEST_BURST()
 
 void UDPSOCKET_ECHOTEST_BURST_NONBLOCK()
 {
+#ifdef MBED_CONF_APP_BAUD_RATE
+    CellularDevice::get_default_instance()->set_baud_rate(MBED_CONF_APP_BAUD_RATE);
+#endif
+
     SocketAddress udp_addr;
     NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &udp_addr);
     udp_addr.set_port(ECHO_SERVER_PORT);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
Baud rate setting added to TLS tests and UDP echo burst tests.

##### Summary of change (*What the change is for and why*)
UDP echo burst tests are failing and TLS tests get stuck when run for WISE_1570 with baud rate 9600 but are fine with 115200 baud rate.
The changes allow the needed baud rate to be configured.

### Pull request type (*required*)
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

