### PR TITLE
Replace calls to printf() with mbed-trace in netsocket tests

### DIFF
--- a/TESTS/integration/COMMON/common_defines_test.h
+++ b/TESTS/integration/COMMON/common_defines_test.h
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "GRNT"
 
 #define ETHERNET 1
 #define WIFI 2

--- a/TESTS/integration/COMMON/download_test.cpp
+++ b/TESTS/integration/COMMON/download_test.cpp
@@ -27,6 +27,7 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 #include <string>
+#include "common_defines_test.h"
 
 #define MAX_THREADS 5
 
@@ -93,7 +94,7 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
             break;
         }
         ThisThread::sleep_for(1000);
-        printf("[NET-%d] Connection failed. Retry %d of %d\r\n", thread_id, tries, MAX_RETRIES);
+        tr_info("[NET-%d] Connection failed. Retry %d of %d", thread_id, tries, MAX_RETRIES);
     }
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, result, "failed to connect");
 
@@ -111,7 +112,7 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
     } else {
         TEST_ASSERT_MESSAGE(0, "wrong thread id");
     }
-    printf("[NET-%d] Registered socket callback function\r\n", thread_id);
+    tr_info("[NET-%d] Registered socket callback function", thread_id);
     event_fired[thread_id] = false;
 
     /* setup request */
@@ -120,7 +121,7 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
     /* construct request */
     size_t req_len = snprintf(request, REQ_BUF_SIZE - 1, req_template, dl_path, dl_host);
     request[req_len] = 0;
-    printf("[NET-%d] Request header (%u): %s\r\n", thread_id, req_len, request);
+    tr_info("[NET-%d] Request header (%u): %s", thread_id, req_len, request);
 
     /* send request to server */
     result = tcpsocket.send(request, req_len);
@@ -130,7 +131,7 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
     char *receive_buffer = &g_receive_buffer[thread_id * RECV_BUF_SIZE];
 
     tcpsocket.set_blocking(false);
-    printf("[NET-%d] Non-blocking socket mode set\r\n", thread_id);
+    tr_info("[NET-%d] Non-blocking socket mode set", thread_id);
 
     size_t received_bytes = 0;
     int body_index = -1;
@@ -166,7 +167,7 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
                     if (body_index < 0) {
                         continue;
                     } else {
-                        printf("[NET-%d] Found body index: %d\r\n", thread_id, body_index);
+                        tr_info("[NET-%d] Found body index: %d", thread_id, body_index);
 
                         /* remove header before comparison */
                         memmove(receive_buffer, &receive_buffer[body_index + 4], result - body_index - 4);
@@ -186,9 +187,9 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
                 speed = float(received_bytes) / timer.read();
                 percent = float(received_bytes) * 100 / float(data_length);
                 time_left = (data_length - received_bytes) / speed;
-                printf("[NET-%d] Received bytes: %u, (%.2f%%, %.2fKB/s, ETA: %02d:%02d:%02d)\r\n",
-                       thread_id, received_bytes, percent, speed / 1024,
-                       time_left / 3600, (time_left / 60) % 60, time_left % 60);
+                tr_info("[NET-%d] Received bytes: %u, (%.2f%%, %.2fKB/s, ETA: %02d:%02d:%02d)",
+                        thread_id, received_bytes, percent, speed / 1024,
+                        time_left / 3600, (time_left / 60) % 60, time_left % 60);
             }
         } while ((result > 0) && (received_bytes < data_length));
     }
@@ -197,10 +198,10 @@ size_t download_test(NetworkInterface *interface, const unsigned char *data, siz
 
     timer.stop();
     float f_received_bytes = float(received_bytes);
-    printf("[NET-%d] Downloaded: %.2fKB (%.2fKB/s, %.2f secs)\r\n", thread_id,
-           f_received_bytes / 1024.,
-           f_received_bytes / (timer.read() * 1024.),
-           timer.read());
+    tr_info("[NET-%d] Downloaded: %.2fKB (%.2fKB/s, %.2f secs)", thread_id,
+            f_received_bytes / 1024.,
+            f_received_bytes / (timer.read() * 1024.),
+            timer.read());
 
     return received_bytes;
 }

--- a/TESTS/integration/COMMON/file_test.cpp
+++ b/TESTS/integration/COMMON/file_test.cpp
@@ -24,6 +24,7 @@
 
 #include "mbed.h"
 #include "unity/unity.h"
+#include "common_defines_test.h"
 
 void file_test_write(const char *file, size_t offset, const unsigned char *data, size_t data_length, size_t block_size)
 {
@@ -58,8 +59,8 @@ void file_test_write(const char *file, size_t offset, const unsigned char *data,
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, result, "could not close file");
 
     timer.stop();
-    printf("[FS] Wrote: \"%s\" %.2fKB (%.2fKB/s, %.2f secs)\r\n", file,
-           float(data_length) / 1024, float(data_length) / timer.read() / 1024, timer.read());
+    tr_info("[FS] Wrote: \"%s\" %.2fKB (%.2fKB/s, %.2f secs)", file,
+            float(data_length) / 1024, float(data_length) / timer.read() / 1024, timer.read());
 }
 
 void file_test_read(const char *file, size_t offset, const unsigned char *data, size_t data_length, size_t block_size)
@@ -100,8 +101,8 @@ void file_test_read(const char *file, size_t offset, const unsigned char *data, 
 
     free(buffer);
 
-    printf("[FS] Read : \"%s\" %.2fKB (%.2fKB/s, %.2f secs)\r\n", file,
-           float(data_length) / 1024, float(data_length) / timer.read() / 1024, timer.read());
+    tr_info("[FS] Read : \"%s\" %.2fKB (%.2fKB/s, %.2f secs)", file,
+            float(data_length) / 1024, float(data_length) / timer.read() / 1024, timer.read());
 }
 
 #endif //#if INTEGRATION_TESTS

--- a/TESTS/integration/net-single/main.cpp
+++ b/TESTS/integration/net-single/main.cpp
@@ -68,12 +68,12 @@ static control_t setup_network(const size_t call_count)
         if (err == NSAPI_ERROR_OK) {
             break;
         } else {
-            printf("[ERROR] Connecting to network. Retrying %d of %d.\r\n", tries, MAX_RETRIES);
+            tr_error("[ERROR] Connecting to network. Retrying %d of %d.", tries, MAX_RETRIES);
         }
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("[NET] IP address is '%s'\n", interface->get_ip_address());
-    printf("[NET] MAC address is '%s'\n", interface->get_mac_address());
+    tr_info("[NET] IP address is '%s'", interface->get_ip_address());
+    tr_info("[NET] MAC address is '%s'", interface->get_mac_address());
     return CaseNext;
 }
 

--- a/TESTS/integration/net-threaded/main.cpp
+++ b/TESTS/integration/net-threaded/main.cpp
@@ -68,12 +68,12 @@ static control_t setup_network(const size_t call_count)
         if (err == NSAPI_ERROR_OK) {
             break;
         } else {
-            printf("[ERROR] Connecting to network. Retrying %d of %d.\r\n", tries, MAX_RETRIES);
+            tr_error("[ERROR] Connecting to network. Retrying %d of %d.", tries, MAX_RETRIES);
         }
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("[NET] IP address is '%s'\n", net->get_ip_address());
-    printf("[NET] MAC address is '%s'\n", net->get_mac_address());
+    tr_info("[NET] IP address is '%s'", net->get_ip_address());
+    tr_info("[NET] MAC address is '%s'", net->get_mac_address());
     return CaseNext;
 }
 

--- a/TESTS/integration/stress-net-fs/main.cpp
+++ b/TESTS/integration/stress-net-fs/main.cpp
@@ -73,12 +73,12 @@ static control_t setup_network(const size_t call_count)
         if (err == NSAPI_ERROR_OK) {
             break;
         } else {
-            printf("[ERROR] Connecting to network. Retrying %d of %d...\r\n", tries, MAX_RETRIES);
+            tr_error("[ERROR] Connecting to network. Retrying %d of %d...", tries, MAX_RETRIES);
         }
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("[NET] IP address is '%s'\n", interface->get_ip_address());
-    printf("[NET] MAC address is '%s'\n", interface->get_mac_address());
+    tr_info("[NET] IP address is '%s'", interface->get_ip_address());
+    tr_info("[NET] MAC address is '%s'", interface->get_mac_address());
     return CaseNext;
 }
 
@@ -206,7 +206,7 @@ void test_malloc()
 
     void *bufferTest = NULL;
     TEST_ASSERT_MESSAGE(size > 0, "Size must not be zero for test");
-    printf("Allocating %d bytes", (int)size);
+    tr_info("Allocating %d bytes", (int)size);
     bufferTest = malloc(size);
     TEST_ASSERT(bufferTest != NULL);
     free(bufferTest);

--- a/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cache.cpp
@@ -59,12 +59,12 @@ void ASYNCHRONOUS_DNS_CACHE()
         int delay_ms = (ticker_us - started_us) / 1000;
 
         static int delay_first = delay_ms / 2;
-        printf("Delays: first: %i, delay_ms: %i\n", delay_first, delay_ms);
+        tr_info("Delays: first: %i, delay_ms: %i", delay_first, delay_ms);
         // Check that cached accesses are at least twice as fast as the first one
         TEST_ASSERT_TRUE(i == 0 || delay_ms <= delay_first);
 
-        printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
-               dns_test_hosts[0], data.addr.get_ip_address(), delay_ms);
+        tr_info("DNS: query \"%s\" => \"%s\", time %i ms",
+                dns_test_hosts[0], data.addr.get_ip_address(), delay_ms);
     }
 }
 #endif // defined(MBED_CONF_RTOS_PRESENT)

--- a/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_cancel.cpp
@@ -44,7 +44,7 @@ void ASYNCHRONOUS_DNS_CANCEL()
             count++;
         } else {
             // No memory to initiate DNS query, callback will not be called
-            printf("Error: No resources to initiate DNS query for %s\n", dns_test_hosts[i]);
+            tr_error("Error: No resources to initiate DNS query for %s", dns_test_hosts[i]);
             data[i].result = data[i].req_result;
             data[i].value_set = true;
         }
@@ -65,21 +65,21 @@ void ASYNCHRONOUS_DNS_CANCEL()
 
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {
         if (!data[i].value_set) {
-            printf("DNS: query \"%s\" => cancel\n", dns_test_hosts[i]);
+            tr_info("DNS: query \"%s\" => cancel", dns_test_hosts[i]);
             continue;
         }
         TEST_ASSERT(data[i].result == NSAPI_ERROR_OK || data[i].result == NSAPI_ERROR_NO_MEMORY || data[i].result == NSAPI_ERROR_BUSY || data[i].result == NSAPI_ERROR_DNS_FAILURE || data[i].result == NSAPI_ERROR_TIMEOUT);
         if (data[i].result == NSAPI_ERROR_OK) {
-            printf("DNS: query \"%s\" => \"%s\"\n",
-                   dns_test_hosts[i], data[i].addr.get_ip_address());
+            tr_info("DNS: query \"%s\" => \"%s\"",
+                    dns_test_hosts[i], data[i].addr.get_ip_address());
         } else if (data[i].result == NSAPI_ERROR_DNS_FAILURE) {
-            printf("DNS: query \"%s\" => DNS failure\n", dns_test_hosts[i]);
+            tr_error("DNS: query \"%s\" => DNS failure", dns_test_hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_TIMEOUT) {
-            printf("DNS: query \"%s\" => timeout\n", dns_test_hosts[i]);
+            tr_error("DNS: query \"%s\" => timeout", dns_test_hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_NO_MEMORY) {
-            printf("DNS: query \"%s\" => no memory\n", dns_test_hosts[i]);
+            tr_error("DNS: query \"%s\" => no memory", dns_test_hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_BUSY) {
-            printf("DNS: query \"%s\" => busy\n", dns_test_hosts[i]);
+            tr_error("DNS: query \"%s\" => busy", dns_test_hosts[i]);
         }
     }
 

--- a/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_non_async_and_async.cpp
@@ -41,8 +41,8 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
     for (unsigned int i = 0; i < MBED_CONF_APP_DNS_TEST_HOSTS_NUM; i++) {
         SocketAddress addr;
         int err = get_interface()->gethostbyname(dns_test_hosts[i], &addr);
-        printf("DNS: query \"%s\" => \"%s\"\n",
-               dns_test_hosts[i], addr.get_ip_address());
+        tr_info("DNS: query \"%s\" => \"%s\"",
+                dns_test_hosts[i], addr.get_ip_address());
 
         TEST_ASSERT_EQUAL(0, err);
         TEST_ASSERT((bool)addr);
@@ -53,8 +53,8 @@ void ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC()
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, data.result);
 
-    printf("DNS: query \"%s\" => \"%s\"\n",
-           dns_test_hosts_second[0], data.addr.get_ip_address());
+    tr_info("DNS: query \"%s\" => \"%s\"",
+            dns_test_hosts_second[0], data.addr.get_ip_address());
 
     TEST_ASSERT(strlen(data.addr.get_ip_address()) > 1);
 }

--- a/TESTS/netsocket/dns/dns_tests.h
+++ b/TESTS/netsocket/dns/dns_tests.h
@@ -19,6 +19,9 @@
 #define DNS_TESTS_H
 
 #include "nsapi_dns.h"
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "GRNT"
 
 #ifndef MBED_CONF_APP_DNS_SIMULT_QUERIES
 #ifdef MBED_CONF_CELLULAR_OFFLOAD_DNS_QUERIES

--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -94,20 +94,20 @@ void do_asynchronous_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsign
         TEST_ASSERT(data[i].result == NSAPI_ERROR_OK || data[i].result == NSAPI_ERROR_NO_MEMORY || data[i].result == NSAPI_ERROR_BUSY || data[i].result == NSAPI_ERROR_DNS_FAILURE || data[i].result == NSAPI_ERROR_TIMEOUT);
         if (data[i].result == NSAPI_ERROR_OK) {
             (*exp_ok)++;
-            printf("DNS: query \"%s\" => \"%s\"\n",
-                   hosts[i], data[i].addr.get_ip_address());
+            tr_info("DNS: query \"%s\" => \"%s\"",
+                    hosts[i], data[i].addr.get_ip_address());
         } else if (data[i].result == NSAPI_ERROR_DNS_FAILURE) {
             (*exp_dns_failure)++;
-            printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => DNS failure", hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_TIMEOUT) {
             (*exp_timeout)++;
-            printf("DNS: query \"%s\" => timeout\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => timeout", hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_NO_MEMORY) {
             (*exp_no_mem)++;
-            printf("DNS: query \"%s\" => no memory\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => no memory", hosts[i]);
         } else if (data[i].result == NSAPI_ERROR_BUSY) {
             (*exp_no_mem)++;
-            printf("DNS: query \"%s\" => busy\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => busy", hosts[i]);
         }
     }
 
@@ -131,22 +131,22 @@ void do_gethostbyname(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_cou
 
         if (err == NSAPI_ERROR_OK) {
             (*exp_ok)++;
-            printf("DNS: query \"%s\" => \"%s\"\n",
-                   hosts[i], address.get_ip_address());
+            tr_info("DNS: query \"%s\" => \"%s\"",
+                    hosts[i], address.get_ip_address());
         } else if (err == NSAPI_ERROR_DNS_FAILURE) {
             (*exp_dns_failure)++;
-            printf("DNS: query \"%s\" => DNS failure\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => DNS failure", hosts[i]);
         } else if (err == NSAPI_ERROR_TIMEOUT) {
             (*exp_timeout)++;
-            printf("DNS: query \"%s\" => timeout\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => timeout", hosts[i]);
         } else if (err == NSAPI_ERROR_NO_MEMORY) {
             (*exp_no_mem)++;
-            printf("DNS: query \"%s\" => no memory\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => no memory", hosts[i]);
         } else if (err == NSAPI_ERROR_BUSY) {
             (*exp_no_mem)++;
-            printf("DNS: query \"%s\" => busy\n", hosts[i]);
+            tr_error("DNS: query \"%s\" => busy", hosts[i]);
         } else {
-            printf("DNS: query \"%s\" => %d, unexpected answer\n", hosts[i], err);
+            tr_error("DNS: query \"%s\" => %d, unexpected answer", hosts[i], err);
             TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_NO_MEMORY || err == NSAPI_ERROR_BUSY || err == NSAPI_ERROR_DNS_FAILURE || err == NSAPI_ERROR_TIMEOUT);
         }
     }
@@ -165,13 +165,13 @@ static void net_bringup()
     net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
+    tr_info("MBED: IP address is '%s'", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void net_bringdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    tr_info("MBED: ifdown");
 }
 
 // Test setup

--- a/TESTS/netsocket/dns/synchronous_dns_cache.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_cache.cpp
@@ -52,8 +52,8 @@ void SYNCHRONOUS_DNS_CACHE()
         // Check that cached accesses are at least twice as fast as the first one
         TEST_ASSERT_TRUE(i == 0 || delay_ms <= delay_first);
 
-        printf("DNS: query \"%s\" => \"%s\", time %i ms\n",
-               dns_test_hosts[0], address.get_ip_address(), delay_ms);
+        tr_info("DNS: query \"%s\" => \"%s\", time %i ms",
+                dns_test_hosts[0], address.get_ip_address(), delay_ms);
     }
 }
 #endif // defined(MBED_CONF_RTOS_PRESENT)

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -76,13 +76,13 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
+    tr_info("MBED: TCPClient IP address is '%s'", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void _ifdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    tr_info("MBED: ifdown");
 }
 
 nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
@@ -92,17 +92,17 @@ nsapi_error_t tcpsocket_connect_to_srv(TCPSocket &sock, uint16_t port)
     NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tcp_addr);
     tcp_addr.set_port(port);
 
-    printf("MBED: Server '%s', port %d\n", tcp_addr.get_ip_address(), tcp_addr.get_port());
+    tr_info("MBED: Server '%s', port %d", tcp_addr.get_ip_address(), tcp_addr.get_port());
 
     nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.open: %d\n", err);
+        tr_error("Error from sock.open: %d", err);
         return err;
     }
 
     err = sock.connect(tcp_addr);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.connect: %d\n", err);
+        tr_error("Error from sock.connect: %d", err);
         return err;
     }
 

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -19,6 +19,9 @@
 #define TCP_TESTS_H
 
 #include "../test_params.h"
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "GRNT"
 
 NetworkInterface *get_interface();
 void drop_bad_packets(TCPSocket &sock, int orig_timeout);

--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -73,11 +73,11 @@ void TCPSOCKET_ECHOTEST()
         fill_tx_buffer_ascii(tcp_global::tx_buffer, BUFF_SIZE);
         sent = sock.send(tcp_global::tx_buffer, pkt_s);
         if (sent < 0) {
-            printf("[Round#%02d] network error %d\n", s_idx, sent);
+            tr_error("[Round#%02d] network error %d", s_idx, sent);
             TEST_FAIL();
             break;
         } else if (sent != pkt_s) {
-            printf("[%02d] sock.send return size %d does not match the expectation %d\n", s_idx, sent, pkt_s);
+            tr_error("[%02d] sock.send return size %d does not match the expectation %d", s_idx, sent, pkt_s);
             TEST_FAIL();
             break;
         }
@@ -86,7 +86,7 @@ void TCPSOCKET_ECHOTEST()
         while (bytes2recv) {
             recvd = sock.recv(&(tcp_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", s_idx, recvd);
+                tr_error("[Round#%02d] network error %d", s_idx, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
                 return;
@@ -111,7 +111,7 @@ void tcpsocket_echotest_nonblock_receive()
             }
             return;
         } else if (recvd < 0) {
-            printf("sock.recv returned an error %d", recvd);
+            tr_error("sock.recv returned an error %d", recvd);
             TEST_FAIL();
             receive_error = true;
         } else {
@@ -172,7 +172,7 @@ void TCPSOCKET_ECHOTEST_NONBLOCK()
                 }
                 continue;
             } else if (sent <= 0) {
-                printf("[Sender#%02d] network error %d\n", s_idx, sent);
+                tr_error("[Sender#%02d] network error %d", s_idx, sent);
                 TEST_FAIL();
                 goto END;
             }

--- a/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
@@ -53,11 +53,11 @@ void TCPSOCKET_ECHOTEST_BURST()
     for (int i = 0; i < BURST_CNT; i++) {
         sent = sock.send(tcp_global::tx_buffer, BURST_SIZE);
         if (sent < 0) {
-            printf("[%02d] network error %d\n", i, sent);
+            tr_error("[%02d] network error %d", i, sent);
             TEST_FAIL();
             break;
         } else if (sent != BURST_SIZE) {
-            printf("[%02d] sock.send return size %d does not match the expectation %d\n", i, sent, BURST_SIZE);
+            tr_error("[%02d] sock.send return size %d does not match the expectation %d", i, sent, BURST_SIZE);
             TEST_FAIL();
             break;
         }
@@ -66,7 +66,7 @@ void TCPSOCKET_ECHOTEST_BURST()
         while (bytes2recv) {
             recvd = sock.recv(&(tcp_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", i, recvd);
+                tr_error("[Round#%02d] network error %d", i, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
                 return;
@@ -104,7 +104,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                tr_error("[%02d] network error %d", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -120,19 +120,19 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
             recvd = sock.recv(&(tcp_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 if (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
-                    printf("[bt#%02d] packet timeout...", i);
+                    tr_error("[bt#%02d] packet timeout...", i);
                     break;
                 }
                 continue;
             } else if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                tr_error("[%02d] network error %d", i, recvd);
                 break;
             }
             bt_left -= recvd;
         }
 
         if (bt_left != 0) {
-            printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
+            tr_error("network error %d, missing %d bytes from a burst", recvd, bt_left);
             TEST_FAIL();
             goto END;
         }

--- a/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_open_limit.cpp
@@ -50,7 +50,7 @@ void TCPSOCKET_OPEN_LIMIT()
             }
             ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
-                printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
+                tr_error("[round#%02d] unable to open new socket, error: %d", i, ret);
                 delete sock;
                 break;
             }
@@ -92,7 +92,7 @@ void TCPSOCKET_OPEN_LIMIT()
             delete tmp->sock;
             delete tmp;
         }
-        printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
+        tr_info("[round#%02d] %d sockets opened", i, open_sockets[i]);
     }
     TEST_ASSERT_EQUAL(open_sockets[0], open_sockets[1]);
     TEST_ASSERT(open_sockets[0] >= 4);

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -115,7 +115,7 @@ void rcv_n_chk_against_rfc864_pattern(TCPSocket &sock)
         recvd_size += rd;
     }
     timer.stop();
-    printf("MBED: Time taken: %fs\n", timer.read());
+    tr_info("MBED: Time taken: %fs", timer.read());
 }
 
 void TCPSOCKET_RECV_100K()
@@ -170,7 +170,7 @@ void rcv_n_chk_against_rfc864_pattern_nonblock(TCPSocket &sock)
         }
     }
     timer.stop();
-    printf("MBED: Time taken: %fs\n", timer.read());
+    tr_info("MBED: Time taken: %fs", timer.read());
 }
 
 static void _sigio_handler(osThreadId id)

--- a/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
@@ -69,7 +69,7 @@ void TCPSOCKET_RECV_TIMEOUT()
                     goto CLEANUP;
                 }
                 int recv_time_ms = (timer.read_us() + 500) / 1000;
-                printf("MBED: recv() took: %dus\n", recv_time_ms);
+                tr_info("MBED: recv() took: %dus", recv_time_ms);
                 if (recv_time_ms > 150) {
                     TEST_ASSERT(150 - recv_time_ms < 51);
                 } else {
@@ -77,7 +77,7 @@ void TCPSOCKET_RECV_TIMEOUT()
                 }
                 continue;
             } else if (recvd < 0) {
-                printf("[pkt#%02d] network error %d\n", i, recvd);
+                tr_error("[pkt#%02d] network error %d", i, recvd);
                 TEST_FAIL();
                 goto CLEANUP;
             }

--- a/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
@@ -46,7 +46,7 @@ void TCPSOCKET_SEND_TIMEOUT()
                 (timer.read_ms() <= 800)) {
             continue;
         }
-        printf("send: err %d, time %d", err, timer.read_ms());
+        tr_error("send: err %d, time %d", err, timer.read_ms());
         TEST_FAIL();
         break;
     }

--- a/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
@@ -70,7 +70,7 @@ static void check_const_len_rand_sequence()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("network error %d\n", sent);
+                tr_error("network error %d", sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -83,7 +83,7 @@ static void check_const_len_rand_sequence()
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 continue;
             } else if (recvd < 0) {
-                printf("network error %d\n", recvd);
+                tr_error("network error %d", recvd);
                 TEST_FAIL();
                 goto END;
             }
@@ -127,7 +127,7 @@ static void check_var_len_rand_sequence()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                tr_error("[%02d] network error %d", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -140,7 +140,7 @@ static void check_var_len_rand_sequence()
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 continue;
             } else if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                tr_error("[%02d] network error %d", i, recvd);
                 TEST_FAIL();
                 goto END;
             }

--- a/TESTS/netsocket/tls/main.cpp
+++ b/TESTS/netsocket/tls/main.cpp
@@ -70,13 +70,13 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TLSClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
+    tr_info("MBED: TLSClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void _ifdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    tr_info("MBED: ifdown\n");
 }
 
 nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
@@ -86,23 +86,23 @@ nsapi_error_t tlssocket_connect_to_srv(TLSSocket &sock, uint16_t port)
     NetworkInterface::get_default_instance()->gethostbyname(ECHO_SERVER_ADDR, &tls_addr);
     tls_addr.set_port(port);
 
-    printf("MBED: Server '%s', port %d\n", tls_addr.get_ip_address(), tls_addr.get_port());
+    tr_info("MBED: Server '%s', port %d\n", tls_addr.get_ip_address(), tls_addr.get_port());
 
     nsapi_error_t err = sock.open(NetworkInterface::get_default_instance());
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.open: %d\n", err);
+        tr_error("Error from sock.open: %d\n", err);
         return err;
     }
 
     err = sock.set_root_ca_cert(tls_global::cert);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.set_root_ca_cert: %d\n", err);
+        tr_error("Error from sock.set_root_ca_cert: %d\n", err);
         return err;
     }
 
     err = sock.connect(tls_addr);
     if (err != NSAPI_ERROR_OK) {
-        printf("Error from sock.connect: %d\n", err);
+        tr_error("Error from sock.connect: %d\n", err);
         return err;
     }
 

--- a/TESTS/netsocket/tls/tls_tests.h
+++ b/TESTS/netsocket/tls/tls_tests.h
@@ -20,6 +20,9 @@
 
 #include "../test_params.h"
 #include "TLSSocket.h"
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "GRNT"
 
 #if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 

--- a/TESTS/netsocket/tls/tlssocket_echotest.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest.cpp
@@ -62,7 +62,7 @@ void TLSSOCKET_ECHOTEST()
     SKIP_IF_TCP_UNSUPPORTED();
     sock = new TLSSocket;
     if (tlssocket_connect_to_echo_srv(*sock) != NSAPI_ERROR_OK) {
-        printf("Error from tlssocket_connect_to_echo_srv\n");
+        tr_error("Error from tlssocket_connect_to_echo_srv\n");
         TEST_FAIL();
         delete sock;
         return;
@@ -76,11 +76,11 @@ void TLSSOCKET_ECHOTEST()
 
         sent = sock->send(tls_global::tx_buffer, pkt_s);
         if (sent < 0) {
-            printf("[Round#%02d] network error %d\n", s_idx, sent);
+            tr_error("[Round#%02d] network error %d\n", s_idx, sent);
             TEST_FAIL();
             break;
         } else if (sent != pkt_s) {
-            printf("[%02d] sock.send return size %d does not match the expectation %d\n", s_idx, sent, pkt_s);
+            tr_error("[%02d] sock.send return size %d does not match the expectation %d\n", s_idx, sent, pkt_s);
             TEST_FAIL();
             break;
         }
@@ -89,7 +89,7 @@ void TLSSOCKET_ECHOTEST()
         while (bytes2recv) {
             recvd = sock->recv(&(tls_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", s_idx, recvd);
+                tr_error("[Round#%02d] network error %d\n", s_idx, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
                 return;
@@ -115,7 +115,7 @@ void tlssocket_echotest_nonblock_receive()
             }
             return;
         } else if (recvd < 0) {
-            printf("sock.recv returned an error %d", recvd);
+            tr_error("sock.recv returned an error %d", recvd);
             TEST_FAIL();
             receive_error = true;
         } else {
@@ -176,7 +176,7 @@ void TLSSOCKET_ECHOTEST_NONBLOCK()
                 }
                 continue;
             } else if (sent <= 0) {
-                printf("[Sender#%02d] network error %d\n", s_idx, sent);
+                tr_error("[Sender#%02d] network error %d\n", s_idx, sent);
                 TEST_FAIL();
                 goto END;
             }

--- a/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tls/tlssocket_echotest_burst.cpp
@@ -54,11 +54,11 @@ void TLSSOCKET_ECHOTEST_BURST()
     for (int i = 0; i < BURST_CNT; i++) {
         sent = sock->send(tls_global::tx_buffer, BURST_SIZE);
         if (sent < 0) {
-            printf("[%02d] network error %d\n", i, sent);
+            tr_error("[%02d] network error %d\n", i, sent);
             TEST_FAIL();
             break;
         } else if (sent != BURST_SIZE) {
-            printf("[%02d] sock.send return size %d does not match the expectation %d\n", i, sent, BURST_SIZE);
+            tr_error("[%02d] sock.send return size %d does not match the expectation %d\n", i, sent, BURST_SIZE);
             TEST_FAIL();
             break;
         }
@@ -67,7 +67,7 @@ void TLSSOCKET_ECHOTEST_BURST()
         while (bytes2recv) {
             recvd = sock->recv(&(tls_global::rx_buffer[sent - bytes2recv]), bytes2recv);
             if (recvd < 0) {
-                printf("[Round#%02d] network error %d\n", i, recvd);
+                tr_error("[Round#%02d] network error %d\n", i, recvd);
                 TEST_FAIL();
                 TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock->close());
                 return;
@@ -106,7 +106,7 @@ void TLSSOCKET_ECHOTEST_BURST_NONBLOCK()
                 }
                 continue;
             } else if (sent < 0) {
-                printf("[%02d] network error %d\n", i, sent);
+                tr_error("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
                 goto END;
             }
@@ -122,19 +122,19 @@ void TLSSOCKET_ECHOTEST_BURST_NONBLOCK()
             recvd = sock->recv(&(tls_global::rx_buffer[BURST_SIZE - bt_left]), BURST_SIZE);
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 if (osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
-                    printf("[bt#%02d] packet timeout...", i);
+                    tr_error("[bt#%02d] packet timeout...", i);
                     break;
                 }
                 continue;
             } else if (recvd < 0) {
-                printf("[%02d] network error %d\n", i, recvd);
+                tr_error("[%02d] network error %d\n", i, recvd);
                 break;
             }
             bt_left -= recvd;
         }
 
         if (bt_left != 0) {
-            printf("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
+            tr_error("network error %d, missing %d bytes from a burst\n", recvd, bt_left);
             TEST_FAIL();
             goto END;
         }

--- a/TESTS/netsocket/tls/tlssocket_open_limit.cpp
+++ b/TESTS/netsocket/tls/tlssocket_open_limit.cpp
@@ -51,7 +51,7 @@ void TLSSOCKET_OPEN_LIMIT()
             }
             ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
-                printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
+                tr_error("[round#%02d] unable to open new socket, error: %d\n", i, ret);
                 delete sock;
                 break;
             }
@@ -93,7 +93,7 @@ void TLSSOCKET_OPEN_LIMIT()
             delete tmp->sock;
             delete tmp;
         }
-        printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
+        tr_info("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
     }
     TEST_ASSERT_EQUAL(open_sockets[0], open_sockets[1]);
     TEST_ASSERT(open_sockets[0] >= 4);

--- a/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tls/tlssocket_recv_timeout.cpp
@@ -69,10 +69,10 @@ void TLSSOCKET_RECV_TIMEOUT()
                     TEST_FAIL();
                     goto CLEANUP;
                 }
-                printf("MBED: recv() took: %dus\n", timer.read_us());
+                tr_info("MBED: recv() took: %dus\n", timer.read_us());
                 continue;
             } else if (recvd < 0) {
-                printf("[pkt#%02d] network error %d\n", i, recvd);
+                tr_error("[pkt#%02d] network error %d\n", i, recvd);
                 TEST_FAIL();
                 goto CLEANUP;
             }

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -63,13 +63,13 @@ static void _ifup()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: UDPClient IP address is '%s'\n", net->get_ip_address() ? net->get_ip_address() : "null");
+    tr_info("MBED: UDPClient IP address is '%s'", net->get_ip_address() ? net->get_ip_address() : "null");
 }
 
 static void _ifdown()
 {
     NetworkInterface::get_default_instance()->disconnect();
-    printf("MBED: ifdown\n");
+    tr_info("MBED: ifdown");
 }
 
 

--- a/TESTS/netsocket/udp/udp_tests.h
+++ b/TESTS/netsocket/udp/udp_tests.h
@@ -19,6 +19,9 @@
 #define UDP_TESTS_H
 
 #include "../test_params.h"
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "GRNT"
 
 NetworkInterface *get_interface();
 void drop_bad_packets(UDPSocket &sock, int orig_timeout);

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -89,7 +89,7 @@ void UDPSOCKET_ECHOTEST()
             } else if (sent == pkt_s) {
                 packets_sent++;
             } else {
-                printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
+                tr_error("[Round#%02d - Sender] error, returned %d", s_idx, sent);
                 continue;
             }
 
@@ -109,7 +109,7 @@ void UDPSOCKET_ECHOTEST()
             if (recvd == pkt_s) {
                 break;
             } else {
-                printf("[Round#%02d - Receiver] error, returned %d\n", s_idx, recvd);
+                tr_error("[Round#%02d - Receiver] error, returned %d", s_idx, recvd);
             }
         }
         // Verify received address is correct
@@ -127,7 +127,7 @@ void UDPSOCKET_ECHOTEST()
     // Packet loss up to 30% tolerated
     if (packets_sent > 0) {
         double loss_ratio = 1 - ((double)packets_recv / (double)packets_sent);
-        printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n", packets_sent, packets_recv, loss_ratio);
+        tr_info("Packets sent: %d, packets received %d, loss ratio %.2lf", packets_sent, packets_recv, loss_ratio);
         TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
@@ -168,7 +168,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
                 }
                 --retry_cnt;
             } else {
-                printf("[Round#%02d - Sender] error, returned %d\n", s_idx, sent);
+                tr_error("[Round#%02d - Sender] error, returned %d", s_idx, sent);
                 continue;
             }
 
@@ -183,7 +183,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
                     --retry_recv;
                     continue;
                 } else if (recvd < 0) {
-                    printf("sock.recvfrom returned %d\n", recvd);
+                    tr_error("sock.recvfrom returned %d", recvd);
                     TEST_FAIL();
                     break;
                 } else if (recvd == pkt_s) {
@@ -205,7 +205,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
     // Packet loss up to 30% tolerated
     if (packets_sent > 0) {
         double loss_ratio = 1 - ((double)packets_recv / (double)packets_sent);
-        printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n", packets_sent, packets_recv, loss_ratio);
+        tr_info("Packets sent: %d, packets received %d, loss ratio %.2lf", packets_sent, packets_recv, loss_ratio);
         TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
 
 #if MBED_CONF_NSAPI_SOCKET_STATS_ENABLED
@@ -219,7 +219,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
             }
         }
         loss_ratio = 1 - ((double)udp_stats[j].recv_bytes / (double)udp_stats[j].sent_bytes);
-        printf("Bytes sent: %d, bytes received %d, loss ratio %.2lf\r\n", udp_stats[j].sent_bytes, udp_stats[j].recv_bytes, loss_ratio);
+        tr_info("Bytes sent: %d, bytes received %d, loss ratio %.2lf", udp_stats[j].sent_bytes, udp_stats[j].recv_bytes, loss_ratio);
         TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
 
 #endif

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -114,12 +114,12 @@ void UDPSOCKET_ECHOTEST_BURST()
                 }
             } else if (recvd < 0) {
                 pkg_fail += BURST_PKTS - j; // Assume all the following packets of the burst to be lost
-                printf("[%02d] network error %d\n", i, recvd);
+                tr_error("[%02d] network error %d", i, recvd);
                 ThisThread::sleep_for(recv_timeout * 1000);
                 recv_timeout *= 2; // Back off,
                 break;
             } else if (temp_addr != udp_addr) {
-                printf("[%02d] packet from wrong address\n", i);
+                tr_info("[%02d] packet from wrong address", i);
                 --j;
                 continue;
             }
@@ -139,15 +139,15 @@ void UDPSOCKET_ECHOTEST_BURST()
             ok_bursts++;
         } else {
             drop_bad_packets(sock, TIMEOUT);
-            printf("[%02d] burst failure, rcv %d\n", i, bt_total);
+            tr_error("[%02d] burst failure, rcv %d", i, bt_total);
         }
     }
 
     free_tx_buffers();
 
     double loss_ratio = 1 - ((double)(BURST_CNT * BURST_PKTS - pkg_fail) / (double)(BURST_CNT * BURST_PKTS));
-    printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
-           BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
+    tr_info("Packets sent: %d, packets received %d, loss ratio %.2lf",
+            BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
     // Packet loss up to 30% tolerated
     TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
     // 70% of the bursts need to be successful
@@ -215,7 +215,7 @@ void UDPSOCKET_ECHOTEST_BURST_NONBLOCK()
                     goto PKT_OK;
                 }
             }
-            printf("[bt#%02d] corrupted packet...", i);
+            tr_error("[bt#%02d] corrupted packet...", i);
             pkg_fail++;
             break;
 PKT_OK:
@@ -233,8 +233,8 @@ PKT_OK:
     free_tx_buffers();
 
     double loss_ratio = 1 - ((double)(BURST_CNT * BURST_PKTS - pkg_fail) / (double)(BURST_CNT * BURST_PKTS));
-    printf("Packets sent: %d, packets received %d, loss ratio %.2lf\r\n",
-           BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
+    tr_info("Packets sent: %d, packets received %d, loss ratio %.2lf",
+            BURST_CNT * BURST_PKTS, BURST_CNT * BURST_PKTS - pkg_fail, loss_ratio);
     // Packet loss up to 30% tolerated
     TEST_ASSERT_DOUBLE_WITHIN(TOLERATED_LOSS_RATIO, EXPECTED_LOSS_RATIO, loss_ratio);
     // 70% of the bursts need to be successful

--- a/TESTS/netsocket/udp/udpsocket_open_limit.cpp
+++ b/TESTS/netsocket/udp/udpsocket_open_limit.cpp
@@ -49,7 +49,7 @@ void UDPSOCKET_OPEN_LIMIT()
             }
             ret = sock->open(NetworkInterface::get_default_instance());
             if (ret == NSAPI_ERROR_NO_MEMORY || ret == NSAPI_ERROR_NO_SOCKET) {
-                printf("[round#%02d] unable to open new socket, error: %d\n", i, ret);
+                tr_error("[round#%02d] unable to open new socket, error: %d", i, ret);
                 delete sock;
                 break;
             }
@@ -89,7 +89,7 @@ void UDPSOCKET_OPEN_LIMIT()
             delete tmp->sock;
             delete tmp;
         }
-        printf("[round#%02d] %d sockets opened\n", i, open_sockets[i]);
+        tr_info("[round#%02d] %d sockets opened", i, open_sockets[i]);
     }
     TEST_ASSERT_EQUAL(open_sockets[0], open_sockets[1]);
     // In case of lwIP one is taken by DHCP -> reduction by one to three

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -62,7 +62,7 @@ void UDPSOCKET_RECV_TIMEOUT()
 
         if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
             osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT);
-            printf("MBED: recvfrom() took: %dms\n", timer.read_ms());
+            tr_info("MBED: recvfrom() took: %dms", timer.read_ms());
             if (timer.read_ms() > 150) {
                 TEST_ASSERT(150 - timer.read_ms() < 51);
             } else {
@@ -70,16 +70,16 @@ void UDPSOCKET_RECV_TIMEOUT()
             }
             continue;
         } else if (recvd < 0) {
-            printf("[bt#%02d] network error %d\n", i, recvd);
+            tr_error("[bt#%02d] network error %d", i, recvd);
             continue;
         } else if (temp_addr != udp_addr) {
-            printf("[bt#%02d] packet from wrong address\n", i);
+            tr_info("[bt#%02d] packet from wrong address", i);
             continue;
         }
         TEST_ASSERT_EQUAL(DATA_LEN, recvd);
         pkt_success++;
     }
 
-    printf("MBED: %d out of %d packets were received.\n", pkt_success, PKT_NUM);
+    tr_info("MBED: %d out of %d packets were received.", pkt_success, PKT_NUM);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }

--- a/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_timeout.cpp
@@ -41,7 +41,7 @@ void UDPSOCKET_SENDTO_TIMEOUT()
     int sent = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
     timer.stop();
     TEST_ASSERT_EQUAL(sizeof(tx_buffer), sent);
-    printf("MBED: Time taken: %fs\n", timer.read());
+    tr_info("MBED: Time taken: %fs", timer.read());
     sock.set_timeout(1000);
 
     timer.reset();
@@ -49,7 +49,7 @@ void UDPSOCKET_SENDTO_TIMEOUT()
     sent = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
     timer.stop();
     TEST_ASSERT_EQUAL(sizeof(tx_buffer), sent);
-    printf("MBED: Time taken: %fs\n", timer.read());
+    tr_info("MBED: Time taken: %fs", timer.read());
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
While troubleshooting why our cellular-enabled target (`EP_AGORA`) was failing some netsocket tests (DNS, TCP, UDP), we determined that the caused seemed to be related to serial output synchronization issues similar to what @ithinuel described in https://github.com/ARMmbed/mbed-os/pull/9954 and https://github.com/ARMmbed/mbed-os/issues/11202. Whenever the Greentea test would hit a `printf()` the test would hang and subsequent test cases would timeout. By replacing the calls to `printf()` with a new wrapper function called `print_to_console()` (which internally calls `printf()` if `MBED_CONF_APP_DISABLE_LOGGING` is not defined) in this PR, all of the tests passed without issue on our target.

For reference here is an example of an `mbed_app.config` file used with our target to pass the tests:
```json
{
    "config": {
        "disable-logging": {
            "help": "Disable printf in print_to_console()",
            "value": null
        }
    },
    "target_overrides": {
        "EP_AGORA": {
            "nsapi.default-cellular-apn": "\"APN\"",
            "target.network-default-interface-type": "CELLULAR",
            "lwip.ipv4-enabled": true,
            "lwip.ipv6-enabled": true,
            "lwip.ethernet-enabled": false,
            "lwip.ppp-enabled": true,
            "lwip.tcp-enabled": true,
            "platform.stdio-convert-newlines": true,
            "platform.stdio-baud-rate": 9600,
            "platform.default-serial-baud-rate": 9600,
            "platform.stdio-buffered-serial": true,
            "lwip.mem-size": 22000,
            "nsapi.dns-response-wait-time": 60000,
            "disable-logging": true
        }
    }
}
```

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->
@maclobdell 
@ithinuel 
----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



