### PR TITLE
Deprecation of ticker attach(float) and attach_us functions

### DIFF
--- a/TESTS/mbed_drivers/lp_ticker/main.cpp
+++ b/TESTS/mbed_drivers/lp_ticker/main.cpp
@@ -201,7 +201,7 @@ void test_attach_us_time(void)
     TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US(DELAY_US), DELAY_US, time_diff);
 }
 
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
 /** Test single callback time via attach(Callback<void()> func, std::chrono::microseconds t)
 
     Given a Ticker
@@ -229,22 +229,22 @@ void test_attach_chrono_microseconds(void)
 Case cases[] = {
     Case("Test attach for 0.001s and time measure", test_attach_time<1000>),
     Case("Test attach_us for 1ms and time measure", test_attach_us_time<1000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach_us for std::chrono::microseconds(1000) and time measure", test_attach_chrono_microseconds<1000>),
 #endif
     Case("Test attach for 0.01s and time measure", test_attach_time<10000>),
     Case("Test attach_us for 10ms and time measure", test_attach_us_time<10000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach_us for std::chrono::microseconds(10000) and time measure", test_attach_chrono_microseconds<10000>),
 #endif
     Case("Test attach for 0.1s and time measure", test_attach_time<100000>),
     Case("Test attach_us for 100ms and time measure", test_attach_us_time<100000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach_us for std::chrono::microseconds(100000) and time measure", test_attach_chrono_microseconds<100000>),
 #endif
     Case("Test attach for 0.5s and time measure", test_attach_time<500000>),
     Case("Test attach_us for 500ms and time measure", test_attach_us_time<500000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach_us for std::chrono::microseconds(500000) and time measure", test_attach_chrono_microseconds<500000>),
 #endif
     Case("Test detach", test_detach),

--- a/TESTS/mbed_drivers/lp_ticker/main.cpp
+++ b/TESTS/mbed_drivers/lp_ticker/main.cpp
@@ -201,16 +201,52 @@ void test_attach_us_time(void)
     TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US(DELAY_US), DELAY_US, time_diff);
 }
 
+#if __cplusplus >= 201103 && !defined __CC_ARM
+/** Test single callback time via attach(Callback<void()> func, std::chrono::microseconds t)
+
+    Given a Ticker
+    When callback attached with time interval specified
+    Then ticker properly executes callback within a specified time interval
+ */
+template<us_timestamp_t DELAY_US>
+void test_attach_chrono_microseconds(void)
+{
+    LowPowerTicker ticker;
+    ticker_callback_flag = 0;
+
+    gtimer.reset();
+    gtimer.start();
+    ticker.attach(callback(stop_gtimer_set_flag), std::chrono::microseconds(DELAY_US));
+    while (!ticker_callback_flag);
+    ticker.detach();
+    const int time_diff = gtimer.read_us();
+
+    TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US(DELAY_US), DELAY_US, time_diff);
+}
+#endif
+
 // Test cases
 Case cases[] = {
     Case("Test attach for 0.001s and time measure", test_attach_time<1000>),
     Case("Test attach_us for 1ms and time measure", test_attach_us_time<1000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach_us for std::chrono::microseconds(1000) and time measure", test_attach_chrono_microseconds<1000>),
+#endif
     Case("Test attach for 0.01s and time measure", test_attach_time<10000>),
     Case("Test attach_us for 10ms and time measure", test_attach_us_time<10000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach_us for std::chrono::microseconds(10000) and time measure", test_attach_chrono_microseconds<10000>),
+#endif
     Case("Test attach for 0.1s and time measure", test_attach_time<100000>),
     Case("Test attach_us for 100ms and time measure", test_attach_us_time<100000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach_us for std::chrono::microseconds(100000) and time measure", test_attach_chrono_microseconds<100000>),
+#endif
     Case("Test attach for 0.5s and time measure", test_attach_time<500000>),
     Case("Test attach_us for 500ms and time measure", test_attach_us_time<500000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach_us for std::chrono::microseconds(500000) and time measure", test_attach_chrono_microseconds<500000>),
+#endif
     Case("Test detach", test_detach),
     Case("Test multi call and time measure", test_multi_call_time),
     Case("Test multi ticker", test_multi_ticker),

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -323,15 +323,81 @@ void test_attach_us_time(void)
     TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US, DELAY_US, time_diff);
 }
 
+#if __cplusplus >= 201103 && !defined __CC_ARM
+/** Test single callback time via attach(Callback<void()> func, std::chrono::microseconds t)
+
+    Given a Ticker
+    When callback attached with time interval specified
+    Then ticker properly executes callback within a specified time interval
+ */
+template<us_timestamp_t DELAY_US>
+void test_attach_chrono_microseconds(void)
+{
+    Ticker ticker;
+    ticker_callback_flag = 0;
+
+    gtimer.reset();
+    gtimer.start();
+    ticker.attach(callback(stop_gtimer_set_flag), std::chrono::microseconds(DELAY_US));
+    while (!ticker_callback_flag);
+    ticker.detach();
+    const int time_diff = gtimer.read_us();
+
+    TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US, DELAY_US, time_diff);
+}
+
+void test_attach_chrono_literals_10ms(void)
+{
+    Ticker ticker;
+    ticker_callback_flag = 0;
+    us_timestamp_t DELAY_US = 10000;
+
+    gtimer.reset();
+    gtimer.start();
+    ticker.attach(callback(stop_gtimer_set_flag), 10ms);
+    while (!ticker_callback_flag);
+    ticker.detach();
+    const int time_diff = gtimer.read_us();
+
+    TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US, DELAY_US, time_diff);
+}
+
+void test_attach_chrono_literals_10000us(void)
+{
+    Ticker ticker;
+    ticker_callback_flag = 0;
+    us_timestamp_t DELAY_US = 10000;
+
+    gtimer.reset();
+    gtimer.start();
+    ticker.attach(callback(stop_gtimer_set_flag), 10000us);
+    while (!ticker_callback_flag);
+    ticker.detach();
+    const int time_diff = gtimer.read_us();
+
+    TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US, DELAY_US, time_diff);
+}
+#endif
 
 // Test cases
 Case cases[] = {
     Case("Test attach for 0.01s and time measure", test_attach_time<10000>),
     Case("Test attach_us for 10ms and time measure", test_attach_us_time<10000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach for std::chrono::microseconds(10000) and time measure", test_attach_chrono_microseconds<10000>),
+#endif
     Case("Test attach for 0.1s and time measure", test_attach_time<100000>),
     Case("Test attach_us for 100ms and time measure", test_attach_us_time<100000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach_us for std::chrono::microseconds(100000) and time measure", test_attach_chrono_microseconds<100000>),
+#endif
     Case("Test attach for 0.5s and time measure", test_attach_time<500000>),
     Case("Test attach_us for 500ms and time measure", test_attach_us_time<500000>),
+#if __cplusplus >= 201103 && !defined __CC_ARM
+    Case("Test attach_us for std::chrono::microseconds(500000) and time measure", test_attach_chrono_microseconds<500000>),
+    Case("Test attach chrono literals 10ms and time measure", test_attach_chrono_literals_10ms),
+    Case("Test attach chrono literals 10000us and time measure", test_attach_chrono_literals_10000us),
+#endif
     Case("Test detach", test_detach),
     Case("Test multi call and time measure", test_multi_call_time),
     Case("Test multi ticker", test_multi_ticker),

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -323,7 +323,7 @@ void test_attach_us_time(void)
     TEST_ASSERT_UINT64_WITHIN(TOLERANCE_US, DELAY_US, time_diff);
 }
 
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
 /** Test single callback time via attach(Callback<void()> func, std::chrono::microseconds t)
 
     Given a Ticker
@@ -383,17 +383,17 @@ void test_attach_chrono_literals_10000us(void)
 Case cases[] = {
     Case("Test attach for 0.01s and time measure", test_attach_time<10000>),
     Case("Test attach_us for 10ms and time measure", test_attach_us_time<10000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach for std::chrono::microseconds(10000) and time measure", test_attach_chrono_microseconds<10000>),
 #endif
     Case("Test attach for 0.1s and time measure", test_attach_time<100000>),
     Case("Test attach_us for 100ms and time measure", test_attach_us_time<100000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach_us for std::chrono::microseconds(100000) and time measure", test_attach_chrono_microseconds<100000>),
 #endif
     Case("Test attach for 0.5s and time measure", test_attach_time<500000>),
     Case("Test attach_us for 500ms and time measure", test_attach_us_time<500000>),
-#if __cplusplus >= 201103 && !defined __CC_ARM
+#if !defined __CC_ARM
     Case("Test attach_us for std::chrono::microseconds(500000) and time measure", test_attach_chrono_microseconds<500000>),
     Case("Test attach chrono literals 10ms and time measure", test_attach_chrono_literals_10ms),
     Case("Test attach chrono literals 10000us and time measure", test_attach_chrono_literals_10000us),

--- a/drivers/source/Ticker.cpp
+++ b/drivers/source/Ticker.cpp
@@ -65,6 +65,16 @@ void Ticker::handler()
 
 void Ticker::attach_us(Callback<void()> func, us_timestamp_t t)
 {
+    do_attach_us(func, t);
+}
+
+void Ticker::attach(Callback<void()> func, std::chrono::microseconds t)
+{
+    do_attach_us(func, t.count());
+}
+
+void Ticker::do_attach_us(Callback<void()> func, us_timestamp_t t)
+{
     core_util_critical_section_enter();
     // lock only for the initial callback setup and this is not low power ticker
     if (!_function && _lock_deepsleep) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Deprecation of Ticker::attach(float) and Ticker::attach_us in favour of Ticker::attach(std::duration).

Notes: 
- It is not required to provide an ARMC5 implementation for attach(std::duration) because the deprecated APIs should be removed at the same time as support for ARMC5 stops. 
- Internal usage of deprecated APIs will be removed in a subsequent PR (post 5.15) 

##### Summary of change (*What the change is for and why*)

APIs marked as deprecated in 5.15.
Greentea test cases added for the new API.

##### Documentation (*Details of any document updates required*)

https://os.mbed.com/docs/mbed-os/v5.14/apis/ticker.html should be updated. Most of the update should come from doxygen updates. Code snippet should be updated to use the new API.

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->
@kjbracey-arm 

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

The following Ticker APIs have been deprecated:
```
void attach(F &&func, float t);
void attach_us(Callback<void()> func, us_timestamp_t t);;
```

The new API to use is: 
```
void attach(Callback<void()> func, std::chrono::duration<Rep, Period> t)
```

##### Impact of changes

##### Migration actions required



