### PR TITLE
Baremetal: Fix ARM toolchain Greentea test compilation for NUCLEO_F411RE

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -19,7 +19,6 @@
         "lora",
         "nfc",
         "network-emac",
-        "nanostack-libservice",
         "flashiap-block-device",
         "system-storage",
         "filesystemstore",
@@ -36,7 +35,8 @@
     ],
     "target_overrides": {
         "*": {
-            "target.device_has_remove": ["EMAC", "USBDEVICE"]
+            "target.device_has_remove": ["EMAC", "USBDEVICE"],
+            "mbed-trace.fea-ipv6": false
         }
      }
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
Removed the nanostack lib service and in mbed-trace with fea-ipv6 to false to remove dependency issue on  greentea test for bare metal with ARM toolchain.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
The Greentea tests were not compiling for the Nucleo F411RE target with the bare metal profile when using the ARM toolchain.
The build failure was due to a missing symbol from a library not included in the bare metal profile (nanostack-hal-mbed-cmsis-rtos). This only occurs for the ARM toolchain because it attempts to resolve all symbols even if not executed (the GCC_ARM toolchain does not attempt to resolve symbols not executed and therefore compiles fine).  In order to solve the build issue, the dependency on the missing symbol is removed by not including the library (nanostack-libservice) that was bringing it in and compiling out sections of the code (mbed_trace) that was relying on it by setting a macro (MBED_CONF_MBED_TRACE_FEA_IPV6) to 0 via the configuration file.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@evedon @hugueskamba @jamesbeyond 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



