### PR TITLE
USB STM32: Don't wrap direct function calls in MBED_ASSERT

### DIFF
--- a/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -239,7 +239,8 @@ void USBPhyHw::init(USBPhyEvents *events)
     // Configure PCD and FIFOs
     hpcd.pData = (void *)this;
     hpcd.State = HAL_PCD_STATE_RESET;
-    MBED_ASSERT(HAL_PCD_Init(&hpcd) == HAL_OK);
+    HAL_StatusTypeDef ret = HAL_PCD_Init(&hpcd);
+    MBED_ASSERT(ret == HAL_OK);
 
 
     uint32_t total_bytes = 0;
@@ -272,7 +273,9 @@ void USBPhyHw::init(USBPhyEvents *events)
 
 void USBPhyHw::deinit()
 {
-    MBED_ASSERT(HAL_PCD_DeInit(&hpcd) == HAL_OK);
+    HAL_StatusTypeDef ret = HAL_PCD_DeInit(&hpcd);
+    MBED_ASSERT(ret == HAL_OK);
+
     NVIC_DisableIRQ(USBHAL_IRQn);
 
     if (events != NULL) {
@@ -288,12 +291,14 @@ bool USBPhyHw::powered()
 
 void USBPhyHw::connect()
 {
-    MBED_ASSERT(HAL_PCD_Start(&hpcd) == HAL_OK);
+    HAL_StatusTypeDef ret = HAL_PCD_Start(&hpcd);
+    MBED_ASSERT(ret == HAL_OK);
 }
 
 void USBPhyHw::disconnect()
 {
-    MBED_ASSERT(HAL_PCD_Stop(&hpcd) == HAL_OK);
+    HAL_StatusTypeDef ret = HAL_PCD_Stop(&hpcd);
+    MBED_ASSERT(ret == HAL_OK);
 }
 
 void USBPhyHw::configure()
@@ -318,7 +323,8 @@ void USBPhyHw::sof_disable()
 
 void USBPhyHw::set_address(uint8_t address)
 {
-    MBED_ASSERT(HAL_PCD_SetAddress(&hpcd, address) == HAL_OK);
+    HAL_StatusTypeDef ret = HAL_PCD_SetAddress(&hpcd, address);
+    MBED_ASSERT(ret == HAL_OK);
 }
 
 void USBPhyHw::remote_wakeup()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Restore USB functionality on STM32 target if `-DNDEBUG` is specified as CFLAGS

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)


dab09f313836b797eb7886d06b40b631d4a94755 added checks on some functions in the form of MBED_ASSERT on the result.
Compiling with -DNDEBUG elides the call, thus breaking the functionality

This patch restores it, while leaving the return check if compiled with standard profile.


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
```C++
 #include "mbed.h"
 #include "USBSerial.h"

USBSerial ser;

int main() {
      while(true) {
      }
      return 0;
}
```

Compiling against 355336ce437d1b6b2b6c9c3addf7492a6f15e364 with `-DNDEBUG` doesn't enumerate the USB peripheral.

    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@jeromecoutant 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



