### PR TITLE
STM32F7: linker scripts updates

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_ARM_STD/stm32f746xg.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_ARM_STD/stm32f746xg.sct
@@ -1,5 +1,7 @@
 #! armcc -E
 ; Scatter-Loading Description File
+;
+; SPDX-License-Identifier: BSD-3-Clause
 ;******************************************************************************
 ;* @attention
 ;*
@@ -12,18 +14,28 @@
 ;*                        opensource.org/licenses/BSD-3-Clause
 ;*
 ;******************************************************************************
+#include "../cmsis_nvic.h"
 
 ; STM32F746xG:
-; FLASH: 1024K (0x100000) @0x08000000
-; RAM1:   256K (0x40000)  @0x20010000
-; RAM2:    64K (0x10000)  @0x20000000
+; FLASH:   1024K (0x100000) @0x08000000
+; SRAM1:    240K (0x3C000)  @0x20010000
+; SRAM2:     16K (0x4000)   @0x2004C000
+; DTCM-RAM:  64K (0x10000)  @0x20000000
+; ITCM-RAM:  16K (0x3FFF)   @0x00000000
+
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x100000
+#define MBED_RAM_START   0x20010000
+#define MBED_RAM_SIZE    0x40000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x10000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x100000
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
@@ -32,14 +44,14 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-#define MBED_RAM_START              0x20010000
-#define MBED_RAM_SIZE               0x40000
-#define MBED_VECTTABLE_RAM_START    0x20000000
-#define MBED_VECTTABLE_RAM_SIZE     0x1C8
+#define MBED_VECTTABLE_RAM_START    (NVIC_RAM_VECTOR_ADDRESS)
+#define MBED_VECTTABLE_RAM_SIZE     (((NVIC_NUM_VECTORS * 4) + 7) AND ~7)
+
 #define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
 #define MBED_CRASH_REPORT_RAM_SIZE  0x100
-#define MBED_RAM0_START             (MBED_RAM_START)
-#define MBED_RAM0_SIZE              (MBED_RAM_SIZE)
+
+#define MBED_RAM0_START  (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
@@ -59,4 +71,3 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
 }
-

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_GCC_ARM/STM32F746xG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_GCC_ARM/STM32F746xG.ld
@@ -1,25 +1,59 @@
 /* Linker script to configure memory regions. */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
+#include "../cmsis_nvic.h"
 
-#if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
-#endif
+/* STM32F746xG:
+FLASH:   1024K (0x100000) @0x08000000
+SRAM1:    240K (0x3C000)  @0x20010000
+SRAM2:     16K (0x4000)   @0x2004C000
+DTCM-RAM:  64K (0x10000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
 
-STACK_SIZE = MBED_BOOT_STACK_SIZE;
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x100000
+#define MBED_RAM_START   0x20010000
+#define MBED_RAM_SIZE    0x40000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x10000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 1024K
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 M_CRASH_DATA_RAM_SIZE = 0x100;
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+STACK_SIZE = MBED_BOOT_STACK_SIZE;
+
+#define MBED_VECTTABLE_RAM_SIZE (((NVIC_NUM_VECTORS * 4) + 7) & 0xFFFFFFF8)
+#define MBED_RAM0_START  (MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE)
+
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x200001C8, LENGTH = 320K - 0x1C8
+  RAM (rwx)  : ORIGIN = MBED_RAM0_START, LENGTH = MBED_RAM0_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -93,7 +127,7 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
-
+    
     .crash_data_ram :
     {
         . = ALIGN(8);

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_IAR/stm32f746xg.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_IAR/stm32f746xg.icf
@@ -1,18 +1,52 @@
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x100000; }
+/* Linker script to configure memory regions.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
 
-/* [ROM = 1024kb = 0x100000] */
+/* STM32F746xG:
+FLASH:   1024K (0x100000) @0x08000000
+SRAM1:    240K (0x3C000)  @0x20010000
+SRAM2:     16K (0x4000)   @0x2004C000
+DTCM-RAM:  64K (0x10000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
+
+if (!isdefinedsymbol(MBED_ROM_START)) { define symbol MBED_ROM_START  = 0x8000000; }
+if (!isdefinedsymbol(MBED_ROM_SIZE)) { define symbol MBED_ROM_SIZE   = 0x200000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_START  = 0x20010000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_SIZE   = 0x40000; }
+if (!isdefinedsymbol(MBED_RAM1_START)) { define symbol MBED_RAM1_START = 0x20000000; }
+if (!isdefinedsymbol(MBED_RAM1_SIZE)) { define symbol MBED_RAM1_SIZE  = 0x10000; }
+
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = MBED_ROM_START; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = MBED_ROM_SIZE; }
+
 define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
-/* [RAM = 320kb = 0x50000] Vector table dynamic copy: 114 vectors = 456 bytes (0x1C8) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001C7; /* Aligned on 8 bytes */
-define symbol __region_CRASH_DATA_RAM_start__  = 0x200001C8;
-define symbol __region_CRASH_DATA_RAM_end__  = 0x200002C7;
-define symbol __region_RAM_start__    = 0x200002C8;
-define symbol __region_RAM_end__      = 0x2004FFFF;
+define symbol NVIC_NUM_VECTORS     = 114; /* This value must match NVIC_NUM_VECTORS in ../cmsis_nvic.h */
+define symbol MBED_VECTTABLE_RAM_SIZE = ((NVIC_NUM_VECTORS * 4) + 7) & ~7;
+define symbol M_CRASH_DATA_RAM_SIZE   = 0x100;
+
+define symbol __NVIC_start__          = MBED_RAM1_START;
+define symbol __region_CRASH_DATA_RAM_start__ = MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE;
+define symbol __NVIC_end__            = __region_CRASH_DATA_RAM_start__ - 1;
+define symbol __region_RAM_start__    = __region_CRASH_DATA_RAM_start__ + M_CRASH_DATA_RAM_SIZE;
+define symbol __region_CRASH_DATA_RAM_end__   = __region_RAM_start__ - 1;
+define symbol __region_RAM_end__      = MBED_RAM1_START + MBED_RAM_SIZE + MBED_RAM1_SIZE - 1;
 
 define symbol __region_ITCMRAM_start__ = 0x00000000;
 define symbol __region_ITCMRAM_end__   = 0x00003FFF;
@@ -20,8 +54,8 @@ define symbol __region_ITCMRAM_end__   = 0x00003FFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
+define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_ITCMRAM_end__];
 
 /* Define Crash Data Symbols */

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_ARM_STD/stm32f756xg.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_ARM_STD/stm32f756xg.sct
@@ -1,5 +1,7 @@
 #! armcc -E
 ; Scatter-Loading Description File
+;
+; SPDX-License-Identifier: BSD-3-Clause
 ;******************************************************************************
 ;* @attention
 ;*
@@ -12,18 +14,28 @@
 ;*                        opensource.org/licenses/BSD-3-Clause
 ;*
 ;******************************************************************************
+#include "../cmsis_nvic.h"
 
 ; STM32F756xG:
-; FLASH: 1024K (0x100000) @0x08000000
-; RAM1:   256K (0x40000)  @0x20010000
-; RAM2:    64K (0x10000)  @0x20000000
+; FLASH:   1024K (0x100000) @0x08000000
+; SRAM1:    240K (0x3C000)  @0x20010000
+; SRAM2:     16K (0x4000)   @0x2004C000
+; DTCM-RAM:  64K (0x10000)  @0x20000000
+; ITCM-RAM:  16K (0x3FFF)   @0x00000000
+
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x100000
+#define MBED_RAM_START   0x20010000
+#define MBED_RAM_SIZE    0x40000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x10000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x100000
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
@@ -32,14 +44,14 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-#define MBED_RAM_START              0x20010000
-#define MBED_RAM_SIZE               0x40000
-#define MBED_VECTTABLE_RAM_START    0x20000000
-#define MBED_VECTTABLE_RAM_SIZE     0x1C8
+#define MBED_VECTTABLE_RAM_START    (NVIC_RAM_VECTOR_ADDRESS)
+#define MBED_VECTTABLE_RAM_SIZE     (((NVIC_NUM_VECTORS * 4) + 7) AND ~7)
+
 #define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
 #define MBED_CRASH_REPORT_RAM_SIZE  0x100
-#define MBED_RAM0_START             (MBED_RAM_START)
-#define MBED_RAM0_SIZE              (MBED_RAM_SIZE)
+
+#define MBED_RAM0_START  (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
@@ -59,4 +71,3 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
 }
-

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_GCC_ARM/STM32F756xG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_GCC_ARM/STM32F756xG.ld
@@ -1,25 +1,59 @@
 /* Linker script to configure memory regions. */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
+#include "../cmsis_nvic.h"
 
-#if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
-#endif
+/* STM32F756xG:
+FLASH:   1024K (0x100000) @0x08000000
+SRAM1:    240K (0x3C000)  @0x20010000
+SRAM2:     16K (0x4000)   @0x2004C000
+DTCM-RAM:  64K (0x10000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
 
-STACK_SIZE = MBED_BOOT_STACK_SIZE;
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x100000
+#define MBED_RAM_START   0x20010000
+#define MBED_RAM_SIZE    0x40000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x10000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 1024K
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 M_CRASH_DATA_RAM_SIZE = 0x100;
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+STACK_SIZE = MBED_BOOT_STACK_SIZE;
+
+#define MBED_VECTTABLE_RAM_SIZE (((NVIC_NUM_VECTORS * 4) + 7) & 0xFFFFFFF8)
+#define MBED_RAM0_START  (MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE)
+
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x200001C8, LENGTH = 320K - 0x1C8
+  RAM (rwx)  : ORIGIN = MBED_RAM0_START, LENGTH = MBED_RAM0_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -93,7 +127,7 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
-
+    
     .crash_data_ram :
     {
         . = ALIGN(8);

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_IAR/stm32f756xg.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_IAR/stm32f756xg.icf
@@ -1,18 +1,52 @@
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x100000; }
+/* Linker script to configure memory regions.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
 
-/* [ROM = 1024kb = 0x100000] */
+/* STM32F756xG:
+FLASH:   1024K (0x100000) @0x08000000
+SRAM1:    240K (0x3C000)  @0x20010000
+SRAM2:     16K (0x4000)   @0x2004C000
+DTCM-RAM:  64K (0x10000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
+
+if (!isdefinedsymbol(MBED_ROM_START)) { define symbol MBED_ROM_START  = 0x8000000; }
+if (!isdefinedsymbol(MBED_ROM_SIZE)) { define symbol MBED_ROM_SIZE   = 0x200000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_START  = 0x20010000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_SIZE   = 0x40000; }
+if (!isdefinedsymbol(MBED_RAM1_START)) { define symbol MBED_RAM1_START = 0x20000000; }
+if (!isdefinedsymbol(MBED_RAM1_SIZE)) { define symbol MBED_RAM1_SIZE  = 0x10000; }
+
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = MBED_ROM_START; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = MBED_ROM_SIZE; }
+
 define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
-/* [RAM = 320kb = 0x50000] Vector table dynamic copy: 114 vectors = 456 bytes (0x1C8) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001C7; /* Aligned on 8 bytes */
-define symbol __region_CRASH_DATA_RAM_start__  = 0x200001C8;
-define symbol __region_CRASH_DATA_RAM_end__  = 0x200002C7;
-define symbol __region_RAM_start__    = 0x200002C8;
-define symbol __region_RAM_end__      = 0x2004FFFF;
+define symbol NVIC_NUM_VECTORS     = 114; /* This value must match NVIC_NUM_VECTORS in ../cmsis_nvic.h */
+define symbol MBED_VECTTABLE_RAM_SIZE = ((NVIC_NUM_VECTORS * 4) + 7) & ~7;
+define symbol M_CRASH_DATA_RAM_SIZE   = 0x100;
+
+define symbol __NVIC_start__          = MBED_RAM1_START;
+define symbol __region_CRASH_DATA_RAM_start__ = MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE;
+define symbol __NVIC_end__            = __region_CRASH_DATA_RAM_start__ - 1;
+define symbol __region_RAM_start__    = __region_CRASH_DATA_RAM_start__ + M_CRASH_DATA_RAM_SIZE;
+define symbol __region_CRASH_DATA_RAM_end__   = __region_RAM_start__ - 1;
+define symbol __region_RAM_end__      = MBED_RAM1_START + MBED_RAM_SIZE + MBED_RAM1_SIZE - 1;
 
 define symbol __region_ITCMRAM_start__ = 0x00000000;
 define symbol __region_ITCMRAM_end__   = 0x00003FFF;
@@ -20,8 +54,8 @@ define symbol __region_ITCMRAM_end__   = 0x00003FFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
+define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_ITCMRAM_end__];
 
 /* Define Crash Data Symbols */

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_STD/stm32f767xi.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_STD/stm32f767xi.sct
@@ -1,5 +1,7 @@
 #! armcc -E
 ; Scatter-Loading Description File
+;
+; SPDX-License-Identifier: BSD-3-Clause
 ;******************************************************************************
 ;* @attention
 ;*
@@ -12,18 +14,28 @@
 ;*                        opensource.org/licenses/BSD-3-Clause
 ;*
 ;******************************************************************************
+#include "../cmsis_nvic.h"
 
 ; STM32F767xI:
-; FLASH: 2048K (0x200000) @0x08000000
-; RAM1:   384K (0x60000)  @0x20020000
-; RAM2:   128K (0x20000)  @0x20000000
+; FLASH:   2048K (0x200000) @0x08000000
+; SRAM1:    368K (0x5C000)  @0x20020000
+; SRAM2:     16K (0x4000)   @0x2007C000
+; DTCM-RAM: 128K (0x20000)  @0x20000000
+; ITCM-RAM:  16K (0x3FFF)   @0x00000000
+
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x200000
+#define MBED_RAM_START   0x20020000
+#define MBED_RAM_SIZE    0x60000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x20000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x200000
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
@@ -32,14 +44,14 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-#define MBED_RAM_START              0x20020000
-#define MBED_RAM_SIZE               0x60000
-#define MBED_VECTTABLE_RAM_START    0x20000000
-#define MBED_VECTTABLE_RAM_SIZE     0x1F8
+#define MBED_VECTTABLE_RAM_START    (NVIC_RAM_VECTOR_ADDRESS)
+#define MBED_VECTTABLE_RAM_SIZE     (((NVIC_NUM_VECTORS * 4) + 7) AND ~7)
+
 #define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
 #define MBED_CRASH_REPORT_RAM_SIZE  0x100
-#define MBED_RAM0_START             (MBED_RAM_START)
-#define MBED_RAM0_SIZE              (MBED_RAM_SIZE)
+
+#define MBED_RAM0_START  (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
@@ -59,4 +71,3 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
 }
-

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
@@ -1,11 +1,42 @@
 /* Linker script to configure memory regions. */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
+#include "../cmsis_nvic.h"
+
+/* STM32F767xI:
+FLASH:   2048K (0x200000) @0x08000000
+SRAM1:    368K (0x5C000)  @0x20020000
+SRAM2:     16K (0x4000)   @0x2007C000
+DTCM-RAM: 128K (0x20000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
+
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x200000
+#define MBED_RAM_START   0x20020000
+#define MBED_RAM_SIZE    0x60000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x20000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 2048K
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 M_CRASH_DATA_RAM_SIZE = 0x100;
@@ -13,13 +44,16 @@ M_CRASH_DATA_RAM_SIZE = 0x100;
 #if !defined(MBED_BOOT_STACK_SIZE)
     #define MBED_BOOT_STACK_SIZE 0x400
 #endif
-
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
+
+#define MBED_VECTTABLE_RAM_SIZE (((NVIC_NUM_VECTORS * 4) + 7) & 0xFFFFFFF8)
+#define MBED_RAM0_START  (MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE)
 
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x200001F8, LENGTH = 512K - 0x1F8
+  RAM (rwx)  : ORIGIN = MBED_RAM0_START, LENGTH = MBED_RAM0_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
@@ -1,18 +1,52 @@
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
+/* Linker script to configure memory regions.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
 
-/* [ROM = 2048kb = 0x200000] */
+/* STM32F767xI:
+FLASH:   2048K (0x200000) @0x08000000
+SRAM1:    368K (0x5C000)  @0x20020000
+SRAM2:     16K (0x4000)   @0x2007C000
+DTCM-RAM: 128K (0x20000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
+
+if (!isdefinedsymbol(MBED_ROM_START)) { define symbol MBED_ROM_START  = 0x8000000; }
+if (!isdefinedsymbol(MBED_ROM_SIZE)) { define symbol MBED_ROM_SIZE   = 0x200000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_START  = 0x20020000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_SIZE   = 0x60000; }
+if (!isdefinedsymbol(MBED_RAM1_START)) { define symbol MBED_RAM1_START = 0x20000000; }
+if (!isdefinedsymbol(MBED_RAM1_SIZE)) { define symbol MBED_RAM1_SIZE  = 0x20000; }
+
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = MBED_ROM_START; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = MBED_ROM_SIZE; }
+
 define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
-/* [RAM = 512kb = 0x80000] Vector table dynamic copy: 126 vectors = 504 bytes (0x1F8) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001F7; /* Aligned on 8 bytes */
-define symbol __region_CRASH_DATA_RAM_start__ = 0x200001F8;
-define symbol __region_CRASH_DATA_RAM_end__   = 0x200002F7;
-define symbol __region_RAM_start__    = 0x200002F8;
-define symbol __region_RAM_end__      = 0x2007FFFF;
+define symbol NVIC_NUM_VECTORS     = 114; /* This value must match NVIC_NUM_VECTORS in ../cmsis_nvic.h */
+define symbol MBED_VECTTABLE_RAM_SIZE = ((NVIC_NUM_VECTORS * 4) + 7) & ~7;
+define symbol M_CRASH_DATA_RAM_SIZE   = 0x100;
+
+define symbol __NVIC_start__          = MBED_RAM1_START;
+define symbol __region_CRASH_DATA_RAM_start__ = MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE;
+define symbol __NVIC_end__            = __region_CRASH_DATA_RAM_start__ - 1;
+define symbol __region_RAM_start__    = __region_CRASH_DATA_RAM_start__ + M_CRASH_DATA_RAM_SIZE;
+define symbol __region_CRASH_DATA_RAM_end__   = __region_RAM_start__ - 1;
+define symbol __region_RAM_end__      = MBED_RAM1_START + MBED_RAM_SIZE + MBED_RAM1_SIZE - 1;
 
 define symbol __region_ITCMRAM_start__ = 0x00000000;
 define symbol __region_ITCMRAM_end__   = 0x00003FFF;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_ARM_STD/stm32f769xi.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_ARM_STD/stm32f769xi.sct
@@ -1,5 +1,7 @@
 #! armcc -E
 ; Scatter-Loading Description File
+;
+; SPDX-License-Identifier: BSD-3-Clause
 ;******************************************************************************
 ;* @attention
 ;*
@@ -12,18 +14,28 @@
 ;*                        opensource.org/licenses/BSD-3-Clause
 ;*
 ;******************************************************************************
+#include "../cmsis_nvic.h"
 
 ; STM32F769xI:
-; FLASH: 2048K (0x200000) @0x08000000
-; RAM1:   384K (0x60000)  @0x20020000
-; RAM2:   128K (0x20000)  @0x20000000
+; FLASH:   2048K (0x200000) @0x08000000
+; SRAM1:    368K (0x5C000)  @0x20020000
+; SRAM2:     16K (0x4000)   @0x2007C000
+; DTCM-RAM: 128K (0x20000)  @0x20000000
+; ITCM-RAM:  16K (0x3FFF)   @0x00000000
+
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x200000
+#define MBED_RAM_START   0x20020000
+#define MBED_RAM_SIZE    0x60000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x20000
 
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x200000
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
@@ -32,14 +44,14 @@
 
 #define Stack_Size MBED_BOOT_STACK_SIZE
 
-#define MBED_RAM_START              0x20020000
-#define MBED_RAM_SIZE               0x60000
-#define MBED_VECTTABLE_RAM_START    0x20000000
-#define MBED_VECTTABLE_RAM_SIZE     0x1F8
+#define MBED_VECTTABLE_RAM_START    (NVIC_RAM_VECTOR_ADDRESS)
+#define MBED_VECTTABLE_RAM_SIZE     (((NVIC_NUM_VECTORS * 4) + 7) AND ~7)
+
 #define MBED_CRASH_REPORT_RAM_START (MBED_VECTTABLE_RAM_START + MBED_VECTTABLE_RAM_SIZE)
 #define MBED_CRASH_REPORT_RAM_SIZE  0x100
-#define MBED_RAM0_START             (MBED_RAM_START)
-#define MBED_RAM0_SIZE              (MBED_RAM_SIZE)
+
+#define MBED_RAM0_START  (MBED_CRASH_REPORT_RAM_START + MBED_CRASH_REPORT_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE - MBED_CRASH_REPORT_RAM_SIZE)
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
 
@@ -59,4 +71,3 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   ARM_LIB_STACK (MBED_RAM0_START+MBED_RAM0_SIZE) EMPTY -Stack_Size { ; stack
   }
 }
-

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_GCC_ARM/STM32F769xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_GCC_ARM/STM32F769xI.ld
@@ -1,23 +1,59 @@
+/* Linker script to configure memory regions. */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
+#include "../cmsis_nvic.h"
+
+/* STM32F769xI:
+FLASH:   2048K (0x200000) @0x08000000
+SRAM1:    368K (0x5C000)  @0x20020000
+SRAM2:     16K (0x4000)   @0x2007C000
+DTCM-RAM: 128K (0x20000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
+
+#define MBED_ROM_START   0x8000000
+#define MBED_ROM_SIZE    0x200000
+#define MBED_RAM_START   0x20020000
+#define MBED_RAM_SIZE    0x60000
+#define MBED_RAM1_START  0x20000000
+#define MBED_RAM1_SIZE   0x20000
+
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
+  #define MBED_APP_START MBED_ROM_START
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 2048K
+  #define MBED_APP_SIZE MBED_ROM_SIZE
 #endif
+
+M_CRASH_DATA_RAM_SIZE = 0x100;
 
 #if !defined(MBED_BOOT_STACK_SIZE)
     #define MBED_BOOT_STACK_SIZE 0x400
 #endif
-
 STACK_SIZE = MBED_BOOT_STACK_SIZE;
 
-/* Linker script to configure memory regions. */
-/* Total: 126 vectors = 504 bytes (0x1F8 + 0 byte for 8-byte data alignment) to be reserved in RAM */
+#define MBED_VECTTABLE_RAM_SIZE (((NVIC_NUM_VECTORS * 4) + 7) & 0xFFFFFFF8)
+#define MBED_RAM0_START  (MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE)
+#define MBED_RAM0_SIZE   (MBED_RAM_SIZE + MBED_RAM1_SIZE - MBED_VECTTABLE_RAM_SIZE)
+
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x200001F8, LENGTH = 512K - 0x1F8
+  RAM (rwx)  : ORIGIN = MBED_RAM0_START, LENGTH = MBED_RAM0_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -91,6 +127,18 @@ SECTIONS
 
     __etext = .;
     _sidata = .;
+    
+    .crash_data_ram :
+    {
+        . = ALIGN(8);
+        __CRASH_DATA_RAM__ = .;
+        __CRASH_DATA_RAM_START__ = .; /* Create a global symbol at data start */
+        KEEP(*(.keep.crash_data_ram))
+        *(.m_crash_data_ram)     /* This is a user defined section */
+        . += M_CRASH_DATA_RAM_SIZE;
+        . = ALIGN(8);
+        __CRASH_DATA_RAM_END__ = .; /* Define a global symbol at data end */
+    } > RAM
 
     .data : AT (__etext)
     {

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_IAR/stm32f769xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_IAR/stm32f769xi.icf
@@ -1,17 +1,52 @@
-/* [ROM = 2048kb = 0x200000] */
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
+/* Linker script to configure memory regions.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2016-2019 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+*/
+
+/* STM32F769xI:
+FLASH:   2048K (0x200000) @0x08000000
+SRAM1:    368K (0x5C000)  @0x20020000
+SRAM2:     16K (0x4000)   @0x2007C000
+DTCM-RAM: 128K (0x20000)  @0x20000000
+ITCM-RAM:  16K (0x3FFF)   @0x00000000
+*/
+
+if (!isdefinedsymbol(MBED_ROM_START)) { define symbol MBED_ROM_START  = 0x8000000; }
+if (!isdefinedsymbol(MBED_ROM_SIZE)) { define symbol MBED_ROM_SIZE   = 0x200000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_START  = 0x20020000; }
+if (!isdefinedsymbol(MBED_RAM_START)) { define symbol MBED_RAM_SIZE   = 0x60000; }
+if (!isdefinedsymbol(MBED_RAM1_START)) { define symbol MBED_RAM1_START = 0x20000000; }
+if (!isdefinedsymbol(MBED_RAM1_SIZE)) { define symbol MBED_RAM1_SIZE  = 0x20000; }
+
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = MBED_ROM_START; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = MBED_ROM_SIZE; }
 
 define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
-/* [RAM = 512kb = 0x80000] */
-/* Total: 126 vectors = 504 bytes (0x1F8 + 0 byte for 8-byte data alignment) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001F7;
-define symbol __region_RAM_start__    = 0x200001F8;
-define symbol __region_RAM_end__      = 0x2007FFFF;
+define symbol NVIC_NUM_VECTORS     = 114; /* This value must match NVIC_NUM_VECTORS in ../cmsis_nvic.h */
+define symbol MBED_VECTTABLE_RAM_SIZE = ((NVIC_NUM_VECTORS * 4) + 7) & ~7;
+define symbol M_CRASH_DATA_RAM_SIZE   = 0x100;
+
+define symbol __NVIC_start__          = MBED_RAM1_START;
+define symbol __region_CRASH_DATA_RAM_start__ = MBED_RAM1_START + MBED_VECTTABLE_RAM_SIZE;
+define symbol __NVIC_end__            = __region_CRASH_DATA_RAM_start__ - 1;
+define symbol __region_RAM_start__    = __region_CRASH_DATA_RAM_start__ + M_CRASH_DATA_RAM_SIZE;
+define symbol __region_CRASH_DATA_RAM_end__   = __region_RAM_start__ - 1;
+define symbol __region_RAM_end__      = MBED_RAM1_START + MBED_RAM_SIZE + MBED_RAM1_SIZE - 1;
 
 define symbol __region_ITCMRAM_start__ = 0x00000000;
 define symbol __region_ITCMRAM_end__   = 0x00003FFF;
@@ -19,8 +54,13 @@ define symbol __region_ITCMRAM_end__   = 0x00003FFF;
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
+define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_ITCMRAM_end__];
+
+/* Define Crash Data Symbols */
+define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
+define exported symbol __CRASH_DATA_RAM_END__ = __region_CRASH_DATA_RAM_end__;
 
 /* Stack and Heap */
 if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {


### PR DESCRIPTION
### Description (*required*)

Since #11711, DTCM-RAM was used only for vectors.

This could make some regression for applications.
(ex with https://os.mbed.com/teams/ST/code/DISCO-F769NI_AUDIO_demo/)


##### Summary of change (*What the change is for and why*)

- DTCM RAM use
- license header update for all files
- alignment for the 3 tool chains
- alignment within the STM32F7 family


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)


----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)


##### Summary of changes

##### Impact of changes

##### Migration actions required



