### PR TITLE
TOOLS: enable build greentea test coverage for HW

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -454,6 +454,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     app_config - location of a chosen mbed_app.json file
     build_profile - a list of mergeable build profiles
     ignore - list of paths to add to mbedignore
+    coverage_patterns - list of patterns for code coverage
     """
 
     # We need to remove all paths which are repeated to avoid

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -437,7 +437,7 @@ def target_supports_toolchain(target, toolchain_name):
 def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                       macros=None, clean=False, jobs=1,
                       notify=None, config=None, app_config=None,
-                      build_profile=None, ignore=None):
+                      build_profile=None, ignore=None, coverage_patterns=None):
     """ Prepares resource related objects - toolchain, target, config
 
     Positional arguments:
@@ -477,6 +477,9 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
         target.default_toolchain = "uARM"
     toolchain_name = selected_toolchain_name
 
+    if coverage_patterns:
+        target.extra_labels.append(u'COVERAGE')
+
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
     except KeyError:
@@ -488,7 +491,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
             profile[key].extend(contents[toolchain_name].get(key, []))
 
     toolchain = cur_tc(
-        target, notify, macros, build_dir=build_dir, build_profile=profile)
+        target, notify, macros, build_dir=build_dir, build_profile=profile, coverage_patterns=coverage_patterns)
 
     toolchain.config = config
     toolchain.jobs = jobs
@@ -511,7 +514,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
                   report=None, properties=None, project_id=None,
                   project_description=None, config=None,
                   app_config=None, build_profile=None, stats_depth=None,
-                  ignore=None, resource_filter=None):
+                  ignore=None, resource_filter=None, coverage_patterns=None):
     """ Build a project. A project may be a test or a user program.
 
     Positional arguments:
@@ -556,7 +559,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, config=config,
-        app_config=app_config, build_profile=build_profile, ignore=ignore)
+        app_config=app_config, build_profile=build_profile, ignore=ignore, coverage_patterns=coverage_patterns)
     toolchain.version_check()
 
     # The first path will give the name to the library
@@ -662,7 +665,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
                   archive=True, notify=None, macros=None, inc_dirs=None, jobs=1,
                   report=None, properties=None, project_id=None,
                   remove_config_header_file=False, app_config=None,
-                  build_profile=None, ignore=None, resource_filter=None):
+                  build_profile=None, ignore=None, resource_filter=None, coverage_patterns=None):
     """ Build a library
 
     Positional arguments:
@@ -713,7 +716,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, app_config=app_config,
-        build_profile=build_profile, ignore=ignore)
+        build_profile=build_profile, ignore=ignore, coverage_patterns=coverage_patterns)
     toolchain.version_check()
 
     # The first path will give the name to the library

--- a/tools/test.py
+++ b/tools/test.py
@@ -29,7 +29,7 @@ sys.path.insert(0, ROOT)
 from tools.config import ConfigException, Config
 from tools.test_configs import get_default_config
 from tools.test_api import find_tests, get_test_config, print_tests, build_tests, test_spec_from_test_builds
-from tools.options import get_default_options_parser, extract_profile, extract_mcus
+from tools.options import get_default_options_parser, extract_profile, extract_mcus, argparse_profile_filestring_type
 from tools.build_api import build_library
 from tools.build_api import print_build_memory_usage
 from tools.build_api import merge_build_data
@@ -125,6 +125,9 @@ def main():
         parser.add_argument("--ignore", dest="ignore", type=argparse_many(str),
                           default=None, help="Comma separated list of patterns to add to mbedignore (eg. ./main.cpp)")
 
+        parser.add_argument("--coverage-filters", dest="coverage_patterns", nargs='+',
+                          default=[], help="match patterns to build with debug compile and coverage linker options")
+        
         parser.add_argument("--icetea",
                             action="store_true",
                             dest="icetea",
@@ -230,6 +233,13 @@ def main():
             if not base_source_paths:
                 base_source_paths = ['.']
 
+            # Coverage requires debug profile
+            if options.coverage_patterns:
+                if toolchain != u'GCC_ARM':
+                    raise ToolException('Coverage supports only GCC_ARM toolchain')
+                options.profile.append(argparse_profile_filestring_type('debug'))
+                print("[Warning] Test building with coverage filters %s" % options.coverage_patterns)
+
             build_report = {}
             build_properties = {}
 
@@ -255,6 +265,7 @@ def main():
                               app_config=config,
                               build_profile=profile,
                               ignore=options.ignore,
+                              coverage_patterns=options.coverage_patterns,
                               resource_filter=resource_filter
                               )
 
@@ -299,6 +310,7 @@ def main():
                     build_profile=profile,
                     stats_depth=options.stats_depth,
                     ignore=options.ignore,
+                    coverage_patterns=options.coverage_patterns,
                     resource_filter=resource_filter)
 
                 # If a path to a test spec is provided, write it to a file

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2112,7 +2112,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                 silent=False, report=None, properties=None,
                 continue_on_build_fail=False, app_config=None,
                 build_profile=None, stats_depth=None, ignore=None,
-                resource_filter=None):
+                resource_filter=None, coverage_patterns=None):
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 
@@ -2168,6 +2168,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
             'toolchain_paths': TOOLCHAIN_PATHS,
             'stats_depth': stats_depth,
             'notify': MockNotifier(),
+            'coverage_patterns': coverage_patterns, 
             'resource_filter': resource_filter
         }
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -63,7 +63,7 @@ class ARM(mbedToolchain):
         return mbedToolchain.generic_check_executable("ARM", 'armcc', 2, 'bin')
 
     def __init__(self, target, notify=None, macros=None,
-                 build_profile=None, build_dir=None):
+                 build_profile=None, build_dir=None, coverage_patterns=None):
         mbedToolchain.__init__(
             self, target, notify, macros, build_dir=build_dir,
             build_profile=build_profile)
@@ -440,7 +440,8 @@ class ARM_STD(ARM):
             notify=None,
             macros=None,
             build_profile=None,
-            build_dir=None
+            build_dir=None,
+            coverage_patterns=None
     ):
         ARM.__init__(
             self,
@@ -448,7 +449,8 @@ class ARM_STD(ARM):
             notify,
             macros,
             build_dir=build_dir,
-            build_profile=build_profile
+            build_profile=build_profile,
+            coverage_patterns=None
         )
         if int(target.build_tools_metadata["version"]) > 0:
             # check only for ARMC5 because ARM_STD means using ARMC5, and thus

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -137,15 +137,18 @@ class GCC(mbedToolchain):
         self.use_distcc = (bool(getenv("DISTCC_POTENTIAL_HOSTS", False))
                            and not getenv("MBED_DISABLE_DISTCC", False))
 
+        # create copies of gcc/ld options as coverage build options, and injects extra coverage options 
         self.coverage_cc = self.cc + ["--coverage", "-DENABLE_LIBGCOV_PORT"]
         self.coverage_cppc = self.cppc + ["--coverage", "-DENABLE_LIBGCOV_PORT"]
         self.coverage_ld = self.ld + ['--coverage', '-Wl,--wrap,GREENTEA_SETUP', '-Wl,--wrap,_Z25GREENTEA_TESTSUITE_RESULTi']
 
+        # for gcc coverage options remove MBED_DEBUG macro (this is required by code coverage function)
         for flag in ["-DMBED_DEBUG"]:
             if flag in self.coverage_cc:
                 self.coverage_cc.remove(flag)
             if flag in self.coverage_cppc:
                 self.coverage_cppc.remove(flag)
+        #  for lg coverage options remove exit wrapper (this is required by code coverage function)
         for flag in ['-Wl,--wrap,exit', '-Wl,--wrap,atexit']:
             if flag in self.coverage_ld:
                 self.coverage_ld.remove(flag)
@@ -224,6 +227,7 @@ class GCC(mbedToolchain):
         return opts
 
     def match_coverage_patterns(self, source):
+        """Check whether the give source file match with coverage patterns, if so return True. """
         for pattern in self.coverage_patterns:
             if fnmatch.fnmatch(source, pattern):
                 return True

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import re
+import fnmatch
 from os.path import join, basename, splitext, dirname, exists
 from os import getenv
 from distutils.spawn import find_executable
@@ -36,14 +37,15 @@ class GCC(mbedToolchain):
     GCC_VERSION_RE = re.compile(b"\d+\.\d+\.\d+")
 
     def __init__(self, target,  notify=None, macros=None, build_profile=None,
-                 build_dir=None):
+                 build_dir=None, coverage_patterns=None):
         mbedToolchain.__init__(
             self,
             target,
             notify,
             macros,
             build_profile=build_profile,
-            build_dir=build_dir
+            build_dir=build_dir,
+            coverage_patterns=coverage_patterns
         )
 
         tool_path = TOOLCHAIN_PATHS['GCC_ARM']
@@ -115,7 +117,7 @@ class GCC(mbedToolchain):
             self.cpu.append("-mno-unaligned-access")
 
         self.flags["common"] += self.cpu
-
+        self.coverage_supported = True
         main_cc = join(tool_path, "arm-none-eabi-gcc")
         main_cppc = join(tool_path, "arm-none-eabi-g++")
         self.asm = [main_cc] + self.flags['asm'] + self.flags["common"]
@@ -134,6 +136,19 @@ class GCC(mbedToolchain):
 
         self.use_distcc = (bool(getenv("DISTCC_POTENTIAL_HOSTS", False))
                            and not getenv("MBED_DISABLE_DISTCC", False))
+
+        self.coverage_cc = self.cc + ["--coverage", "-DENABLE_LIBGCOV_PORT"]
+        self.coverage_cppc = self.cppc + ["--coverage", "-DENABLE_LIBGCOV_PORT"]
+        self.coverage_ld = self.ld + ['--coverage', '-Wl,--wrap,GREENTEA_SETUP', '-Wl,--wrap,_Z25GREENTEA_TESTSUITE_RESULTi']
+
+        for flag in ["-DMBED_DEBUG"]:
+            if flag in self.coverage_cc:
+                self.coverage_cc.remove(flag)
+            if flag in self.coverage_cppc:
+                self.coverage_cppc.remove(flag)
+        for flag in ['-Wl,--wrap,exit', '-Wl,--wrap,atexit']:
+            if flag in self.coverage_ld:
+                self.coverage_ld.remove(flag)
 
     def version_check(self):
         stdout, _, retcode = run_cmd([self.cc[0], "--version"], redirect=True)
@@ -208,6 +223,12 @@ class GCC(mbedToolchain):
             opts = opts + self.get_config_option(config_header)
         return opts
 
+    def match_coverage_patterns(self, source):
+        for pattern in self.coverage_patterns:
+            if fnmatch.fnmatch(source, pattern):
+                return True
+        return False
+
     def assemble(self, source, object, includes):
         # Build assemble command
         cmd = self.asm + self.get_compile_options(
@@ -231,9 +252,13 @@ class GCC(mbedToolchain):
         return [cmd]
 
     def compile_c(self, source, object, includes):
+        if self.coverage_patterns and self.match_coverage_patterns(source):
+            return self.compile(self.coverage_cc, source, object, includes)
         return self.compile(self.cc, source, object, includes)
 
     def compile_cpp(self, source, object, includes):
+        if self.coverage_patterns and self.match_coverage_patterns(source):
+             return self.compile(self.coverage_cppc, source, object, includes)
         return self.compile(self.cppc, source, object, includes)
 
     def link(self, output, objects, libraries, lib_dirs, mem_map):
@@ -257,7 +282,7 @@ class GCC(mbedToolchain):
         # Build linker command
         map_file = splitext(output)[0] + ".map"
         cmd = (
-            self.ld +
+            (self.coverage_ld if self.coverage_patterns else self.ld) +
             ["-o", output, "-Wl,-Map=%s" % map_file] +
             objects +
             ["-Wl,--start-group"] +

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -44,7 +44,7 @@ class IAR(mbedToolchain):
         )
 
     def __init__(self, target, notify=None, macros=None, build_profile=None,
-                 build_dir=None):
+                 build_dir=None, coverage_patterns=None):
         mbedToolchain.__init__(
             self,
             target,

--- a/tools/toolchains/mbed_toolchain.py
+++ b/tools/toolchains/mbed_toolchain.py
@@ -132,7 +132,7 @@ class mbedToolchain:
     profile_template = {'common': [], 'c': [], 'cxx': [], 'asm': [], 'ld': []}
 
     def __init__(self, target, notify=None, macros=None, build_profile=None,
-                 build_dir=None):
+                 build_dir=None, coverage_patterns=None):
         self.target = target
         self.name = self.__class__.__name__
 
@@ -189,6 +189,9 @@ class mbedToolchain:
 
         # Used by the mbed Online Build System to build in chrooted environment
         self.CHROOT = None
+
+        self.coverage_supported = False
+        self.coverage_patterns = coverage_patterns
 
         # post-init hook used by the online compiler TODO: remove this.
         self.init()


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)

This PR adds a hidden option `--coverage-filters` to the `mbed test` function. this option allows filters to be passed into the tests building stage. for the files matches with filters will be compiled with a gcov option, the rest of the files will be covered by the default compiler options.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)


- This option is key to enabling code coverage from HW, only in the way the gcov complied images should be small enough to fit a HW target
- This option only applies to GCC_ARM toolchain, no impact to other toolchains
- This option is not visible from `mbed test --help` , so no public users impact, because the function is still in an experimental stage.

- for the file that matches with given filter compiler options `--coverage`, `-DENABLE_LIBGCOV_PORT` are added

- linker options `--coverage`, `-Wl,--wrap,GREENTEA_SETUP`, `-Wl,--wrap,_Z25GREENTEA_TESTSUITE_RESULTi` are added if the option is enabled.

- if the option is not in use normal mbed test option will not get impacted

##### Documentation (*Details of any document updates required*)
becasue this is 
----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)
@mark-edgeworth 
<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



