### PR TITLE
TLSSOCKET_HANDSHAKE_INVALID  test skip if  DNS AAA record not available.

### DIFF
--- a/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
+++ b/TESTS/netsocket/tls/tlssocket_handshake_invalid.cpp
@@ -30,6 +30,14 @@ void TLSSOCKET_HANDSHAKE_INVALID()
 {
     const int https_port = 443;
     SKIP_IF_TCP_UNSUPPORTED();
+
+#if (MBED_CONF_NSAPI_DEFAULT_STACK == NANOSTACK || (MBED_CONF_NSAPI_DEFAULT_STACK == LWIP && defined(MBED_CONF_LWIP_PPP_IPV6_ENABLED)))
+    SocketAddress address;
+    nsapi_error_t result = NetworkInterface::get_default_instance()->gethostbyname("expired.badssl.com", &address);
+    if (result != NSAPI_ERROR_OK) {
+        TEST_SKIP_MESSAGE(" badssl.com not supported IP6 AAA records");
+    }
+#endif
     TLSSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(NetworkInterface::get_default_instance()));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.set_root_ca_cert(tls_global::cert));


### PR DESCRIPTION

### Description (*required*)

TLSSOCKET_HANDSHAKE_INVALID  test skip if  DNS AAA record not available.

##### Summary of change (*What the change is for and why*)

TLS  test  sevrver " badssl.com"doesn't support DNS AAA records for IPV6.
To avoid test fail if  no IPV4 is chosen this test is skipped.
##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

 
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)


    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@SeppoTakalo 
@AnttiKauppila 
@michalpasztamobica 

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



