### PR TITLE
Update MPN for CYW9P62S1_43012EVB_01 board

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -9257,14 +9257,15 @@
         "features": ["BLE"],
         "components_add": ["WHD", "43012", "CYW43XXX"],
         "components_remove": ["QSPIF"],
-        "device_has_remove": ["ANALOGOUT", "CRC", "TRNG", "QSPI"],
+        "device_has_remove": ["ANALOGOUT", "QSPI"],
         "macros_remove": ["MBEDTLS_CONFIG_HW_SUPPORT"],
         "extra_labels_add": [
             "PSOC6_01",
+            "MXCRYPTO_01",
             "CORDIO"
         ],
         "extra_labels_remove": ["MXCRYPTO"],
-        "macros_add": ["CY8C6247FDI_D32", "CYHAL_UDB_SDIO", "CYBSP_WIFI_CAPABLE"],
+        "macros_add": ["CY8C6247FDI_D52", "CYHAL_UDB_SDIO", "CYBSP_WIFI_CAPABLE"],
         "detect_code": ["1903"],
         "post_binary_hook": {
             "function": "PSOC6Code.complete"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

Update MPN on the CYW9P62S1_43012EVB_01 board to match latest revisions
This depends on PR #11884

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)

Update MPN on the CYW9P62S1_43012EVB_01 board to match latest revisions

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

[CYW9P62S1_43012EVB_01.txt](https://github.com/ARMmbed/mbed-os/files/3866267/CYW9P62S1_43012EVB_01.txt)
NOTE: The kvstore failures are due to #11879. The sleep failures are due to a known incompatibility between the sleep tests and our UART driver.
<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
      

----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



