### PR TITLE
Extend at_cmd_str to support AT commands with multiple response messages

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1336,10 +1336,8 @@ nsapi_error_t ATHandler::at_cmd_str_va(const char *cmd, const char *cmd_chr, con
         resp_start();
     }
 
-    for (int i = 0; i < desc_count; i ++)
-    {
-        if (resp_buf_desc[i].resp_buf_ptr)
-        {
+    for (int i = 0; i < desc_count; i ++) {
+        if (resp_buf_desc[i].resp_buf_ptr) {
             *(resp_buf_desc[i].resp_buf_ptr) = '\0';
         }
         read_string(resp_buf_desc[i].resp_buf_ptr, resp_buf_desc[i].resp_buf_size);

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -303,6 +303,20 @@ public:
     nsapi_error_t at_cmd_str(const char *cmd, const char *cmd_chr, char *resp_buf, size_t resp_buf_size, const char *format = "", ...);
 
     /**
+     * @brief at_cmd_str Send an AT command and read a single string response. Locks and unlocks ATHandler for operation
+     * @param cmd AT command in form +<CMD> (will be used also in response reading, no extra chars allowed)
+     * @param cmd_chr Char to be added to specific AT command: '?', '=' or ''. Will be used as such so '=1' is valid as well.
+     * @param resp_buf_0 First response buffer
+     * @param resp_buf_0_size First response buffer size
+     * @param resp_buf_1 Second response buffer
+     * @param resp_buf_1_size Second response buffer size
+     * @param format Format string for variadic arguments to be added to AT command; No separator needed.
+     *        Use %d for integer, %s for string and %b for byte string (requires 2 arguments: string and length)
+     * @return last error that happened when parsing AT responses
+     */
+    nsapi_error_t at_cmd_str(const char *cmd, const char *cmd_chr, char *resp_buf_0, size_t resp_buf_0_size, char *resp_buf_1, size_t resp_buf_1_size, const char *format = "", ...);
+
+    /**
      * @brief at_cmd_int Send an AT command and read a single integer response. Locks and unlocks ATHandler for operation
      * @param cmd AT command in form +<CMD> (will be used also in response reading, no extra chars allowed)
      * @param cmd_chr Char to be added to specific AT command: '?', '=' or ''. Will be used as such so '=1' is valid as well.
@@ -660,6 +674,13 @@ private:
         AT_TX
     };
     void debug_print(const char *p, int len, ATType type);
+
+    /** AT response buffer descriptor */
+    struct resp_buf_desc_t {
+        char  *resp_buf_ptr;
+        size_t resp_buf_size;
+    };
+    nsapi_error_t at_cmd_str_va(const char *cmd, const char *cmd_chr, const resp_buf_desc_t *resp_buf_desc, const int desc_count, const char *format, const va_list list);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -303,7 +303,7 @@ public:
     nsapi_error_t at_cmd_str(const char *cmd, const char *cmd_chr, char *resp_buf, size_t resp_buf_size, const char *format = "", ...);
 
     /**
-     * @brief at_cmd_str Send an AT command and read a single string response. Locks and unlocks ATHandler for operation
+     * @brief at_cmd_str Send an AT command and read two-string response. Locks and unlocks ATHandler for operation
      * @param cmd AT command in form +<CMD> (will be used also in response reading, no extra chars allowed)
      * @param cmd_chr Char to be added to specific AT command: '?', '=' or ''. Will be used as such so '=1' is valid as well.
      * @param resp_buf_0 First response buffer


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
### Description (*required*)
Current at_cmd_str API takes a single buffer pointer to get single response message. Some AT commands such as AT+CSIM return two-string response. This PR extends this API to support these commands.
<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
##### Summary of change (*What the change is for and why*)
Extends at_cmd_str to support AT commands with two response messages.

##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

<!--
    Optional
    Request additional reviewers with @username
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes
In ATHandler.h, at_cmd_str() function sends an AT command and reads a single string response. An overloading API of the same name is now added to support sending an AT command and receiving two-string response. The newly added API takes two additional parameters to specify the location and the size of the storage buffer for the second string response. The rest of the parameters are the same as the original at_cmd_str() API.

##### Impact of changes
None expected.

##### Migration actions required
None.


