### PR TITLE
LPC55S69_NS default TDBStore size increased to 32kB

### DIFF
--- a/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
+++ b/features/storage/kvstore/conf/tdb_internal/mbed_lib.json
@@ -15,6 +15,10 @@
             "internal_size": "0x8000",
             "internal_base_address": "0x00028000"
         },
+        "LPC55S69_NS": {
+            "internal_size": "0x8000",
+            "internal_base_address": "0x00090000"
+        },
         "DISCO_H747I": {
             "internal_size": "2*FLASH_SECTOR_SIZE",
             "internal_base_address": "0x080C0000"

--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -134,6 +134,11 @@ TDBStore::TDBStore(BlockDevice *bd) : _ram_table(0), _max_keys(0),
     for (int i = 0; i < _max_open_iterators; i++) {
         _iterator_table[i] = { 0 };
     }
+
+    /* Minimum space required by Reserved area and master record */
+    MBED_ASSERT(bd->size()
+                >= (align_up(RESERVED_AREA_SIZE + sizeof(reserved_trailer_t), _prog_size)
+                    + record_size(master_rec_key, sizeof(master_record_data_t))));
 }
 
 TDBStore::~TDBStore()


### PR DESCRIPTION
### Description (*required*)
Previously the size was 2 pages - 1kB - which isn't sufficient to store Reserved Area and Master Record. Reserved Area requires one page and Master Record takes two pages. With 512B page size and having two areas, active and inactive, the minimum size requirement becomes 2 areas * 3 pages = 3kB. That isn't enough to store any keys though.

Added a sanity check to TDBStore constructor. Only effective when the binary is build with debug profile

##### Summary of change (*What the change is for and why*)


##### Documentation (*Details of any document updates required*)

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

<!--
    Required
    For example, add test results for new target
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

#### Before
```
| target              | platform_name | test suite                                                  | test case                                                                   | passed | failed | result  | elapsed_time (sec) |
|---------------------|---------------|-------------------------------------------------------------|-----------------------------------------------------------------------------|--------|--------|---------|--------------------|
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-buffered_block_device    | BufferedBlockDevice functionality test                                      | 1      | 0      | OK      | 0.25               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-flashsim_block_device    | FlashSimBlockDevice functionality test                                      | 1      | 0      | OK      | 0.08               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | DEFAULT Testing get type functionality                                      | 1      | 0      | OK      | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing BlockDevice erase functionality                            | 1      | 0      | OK      | 0.38               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Deinit block device                                        | 1      | 0      | OK      | 0.12               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Init block device                                          | 1      | 0      | OK      | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing contiguous erase, write and read                           | 1      | 0      | OK      | 0.37               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing multi threads erase program read                           | 1      | 0      | OK      | 0.48               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing program read small data sizes                              | 1      | 0      | OK      | 0.15               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing read write random blocks                                   | 1      | 0      | OK      | 0.27               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing unaligned erase blocks                                     | 1      | 0      | OK      | 0.14               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-heap_block_device        | features-storage-tests-blockdevice-heap_block_device                        | 0      | 1      | ERROR   | 405.14             |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-mbr_block_device         | Testing formatting of master boot record                                    | 1      | 0      | OK      | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-mbr_block_device         | Testing mbr attributes                                                      | 1      | 0      | OK      | 0.61               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-mbr_block_device         | Testing mbr read write                                                      | 1      | 0      | OK      | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-util_block_device        | Testing chaining of block devices                                           | 1      | 0      | OK      | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-util_block_device        | Testing profiling of block devices                                          | 1      | 0      | OK      | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-util_block_device        | Testing slicing of a block device                                           | 1      | 0      | OK      | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over flashiap default placement | 0      | 0      | ERROR   | 0.0                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over last two sectors           | 0      | 0      | SKIPPED | 0.0                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to injected devicekey                                 | 0      | 0      | SKIPPED | 0.0                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | features-storage-tests-kvstore-static_tests                                 | 0      | 1      | ERROR   | 84.08              |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-tdbstore_whitebox            | features-storage-tests-kvstore-tdbstore_whitebox                            | 0      | 1      | ERROR   | 405.35             |
mbedgt: test case results: 2 SKIPPED / 17 OK / 4 ERROR
```

#### After
```
| target              | platform_name | test suite                                                  | test case                                                                   | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|-------------------------------------------------------------|-----------------------------------------------------------------------------|--------|--------|--------|--------------------|
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-buffered_block_device    | BufferedBlockDevice functionality test                                      | 1      | 0      | OK     | 0.25               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-flashsim_block_device    | FlashSimBlockDevice functionality test                                      | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | DEFAULT Testing get type functionality                                      | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing BlockDevice erase functionality                            | 1      | 0      | OK     | 0.37               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Deinit block device                                        | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing Init block device                                          | 1      | 0      | OK     | 0.09               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing contiguous erase, write and read                           | 1      | 0      | OK     | 0.36               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing multi threads erase program read                           | 1      | 0      | OK     | 0.49               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing program read small data sizes                              | 1      | 0      | OK     | 0.14               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing read write random blocks                                   | 1      | 0      | OK     | 0.28               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-general_block_device     | FLASHIAP Testing unaligned erase blocks                                     | 1      | 0      | OK     | 0.12               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-heap_block_device        | Testing get type functionality                                              | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-heap_block_device        | Testing read write random blocks                                            | 1      | 0      | OK     | 1.95               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-mbr_block_device         | Testing formatting of master boot record                                    | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-mbr_block_device         | Testing mbr attributes                                                      | 1      | 0      | OK     | 0.62               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-mbr_block_device         | Testing mbr read write                                                      | 1      | 0      | OK     | 0.04               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-util_block_device        | Testing chaining of block devices                                           | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-util_block_device        | Testing profiling of block devices                                          | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-blockdevice-util_block_device        | Testing slicing of a block device                                           | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over flashiap default placement | 1      | 0      | OK     | 0.19               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to devicekey with tdb over last two sectors           | 1      | 0      | OK     | 0.23               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-direct_access_devicekey_test | Testing direct access to injected devicekey                                 | 1      | 0      | OK     | 0.08               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_buffer_null_size_not_zero                                               | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_buffer_size_bigger_than_data_real_size                                  | 0      | 4      | FAIL   | 0.44               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_buffer_size_is_zero                                                     | 0      | 3      | FAIL   | 0.38               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_buffer_size_smaller_than_data_real_size                                 | 0      | 4      | FAIL   | 0.44               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_existed_key                                                        | 0      | 3      | FAIL   | 0.27               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_info_null                                                          | 1      | 0      | OK     | 0.04               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_key_length_exceeds_max                                             | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_key_null                                                           | 1      | 0      | OK     | 0.04               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_non_existing_key                                                   | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_overwritten_key                                                    | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_info_removed_key                                                        | 0      | 2      | FAIL   | 0.33               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_key_length_exceeds_max                                                  | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_key_null                                                                | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_key_that_was_set_twice                                                  | 0      | 5      | FAIL   | 0.57               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_non_existing_key                                                        | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_removed_key                                                             | 0      | 2      | FAIL   | 0.33               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | get_several_keys_multithreaded                                              | 0      | 11     | FAIL   | 1.12               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_close_right_after_iterator_open                                    | 1      | 0      | OK     | 0.08               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list                                                    | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list_keys_removed                                       | 1      | 0      | OK     | 0.09               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_empty_list_non_matching_prefix                                | 1      | 0      | OK     | 0.09               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_full_list                                                     | 1      | 0      | OK     | 0.08               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_key_size_zero                                                 | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_one_key_list                                                  | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_path_check                                                    | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_remove_while_iterating                                        | 1      | 0      | OK     | 0.15               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_next_several_overwritten_keys                                      | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | iterator_open_it_null                                                       | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | kvstore_init                                                                | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | remove_existed_key                                                          | 0      | 2      | FAIL   | 0.33               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | remove_key_length_exceeds_max                                               | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | remove_key_null                                                             | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | remove_non_existing_key                                                     | 0      | 1      | FAIL   | 0.2                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | remove_removed_key                                                          | 0      | 3      | FAIL   | 0.48               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_buffer_null_size_not_zero                                               | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_buffer_size_is_zero                                                     | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_length_exceeds_max                                                  | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_null                                                                | 1      | 0      | OK     | 0.04               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_value_fifteen_byte_size                                             | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_value_five_byte_size                                                | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_value_one_byte_size                                                 | 1      | 0      | OK     | 0.05               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_value_seventeen_byte_size                                           | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_key_value_two_byte_size                                                 | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_same_key_several_time                                                   | 1      | 0      | OK     | 0.06               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_several_key_value_sizes                                                 | 0      | 62     | FAIL   | 6.57               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_several_keys_multithreaded                                              | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_several_unvalid_key_names                                               | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_write_once_flag_try_remove                                              | 1      | 0      | OK     | 0.1                |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-static_tests                 | set_write_once_flag_try_set_twice                                           | 1      | 0      | OK     | 0.07               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: Error inject test                                                 | 1      | 0      | OK     | 0.12               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: Multiple set test                                                 | 1      | 0      | OK     | 0.11               |
| LPC55S69_NS-GCC_ARM | LPC55S69      | features-storage-tests-kvstore-tdbstore_whitebox            | TDBStore: White box test                                                    | 1      | 0      | OK     | 0.11               |
mbedgt: test case results: 12 FAIL / 62 OK
```    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

@SeppoTakalo 
@teetak01 

----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

##### Summary of changes

##### Impact of changes

##### Migration actions required



