### PR TITLE
Speed up unittests by not limitting Make to spawn more processes

### DIFF
--- a/UNITTESTS/unit_test/test.py
+++ b/UNITTESTS/unit_test/test.py
@@ -110,7 +110,6 @@ class UnitTestTool(object):
         # Speed up compilation by running on more than one core
         count = psutil.cpu_count()
         args.append("-j{}".format(count+1))
-        args.append("-l{}".format(count))
 
         if logging.getLogger().getEffectiveLevel() == logging.DEBUG:
             args.append("VERBOSE=1")


### PR DESCRIPTION
### Description 
#### Summary of change <!-- Required -->

Speed up unittests by not limitting Make to spawn more processes.

By default, the Make will use as many processes as specified by `-j[N]` parameter. But if there is a parameter `-l[N]` parameter given, it does not spawn any more processes, if load average is over N.

This greatly limits the effect of parallel build. On Mac OS X, I can see load average as high as 40, when building unittests. This is normal, and the system is still responsive.

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JuhPuur 

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
