### PR TITLE
minimal-printf: Enable using a target configuration parameter

### DIFF
--- a/platform/source/minimal-printf/README.md
+++ b/platform/source/minimal-printf/README.md
@@ -26,6 +26,22 @@ Floating point limitations:
 * All floating points are treated as %f.
 * No support for inf, infinity or nan
 
+## Usage
+
+
+To replace the standard implementation of the printf functions with the ones in this library:
+
+Modify your application configuration file to override the parameter `target.printf` with the value `minimal-printf` as shown below:
+
+```json
+    "target_overrides": {
+        "*": {
+            "target.printf": "minimal-printf",
+        }
+    }
+```
+
+
 ## Configuration
 
 
@@ -60,22 +76,12 @@ In mbed_app.json:
 ```json
     "target_overrides": {
         "*": {
+            "target.printf": "minimal-printf",
             "platform.minimal-printf-enable-floating-point": false,
             "platform.minimal-printf-set-floating-point-max-decimals": 6,
             "platform.minimal-printf-enable-64-bit": false
         }
     }
-```
-
-## Usage
-
-
-To replace the standard implementation of the printf functions with the ones in this library:
-
-Compile with mbed-cli using the custom `minimal-printf` profile. For example, to compile in release mode:
-
-```
-$ mbed compile -t <toolchain> -m <target> --profile release --profile mbed-os/tools/profiles/extensions/minimal-printf.json
 ```
 
 ## Size comparison

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -15,6 +15,7 @@
         "default_lib": "std",
         "bootloader_supported": false,
         "static_memory_defines": true,
+        "printf_lib": "std",
         "config": {
             "console-uart": {
                 "help": "Target has UART console on pins STDIO_UART_TX, STDIO_UART_RX. Value is only significant if target has SERIAL device.",

--- a/tools/test/toolchains/test_toolchains.py
+++ b/tools/test/toolchains/test_toolchains.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Copyright (c) 2019 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test the arm toolchain."""
+
+import os
+import sys
+from unittest import TestCase
+
+import mock
+
+
+ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+sys.path.insert(0, ROOT)
+
+from tools.toolchains.arm import ARM_STD, ARM_MICRO, ARMC6
+from tools.toolchains.gcc import GCC_ARM
+from tools.toolchains.iar import IAR
+
+
+class TestArmToolchain(TestCase):
+    """Test Arm classes."""
+
+    def test_arm_minimal_printf(self):
+        """Test that linker flags are correctly added to an instance of ARM."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.printf_lib = "minimal-printf"
+        mock_target.supported_toolchains = ["ARM", "uARM", "ARMC5"]
+
+        arm_std_obj = ARM_STD(mock_target)
+        arm_micro_obj = ARM_MICRO(mock_target)
+        arm_c6_obj = ARMC6(mock_target)
+
+        self.assertIn("-DMBED_MINIMAL_PRINTF", arm_std_obj.flags["common"])
+        self.assertIn("-DMBED_MINIMAL_PRINTF", arm_micro_obj.flags["common"])
+        self.assertIn("-DMBED_MINIMAL_PRINTF", arm_c6_obj.flags["common"])
+
+
+class TestGccToolchain(TestCase):
+    """Test the GCC class."""
+
+    def test_gcc_minimal_printf(self):
+        """Test that linker flags are correctly added to an instance of GCC_ARM."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.printf_lib = "minimal-printf"
+        mock_target.supported_toolchains = ["GCC_ARM"]
+        mock_target.is_TrustZone_secure_target = False
+
+        gcc_obj = GCC_ARM(mock_target)
+
+        self.assertIn("-DMBED_MINIMAL_PRINTF", gcc_obj.flags["common"])
+
+        minimal_printf_wraps = [
+            "-Wl,--wrap,printf",
+            "-Wl,--wrap,sprintf",
+            "-Wl,--wrap,snprintf",
+            "-Wl,--wrap,vprintf",
+            "-Wl,--wrap,vsprintf",
+            "-Wl,--wrap,vsnprintf",
+            "-Wl,--wrap,fprintf",
+            "-Wl,--wrap,vfprintf",
+        ]
+
+        for i in minimal_printf_wraps:
+            self.assertIn(i, gcc_obj.flags["ld"])
+
+
+class TestIarToolchain(TestCase):
+    """Test the IAR class."""
+
+    def test_iar_minimal_printf(self):
+        """Test that linker flags are correctly added to an instance of GCC_ARM."""
+        mock_target = mock.MagicMock()
+        mock_target.core = "Cortex-M4"
+        mock_target.printf_lib = "minimal-printf"
+        mock_target.supported_toolchains = ["IAR"]
+        mock_target.is_TrustZone_secure_target = False
+
+        iar_obj = IAR(mock_target)
+        var = "-DMBED_MINIMAL_PRINTF"
+        self.assertIn("-DMBED_MINIMAL_PRINTF", iar_obj.flags["common"])

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -81,6 +81,8 @@ class ARM(mbedToolchain):
             if "--library_type=microlib" not in self.flags['common']:
                 self.flags['common'].append("--library_type=microlib")
 
+        self.check_and_add_minimal_printf(target)
+
         cpu = {
             "Cortex-M0+": "Cortex-M0plus",
             "Cortex-M4F": "Cortex-M4.fp.sp",
@@ -568,6 +570,8 @@ class ARMC6(ARM_STD):
             if "--library_type=microlib" not in self.flags['asm']:
                 self.flags['asm'].append("--library_type=microlib")
 
+        self.check_and_add_minimal_printf(target)
+
         if target.is_TrustZone_secure_target:
             if kwargs.get('build_dir', False):
                 # Output secure import library
@@ -767,3 +771,4 @@ class ARMC6(ARM_STD):
             cmd.insert(1, "--ide=mbed")
 
         return cmd
+

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -58,6 +58,26 @@ class GCC(mbedToolchain):
             self.flags["common"].append("-DMBED_RTOS_SINGLE_THREAD")
             self.flags["ld"].append("--specs=nano.specs")
 
+        self.check_and_add_minimal_printf(target)
+
+        if getattr(target, "printf_lib", "std") == "minimal-printf":
+            minimal_printf_wraps = [
+                "-Wl,--wrap,printf",
+                "-Wl,--wrap,sprintf",
+                "-Wl,--wrap,snprintf",
+                "-Wl,--wrap,vprintf",
+                "-Wl,--wrap,vsprintf",
+                "-Wl,--wrap,vsnprintf",
+                "-Wl,--wrap,fprintf",
+                "-Wl,--wrap,vfprintf",
+            ]
+
+            # Add the linker option to wrap the f\v\s\printf functions if not
+            # already added.
+            for minimal_printf_wrap in minimal_printf_wraps:
+                if minimal_printf_wrap not in self.flags["ld"]:
+                    self.flags["ld"].append(minimal_printf_wrap)
+
         self.cpu = []
         if target.is_TrustZone_secure_target:
             # Enable compiler security extensions

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -69,6 +69,8 @@ class IAR(mbedToolchain):
             define_string = self.make_ld_define("DOMAIN_NS", "0x1")
             self.flags["ld"].append(define_string)
 
+        self.check_and_add_minimal_printf(target)
+
         core = target.core_without_NS
         cpu = {
             "Cortex-M7F": "Cortex-M7.fp.sp",

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -1086,6 +1086,14 @@ class mbedToolchain:
             self._overwrite_when_not_equal(where, json.dumps(
                 to_dump, sort_keys=True, indent=4))
 
+    def check_and_add_minimal_printf(self, target):
+        """Add toolchain flag if minimal-printf is selected."""
+        if (
+            getattr(target, "printf_lib", "std") == "minimal-printf"
+            and "-DMBED_MINIMAL_PRINTF" not in self.flags["common"]
+        ):
+            self.flags["common"].append("-DMBED_MINIMAL_PRINTF")
+
     @staticmethod
     def _overwrite_when_not_equal(filename, content):
         if not exists(filename) or content != open(filename).read():


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
[Minimal-printf](https://github.com/ARMmbed/mbed-os/tree/master/platform/source/minimal-printf) is currently enabled using a [build profile extension](https://github.com/ARMmbed/mbed-os/blob/master/tools/profiles/extensions/minimal-printf.json); this is not the commonly used way to configure Mbed OS. Configuration of Mbed OS is usually done by overriding configuration parameters with a JSON file.

This PR adds a configuration parameter to enable Minimal-printf.

##### Documentation (*Details of any document updates required*)
[Minimal printf README](https://github.com/ARMmbed/mbed-os/blob/master/platform/source/minimal-printf/README.md)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@bulislaw @madchutney @evedon @rajkan01 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes
Add ability to enable Minimal printf using configuration parammeter.
A new configuration parameter `target.printf_lib` has been added to enable it.
##### Impact of changes
Convenient and familiar way to configure Mbed OS.
##### Migration actions required
N/A


