### PR TITLE
DISCO STM32H747I ETHERNET support, but disabled.

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32H7/TARGET_DISCO_H747I/stm32h7_eth_init.c
+++ b/features/netsocket/emac-drivers/TARGET_STM/TARGET_STM32H7/TARGET_DISCO_H747I/stm32h7_eth_init.c
@@ -1,0 +1,149 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define ETHERNET 1
+#if (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET)
+#if !defined(DISCO_H747I_ETHERNET_SOLDERBRIGE)
+#error Hardware modifications are required for Ethernet on DISCO_H747I. see https://os.mbed.com/teams/ST/wiki/DISCO_H747I-modifications-for-Ethernet
+#endif
+#endif
+
+#ifndef USE_USER_DEFINED_HAL_ETH_MSPINIT
+
+#include "stm32h7xx_hal.h"
+
+#define ETH_TX_EN_Pin GPIO_PIN_11
+#define ETH_TX_EN_GPIO_Port GPIOG
+#define ETH_TXD1_Pin GPIO_PIN_12
+#define ETH_TXD1_GPIO_Port GPIOG
+#define ETH_TXD0_Pin GPIO_PIN_13
+#define ETH_TXD0_GPIO_Port GPIOG
+#define ETH_MDC_SAI4_D1_Pin GPIO_PIN_1
+#define ETH_MDC_SAI4_D1_GPIO_Port GPIOC
+#define ETH_MDIO_Pin GPIO_PIN_2
+#define ETH_MDIO_GPIO_Port GPIOA
+#define ETH_REF_CLK_Pin GPIO_PIN_1
+#define ETH_REF_CLK_GPIO_Port GPIOA
+#define ETH_CRS_DV_Pin GPIO_PIN_7
+#define ETH_CRS_DV_GPIO_Port GPIOA
+#define ETH_RXD0_Pin GPIO_PIN_4
+#define ETH_RXD0_GPIO_Port GPIOC
+#define ETH_RXD1_Pin GPIO_PIN_5
+#define ETH_RXD1_GPIO_Port GPIOC
+
+
+/**
+ * Override HAL Eth Init function
+ */
+void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
+{
+    GPIO_InitTypeDef GPIO_InitStruct;
+    if(heth->Instance == ETH)
+    {
+        /* Disable DCache for STM32H7 family */
+        SCB_DisableDCache();
+
+        /* GPIO Ports Clock Enable */
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        // __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        __HAL_RCC_GPIOG_CLK_ENABLE();
+        // __HAL_RCC_GPIOH_CLK_ENABLE();
+
+        /* Enable Peripheral clock */
+        __HAL_RCC_ETH1MAC_CLK_ENABLE();
+        __HAL_RCC_ETH1TX_CLK_ENABLE();
+        __HAL_RCC_ETH1RX_CLK_ENABLE();
+
+    /**ETH GPIO Configuration    
+    PG11     ------> ETH_TX_EN
+    PG12     ------> ETH_TXD1
+    PG13     ------> ETH_TXD0
+    PC1     ------> ETH_MDC
+    PA2     ------> ETH_MDIO
+    PA1     ------> ETH_REF_CLK
+    PA7     ------> ETH_CRS_DV
+    PC4     ------> ETH_RXD0
+    PC5     ------> ETH_RXD1 
+    */
+    GPIO_InitStruct.Pin = ETH_TX_EN_Pin|ETH_TXD1_Pin|ETH_TXD0_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+    HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = ETH_MDC_SAI4_D1_Pin|ETH_RXD0_Pin|ETH_RXD1_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+    GPIO_InitStruct.Pin = ETH_MDIO_Pin|ETH_REF_CLK_Pin|ETH_CRS_DV_Pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF11_ETH;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    }
+}
+
+/**
+ * Override HAL Eth DeInit function
+ */
+void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
+{
+    if(heth->Instance == ETH)
+    {
+    /* Peripheral clock disable */
+    __HAL_RCC_ETH1MAC_CLK_DISABLE();
+    __HAL_RCC_ETH1TX_CLK_DISABLE();
+    __HAL_RCC_ETH1RX_CLK_DISABLE();
+  
+    /**ETH GPIO Configuration    
+    PG11     ------> ETH_TX_EN
+    PG12     ------> ETH_TXD1
+    PG13     ------> ETH_TXD0
+    PC1     ------> ETH_MDC
+    PA2     ------> ETH_MDIO
+    PA1     ------> ETH_REF_CLK
+    PA7     ------> ETH_CRS_DV
+    PC4     ------> ETH_RXD0
+    PC5     ------> ETH_RXD1 
+    */
+    HAL_GPIO_DeInit(GPIOG, ETH_TX_EN_Pin|ETH_TXD1_Pin|ETH_TXD0_Pin);
+
+    HAL_GPIO_DeInit(GPIOC, ETH_MDC_SAI4_D1_Pin|ETH_RXD0_Pin|ETH_RXD1_Pin);
+
+    HAL_GPIO_DeInit(GPIOA, ETH_MDIO_Pin|ETH_REF_CLK_Pin|ETH_CRS_DV_Pin);
+    }
+}
+
+#endif /* USE_USER_DEFINED_HAL_ETH_MSPINIT */

--- a/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM/stm32xx_emac.cpp
@@ -317,9 +317,7 @@ bool STM32_EMAC::low_level_init_successful()
 }
 #else // ETH_IP_VERSION_V2
 {
-    uint32_t idx, duplex, speed = 0;
-    int32_t PHYLinkState;
-    ETH_MACConfigTypeDef MACConf;
+    uint32_t idx;
 
     MPU_Config();
 

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I_CM7/TOOLCHAIN_ARM_STD/stm32h747xI.sct
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I_CM7/TOOLCHAIN_ARM_STD/stm32h747xI.sct
@@ -41,11 +41,25 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  
+
   RW_IRAM1 (MBED_RAM0_START) (MBED_RAM0_SIZE-Stack_Size)  {  ; RW data
    .ANY (+RW +ZI)
   }
 
   ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
+
+  RW_DMARxDscrTab 0x30040000 0x60 {
+    *(.RxDecripSection)
+  }
+  RW_DMATxDscrTab 0x30040100 0x140 {
+    *(.TxDecripSection)
+  }
+  RW_Rx_Buffb 0x30040400 0x1800 {
+    *(.RxArraySection)
+  }
+  RW_Eth_Ram 0x30044000 0x4000 {
+    *(.ethusbram)
+  }
+
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I_CM7/TOOLCHAIN_GCC_ARM/STM32H747xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I_CM7/TOOLCHAIN_GCC_ARM/STM32H747xI.ld
@@ -183,4 +183,19 @@ SECTIONS
 
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+    .lwip_sec (NOLOAD) : {
+        . = ABSOLUTE(0x30040000);
+        *(.RxDecripSection)
+
+        . = ABSOLUTE(0x30040100);
+        *(.TxDecripSection)
+
+        . = ABSOLUTE(0x30040400);
+        *(.RxArraySection)
+
+        . = ABSOLUTE(0x30044000);
+        *(.ethusbram)
+
+    } >RAM_D2 AT> FLASH
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I_CM7/TOOLCHAIN_IAR/stm32h747xI.icf
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H747xI/TARGET_DISCO_H747I_CM7/TOOLCHAIN_IAR/stm32h747xI.icf
@@ -37,6 +37,10 @@ define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
+// Memory region used for ethernet
+define region eth_mem_region = mem:[from 0x30044000 to 0x30048000 ];
+place in eth_mem_region	{ section .ethusbram };
+
 // Stack and Heap
 define symbol __size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __size_heap__   = 0x10000; // 64KB


### PR DESCRIPTION
### Description 
Add support of ethernet for DISCO_H747I,
Ethernet is disabled by default, because some hardware modifications are required on the board DISCO_H747I.
see https://os.mbed.com/teams/ST/wiki/DISCO_H747I-modifications-for-Ethernet

By default, all necessary DISCO_H747I MCU pins for ethernet are not connected ethernet controller (but instead are used for audio use cases). Consequently following modifications are requitred in order to use ethernet on DISCO_H747I:

1) Hardware:
Modify solder bridges and resistor as below (for details, refer to STM32H747I-DISCO board user manual https://www.st.com/resource/en/user_manual/dm00504240.pdf):

   * SB21, SB45 and R87 should be opened
   * SB22, SB44, SB17 and SB8 should be closed

2) Software:
Create (or update) file 'mbed_app.json':

```
{
    "target_overrides": {
        "DISCO_H747I": {
            "target.network-default-interface-type": "ETHERNET",
            "target.macros_add": [
                "DISCO_H747I_ETHERNET_SOLDERBRIGE"
            ],
            "target.device_has_add": [
                "EMAC"
            ]
        }
    }
}
```
----------------------------------------------------------------------------------------------------------------
### Pull request type
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

All tests 'netsocket...'  are PASSED with IAR, GCC_ARM and ARM.





