### PR TITLE
DISCO_L475VG_IOT01A: Fix baremetal profile Greentea tests

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -32,6 +32,7 @@
         "events",
         "kv-global-api",
         "sd",
+        "qspif",
         "nvstore"
     ],
     "target_overrides": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
The build was missing the `"qspif"` lib to sucessefully build.

`mbed test -t GCC_ARM --app-config TESTS/configs/baremetal.json -m DISCO_L475VG_IOT01A`

```bash
mbedgt: test suite report:
| target                      | platform_name       | test suite                                                                   | result | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|------------------------------------------------------------------------------|--------|--------------------|-------------|
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-device_key-tests-device_key-functionality                           | OK     | 44.62              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test                        | OK     | 28.21              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test_default                | OK     | 28.37              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-case_async_validate               | OK     | 30.74              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-case_control_async                | OK     | 36.58              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-case_control_repeat               | OK     | 30.25              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-case_selection                    | OK     | 28.32              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-case_setup_failure                | OK     | 28.66              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | OK     | 28.62              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-control_type                      | OK     | 30.48              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | OK     | 29.12              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | OK     | 30.11              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | OK     | 28.28              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | OK     | 28.47              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-test_setup_failure                | OK     | 28.49              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-test_skip                         | OK     | 28.42              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-nvstore-tests-nvstore-functionality                         | OK     | 31.59              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-buffered_block_device                     | OK     | 29.51              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-flashsim_block_device                     | OK     | 29.34              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-general_block_device                      | OK     | 46.41              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-heap_block_device                         | OK     | 31.19              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-mbr_block_device                          | OK     | 30.77              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-blockdevice-util_block_device                         | OK     | 30.5               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-direct_access_devicekey_test                  | OK     | 42.04              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-static_tests                                  | OK     | 56.92              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | features-storage-tests-kvstore-tdbstore_whitebox                             | OK     | 28.61              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-events-queue                                                           | OK     | 40.14              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-events-timing                                                          | OK     | 91.0               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-c_strings                                                 | OK     | 30.5               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-crc                                                       | OK     | 29.69              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-dev_null                                                  | OK     | 29.35              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-echo                                                      | OK     | 32.77              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-flashiap                                                  | OK     | 31.44              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-generic_tests                                             | OK     | 28.66              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-lp_ticker                                                 | OK     | 35.77              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-lp_timer                                                  | OK     | 34.11              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-reset_reason                                              | OK     | 37.98              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-rtc                                                       | OK     | 44.57              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-sleep_lock                                                | OK     | 28.29              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-stl_features                                              | OK     | 30.11              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-ticker                                                    | OK     | 75.19              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-timeout                                                   | OK     | 103.26             | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-timer                                                     | OK     | 36.77              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-timerevent                                                | OK     | 31.06              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_functional-callback                                               | OK     | 32.26              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_functional-callback_big                                           | OK     | 32.31              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_functional-callback_small                                         | OK     | 30.98              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_functional-functionpointer                                        | OK     | 28.58              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-crc                                                           | OK     | 29.95              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-critical_section                                              | OK     | 27.85              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash                                                         | OK     | 30.48              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-gpio                                                          | OK     | 28.17              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-minimum_requirements                                          | OK     | 27.93              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-mpu                                                           | OK     | 29.33              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-pinmap                                                        | OK     | 29.65              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-qspi                                                          | OK     | 53.86              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-reset_reason                                                  | OK     | 36.49              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-rtc                                                           | OK     | 72.59              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-rtc_reset                                                     | OK     | 37.07              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-rtc_time                                                      | OK     | 33.7               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-rtc_time_conv                                                 | OK     | 90.26              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-sleep                                                         | OK     | 31.09              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-sleep_manager                                                 | OK     | 33.38              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-sleep_manager_racecondition                                   | OK     | 38.25              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-ticker                                                        | OK     | 43.61              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-trng                                                          | OK     | 32.95              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-us_ticker                                                     | OK     | 28.17              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-watchdog_reset                                                | OK     | 40.31              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-watchdog_timing                                               | OK     | 60.36              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-circularbuffer                                           | OK     | 35.57              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-critical_section                                         | OK     | 30.64              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-error_handling                                           | OK     | 29.52              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-filehandle                                               | OK     | 34.79              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-minimal-printf                                           | OK     | 36.39              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-sharedptr                                                | OK     | 29.65              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-singletonptr                                             | OK     | 29.35              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-stream                                                   | OK     | 32.91              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-system_reset                                             | OK     | 29.9               | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-transaction                                              | OK     | 29.11              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbed_platform-wait_ns                                                  | OK     | 32.27              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-mbed-attributes                                              | OK     | 30.75              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-mbed-call_before_main                                        | OK     | 25.82              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-mbed-cpp                                                     | OK     | 26.07              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-mbed-div                                                     | OK     | 26.37              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-mbed-static_assert                                           | OK     | 27.37              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-rtos-mbed-malloc                                             | OK     | 29.27              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-rtos-mbed-systimer                                           | OK     | 31.03              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedtls-multi                                                          | OK     | 30.22              | default     |
| DISCO_L475VG_IOT01A-GCC_ARM | DISCO_L475VG_IOT01A | tests-mbedtls-selftest                                                       | OK     | 36.56              | default     |
mbedgt: test suite results: 89 OK


mbedgt: test case results: 533 OK
mbedgt: completed in 3189.91 sec
```

##### Summary of change (*What the change is for and why*)


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@evedon @rajkan01 @jamesbeyond 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



