### PR TITLE
SerialBase.h|cpp [-Wreorder] compiler warning fix

### DIFF
--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -329,26 +329,26 @@ protected:
 
 #if DEVICE_SERIAL_ASYNCH
     CThunk<SerialBase> _thunk_irq;
-    DMAUsage _tx_usage;
-    DMAUsage _rx_usage;
+    DMAUsage _tx_usage = DMA_USAGE_NEVER;
+    DMAUsage _rx_usage = DMA_USAGE_NEVER;
     event_callback_t _tx_callback;
     event_callback_t _rx_callback;
-    bool _tx_asynch_set;
-    bool _rx_asynch_set;
+    bool _tx_asynch_set = false;
+    bool _rx_asynch_set = false;
 #endif
 
-    serial_t         _serial;
+    serial_t         _serial {};
     Callback<void()> _irq[IrqCnt];
     int              _baud;
-    bool             _rx_enabled;
-    bool             _tx_enabled;
+    bool             _rx_enabled = true;
+    bool             _tx_enabled = true;
     const PinName    _tx_pin;
     const PinName    _rx_pin;
 
 #if DEVICE_SERIAL_FC
-    Flow             _flow_type;
-    PinName          _flow1;
-    PinName          _flow2;
+    Flow             _flow_type = Disabled;
+    PinName          _flow1 = NC;
+    PinName          _flow2 = NC;
 #endif
 
 #endif

--- a/drivers/source/SerialBase.cpp
+++ b/drivers/source/SerialBase.cpp
@@ -25,20 +25,9 @@ namespace mbed {
 
 SerialBase::SerialBase(PinName tx, PinName rx, int baud) :
 #if DEVICE_SERIAL_ASYNCH
-    _thunk_irq(this), _tx_usage(DMA_USAGE_NEVER),
-    _rx_usage(DMA_USAGE_NEVER), _tx_callback(NULL),
-    _rx_callback(NULL), _tx_asynch_set(false),
-    _rx_asynch_set(false),
+    _thunk_irq(this),
 #endif
-    _serial(),
     _baud(baud),
-#if DEVICE_SERIAL_FC
-    _flow_type(Disabled),
-    _flow1(NC),
-    _flow2(NC),
-#endif
-    _rx_enabled(true),
-    _tx_enabled(true),
     _tx_pin(tx),
     _rx_pin(rx)
 {


### PR DESCRIPTION
### Description (*required*)

The initialization order was not quite right, so aligning the .cpp
to match order .h.  This hixes the following compiler warning:

```
[Warning] SerialBase.h@351,22: 'mbed::SerialBase::_flow2' will be initialized after [-Wreorder]
[Warning] SerialBase.h@343,22:   'bool mbed::SerialBase::_rx_enabled' [-Wreorder]
[Warning] SerialBase.cpp@26,1:   when initialized here [-Wreorder]

```
##### Summary of change (*What the change is for and why*)

Fix compiler warning in SerialBase.h|cpp.

##### Documentation (*Details of any document updates required*)

None.

### Pull request type (*required*)

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
### Release Notes (*required for feature/major PRs*)

Not worth mentioning in release notes.
