### PR TITLE
S2-LP: sync with development repository

### DIFF
--- a/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
+++ b/components/802.15.4_RF/stm-s2lp-rf-driver/source/NanostackRfPhys2lp.cpp
@@ -543,6 +543,19 @@ static void rf_set_channel_configuration_registers(void)
         rf_channel_multiplier++;
     }
     rf_write_register(CHSPACE, ch_space);
+    /* Preamble is set for S2-LP as repetitions of 01 or 10 pair
+     *
+     * For datarate < 150kbps, using phyFskPreambleLength = 8 repetitions of 01010101
+     * For datarate >= 150kbps and datarate < 300kbps, using phyFskPreambleLength = 12 repetitions of 01010101
+     * For datarate >= 300kbps, using phyFskPreambleLength = 24 repetitions of 01010101
+     */
+    uint8_t preamble_len = 24 * 4;
+    if (phy_subghz.datarate < 150000) {
+        preamble_len = 8 * 4;
+    } else if (phy_subghz.datarate < 300000) {
+        preamble_len = 12 * 4;
+    }
+    rf_write_register(PCKTCTRL5, preamble_len);
 }
 
 static void rf_init_registers(void)
@@ -557,7 +570,6 @@ static void rf_init_registers(void)
     rf_write_register_field(PCKTCTRL2, PCKT_FCS_TYPE_FIELD, PCKT_FCS_TYPE_4_OCTET);
     rf_write_register_field(PCKTCTRL3, PCKT_RXMODE_FIELD, PCKT_RXMODE_NORMAL);
     rf_write_register_field(PCKTCTRL3, PCKT_BYTE_SWAP_FIELD, PCKT_BYTE_SWAP_LSB);
-    rf_write_register(PCKTCTRL5, PCKT_PREAMBLE_LEN);
     rf_write_register_field(PCKTCTRL6, PCKT_SYNCLEN_FIELD, PCKT_SYNCLEN);
     rf_write_register_field(QI, PQI_TH_FIELD, PQI_TH);
     rf_write_register_field(QI, SQI_EN_FIELD, SQI_EN);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Nanostack RF driver updates for Mbed OS 5.15


##### Summary of change (*What the change is for and why*)
S2-LP RF driver:

 - Updated to v1.0.1
 - Fixed preamble configuration to follow Wi-SUN specification (depends on datarate)

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@mikter @juhhei01 @artokin 

----------------------------------------------------------------------------------------------------------------




