### PR TITLE
UBLOX_EVK_ODIN_W2: Fix baremetal build and greentea tests

### DIFF
--- a/features/FEATURE_BLE/mbed_lib.json
+++ b/features/FEATURE_BLE/mbed_lib.json
@@ -1,6 +1,7 @@
 {
     "name": "ble",
     "config": {
+        "present": 1,
         "ble-role-observer": {
             "help": "Include observer BLE role support (scanning for and processing advertising packets).",
             "value": true,

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/driver/main.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/driver/main.cpp
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if !MBED_CONF_BLE_PRESENT
+#error [NOT_SUPPORTED] BLE cordio test cases require the BLE library.
+#else
 
 #include <stdio.h>
 
@@ -109,3 +112,5 @@ Specification specification(greentea_test_setup, cases, greentea_test_teardown_h
 int main() {
     return !Harness::run(specification);
 }
+
+#endif // !MBED_CONF_BLE_PRESENT

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/transport/main.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/TESTS/cordio_hci/transport/main.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#if !MBED_CONF_BLE_PRESENT
+#error [NOT_SUPPORTED] BLE cordio test cases require the BLE library.
+#else
+
 #include <stdio.h>
 #include <algorithm>
 
@@ -265,3 +269,5 @@ int main()
     return !Harness::run(specification);
 }
 #endif // CORDIO_ZERO_COPY_HCI
+
+#endif //!MBED_CONF_BLE_PRESENT

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -1,6 +1,7 @@
 {
     "name": "lwip",
     "config": {
+        "present": 1,
         "ipv4-enabled": {
             "help": "Enable IPv4",
             "value": true

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if MBED_CONF_LWIP_PRESENT
+
 #include "OdinWiFiInterface.h"
 #include "cb_main.h"
 #include "cb_wlan.h"
@@ -2107,3 +2109,4 @@ static cbTARGET_PowerSaveMode convertPowerSaveAtToIoctl(target_power_save_mode_e
     return mode;
 }
 
+#endif // MBED_CONF_LWIP_PRESENT

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
@@ -1,5 +1,5 @@
 /* ODIN-W2 implementation of WiFiInterface
- * Copyright (c) 2016 u-blox Malmö AB
+ * Copyright (c) 2016 u-blox Malmï¿½ AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 #ifndef ODIN_WIFI_INTERFACE_H
 #define ODIN_WIFI_INTERFACE_H
+
+#if MBED_CONF_LWIP_PRESENT
 
 #include "WiFiInterface.h"
 #if DEVICE_WIFI_AP
@@ -443,3 +445,5 @@ private:
 };
 
 #endif
+
+#endif // MBED_CONF_LWIP_PRESENT

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/default_wifi_interface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/default_wifi_interface.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#ifdef MBED_CONF_LWIP_PRESENT
+
 #include "OdinWiFiInterface.h"
 
 WiFiInterface *WiFiInterface::get_target_default_instance()
@@ -22,3 +24,5 @@ WiFiInterface *WiFiInterface::get_target_default_instance()
     static OdinWiFiInterface wifi;
     return &wifi;
 }
+
+#endif // MBED_CONF_LWIP_PRESENT


### PR DESCRIPTION
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->

Remove lwIP reliant networking and BLE tests for baremetal

Mbed OS 5 ported lwIP in its OS mode and uses threads. Networking
that rely on lwIP needs to be removed so it can be compiled with the
baremetal profile.

The BLE cordio Greentea tests are also disabled given that the feature
is not supported without an RTOS.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->

##### Summary of change (*What the change is for and why*)
The changes allow the baremetal greentea tests to successfully build and run on the target.
`mbed test -t GCC_ARM --app-config TESTS/configs/baremetal.json -m UBLOX_EVK_ODIN_W2`
```bash
| target                    | platform_name     | test suite                                                                   | result | elapsed_time (sec) | copy_method |
|---------------------------|-------------------|------------------------------------------------------------------------------|--------|--------------------|-------------|
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | components-storage-blockdevice-component_sd-tests-filesystem-dirs            | OK     | 110.61             | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | components-storage-blockdevice-component_sd-tests-filesystem-files           | OK     | 50.44              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | components-storage-blockdevice-component_sd-tests-filesystem-fopen           | OK     | 107.49             | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | components-storage-blockdevice-component_sd-tests-filesystem-seek            | OK     | 58.09              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-device_key-tests-device_key-functionality                           | OK     | 50.67              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-basic_test                        | OK     | 22.24              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-basic_test_default                | OK     | 22.64              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-case_async_validate               | OK     | 24.08              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-case_control_async                | OK     | 30.37              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-case_control_repeat               | OK     | 24.46              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-case_selection                    | OK     | 22.98              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-case_setup_failure                | OK     | 22.87              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | OK     | 23.53              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-control_type                      | OK     | 23.74              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | OK     | 23.3               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | OK     | 23.98              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | OK     | 22.41              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | OK     | 21.94              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-test_setup_failure                | OK     | 22.19              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-frameworks-utest-tests-unit_tests-test_skip                         | OK     | 22.42              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-nvstore-tests-nvstore-functionality                         | OK     | 27.49              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-blockdevice-buffered_block_device                     | OK     | 22.21              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-blockdevice-flashsim_block_device                     | OK     | 21.88              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-blockdevice-general_block_device                      | OK     | 47.55              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-blockdevice-heap_block_device                         | OK     | 23.11              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-blockdevice-mbr_block_device                          | OK     | 23.42              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-blockdevice-util_block_device                         | OK     | 23.05              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-filesystem-general_filesystem                         | OK     | 68.86              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-kvstore-direct_access_devicekey_test                  | OK     | 32.96              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-kvstore-static_tests                                  | OK     | 42.91              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | features-storage-tests-kvstore-tdbstore_whitebox                             | OK     | 23.25              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-events-queue                                                           | OK     | 20.1               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-events-timing                                                          | OK     | 72.37              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed-crypto-sanity                                                     | OK     | 18.93              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-c_strings                                                 | OK     | 12.97              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-crc                                                       | OK     | 11.69              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-dev_null                                                  | OK     | 12.57              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-echo                                                      | OK     | 12.73              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-flashiap                                                  | OK     | 28.51              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-generic_tests                                             | OK     | 11.49              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-lp_ticker                                                 | OK     | 17.87              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-lp_timer                                                  | OK     | 16.8               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-reset_reason                                              | OK     | 15.89              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-rtc                                                       | OK     | 26.74              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-sleep_lock                                                | OK     | 11.12              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-stl_features                                              | OK     | 23.7               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-ticker                                                    | OK     | 36.38              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-timeout                                                   | OK     | 50.18              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-timer                                                     | OK     | 19.05              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_drivers-timerevent                                                | OK     | 13.07              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_functional-callback                                               | OK     | 13.06              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_functional-callback_big                                           | OK     | 13.14              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_functional-callback_small                                         | OK     | 13.07              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_functional-functionpointer                                        | OK     | 11.29              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-critical_section                                              | OK     | 11.22              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-flash                                                         | OK     | 15.51              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-gpio                                                          | OK     | 10.84              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-minimum_requirements                                          | OK     | 11.06              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-pinmap                                                        | OK     | 11.7               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-reset_reason                                                  | OK     | 15.84              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-rtc                                                           | OK     | 54.88              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-rtc_reset                                                     | OK     | 29.22              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-rtc_time                                                      | OK     | 15.24              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-rtc_time_conv                                                 | OK     | 29.29              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-sleep                                                         | OK     | 12.8               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-sleep_manager                                                 | OK     | 26.63              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-sleep_manager_racecondition                                   | OK     | 20.94              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-ticker                                                        | OK     | 23.1               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-trng                                                          | OK     | 12.67              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-us_ticker                                                     | OK     | 10.84              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-watchdog_reset                                                | OK     | 18.63              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-watchdog_timing                                               | OK     | 38.22              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-circularbuffer                                           | OK     | 17.93              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-critical_section                                         | OK     | 12.87              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-error_handling                                           | OK     | 11.61              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-filehandle                                               | OK     | 13.17              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-minimal-printf                                           | OK     | 17.4               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-sharedptr                                                | OK     | 11.89              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-singletonptr                                             | OK     | 11.1               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-stream                                                   | OK     | 12.41              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-system_reset                                             | OK     | 11.62              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-transaction                                              | OK     | 11.83              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_platform-wait_ns                                                  | OK     | 13.35              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-mbed-attributes                                              | OK     | 12.98              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-mbed-call_before_main                                        | OK     | 10.42              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-mbed-cpp                                                     | OK     | 10.54              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-mbed-div                                                     | OK     | 10.51              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-mbed-static_assert                                           | OK     | 10.77              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-rtos-mbed-malloc                                             | OK     | 12.55              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedmicro-rtos-mbed-systimer                                           | OK     | 13.39              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedtls-multi                                                          | OK     | 12.2               | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-mbedtls-selftest                                                       | OK     | 14.31              | default     |
| UBLOX_EVK_ODIN_W2-GCC_ARM | UBLOX_EVK_ODIN_W2 | tests-psa-crypto_init                                                        | OK     | 12.08              | default     |
mbedgt: test suite results: 93 OK
mbedgt: test case results: 372 OK
```

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

    Run the below command as baremetal tests are not enabled in CI
    $ mbed test -t gcc_ARM --app-config TESTS/configs/baremetal.json -m UBLOX_EVK_ODIN_W2
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@rajkan01 @evedon @jamesbeyond 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



