### PR TITLE
IOTBTOOL-333: Fix SimpleQueue build failure on py3

### DIFF
--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -556,9 +556,7 @@ class mbedToolchain:
                             ])
                         objects.append(result['object'])
                     except ToolException as err:
-                        if p._taskqueue.queue:
-                            p._taskqueue.queue.clear()
-                            sleep(0.5)
+                        # Stop the worker processes immediately without completing outstanding work
                         p.terminate()
                         p.join()
                         raise ToolException(err)


### PR DESCRIPTION

### Description (*required*)

The build system was using an internal feature of the Pool class that is unavailable
in a py3 system. This would cause an exception if tool execution failed.
Offending code has now been removed and tested on py3; error is no longer produced.

##### Summary of change (*What the change is for and why*)

See above

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

##### Summary of changes

##### Impact of changes

##### Migration actions required



