### PR TITLE
Baremetal: Fix ARM-microlib Greentea test minimal-printf test case run for NUCLEO_F411RE

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
+++ b/TESTS/mbed_platform/minimal-printf/compliance/main.cpp
@@ -856,11 +856,14 @@ static control_t test_snprintf_buffer_overflow_generic(const char *fmt, T data)
     char buffer_minimal[buf_size];
     int result_baseline;
     int result_minimal;
-
+//There is a bug in Microlib snprintf with zero byte copy.
+//https://jira.arm.com/browse/SDCOMP-54710
+#if !defined(__MICROLIB)
     /* empty buffer test */
     result_minimal = mbed_snprintf(buffer_minimal, 0, fmt, data);
     result_baseline = snprintf(buffer_baseline, 0, fmt, data);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+#endif
 
     /* buffer isn't large enough, output needs to be truncated */
     result_minimal = mbed_snprintf(buffer_minimal, buf_size - 2, fmt, data);


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
The minimal-printf baremetal greentea test were not running for the Nucleo F11RE target when using with ARM toolchain


#### Summary of change <!-- Required -->
Microlib Snprinf function with zero byte copy was not working and it seems to be a bug in microlib snprintf implementation so added the !defined(__MICROLIB) guard in minimal-printf test case where snprintf function with zero byte copy call and compilation tools team raised a bug https://jira.arm.com/browse/SDCOMP-54710 to fix snprintf zero byte copy issue.

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@hugueskamba @evedon 
<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
