### PR TITLE
BLE: Added call to delete the security database object upon SM reset. 

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
@@ -137,6 +137,7 @@ ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::setData
 
 template<template<class> class TPalSecurityManager, template<class> class SigningMonitor>
 ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::reset_(void) {
+    delete _db;
     _pal.reset();
     SecurityManager::reset_();
 


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

This patch deletes the security database object upon calling `SecurityManager::reset()`.

Resolves #11768 (for now...)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

Previously, there was no normal method to have the security manager close the security database file (if using a file-based security database, as the Mbed SM does if not using a volatile, RAM-based database). 

In some cases, this prevented the file from ever being fully flushed to flash if using a block device or filesystem that buffers write operations. The result of this was that for some applications/targets there was no official way to get BLE bonding persistence to work.

This fix allows the file to be closed by the OS and flushed to disk upon calling `SecurityManager::reset()`.

Users should note that if calling `SecurityManager::reset()` to flush the database file to flash, they will also have to reinitialize the SecurityManager (set up an event handler, configure settings, etc).


##### Documentation (*Details of any document updates required*)

See issue #11768 for details.

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

I identified the problem and fix through the following method:

Tested on target: `EP_AGORA` but should be same for all nRF52840-based targets.

1.) Upon startup, application initializes `SPIFBlockDevice` and FATFileSystem (also used LittleFileSystem with same results)
2.) BLE was initialized and SecurityManager configured to write to a file -- `/fs/sec.dat`
3.) nRFConnect and an nRF52840_DK were used to connect and pair/bond with the target -- triggering the SecurityManager to store keys related to the connection
4.) Upon disconnection, a USBMSD object was created to present the FATFileSystem as a mass storage device to my laptop
5.) While the file existed in both cases, when I inspected the size and content of the file I found that **with the code currently in master the file was never written to -- size of 0 bytes**. With this fix, the file is correctly written to and is 568 or so bytes in size.

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@paul-szczepanek-arm
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



