### PR TITLE
Add Mbed Bootloader to be build on every PR.

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -475,6 +475,22 @@
         "baud_rate": 9600,
         "compare_log": ["mbed-os-example-atecc608a/tests/atecc608a.log"],
         "auto-update" : true
+    },
+    {
+        "name": "mbed-bootloader",
+        "github":"https://github.com/ARMmbed/mbed-bootloader",
+        "sub-repo-example": false,
+        "subs": [],
+        "features" : [],
+        "targets" : ["K64F", "DISCO_L475VG_IOT01A", "NRF52840_DK", "NUCLEO_F303RE", "NUCLEO_F429ZI"],
+        "toolchains" : ["GCC_ARM"],
+        "exporters": [],
+        "compile" : true,
+        "export": false,
+        "test" : false,
+        "baud_rate": 115200,
+        "compare_log": ["mbed-bootloader/TESTS/booting.log"],
+        "auto-update" : true
     }
   ]
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Add Mbed Bootloader to be build on every PR.

This is done by adding Mbed Bootloader into `examples.json` with some targets. Mbed OS scripts will automatically fetch and build the bootloader against PRs.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

Add Mbed Bootloader as one of the examples.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@jamesbeyond @VeliMattiLahtela 


