### PR TITLE
Change mbed-os-example-wifi to build only DISCO_L475VG_IOT01A

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -116,7 +116,7 @@
       "sub-repo-example": false,
       "subs": [],
       "features" : [],
-      "targets" : [],
+      "targets" : ["DISCO_L475VG_IOT01A"],
       "toolchains" : [],
       "exporters": [],
       "compile" : true,


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
Currently mbed-os-example-blinky and mbed-os-example-wifi are built for each and every target in Mbed OS. This will change that only DISCO_L475VG_IOT01A is built for mbed-os-example-wifi. DISCO_L475VG_IOT01A was chosen as its one of the wi-fi supported boards and having integrated wi-fi.


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Build passed with GCC_ARM locally in Mac OS X

Passed Example Compilation:
+----------------------+---------------------+-----------+----------+--------------+
| EXAMPLE NAME         |        TARGET       | TOOLCHAIN | TEST GEN | BUILD RESULT |
+----------------------+---------------------+-----------+----------+--------------+
| mbed-os-example-wifi | DISCO_L475VG_IOT01A |  GCC_ARM  | TEST_OFF |    PASSED    |
+----------------------+---------------------+-----------+----------+--------------+
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



