### PR TITLE
EFM32: Enable RESET_REASON and WATCHDOG for EFM32GG11_STK3701

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7000,6 +7000,7 @@
             "PORTOUT",
             "PWMOUT",
             "QSPI",
+            "RESET_REASON",
             "RTC",
             "SERIAL",
             "SERIAL_ASYNCH",
@@ -7011,7 +7012,8 @@
             "USTICKER",
             "TRNG",
             "FLASH",
-            "MPU"
+            "MPU",
+            "WATCHDOG"
         ],
         "forced_reset_timeout": 5,
         "config": {


### PR DESCRIPTION
### Description _(required)_

All EFM32 targets list `RESET_REASON` and `WATCHDOG` in `device_has`, apart of EFM32GG11_STK3701. There seems to be no reason for this, it was probably just missed by mistake. I have validated both features on a physical device and confirmed that they work.

----------------------------------------------------------------------------------------------------------------
### Pull request type _(required)_

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results _(required)_

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

##### Migration actions required _(required)_

None.

