### PR TITLE
Remove ITM Trace support from Arduino Nano 33 BLE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7894,7 +7894,7 @@
         "features_add": ["BLE", "STORAGE"],
         "components_remove": ["QSPIF"],
         "components_add": ["FLASHIAP"],
-        "device_has_remove": ["QSPI"],
+        "device_has_remove": ["QSPI", "ITM"],
         "device_has_add": ["FLASH"],
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description

Remove ITM Trace support from Arduino Nano 33 BLE target definition.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change

Arduino Nano 33 BLE doesn't expose ITM Trace pins which instead are used for external I2C.

When ITM trace is enabled applications need to reset both `CoreDebug->DEMCR` and `NRF_CLOCK->TRACECONFIG` in user code to get I2C working. `CoreDebug->DEMCR` and `NRF_CLOCK->TRACECONFIG` are otherwise configured at [SystemInit](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/system_nrf52840.c#L201).

This patch removes `ITM` from target features.

----------------------------------------------------------------------------------------------------------------
### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

<!--
    Required
    For example, add test results for new target
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
   



