### PR TITLE
Fix flag checks to allow disabling unsecure tests

### DIFF
--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -34,15 +34,15 @@
     !defined(MBED_CONF_APP_WIFI_CH_SECURE)     || \
     !defined(MBED_CONF_APP_WIFI_PASSWORD)      || \
     !defined(MBED_CONF_APP_WIFI_SECURE_SSID)   || \
-    !defined MBED_CONF_APP_WIFI_SECURE_PROTOCOL)
+    !defined(MBED_CONF_APP_WIFI_SECURE_PROTOCOL))
 #error [NOT_SUPPORTED] Requires parameters from mbed_app.json (for secure connections)
 #else
 
 #if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID) &&  \
-    !defined(MBED_CONF_APP_AP_MAC_UNSECURE)    || \
+   (!defined(MBED_CONF_APP_AP_MAC_UNSECURE)    || \
     !defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
     !defined(MBED_CONF_APP_WIFI_CH_UNSECURE)   || \
-    !defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
+    !defined(MBED_CONF_APP_WIFI_UNSECURE_SSID))
 #error [NOT_SUPPORTED] Requires parameters from mbed_app.json (for unsecure connections)
 #else
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
Fixed checking of configuration for unsecure tests to allow easier disabling of it. Now unsecure tests can be disabled by just removing MBED_CONF_APP_WIFI_UNSECURE_SSID configuration from json (similar to secure tests).
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

This is just a test set up configuration change. In CI both secure and unsecure are tested but after this fix, it is easier to run just secure tests.

<!--
    Required
    For example, add test results for new target
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



