### PR TITLE
Fixed greentea FileHandle test for microlib

### DIFF
--- a/TESTS/mbed_platform/FileHandle/main.cpp
+++ b/TESTS/mbed_platform/FileHandle/main.cpp
@@ -360,7 +360,7 @@ void test_fprintf_fscanf()
     TEST_ASSERT_EQUAL_INT(str1_size, fprintf_ret);
 
 #if !defined(__MICROLIB)
-    // feof() and ferror() functions are not supported for Microlib.
+    // feof() and ferror() functions are not supported in Microlib.
     // write 3; expected written 2
     TestFile<FS>::resetFunctionCallHistory();
     fprintf_ret = fprintf(file, "%s", str2);

--- a/TESTS/mbed_platform/FileHandle/main.cpp
+++ b/TESTS/mbed_platform/FileHandle/main.cpp
@@ -94,7 +94,9 @@ void test_fwrite_fread()
     TestFile<FS>::resetFunctionCallHistory();
     write_ret = std::fwrite(str2, 1, str2_size, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
+#endif
     std::clearerr(file);
 
     // ARMCC/IAR returns 0 here instead of number of elements successfully written !!!
@@ -104,7 +106,9 @@ void test_fwrite_fread()
     TestFile<FS>::resetFunctionCallHistory();
     write_ret = std::fwrite(str1, 1, str1_size, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(0, write_ret);
 
     std::rewind(file);
@@ -120,7 +124,9 @@ void test_fwrite_fread()
     TestFile<FS>::resetFunctionCallHistory();
     read_ret = std::fread(read_buf, 1, str2_size, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
+#endif
     std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(str2_size - 1, read_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(str2, read_buf, str2_size - 1));
@@ -129,7 +135,9 @@ void test_fwrite_fread()
     TestFile<FS>::resetFunctionCallHistory();
     read_ret = std::fread(read_buf, 1, str2_size, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(0, read_ret);
 
     std::fclose(file);
@@ -187,7 +195,9 @@ void test_fputc_fgetc()
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fputc(char_buf[0], file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(EOF, ret);
 
     std::rewind(file);
@@ -212,7 +222,9 @@ void test_fputc_fgetc()
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fgetc(file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(EOF, ret);
 
     std::fclose(file);
@@ -261,7 +273,9 @@ void test_fputs_fgets()
     TestFile<FS>::resetFunctionCallHistory();
     fputs_ret = std::fputs(str2, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
+#endif
     std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(EOF, fputs_ret);
 
@@ -269,7 +283,9 @@ void test_fputs_fgets()
     TestFile<FS>::resetFunctionCallHistory();
     fputs_ret = std::fputs(str1, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(EOF, fputs_ret);
 
     std::rewind(file);
@@ -285,7 +301,9 @@ void test_fputs_fgets()
     TestFile<FS>::resetFunctionCallHistory();
     fgets_ret = std::fgets(read_buf, str2_size + 1, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
+#endif
     std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(read_buf, fgets_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(read_buf, str2, str2_size - 2));
@@ -294,7 +312,9 @@ void test_fputs_fgets()
     TestFile<FS>::resetFunctionCallHistory();
     fgets_ret = std::fgets(read_buf, str2_size + 1, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(NULL, fgets_ret);
 
     std::fclose(file);
@@ -339,6 +359,8 @@ void test_fprintf_fscanf()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_EQUAL_INT(str1_size, fprintf_ret);
 
+#if !defined(__MICROLIB)
+    // feof() and ferror() functions are not supported for Microlib.
     // write 3; expected written 2
     TestFile<FS>::resetFunctionCallHistory();
     fprintf_ret = fprintf(file, "%s", str2);
@@ -353,7 +375,17 @@ void test_fprintf_fscanf()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
     TEST_ASSERT_TRUE(fprintf_ret < 0);
-
+#else
+    // Writing remaining available file space of 2 characters
+    // to make further fscanf() test to pass.
+    // write 2; expected written 2
+    TestFile<FS>::resetFunctionCallHistory();
+    fprintf_ret = 0;
+    fprintf_ret += fprintf(file, "%c", str2[0]);
+    fprintf_ret += fprintf(file, "%c", str2[1]);
+    TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
+    TEST_ASSERT_EQUAL_INT(2, fprintf_ret);
+#endif
     std::rewind(file);
 
     // read 3; expected read 3
@@ -367,8 +399,10 @@ void test_fprintf_fscanf()
     TestFile<FS>::resetFunctionCallHistory();
     fscanf_ret = fscanf(file, "%3s", read_buf);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
     std::clearerr(file);
+#endif
     TEST_ASSERT_EQUAL_INT(1, fscanf_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(read_buf, str2, str2_size - 1));
 
@@ -376,7 +410,9 @@ void test_fprintf_fscanf()
     TestFile<FS>::resetFunctionCallHistory();
     fscanf_ret = fscanf(file, "%3s", read_buf);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
+#if !defined(__MICROLIB)
     TEST_ASSERT_TRUE(std::feof(file) != 0);
+#endif
     TEST_ASSERT_EQUAL_INT(EOF, fscanf_ret);
 
     std::fclose(file);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
As per "Difference between microlib and the default c library" from "http://arminfo.emea.arm.com/help/index.jsp?topic=/com.arm.doc.100073_0612_00_en/chr1358938938431.html" Microlib is not supported feof() and ferror() functions so modified all the test cases to pass without using feof() and ferror().

#### Summary of change <!-- Required -->
1. Added __MICROLIB guard in filehandle test cases wherever feof() and ferror() are called to solve "undefine symbol feof" compilation issue.
2. Modified "fprintf/fscanf" test case to remove the code which was relying on feof().

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon @hugueskamba 
<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
