### PR TITLE
Improve API documentation and test coverage

### DIFF
--- a/UNITTESTS/features/netsocket/EthernetInterface/test_EthernetInterface.cpp
+++ b/UNITTESTS/features/netsocket/EthernetInterface/test_EthernetInterface.cpp
@@ -17,6 +17,9 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+
+#include "OnboardNetworkStack_mock.h"
+
 #include "features/netsocket/EthernetInterface.h"
 #include <iostream>
 
@@ -50,62 +53,9 @@ MBED_WEAK EMAC &EMAC::get_default_instance()
     return MockEMAC::get_instance();
 }
 
-class EmacNetworkStackMock : public OnboardNetworkStack {
-public:
-    MOCK_METHOD3(gethostbyname, nsapi_error_t(const char *host, SocketAddress *address, nsapi_version_t version));
-    MOCK_METHOD1(add_dns_server, nsapi_error_t(const SocketAddress &address));
-    MOCK_METHOD2(call_in, nsapi_error_t(int delay, mbed::Callback<void()> func));
-    MOCK_METHOD2(socket_open, nsapi_error_t(nsapi_socket_t *handle, nsapi_protocol_t proto));
-    MOCK_METHOD1(socket_close, nsapi_error_t(nsapi_socket_t handle));
-    MOCK_METHOD2(socket_bind, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address));
-    MOCK_METHOD2(socket_listen, nsapi_error_t(nsapi_socket_t handle, int backlog));
-    MOCK_METHOD2(socket_connect, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address));
-    MOCK_METHOD3(socket_accept, nsapi_error_t(nsapi_socket_t server, nsapi_socket_t *handle, SocketAddress *address));
-    MOCK_METHOD3(socket_send, nsapi_error_t(nsapi_socket_t handle, const void *data, nsapi_size_t size));
-    MOCK_METHOD3(socket_recv, nsapi_error_t(nsapi_socket_t handle, void *data, nsapi_size_t size));
-    MOCK_METHOD4(socket_sendto, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size));
-    MOCK_METHOD4(socket_recvfrom, nsapi_error_t(nsapi_socket_t handle, SocketAddress *address, void *data, nsapi_size_t size));
-    MOCK_METHOD5(setsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen));
-    MOCK_METHOD5(getsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned *optlen));
-    MOCK_METHOD3(socket_attach, void(nsapi_socket_t handle, void (*callback)(void *), void *data));
-    MOCK_METHOD3(add_ethernet_interface, nsapi_error_t(EMAC &emac, bool default_if, OnboardNetworkStack::Interface **interface_out));
-
-    static EmacNetworkStackMock &get_instance()
-    {
-        static EmacNetworkStackMock stackMock1;
-        return stackMock1;
-    }
-
-    class InterfaceMock : public OnboardNetworkStack::Interface {
-    public:
-
-        static InterfaceMock &get_instance()
-        {
-            static InterfaceMock test_interface;
-            return test_interface;
-        }
-        MOCK_METHOD6(bringup, nsapi_error_t(bool dhcp, const char *ip,
-                                            const char *netmask, const char *gw,
-                                            nsapi_ip_stack_t stack,
-                                            bool blocking
-                                           ));
-        MOCK_METHOD0(bringdown, nsapi_error_t());
-        MOCK_METHOD1(attach, void(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb));
-        MOCK_CONST_METHOD0(get_connection_status, nsapi_connection_status_t());
-        MOCK_METHOD2(get_mac_address, char *(char *buf, nsapi_size_t buflen));
-        MOCK_METHOD1(get_ip_address, nsapi_error_t(SocketAddress *address));
-        MOCK_METHOD2(get_ip_address, char *(char *buf, nsapi_size_t buflen));
-        MOCK_METHOD1(get_netmask, nsapi_error_t(SocketAddress *address));
-        MOCK_METHOD2(get_netmask, char *(char *buf, nsapi_size_t buflen));
-        MOCK_METHOD1(get_gateway, nsapi_error_t(SocketAddress *address));
-        MOCK_METHOD2(get_gateway, char *(char *buf, nsapi_size_t buflen));
-        MOCK_METHOD1(get_ipv6_link_local_address, nsapi_error_t(SocketAddress *address));
-    };
-};
-
 OnboardNetworkStack &OnboardNetworkStack::get_default_instance()
 {
-    return EmacNetworkStackMock::get_instance();
+    return OnboardNetworkStackMock::get_instance();
 }
 
 // Implementaion in in NetworkInterfaceDefaults.cpp
@@ -126,15 +76,15 @@ using ::testing::SetArgReferee;
 class TestEthernetInterface: public testing::Test {
 protected:
     EthernetInterface *iface;
-    EmacNetworkStackMock *stackMock;
+    OnboardNetworkStackMock *stackMock;
     MockEMAC *emacMock;
-    EmacNetworkStackMock::InterfaceMock *netStackIface;
+    OnboardNetworkStackMock::InterfaceMock *netStackIface;
     virtual void SetUp()
     {
-        stackMock = &EmacNetworkStackMock::get_instance();
+        stackMock = &OnboardNetworkStackMock::get_instance();
         emacMock = &MockEMAC::get_instance();
-        netStackIface = &EmacNetworkStackMock::InterfaceMock::get_instance();
-        iface = new EthernetInterface(MockEMAC::get_instance(), EmacNetworkStackMock::get_instance());
+        netStackIface = &OnboardNetworkStackMock::InterfaceMock::get_instance();
+        iface = new EthernetInterface(MockEMAC::get_instance(), OnboardNetworkStackMock::get_instance());
     }
 
     virtual void TearDown()

--- a/UNITTESTS/features/netsocket/NetworkInterface/test_NetworkInterface.cpp
+++ b/UNITTESTS/features/netsocket/NetworkInterface/test_NetworkInterface.cpp
@@ -148,6 +148,12 @@ TEST_F(TestNetworkInterface, set_blocking)
     EXPECT_EQ(iface->set_blocking(true), NSAPI_ERROR_UNSUPPORTED);
 }
 
+TEST_F(TestNetworkInterface, get_ipv6_link_local_address)
+{
+    SocketAddress a;
+    EXPECT_EQ(iface->get_ipv6_link_local_address(&a), NSAPI_ERROR_UNSUPPORTED);
+}
+
 void my_iface_callback(nsapi_event_t e, intptr_t i)
 {
     (void)e;

--- a/UNITTESTS/features/netsocket/PPPInterface/test_PPPInterface.cpp
+++ b/UNITTESTS/features/netsocket/PPPInterface/test_PPPInterface.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "OnboardNetworkStack_mock.h"
+
+#include "features/netsocket/PPPInterface.h"
+#include <iostream>
+#include "FileHandle_stub.h"
+
+
+OnboardNetworkStack &OnboardNetworkStack::get_default_instance()
+{
+    return OnboardNetworkStackMock::get_instance();
+}
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnArg;
+using ::testing::SaveArg;
+using ::testing::SaveArgPointee;
+using ::testing::SetArrayArgument;
+using ::testing::SetArgPointee;
+using ::testing::SetArgReferee;
+
+class MockPPP : public PPP {
+public:
+    MOCK_METHOD0(power_up, bool());
+    MOCK_METHOD0(power_down, void());
+    MOCK_METHOD0(get_mtu_size, uint32_t());
+    MOCK_CONST_METHOD0(get_align_preference, uint32_t());
+    MOCK_CONST_METHOD2(get_ifname, void(char *name, uint8_t size));
+    MOCK_METHOD2(link_out, bool(net_stack_mem_buf_t *buf, nsapi_ip_stack_t ip_stack));
+    MOCK_METHOD1(set_stream, void(mbed::FileHandle *stream));
+    MOCK_METHOD1(set_ip_stack, void(nsapi_ip_stack_t ip_stack));
+    MOCK_METHOD2(set_credentials, void(const char *uname, const char *password));
+    MOCK_METHOD1(get_ip_address, const nsapi_addr_t *(nsapi_version_t version));
+    MOCK_METHOD0(get_netmask, const nsapi_addr_t *());
+    MOCK_METHOD0(get_gateway, const nsapi_addr_t *());
+    MOCK_METHOD1(get_dns_server, const nsapi_addr_t *(uint8_t index));
+    MOCK_METHOD1(set_link_input_cb, void(ppp_link_input_cb_t input_cb));
+    MOCK_METHOD1(set_link_state_cb, void(ppp_link_state_change_cb_t state_cb));
+    MOCK_METHOD1(set_memory_manager, void(NetStackMemoryManager &mem_mngr));
+
+    static MockPPP &get_instance()
+    {
+        static MockPPP pppMock1;
+        return pppMock1;
+    }
+};
+
+MBED_WEAK PPP &PPP::get_default_instance()
+{
+    return MockPPP::get_instance();
+}
+
+class TestPPPInterface: public testing::Test {
+protected:
+    PPPInterface *iface;
+    OnboardNetworkStackMock *stackMock;
+    MockPPP *pppMock;
+    OnboardNetworkStackMock::InterfaceMock *netStackIface;
+    virtual void SetUp()
+    {
+        stackMock = &OnboardNetworkStackMock::get_instance();
+        pppMock = &MockPPP::get_instance();
+        netStackIface = &OnboardNetworkStackMock::InterfaceMock::get_instance();
+        iface = new PPPInterface(MockPPP::get_instance(), OnboardNetworkStackMock::get_instance());
+    }
+
+    virtual void TearDown()
+    {
+        // Do not delete the mocks pointers, as they point to statically allocated singletons.
+        delete iface;
+    }
+
+    /* Enclose the heavily-used connection procedure to improve code redability */
+    void doConnect(bool blocking = true)
+    {
+        EXPECT_CALL(*pppMock, set_stream(_));
+        EXPECT_CALL(*pppMock, set_ip_stack(_));
+        EXPECT_CALL(*pppMock, set_credentials(_, _));
+        EXPECT_CALL(*stackMock, add_ppp_interface(testing::Ref(*pppMock), true, _))
+        .Times(1)
+        .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_OK)));
+        EXPECT_CALL(*netStackIface, attach(_))
+        .Times(1)
+        .RetiresOnSaturation();
+        EXPECT_CALL(*netStackIface, bringup(false, NULL, NULL, NULL, DEFAULT_STACK, blocking))
+        .Times(1)
+        .WillOnce(Return(NSAPI_ERROR_OK));
+        EXPECT_EQ(NSAPI_ERROR_OK, iface->connect());
+    }
+
+    static void cb(nsapi_event_t ev, intptr_t ptr)
+    {
+
+    }
+};
+
+TEST_F(TestPPPInterface, constructor_default)
+{
+    EXPECT_TRUE(iface);
+    // Test that this clas presents itself correctly
+    EXPECT_NE(nullptr, iface->pppInterface());
+
+    EXPECT_EQ(nullptr, iface->emacInterface());
+    EXPECT_EQ(nullptr, iface->ethInterface());
+    EXPECT_EQ(nullptr, iface->wifiInterface());
+    EXPECT_EQ(nullptr, iface->cellularBase());
+    EXPECT_EQ(nullptr, iface->cellularInterface());
+    EXPECT_EQ(nullptr, iface->meshInterface());
+}
+
+TEST_F(TestPPPInterface, connect)
+{
+    mbed::FileHandle_stub handle;
+    nsapi_ip_stack_t stack = IPV4_STACK;
+    iface->set_credentials("uname", "passwd");
+    iface->set_stream(&handle);
+    iface->set_ip_stack(stack);
+
+    EXPECT_CALL(*pppMock, set_stream(&handle));
+    EXPECT_CALL(*pppMock, set_ip_stack(stack));
+    EXPECT_CALL(*pppMock, set_credentials("uname", "passwd"));
+    EXPECT_CALL(*stackMock, add_ppp_interface(testing::Ref(*pppMock), true, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_OK)));
+    EXPECT_CALL(*netStackIface, attach(_))
+    .Times(1)
+    .RetiresOnSaturation();
+    EXPECT_CALL(*netStackIface, bringup(false, NULL, NULL, NULL, stack, true))
+    .Times(1)
+    .WillOnce(Return(NSAPI_ERROR_OK));
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->connect());
+}
+
+TEST_F(TestPPPInterface, connect_failure)
+{
+    EXPECT_CALL(*pppMock, set_stream(_));
+    EXPECT_CALL(*pppMock, set_ip_stack(_));
+    EXPECT_CALL(*pppMock, set_credentials(_, _));
+    EXPECT_CALL(*stackMock, add_ppp_interface(testing::Ref(*pppMock), true, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_NO_MEMORY)));
+    EXPECT_EQ(NSAPI_ERROR_NO_MEMORY, iface->connect());
+}
+
+TEST_F(TestPPPInterface, disconnect_without_connecting)
+{
+    EXPECT_EQ(NSAPI_ERROR_NO_CONNECTION, iface->disconnect());
+}
+
+TEST_F(TestPPPInterface, disconnect)
+{
+    doConnect();
+
+    EXPECT_CALL(*netStackIface, bringdown())
+    .Times(1)
+    .WillOnce(Return(NSAPI_ERROR_OK));
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->disconnect());
+}
+
+TEST_F(TestPPPInterface, set_network)
+{
+    char ipAddress[NSAPI_IPv4_SIZE] = "127.0.0.1";
+    char netmask[NSAPI_IPv4_SIZE] = "255.255.0.0";
+    char gateway[NSAPI_IPv4_SIZE] = "127.0.0.2";
+
+    const char *ipAddressArg;
+    const char *netmaskArg;
+    const char *gatewayArg;
+
+    EXPECT_EQ(0, iface->get_ip_address());
+    EXPECT_EQ(0, iface->get_netmask());
+    EXPECT_EQ(0, iface->get_gateway());
+
+    EXPECT_CALL(*pppMock, set_stream(_));
+    EXPECT_CALL(*pppMock, set_ip_stack(_));
+    EXPECT_CALL(*pppMock, set_credentials(_, _));
+
+    // Set the network data
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->set_network(ipAddress, netmask, gateway));
+
+    // Now the bringup should have different arguments. We can't use doConnect method.
+    EXPECT_CALL(*stackMock, add_ppp_interface(testing::Ref(*pppMock), true, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_OK)));
+    EXPECT_CALL(*netStackIface, attach(_))
+    .Times(1)
+    .RetiresOnSaturation();
+    // Do not put the expected char * arguments, as they are pointers and would not match
+    EXPECT_CALL(*netStackIface, bringup(false, _, _, _, DEFAULT_STACK, true))
+    .Times(1)
+    .WillOnce(DoAll(SaveArg<1>(&ipAddressArg),
+                    SaveArg<2>(&netmaskArg),
+                    SaveArg<3>(&gatewayArg),
+                    Return(NSAPI_ERROR_OK)));
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->connect());
+    // Check the contents of the stored pointer arguments.
+    EXPECT_TRUE(0 == strcmp(ipAddress, ipAddressArg));
+    EXPECT_TRUE(0 == strcmp(netmask, netmaskArg));
+    EXPECT_TRUE(0 == strcmp(gateway, gatewayArg));
+
+    // Testing the getters makes sense now.
+    EXPECT_CALL(*netStackIface, get_ip_address(_, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<0>(*ipAddress), Return(ipAddress)));
+    EXPECT_EQ(std::string(ipAddress), std::string(iface->get_ip_address()));
+
+    EXPECT_CALL(*netStackIface, get_netmask(_, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<0>(*netmask), Return(netmask)));
+    EXPECT_EQ(std::string(netmask), std::string(iface->get_netmask()));
+
+    EXPECT_CALL(*netStackIface, get_gateway(_, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<0>(*gateway), Return(gateway)));
+    EXPECT_EQ(std::string(gateway), std::string(iface->get_gateway()));
+}
+
+TEST_F(TestPPPInterface, get_connection_status)
+{
+    EXPECT_EQ(NSAPI_STATUS_DISCONNECTED, iface->get_connection_status());
+
+    doConnect();
+
+    EXPECT_CALL(*netStackIface, get_connection_status())
+    .Times(1)
+    .WillOnce(Return(NSAPI_STATUS_LOCAL_UP));
+    EXPECT_EQ(NSAPI_STATUS_LOCAL_UP, iface->get_connection_status());
+}
+
+TEST_F(TestPPPInterface, get_interface_name)
+{
+    char name[100];
+    memset(name, '\0', 100);
+    EXPECT_EQ(NULL, iface->get_interface_name(name));
+
+    doConnect();
+
+    EXPECT_EQ(NULL, iface->get_interface_name(name));
+
+    EXPECT_CALL(*netStackIface, get_interface_name(name))
+    .Times(1)
+    .WillOnce(Return(name));
+    EXPECT_EQ(name, iface->get_interface_name(name));
+}
+
+TEST_F(TestPPPInterface, set_as_default)
+{
+    doConnect();
+
+    EXPECT_CALL(*stackMock, set_default_interface(netStackIface))
+    .Times(1);
+    iface->set_as_default();
+}
+
+TEST_F(TestPPPInterface, attach)
+{
+    doConnect();
+    EXPECT_CALL(*netStackIface, attach(_)) // TODO: check that the correct function is passed.
+    .Times(1);
+    iface->attach(cb);
+}
+
+TEST_F(TestPPPInterface, set_dhcp)
+{
+    EXPECT_EQ(NSAPI_ERROR_UNSUPPORTED, iface->set_dhcp(false));
+    doConnect(true);
+}
+
+TEST_F(TestPPPInterface, set_blocking)
+{
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->set_blocking(false));
+    doConnect(false);
+}

--- a/UNITTESTS/features/netsocket/PPPInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/PPPInterface/unittest.cmake
@@ -25,7 +25,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/PPPInterface/test_PPPInterface.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/FileHandle_stub.cpp

--- a/UNITTESTS/features/netsocket/PPPInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/PPPInterface/unittest.cmake
@@ -1,0 +1,41 @@
+
+####################
+# UNIT TESTS
+####################
+
+# Unit test suite name
+set(TEST_SUITE_NAME "features_netsocket_PPPInterface")
+
+# Source files
+set(unittest-sources
+  ../features/netsocket/SocketAddress.cpp
+  ../features/netsocket/PPPInterface.cpp
+  ../features/netsocket/EMACInterface.cpp
+  ../features/netsocket/NetworkInterface.cpp
+  ../features/netsocket/NetworkStack.cpp
+  ../features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
+  ../features/frameworks/nanostack-libservice/source/libip6string/ip6tos.c
+  ../features/frameworks/nanostack-libservice/source/libip4string/stoip4.c
+  ../features/frameworks/nanostack-libservice/source/libip6string/stoip6.c
+  ../features/frameworks/nanostack-libservice/source/libBits/common_functions.c
+  ../features/frameworks/nanostack-libservice/source/libList/ns_list.c
+)
+
+# Test files
+set(unittest-test-sources
+  features/netsocket/PPPInterface/test_PPPInterface.cpp
+  stubs/Mutex_stub.cpp
+  stubs/mbed_assert_stub.c
+  stubs/equeue_stub.c
+  stubs/EventQueue_stub.cpp
+  stubs/FileHandle_stub.cpp
+  stubs/mbed_shared_queues_stub.cpp
+  stubs/nsapi_dns_stub.cpp
+  stubs/EventFlags_stub.cpp
+  stubs/stoip4_stub.c
+  stubs/ip4tos_stub.c
+  stubs/NetworkStack_stub.cpp
+  stubs/NetworkInterfaceDefaults_stub.cpp
+  stubs/SocketStats_Stub.cpp
+  stubs/mbed_error.c
+)

--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -110,10 +110,11 @@ TEST_F(TestTCPSocket, connect_with_timeout)
 TEST_F(TestTCPSocket, connect_error_is_connected)
 {
     socket->open((NetworkStack *)&stack);
-    stack.return_values.push_back(NSAPI_ERROR_ALREADY);
     stack.return_values.push_back(NSAPI_ERROR_IS_CONNECTED);
+    stack.return_values.push_back(NSAPI_ERROR_ALREADY);
     const SocketAddress a("127.0.0.1", 1024);
     socket->set_timeout(1);
+    EXPECT_EQ(socket->connect(a), NSAPI_ERROR_IS_CONNECTED);
     EXPECT_EQ(socket->connect(a), NSAPI_ERROR_OK);
 }
 
@@ -277,4 +278,10 @@ TEST_F(TestTCPSocket, accept_would_block)
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
     EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket *>(NULL));
     EXPECT_EQ(error, NSAPI_ERROR_WOULD_BLOCK);
+}
+
+TEST_F(TestTCPSocket, unsupported_api)
+{
+    SocketAddress addr;
+    EXPECT_EQ(socket->join_multicast_group(addr), NSAPI_ERROR_UNSUPPORTED);
 }

--- a/UNITTESTS/features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
+++ b/UNITTESTS/features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
@@ -17,6 +17,7 @@
 
 #include "gtest/gtest.h"
 #include "features/netsocket/WiFiAccessPoint.h"
+#include "features/netsocket/NetworkInterface.h"
 #include <cstring>
 
 class TestWiFiAccessPoint : public testing::Test {

--- a/UNITTESTS/stubs/NetworkStack_stub.h
+++ b/UNITTESTS/stubs/NetworkStack_stub.h
@@ -21,6 +21,13 @@
 #include "netsocket/NetworkStack.h"
 #include <list>
 
+/*
+ * Note: If you want to:
+ * - control and/or set expectations for the data returned/sent from/to the stack
+ * - set expectations on the calls to NetworkStack
+ * See OnboardNetworkStack_mock.h and its OnboardNetworkStackMock class.
+ */
+
 class NetworkStackstub : public NetworkStack {
 public:
     std::list<nsapi_error_t> return_values;

--- a/UNITTESTS/stubs/OnboardNetworkStack_mock.h
+++ b/UNITTESTS/stubs/OnboardNetworkStack_mock.h
@@ -47,6 +47,8 @@ public:
     MOCK_METHOD5(getsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned *optlen));
     MOCK_METHOD3(socket_attach, void(nsapi_socket_t handle, void (*callback)(void *), void *data));
     MOCK_METHOD3(add_ethernet_interface, nsapi_error_t(EMAC &emac, bool default_if, OnboardNetworkStack::Interface **interface_out));
+    MOCK_METHOD3(add_ppp_interface, nsapi_error_t(PPP &ppp, bool default_if, OnboardNetworkStack::Interface **interface_out));
+    MOCK_METHOD1(set_default_interface, void (OnboardNetworkStack::Interface *interface));
 
     static OnboardNetworkStackMock &get_instance()
     {
@@ -70,11 +72,15 @@ public:
         MOCK_METHOD0(bringdown, nsapi_error_t());
         MOCK_METHOD1(attach, void(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb));
         MOCK_CONST_METHOD0(get_connection_status, nsapi_connection_status_t());
+        MOCK_METHOD1(get_interface_name, char *(char *buf));
         MOCK_METHOD2(get_mac_address, char *(char *buf, nsapi_size_t buflen));
         MOCK_METHOD2(get_ip_address, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD1(get_ip_address, nsapi_error_t (SocketAddress *address));
         MOCK_METHOD1(get_ipv6_link_local_address, nsapi_error_t(SocketAddress *address));
         MOCK_METHOD2(get_netmask, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD1(get_netmask, nsapi_error_t (SocketAddress *address));
         MOCK_METHOD2(get_gateway, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD1(get_gateway, nsapi_error_t (SocketAddress *address));
     };
 };
 

--- a/UNITTESTS/stubs/OnboardNetworkStack_mock.h
+++ b/UNITTESTS/stubs/OnboardNetworkStack_mock.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UNITTESTS_STUBS_ONBOARDNETWORKSTACK_MOCK_H_
+#define UNITTESTS_STUBS_ONBOARDNETWORKSTACK_MOCK_H_
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "netsocket/OnboardNetworkStack.h"
+
+/*
+ * Note: If all you need is a simple stub with basic return value control
+ * consider using NetworkStack_stub.h and its NetworkStackstub class.
+ */
+
+class OnboardNetworkStackMock : public OnboardNetworkStack {
+public:
+    MOCK_METHOD3(gethostbyname, nsapi_error_t(const char *host, SocketAddress *address, nsapi_version_t version));
+    MOCK_METHOD1(add_dns_server, nsapi_error_t(const SocketAddress &address));
+    MOCK_METHOD2(call_in, nsapi_error_t(int delay, mbed::Callback<void()> func));
+    MOCK_METHOD2(socket_open, nsapi_error_t(nsapi_socket_t *handle, nsapi_protocol_t proto));
+    MOCK_METHOD1(socket_close, nsapi_error_t(nsapi_socket_t handle));
+    MOCK_METHOD2(socket_bind, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address));
+    MOCK_METHOD2(socket_listen, nsapi_error_t(nsapi_socket_t handle, int backlog));
+    MOCK_METHOD2(socket_connect, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address));
+    MOCK_METHOD3(socket_accept, nsapi_error_t(nsapi_socket_t server, nsapi_socket_t *handle, SocketAddress *address));
+    MOCK_METHOD3(socket_send, nsapi_error_t(nsapi_socket_t handle, const void *data, nsapi_size_t size));
+    MOCK_METHOD3(socket_recv, nsapi_error_t(nsapi_socket_t handle, void *data, nsapi_size_t size));
+    MOCK_METHOD4(socket_sendto, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size));
+    MOCK_METHOD4(socket_recvfrom, nsapi_error_t(nsapi_socket_t handle, SocketAddress *address, void *data, nsapi_size_t size));
+    MOCK_METHOD5(setsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen));
+    MOCK_METHOD5(getsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned *optlen));
+    MOCK_METHOD3(socket_attach, void(nsapi_socket_t handle, void (*callback)(void *), void *data));
+    MOCK_METHOD3(add_ethernet_interface, nsapi_error_t(EMAC &emac, bool default_if, OnboardNetworkStack::Interface **interface_out));
+
+    static OnboardNetworkStackMock &get_instance()
+    {
+        static OnboardNetworkStackMock stackMock1;
+        return stackMock1;
+    }
+
+    class InterfaceMock : public OnboardNetworkStack::Interface {
+    public:
+
+        static InterfaceMock &get_instance()
+        {
+            static InterfaceMock test_interface;
+            return test_interface;
+        }
+        MOCK_METHOD6(bringup, nsapi_error_t(bool dhcp, const char *ip,
+                                            const char *netmask, const char *gw,
+                                            nsapi_ip_stack_t stack,
+                                            bool blocking
+                                           ));
+        MOCK_METHOD0(bringdown, nsapi_error_t());
+        MOCK_METHOD1(attach, void(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb));
+        MOCK_CONST_METHOD0(get_connection_status, nsapi_connection_status_t());
+        MOCK_METHOD2(get_mac_address, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD2(get_ip_address, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD1(get_ipv6_link_local_address, nsapi_error_t(SocketAddress *address));
+        MOCK_METHOD2(get_netmask, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD2(get_gateway, char *(char *buf, nsapi_size_t buflen));
+    };
+};
+
+
+#endif /* UNITTESTS_STUBS_ONBOARDNETWORKSTACK_MOCK_H_ */

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -74,96 +74,54 @@ public:
      *  Requires that the network is disconnected
      *
      *  @param dhcp     False to disable dhcp (defaults to enabled)
-     *  @return         0 on success, negative error code on failure
+     *  @retval         NSAPI_ERROR_OK on success.
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if operation is not supported.
      */
     virtual nsapi_error_t set_dhcp(bool dhcp);
 
-    /** Start the interface
-     *  @return             0 on success, negative on failure
-     */
+    /** @copydoc NetworkInterface::connect */
     virtual nsapi_error_t connect();
 
-    /** Stop the interface
-     *  @return             0 on success, negative on failure
-     */
+    /** @copydoc NetworkInterface::disconnect */
     virtual nsapi_error_t disconnect();
 
-    /** Get the local MAC address
-     *
-     *  Provided MAC address is intended for info or debug purposes and
-     *  may not be provided if the underlying network interface does not
-     *  provide a MAC address
-     *
-     *  @return         Null-terminated representation of the local MAC address
-     *                  or null if no MAC address is available
-     */
+    /** @copydoc NetworkInterface::get_mac_address */
     virtual const char *get_mac_address();
 
-    /** Get the local IP address
-     *
-     *  @return         Null-terminated representation of the local IP address
-     *                  or null if no IP address has been received
-     */
+    /** @copydoc NetworkInterface::get_ip_address */
     virtual nsapi_error_t get_ip_address(SocketAddress *address);
 
     MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_ip_address();
 
-    /** Get the IPv6 link local address
-     *
-     *  @address        SocketAddress representation of the link local IPv6 address
-     *  @return         0 on success, negative error code on failure
-     */
+    /** @copydoc NetworkInterface::get_ipv6_link_local_address */
     virtual nsapi_error_t get_ipv6_link_local_address(SocketAddress *address);
 
-    /** Get the local network mask
-     *
-     *  @return         Null-terminated representation of the local network mask
-     *                  or null if no network mask has been received
-     */
+    /** @copydoc NetworkInterface::get_netmask */
     virtual nsapi_error_t get_netmask(SocketAddress *address);
 
     MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_netmask();
 
-    /** Get the local gateways
-     *
-     *  @return         Null-terminated representation of the local gateway
-     *                  or null if no network mask has been received
-     */
+    /** @copydoc NetworkInterface::get_gateway */
     virtual nsapi_error_t get_gateway(SocketAddress *address);
 
     MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_gateway();
 
-    /** Get the network interface name
-      *
-      *  @return         Null-terminated representation of the network interface name
-      *                  or null if  interface not exists
-      */
+    /** @copydoc NetworkInterface::get_interface_name */
     virtual char *get_interface_name(char *interface_name);
 
-    /** Set the network interface as default one
-      */
+    /** @copydoc NetworkInterface::set_as_default */
     virtual void set_as_default();
 
-    /** Register callback for status reporting
-     *
-     *  @param status_cb The callback for status changes
-     */
+    /** @copydoc NetworkInterface::attach */
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
-    /** Get the connection status
-     *
-     *  @return         The connection status according to nsapi_connection_status_t
-     */
+    /** @copydoc NetworkInterface::get_connection_status */
     virtual nsapi_connection_status_t get_connection_status() const;
 
-    /** Set blocking status of connect() which by default should be blocking
-     *
-     *  @param blocking true if connect is blocking
-     *  @return         0 on success, negative error code on failure
-     */
+    /** @copydoc NetworkInterface::set_blocking */
     virtual nsapi_error_t set_blocking(bool blocking);
 
     /** Provide access to the EMAC

--- a/features/netsocket/InternetDatagramSocket.h
+++ b/features/netsocket/InternetDatagramSocket.h
@@ -42,6 +42,7 @@ public:
      *  @param size     Size of the buffer in bytes.
      *  @retval         int Number of sent bytes on success.
      *  @retval         NSAPI_ERROR_NO_SOCKET in case socket was not created correctly.
+     *  @retval         NSAPI_ERROR_DNS_FAILURE if the DNS address of host could not be resolved
      *  @retval         NSAPI_ERROR_WOULD_BLOCK in case non-blocking mode is enabled
      *                  and send cannot be performed immediately.
      *  @retval         int Other negative error codes for stack-related failures.
@@ -60,8 +61,6 @@ public:
      *  @param address  The SocketAddress of the remote host.
      *  @param data     Buffer of data to send to the host.
      *  @param size     Size of the buffer in bytes.
-     *  @retval         NSAPI_ERROR_DNS_FAILURE in case the address parameter cannot
-     *                  be resolved.
      *  @retval         NSAPI_ERROR_NO_SOCKET in case socket was not created correctly.
      *  @retval         NSAPI_ERROR_WOULD_BLOCK in case non-blocking mode is enabled
      *                  and send cannot be performed immediately.
@@ -120,6 +119,7 @@ public:
      *  @retval         NSAPI_ERROR_NO_SOCKET in case socket was not created correctly.
      *  @retval         NSAPI_ERROR_WOULD_BLOCK in case non-blocking mode is enabled
      *                  and send cannot be performed immediately.
+     *  #retval         NSAPI_ERROR_NO_ADDRESS if the address was not set with connect().
      *  @retval         int Other negative error codes for stack-related failures.
      *                  See \ref NetworkStack::socket_send.
      */

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -162,7 +162,8 @@ public:
      *  @param ip_address SocketAddress object containing the local IP address
      *  @param netmask    SocketAddress object containing the local network mask
      *  @param gateway    SocketAddress object containing the local gateway
-     *  @return           NSAPI_ERROR_OK on success, negative error code on failure
+     *  @retval           NSAPI_ERROR_OK on success
+     *  @retval           NSAPI_ERROR_UNSUPPORTED if this function is unsupported
      */
     virtual nsapi_error_t set_network(const SocketAddress &ip_address, const SocketAddress &netmask, const SocketAddress &gateway);
 
@@ -175,7 +176,8 @@ public:
      *  that the network is disconnected.
      *
      *  @param dhcp     True to enable DHCP.
-     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
+     *  @retval         NSAPI_ERROR_OK on success.
+     *  @retval         NSAPI_ERROR_UNSUPPORTED if operation is not supported.
      */
     virtual nsapi_error_t set_dhcp(bool dhcp);
 
@@ -228,7 +230,9 @@ public:
      *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC).
      *  @param interface_name  Network interface name
-     *  @return         NSAPI_ERROR_OK on success, negative error code on failure.
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         int Negative error code on failure.
+     *                  See @ref NetworkStack::gethostbyname
      */
     virtual nsapi_error_t gethostbyname(const char *host,
                                         SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC, const char *interface_name = NULL);

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -90,7 +90,10 @@ public:
      *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
      *  @param interface_name  Network interface_name
-     *  @return         NSAPI_ERROR_OK on success, negative error code on failure
+     *  @retval         NSAPI_ERROR_OK on success
+     *  @retval         NSAPI_ERROR_PARAMETER if invalid (null) name is provided
+     *  @retval         NSAPI_ERROR_DNS_FAILURE if DNS resolution fails
+     *  @retval         int other negative errors, see @ref nsapi_dns_query
      */
     virtual nsapi_error_t gethostbyname(const char *host,
                                         SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC, const char *interface_name = NULL);

--- a/features/netsocket/PPPInterface.cpp
+++ b/features/netsocket/PPPInterface.cpp
@@ -80,7 +80,7 @@ nsapi_error_t PPPInterface::disconnect()
     if (_interface) {
         return _interface->bringdown();
     }
-    return NSAPI_ERROR_OK;
+    return NSAPI_ERROR_NO_CONNECTION;
 }
 
 const char *PPPInterface::get_ip_address()

--- a/features/netsocket/PPPInterface.h
+++ b/features/netsocket/PPPInterface.h
@@ -50,34 +50,16 @@ public:
                  OnboardNetworkStack &stack = OnboardNetworkStack::get_default_instance());
     virtual ~PPPInterface();
 
-    /** Set a static IP address
-     *
-     *  Configures this network interface to use a static IP address.
-     *  Implicitly disables DHCP, which can be enabled in set_dhcp.
-     *  Requires that the network is disconnected.
-     *
-     *  @param ip_address  Null-terminated representation of the local IP address
-     *  @param netmask     Null-terminated representation of the local network mask
-     *  @param gateway     Null-terminated representation of the local gateway
-     *  @return            0 on success, negative error code on failure
-     */
+    /** @copydoc NetworkInterface::set_network */
     virtual nsapi_error_t set_network(const char *ip_address, const char *netmask, const char *gateway);
 
-    /** Start the interface
-     *  @return             0 on success, negative on failure
-     */
+    /** @copydoc NetworkInterface::connect */
     virtual nsapi_error_t connect();
 
-    /** Stop the interface
-     *  @return             0 on success, negative on failure
-     */
+    /** @copydoc NetworkInterface::disconnect */
     virtual nsapi_error_t disconnect();
 
-    /** Get the local IP address
-     *
-     *  @return         Null-terminated representation of the local IP address
-     *                  or null if no IP address has been received
-     */
+    /** @copydoc NetworkInterface::get_ip_address */
     virtual const char *get_ip_address();
 
     /** @copydoc NetworkInterface::get_ip_address */
@@ -89,48 +71,25 @@ public:
     /** @copydoc NetworkInterface::get_gateway */
     virtual nsapi_error_t get_gateway(SocketAddress *address);
 
-    /** Get the local network mask
-     *
-     *  @return         Null-terminated representation of the local network mask
-     *                  or null if no network mask has been received
-     */
+    /** @copydoc NetworkInterface::get_netmask */
     virtual const char *get_netmask();
 
-    /** Get the local gateways
-     *
-     *  @return         Null-terminated representation of the local gateway
-     *                  or null if no network mask has been received
-     */
+    /** @copydoc NetworkInterface::get_gateway */
     virtual const char *get_gateway();
 
-    /** Get the network interface name
-     *
-     *  @return         Null-terminated representation of the network interface name
-     *                  or null if  interface not exists
-     */
+    /** @copydoc NetworkInterface::get_interface_name */
     virtual char *get_interface_name(char *interface_name);
 
-    /** Set the network interface as default one
-      */
+    /** @copydoc NetworkInterface::set_as_default */
     virtual void set_as_default();
 
-    /** Register callback for status reporting
-     *
-     *  @param status_cb The callback for status changes
-     */
+    /** @copydoc NetworkInterface::attach */
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
-    /** Get the connection status
-     *
-     *  @return         The connection status according to nsapi_connection_status_t
-     */
+    /** @copydoc NetworkInterface::get_connection_status */
     virtual nsapi_connection_status_t get_connection_status() const;
 
-    /** Set blocking status of connect() which by default should be blocking
-     *
-     *  @param blocking true if connect is blocking
-     *  @return         0 on success, negative error code on failure
-     */
+    /** @copydoc NetworkInterface::set_blocking */
     virtual nsapi_error_t set_blocking(bool blocking);
 
     /** Sets file stream used to communicate with modem

--- a/features/netsocket/SocketAddress.h
+++ b/features/netsocket/SocketAddress.h
@@ -160,6 +160,8 @@ public:
     /** Copy address from another SocketAddress
      *
      * @param addr  SocketAddress to copy
+     *
+     * @retval SocketAddress reference to this address
      */
     SocketAddress &operator=(const SocketAddress &addr);
 

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -197,7 +197,10 @@ public:
      *  By default, accept blocks until incoming connection occurs. If socket is set to
      *  non-blocking or times out, error is set to NSAPI_ERROR_WOULD_BLOCK.
      *
-     *  @param error      pointer to storage of the error value or NULL
+     *  @param error      pointer to storage of the error value or NULL:
+     *                    NSAPI_ERROR_OK on success
+     *                    NSAPI_ERROR_WOULD_BLOCK if socket is set to non-blocking and would block
+     *                    NSAPI_ERROR_NO_SOCKET if the socket was not open
      *  @return           pointer to a socket
      */
     virtual TCPSocket *accept(nsapi_error_t *error = NULL);

--- a/features/netsocket/TLSSocketWrapper.h
+++ b/features/netsocket/TLSSocketWrapper.h
@@ -92,6 +92,9 @@ public:
      * @note Must be called before calling connect()
      *
      * @param root_ca_pem Root CA Certificate in PEM format.
+     * @retval NSAPI_ERROR_OK on success.
+     * @retval NSAPI_ERROR_NO_MEMORY in case there is not enough memory to allocate certificate.
+     * @retval NSAPI_ERROR_PARAMETER in case the provided root_ca parameter failed parsing.
      */
     nsapi_error_t set_root_ca_cert(const char *root_ca_pem);
 

--- a/features/netsocket/nsapi_dns.h
+++ b/features/netsocket/nsapi_dns.h
@@ -85,8 +85,7 @@ nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
  *  @param addr     Destination for the host address
  *  @param interface_name Network interface name
  *  @param version  IP version to resolve (defaults to NSAPI_IPv4)
- *  @return         0 on success, negative error code on failure
- *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
+ *  @return         See @ref nsapi_dns_query_multiple
  */
 nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
                               SocketAddress *addr, const char *interface_name, nsapi_version_t version = NSAPI_IPv4);
@@ -156,8 +155,12 @@ nsapi_error_t nsapi_dns_query(S *stack, const char *host,
  *  @param addr       Array for the host addresses
  *  @param addr_count Number of addresses allocated in the array
  *  @param version    IP version to resolve (defaults to NSAPI_IPv4)
- *  @return           Number of addresses found on success, negative error code on failure
- *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
+ *  @return           Positive number of addresses found on success
+ *  @retval           NSAPI_ERROR_PARAMETER if provided parameters are invalid
+ *  @retval           NSAPI_ERROR_NO_MEMORY if allocation fails due to lack of memory
+ *  @retval           NSAPI_ERROR_DNS_FAILURE if DNS resolution fails
+ *  @retval           NSAPI_ERROR_WOULD_BLOCK in case non-blocking mode is enabled and
+ *                    DNS cannot be resolved immediately.
  */
 nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
                                                SocketAddress *addr, nsapi_size_t addr_count,  const char *interface_name, nsapi_version_t version = NSAPI_IPv4);


### PR DESCRIPTION
### Description (*required*)

Harden `netsocket` APIs in documentation and unittests.
Continuation of the task started in https://github.com/ARMmbed/mbed-os/pull/11808.

##### Summary of change (*What the change is for and why*)

I've gone through the Doxygen docs of our APIs and tried to make sure all returnable errors are explicitly mentioned and references are given to underlying APIs, if they can return other errors. Then I went to check if existing unittests cover all the possible return values.

The goal is for the users to be able to only check returnable errors, rather than go through all possible `nsapi_error_t` values.

The only untested APIs are:
* `L3IP` - It includes `LWIPStack.h` and basically requires full LWIP configuration - quite an overkill for testing what is effectively a wrapper class.
* fully abstract classes (like `DNS`, `WiFiInterface`, `MeshInterface`) - as they have no code to test. It is also difficult to predict possible return values, as they may depend on the underlying driver implementation.
* I assumed cellular APIs are under control and supervision of cellular team and did not touch those.

There is [one functional change](https://github.com/ARMmbed/mbed-os/compare/master...michalpasztamobica:api_hardening?expand=1#diff-6ba52d78bb7f6d5826a3e2e085cb9ccfR83) in the return value of PPPInterface function. Reviewers, please pay attention 😃 .

I hae also moved `OnboardNetworkStackMock` function it its own file and explicitly called the file a `_mock`. I hope this is OK? (Alternatively, we could create a `mocks` directory, next to the existing `stubs`, or call the file a `_stub`, even though it contains a mock).

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@AnttiKauppila 