### PR TITLE
Fix for sending IPv6 UDP packet over link local interface

### DIFF
--- a/features/lwipstack/LWIPStack.cpp
+++ b/features/lwipstack/LWIPStack.cpp
@@ -439,7 +439,7 @@ nsapi_size_or_error_t LWIP::socket_sendto(nsapi_socket_t handle, const SocketAdd
     }
     if (netif_) {
         if ((addr.version == NSAPI_IPv4 && !get_ipv4_addr(netif_)) ||
-                (addr.version == NSAPI_IPv6 && !get_ipv6_addr(netif_))) {
+                (addr.version == NSAPI_IPv6 && !get_ipv6_addr(netif_) && !get_ipv6_link_local_addr(netif_))) {
             return NSAPI_ERROR_PARAMETER;
         }
     }

--- a/features/lwipstack/lwip_tools.cpp
+++ b/features/lwipstack/lwip_tools.cpp
@@ -273,11 +273,8 @@ bool convert_mbed_addr_to_lwip(ip_addr_t *out, const nsapi_addr_t *in)
 
 #if LWIP_IPV4 && LWIP_IPV6
     if (in->version == NSAPI_UNSPEC) {
-#if IP_VERSION_PREF == PREF_IPV4
-        ip_addr_set_zero_ip4(out);
-#else
-        ip_addr_set_zero_ip6(out);
-#endif
+        ip6_addr_set_zero(ip_2_ip6(out));
+        IP_SET_TYPE(out, IPADDR_TYPE_ANY);
         return true;
     }
 #endif


### PR DESCRIPTION
### Description (*required*)
Modified LwIP stack and LwIP mbed-os wrapper to support sending IPv6 UDP packets when IPv4 and IPv6 dual mode stack is enabled and the IPv6 packet is sent over link-local interface

##### Summary of change (*What the change is for and why*)
LWIPStack.cpp: 
  LWIP::socket_sendto( )API checks for valid IPv6 interface before sending the packet using netconn  API. This condition check would return NSAPI_ERROR_PARAMETER error, when the UDP packet is sent on IPv6 link local interface. Hence modified the condition check to take address this use case.

lwip_tools.cpp:
  convert_mbed_addr_to_lwip() API reset the ip_addr_t address to IPv4 when IP version is NSAPI_UNSPEC. Hence when dual  IPv4 and IPv6 stack is enabled, local_ip is set to IPADDR_TYPE_V4.
During UDP packet send the type will be checked for IPADDR_TYPE_ANY since dual stack is enabled.
Hence setting the type to IPADDR_TYPE_ANY is done as part of convert_mbed_addr_to_lwip() when dual stack is enabled.

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

---------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

##### Summary of changes

##### Impact of changes

##### Migration actions required



