### PR TITLE
LittleFS: correct CRC calculation 

### DIFF
--- a/features/storage/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.cpp
@@ -24,7 +24,7 @@ namespace mbed {
 
 extern "C" void lfs_crc(uint32_t *crc, const void *buffer, size_t size)
 {
-    uint32_t initial_xor = *crc;
+    uint32_t initial_xor = lfs_rbit(*crc);
     // lfs_cache_crc calls lfs_crc for every byte individually, so can't afford
     // start-up overhead for hardware acceleration. Limit to table-based.
     MbedCRC<POLY_32BIT_ANSI, 32, CrcMode::TABLE> ct(initial_xor, 0x0, true, true);

--- a/features/storage/filesystem/littlefs/TESTS/filesystem/seek/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem/seek/main.cpp
@@ -535,7 +535,7 @@ void test_boundary_seek_and_write()
         size = strlen("hedgehoghog");
         const off_t offsets[] = {512, 1020, 513, 1021, 511, 1019};
 
-        for (int i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
+        for (size_t i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
             off_t off = offsets[i];
             memcpy(buffer, "hedgehoghog", size);
             res = file[0].seek(off, SEEK_SET);

--- a/features/storage/filesystem/littlefs/littlefs/lfs_util.h
+++ b/features/storage/filesystem/littlefs/littlefs/lfs_util.h
@@ -47,6 +47,7 @@ extern "C"
 #ifdef __MBED__
 #include "mbed_debug.h"
 #include "mbed_assert.h"
+#include "cmsis_compiler.h"
 #else
 #define MBED_LFS_ENABLE_INFO   false
 #define MBED_LFS_ENABLE_DEBUG  true
@@ -181,6 +182,21 @@ static inline uint32_t lfs_fromle32(uint32_t a) {
 // Convert to 32-bit little-endian from native order
 static inline uint32_t lfs_tole32(uint32_t a) {
     return lfs_fromle32(a);
+}
+
+// Reverse the bits in a
+static inline uint32_t lfs_rbit(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && MBED_LFS_INTRINSICS && \
+    defined(__MBED__)
+    return __RBIT(a);
+#else
+    a = ((a & 0xaaaaaaaa) >> 1) | ((a & 0x55555555) << 1);
+    a = ((a & 0xcccccccc) >> 2) | ((a & 0x33333333) << 2);
+    a = ((a & 0xf0f0f0f0) >> 4) | ((a & 0x0f0f0f0f) << 4);
+    a = ((a & 0xff00ff00) >> 8) | ((a & 0x00ff00ff) << 8);
+    a = (a >> 16) | (a << 16);
+    return a;
+#endif
 }
 
 // Calculate CRC-32 with polynomial = 0x04c11db7


### PR DESCRIPTION
### Description (*required*)

When using MbedCRC, init value must be non-reversed, regardless of `reflect_data` or `reflect_out` settings. This means we need to reflect the intermediate output before using it as the next init value.

(In GCC this ends up putting in two `RBIT` instructions back-to-back, because it's implemented as assembler, so it doesn't know how to optimise. In ARMC6, `__RBIT` is implemented as an intrinsic, so adding this reflection cancels the existing reflection and makes the code smaller).

##### Summary of change (*What the change is for and why*)

Fixes #11879


##### Documentation (*Details of any document updates required*)

n/a

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

Fixes issue caused by #11559, so depends on that.

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Is covered by existing tests, but they're not being run?
    
