### PR TITLE
Skip Bare Metal green tea test for PSA component

### DIFF
--- a/TESTS/mbedtls/selftest/main.cpp
+++ b/TESTS/mbedtls/selftest/main.cpp
@@ -18,7 +18,9 @@
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+#if defined(MBED_CONF_RTOS_PRESENT)
 #include "rtos.h"
+#endif
 
 using namespace utest::v1;
 

--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -16,6 +16,10 @@
 * limitations under the License.
 */
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA attestation test case requires RTOS to run.
+#else
+
 #include "psa/crypto.h"
 
 #if ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
@@ -157,3 +161,4 @@ int main()
 }
 
 #endif // ((!defined(TARGET_PSA)) || (!defined(MBEDTLS_PSA_CRYPTO_C)))
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/TESTS/psa/attestation/main.cpp
+++ b/TESTS/psa/attestation/main.cpp
@@ -17,7 +17,7 @@
 */
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA attestation test case requires RTOS to run.
+#error [NOT_SUPPORTED] PSA attestation test cases require RTOS to run.
 #else
 
 #include "psa/crypto.h"

--- a/TESTS/psa/its_ps/main.cpp
+++ b/TESTS/psa/its_ps/main.cpp
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-#ifndef TARGET_PSA
-#error [NOT_SUPPORTED] ITS/PS tests can run only on PSA-enabled targets.
+#if !defined(TARGET_PSA) || !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] ITS/PS tests can run only on PSA-enabled targets and RTOS.
 #else
 
 #include "greentea-client/test_env.h"
@@ -238,4 +238,4 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // TARGET_PSA
+#endif // TARGET_PSA || !defined(MBED_CONF_RTOS_PRESENT)

--- a/TESTS/psa/its_ps/main.cpp
+++ b/TESTS/psa/its_ps/main.cpp
@@ -16,8 +16,12 @@
 * limitations under the License.
 */
 
-#if !defined(TARGET_PSA) || !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] ITS/PS tests can run only on PSA-enabled targets and RTOS.
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] ITS/PS test cases require RTOS to run.
+#else
+
+#ifndef TARGET_PSA
+#error [NOT_SUPPORTED] ITS/PS tests can run only on PSA-enabled targets.
 #else
 
 #include "greentea-client/test_env.h"
@@ -238,4 +242,5 @@ int main()
     return !Harness::run(specification);
 }
 
-#endif // TARGET_PSA || !defined(MBED_CONF_RTOS_PRESENT)
+#endif // TARGET_PSA
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/main.c
@@ -1,9 +1,13 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance attestation test cases requires RTOS to run.
+#else
 void test_entry_a001(val_api_t *val_api, psa_api_t *psa_api); 
 
 int main(void)
 {
     test_start(test_entry_a001, COMPLIANCE_TEST_ATTESTATION);
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_attestation/test_a001/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance attestation test cases requires RTOS to run.
+#error [NOT_SUPPORTED] PSA compliance attestation test cases require RTOS to run.
 #else
 void test_entry_a001(val_api_t *val_api, psa_api_t *psa_api); 
 

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s001/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s001/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s001(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p001, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s001/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s001/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p001, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s002/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s002/main.c
@@ -1,6 +1,9 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 #include "lifecycle.h"
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
 
 #ifdef ITS_TEST
 void test_entry_s002(val_api_t *val_api, psa_api_t *psa_api);
@@ -16,3 +19,4 @@ int main(void)
     test_start(test_entry_p002, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s002/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s002/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 #include "lifecycle.h"
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p002, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s004/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s004/main.c
@@ -1,5 +1,8 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
 
 #ifdef ITS_TEST
 void test_entry_s004(val_api_t *val_api, psa_api_t *psa_api);
@@ -15,3 +18,4 @@ int main(void)
     test_start(test_entry_p004, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s004/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s004/main.c
@@ -1,7 +1,7 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -18,4 +18,4 @@ int main(void)
     test_start(test_entry_p004, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s005/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s005/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s005(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p005, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s005/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s005/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p005, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s006/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s006/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s006(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p006, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s006/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s006/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p006, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s007/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s007/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s007(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p007, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s007/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s007/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p007, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s008/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s008/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s008(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p008, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s008/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s008/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p008, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s009/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s009/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s009(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p009, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s009/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s009/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p009, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s010/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s010/main.c
@@ -1,6 +1,10 @@
 #include "val_interfaces.h"
 #include "pal_mbed_os_intf.h"
 
+#if !defined(MBED_CONF_RTOS_PRESENT)
+#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#else
+
 #ifdef ITS_TEST
 void test_entry_s010(val_api_t *val_api, psa_api_t *psa_api);
 #elif PS_TEST
@@ -15,3 +19,4 @@ int main(void)
     test_start(test_entry_p010, COMPLIANCE_TEST_STORAGE);
 #endif
 }
+#endif

--- a/components/TARGET_PSA/TESTS/compliance_its/test_s010/main.c
+++ b/components/TARGET_PSA/TESTS/compliance_its/test_s010/main.c
@@ -2,7 +2,7 @@
 #include "pal_mbed_os_intf.h"
 
 #if !defined(MBED_CONF_RTOS_PRESENT)
-#error [NOT_SUPPORTED] PSA compliance its test cases requires RTOS to run
+#error [NOT_SUPPORTED] PSA compliance its test cases require RTOS to run
 #else
 
 #ifdef ITS_TEST
@@ -19,4 +19,4 @@ int main(void)
     test_start(test_entry_p010, COMPLIANCE_TEST_STORAGE);
 #endif
 }
-#endif
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/features/frameworks/TARGET_PSA/pal/pal_mbed_os_intf.cpp
+++ b/features/frameworks/TARGET_PSA/pal/pal_mbed_os_intf.cpp
@@ -135,9 +135,11 @@ int test_start(test_entry_f test_f, compliance_test_type type)
 {
     test_g = test_f;
     type_g = type;
+#if defined(MBED_CONF_RTOS_PRESENT)
     MBED_ASSERT((type > COMPLIANCE_TEST_START) && (type < COMPLIANCE_TEST_END));
     Thread thread(osPriorityNormal, TEST_STACK_SIZE, NULL);
     thread.start(main_wrapper);
     thread.join();
+#endif
     return 0;
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
PSA test framework requires RTOS to run so added MBED_CONF_RTOS_PRESENT to all the test cases.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
1. PSA components get added to green tea test build based on targets.json.
2. PSA test framework uses RTOS threads and test cases run on this created threads.
3. Added MBED_CONF_RTOS_PRESENT guard to all PSA test cases to skip in the green tea test framework
- Note: These changes are done as identified that PSA component uses RTOS API and not a very detailed analysis of the component.

4. Tested the green tea test on below list of targets with bare metal config and added the logs in
IOTCORE-1397[https://jira.arm.com/browse/IOTCORE-1397] Jira ticket
- K64F
- K66F
- Nucleo F429ZI
- Nucleo F411RE
- Nucleo L073RZ
- Nucleo F207ZG
5. A main green tea test framework and mbed-os test cases change for bare metal is available in PR #11721

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@Patater @jamesbeyond @evedon @hugueskamba 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



