### PR TITLE
Allow MBED_ASSERT to throw errors in unittests, so we can verify it.

### DIFF
--- a/UNITTESTS/drivers/PwmOut/unittest.cmake
+++ b/UNITTESTS/drivers/PwmOut/unittest.cmake
@@ -19,7 +19,7 @@ set(unittest-sources
 set(unittest-test-sources
   drivers/PwmOut/test_pwmout.cpp
   stubs/mbed_critical_stub.c
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/pwmout_api_stub.c
 )
 

--- a/UNITTESTS/drivers/Watchdog/unittest.cmake
+++ b/UNITTESTS/drivers/Watchdog/unittest.cmake
@@ -19,7 +19,7 @@ set(unittest-sources
 set(unittest-test-sources
   drivers/Watchdog/test_watchdog.cpp  
   stubs/mbed_critical_stub.c  
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/watchdog_api_stub.c
 )
 

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularbase/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularbase/unittest.cmake
@@ -21,7 +21,7 @@ set(unittest-sources
 # Test files
 set(unittest-test-sources
   features/cellular/framework/AT/at_cellularbase/at_cellularbasetest.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/ATHandler_stub.cpp
   stubs/EventQueue_stub.cpp
   stubs/FileHandle_stub.cpp

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularcontext/unittest.cmake
@@ -30,7 +30,7 @@ set(unittest-test-sources
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/FileHandle_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/NetworkInterface_stub.cpp
   stubs/NetworkInterfaceDefaults_stub.cpp
   stubs/NetworkStack_stub.cpp

--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   stubs/NetworkInterfaceDefaults_stub.cpp
   stubs/EventQueue_stub.cpp
   stubs/FileHandle_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/CellularDevice_stub.cpp
   stubs/NetworkStack_stub.cpp
   stubs/AT_CellularContext_stub.cpp

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularinformation/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularinformation/unittest.cmake
@@ -24,7 +24,7 @@ set(unittest-test-sources
   stubs/AT_CellularBase_stub.cpp
   stubs/EventQueue_stub.cpp
   stubs/FileHandle_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/ConditionVariable_stub.cpp
   stubs/Mutex_stub.cpp
 )

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/unittest.cmake
@@ -25,7 +25,7 @@ set(unittest-test-sources
   stubs/EventQueue_stub.cpp
   stubs/FileHandle_stub.cpp
   stubs/us_ticker_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/SocketAddress_stub.cpp
   stubs/randLIB_stub.cpp
   stubs/ConditionVariable_stub.cpp

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsms/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsms/unittest.cmake
@@ -25,7 +25,7 @@ set(unittest-test-sources
   stubs/FileHandle_stub.cpp
   stubs/CellularUtil_stub.cpp
   stubs/us_ticker_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/ThisThread_stub.cpp
   stubs/mbed_wait_api_stub.cpp
   stubs/ConditionVariable_stub.cpp

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
@@ -27,7 +27,7 @@ set(unittest-test-sources
   stubs/us_ticker_stub.cpp
   stubs/NetworkStack_stub.cpp
   stubs/SocketAddress_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/ThisThread_stub.cpp
   stubs/ConditionVariable_stub.cpp
   stubs/Mutex_stub.cpp

--- a/UNITTESTS/features/cellular/framework/AT/athandler/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/unittest.cmake
@@ -27,7 +27,7 @@ set(unittest-test-sources
   stubs/us_ticker_stub.cpp
   stubs/UARTSerial_stub.cpp
   stubs/SerialBase_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_poll_stub.cpp
   stubs/Timer_stub.cpp
   stubs/equeue_stub.c

--- a/UNITTESTS/features/cellular/framework/device/cellularcontext/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellularcontext/unittest.cmake
@@ -22,7 +22,7 @@ set(unittest-test-sources
   stubs/FileHandle_stub.cpp
   stubs/CellularStateMachine_stub.cpp
   stubs/EventQueue_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/UARTSerial_stub.cpp
   stubs/SerialBase_stub.cpp
   stubs/ATHandler_stub.cpp

--- a/UNITTESTS/features/cellular/framework/device/cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellulardevice/unittest.cmake
@@ -22,7 +22,7 @@ set(unittest-test-sources
   stubs/FileHandle_stub.cpp
   stubs/CellularStateMachine_stub.cpp
   stubs/EventQueue_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/UARTSerial_stub.cpp
   stubs/SerialBase_stub.cpp
   stubs/ATHandler_stub.cpp

--- a/UNITTESTS/features/cellular/framework/device/cellularstatemachine/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellularstatemachine/unittest.cmake
@@ -22,7 +22,7 @@ set(unittest-test-sources
   stubs/FileHandle_stub.cpp
   stubs/CellularDevice_stub.cpp
   stubs/EventQueue_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/UARTSerial_stub.cpp
   stubs/SerialBase_stub.cpp
   stubs/ATHandler_stub.cpp

--- a/UNITTESTS/features/lorawan/loramac/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loramac/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/loramac/Test_LoRaMac.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANStack_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/LoRaMacCrypto_stub.cpp
   stubs/LoRaMacChannelPlan_stub.cpp
   stubs/LoRaWANTimer_stub.cpp

--- a/UNITTESTS/features/lorawan/loramaccommand/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loramaccommand/unittest.cmake
@@ -32,7 +32,7 @@ set(unittest-includes ${unittest-includes}
 # Test & stub files
 set(unittest-test-sources
   features/lorawan/loramaccommand/Test_LoRaMacCommand.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/LoRaPHY_stub.cpp
 )
 

--- a/UNITTESTS/features/lorawan/loramaccrypto/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loramaccrypto/unittest.cmake
@@ -35,7 +35,7 @@ set(unittest-test-sources
   stubs/cipher_stub.c
   stubs/aes_stub.c
   stubs/cmac_stub.c
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   ../features/nanostack/coap-service/test/coap-service/unittest/stub/mbedtls_stub.c
 
 )

--- a/UNITTESTS/features/lorawan/loraphy/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphy/unittest.cmake
@@ -33,7 +33,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-test-sources
   features/lorawan/loraphy/Test_LoRaPHY.cpp
   stubs/LoRaWANTimer_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 )
 
 

--- a/UNITTESTS/features/lorawan/loraphyas923/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphyas923/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/loraphyas923/Test_LoRaPHYAS923.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANTimer_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphyau915/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphyau915/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANTimer_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphycn470/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphycn470/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANTimer_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphycn779/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphycn779/unittest.cmake
@@ -33,7 +33,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-test-sources
   features/lorawan/loraphycn779/Test_LoRaPHYCN779.cpp
   stubs/LoRaPHY_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphyeu433/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphyeu433/unittest.cmake
@@ -33,7 +33,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-test-sources
   features/lorawan/loraphyeu433/Test_LoRaPHYEU433.cpp
   stubs/LoRaPHY_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphyeu868/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphyeu868/unittest.cmake
@@ -33,7 +33,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-test-sources
   features/lorawan/loraphyeu868/Test_LoRaPHYEU868.cpp
   stubs/LoRaPHY_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphyin865/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphyin865/unittest.cmake
@@ -33,7 +33,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-test-sources
   features/lorawan/loraphyin865/Test_LoRaPHYIN865.cpp
   stubs/LoRaPHY_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphykr920/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphykr920/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/loraphykr920/Test_LoRaPHYKR920.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANTimer_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/loraphyus915/unittest.cmake
+++ b/UNITTESTS/features/lorawan/loraphyus915/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANTimer_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 
 )
 

--- a/UNITTESTS/features/lorawan/lorawaninterface/unittest.cmake
+++ b/UNITTESTS/features/lorawan/lorawaninterface/unittest.cmake
@@ -35,7 +35,7 @@ set(unittest-test-sources
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaWANStack_stub.cpp
   stubs/LoRaMac_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/LoRaMacCrypto_stub.cpp
   stubs/LoRaMacChannelPlan_stub.cpp
   stubs/LoRaWANTimer_stub.cpp

--- a/UNITTESTS/features/lorawan/lorawanstack/unittest.cmake
+++ b/UNITTESTS/features/lorawan/lorawanstack/unittest.cmake
@@ -34,7 +34,7 @@ set(unittest-test-sources
   features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
   stubs/LoRaPHY_stub.cpp
   stubs/LoRaMac_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/LoRaMacCrypto_stub.cpp
   stubs/LoRaMacChannelPlan_stub.cpp

--- a/UNITTESTS/features/lorawan/lorawantimer/unittest.cmake
+++ b/UNITTESTS/features/lorawan/lorawantimer/unittest.cmake
@@ -33,7 +33,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-test-sources
   features/lorawan/lorawantimer/Test_LoRaWANTimer.cpp
   stubs/EventQueue_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/equeue_stub.c
 )
 

--- a/UNITTESTS/features/netsocket/DTLSSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/DTLSSocket/unittest.cmake
@@ -22,7 +22,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/DTLSSocket/test_DTLSSocket.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/DTLSSocketWrapper/unittest.cmake
+++ b/UNITTESTS/features/netsocket/DTLSSocketWrapper/unittest.cmake
@@ -21,7 +21,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/DTLSSocketWrapper/test_DTLSSocketWrapper.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/EthernetInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/EthernetInterface/unittest.cmake
@@ -25,7 +25,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/EthernetInterface/test_EthernetInterface.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_shared_queues_stub.cpp

--- a/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
@@ -17,7 +17,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/InternetSocket/test_InternetSocket.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/NetworkInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/NetworkInterface/unittest.cmake
@@ -19,7 +19,7 @@ set(unittest-sources
 # Test files
 set(unittest-test-sources
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_shared_queues_stub.cpp

--- a/UNITTESTS/features/netsocket/NetworkStack/unittest.cmake
+++ b/UNITTESTS/features/netsocket/NetworkStack/unittest.cmake
@@ -21,7 +21,7 @@ set(unittest-sources
 # Test files
 set(unittest-test-sources
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/equeue_stub.c
   stubs/EventQueue_stub.cpp
   stubs/mbed_error.c

--- a/UNITTESTS/features/netsocket/TCPServer/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPServer/unittest.cmake
@@ -21,7 +21,7 @@ set(unittest-sources
 
 set(unittest-test-sources
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
@@ -18,7 +18,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/TCPSocket/test_TCPSocket.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/TLSSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TLSSocket/unittest.cmake
@@ -20,7 +20,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/TLSSocket/test_TLSSocket.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/TLSSocketWrapper/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TLSSocketWrapper/unittest.cmake
@@ -19,7 +19,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/TLSSocketWrapper/test_TLSSocketWrapper.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
@@ -19,7 +19,7 @@ set(unittest-sources
 set(unittest-test-sources
   features/netsocket/UDPSocket/test_UDPSocket.cpp
   stubs/Mutex_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_atomic_stub.c
   stubs/mbed_critical_stub.c
   stubs/equeue_stub.c

--- a/UNITTESTS/features/netsocket/cellular/CellularNonIPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/cellular/CellularNonIPSocket/unittest.cmake
@@ -20,5 +20,5 @@ set(unittest-test-sources
   stubs/EventFlags_stub.cpp
   stubs/Mutex_stub.cpp
   stubs/CellularContext_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 )

--- a/UNITTESTS/features/netsocket/nsapi_dns/unittest.cmake
+++ b/UNITTESTS/features/netsocket/nsapi_dns/unittest.cmake
@@ -21,7 +21,7 @@ set(unittest-sources
 set(unittest-test-sources
   stubs/Mutex_stub.cpp
   ../features/netsocket/SocketAddress.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/NetworkStack_stub.cpp
   stubs/NetworkInterfaceDefaults_stub.cpp
   stubs/mbed_atomic_stub.c

--- a/UNITTESTS/features/storage/blockdevice/HeapBlockDevice/test.cpp
+++ b/UNITTESTS/features/storage/blockdevice/HeapBlockDevice/test.cpp
@@ -50,6 +50,12 @@ TEST_F(HeapBlockDeviceTest, constructor)
     EXPECT_EQ(one.deinit(), BD_ERROR_OK);
 }
 
+TEST_F(HeapBlockDeviceTest, constructor_wrong_size)
+{
+    mbed_assert_throw_errors=true;
+    ASSERT_ANY_THROW(mbed::HeapBlockDevice one(3050, 100));
+}
+
 TEST_F(HeapBlockDeviceTest, double_init)
 {
     mbed::HeapBlockDevice one{DEVICE_SIZE};

--- a/UNITTESTS/features/storage/blockdevice/HeapBlockDevice/unittest.cmake
+++ b/UNITTESTS/features/storage/blockdevice/HeapBlockDevice/unittest.cmake
@@ -11,7 +11,7 @@ set(unittest-includes ${unittest-includes}
 set(unittest-sources
   ../features/storage/blockdevice/HeapBlockDevice.cpp
   stubs/mbed_atomic_stub.c
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 )
 
 set(unittest-test-sources

--- a/UNITTESTS/moduletests/storage/blockdevice/SlicingBlockDevice/unittest.cmake
+++ b/UNITTESTS/moduletests/storage/blockdevice/SlicingBlockDevice/unittest.cmake
@@ -12,7 +12,7 @@ set(unittest-sources
   ../features/storage/blockdevice/SlicingBlockDevice.cpp
   ../features/storage/blockdevice/HeapBlockDevice.cpp
   stubs/mbed_atomic_stub.c
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
 )
 
 set(unittest-test-sources

--- a/UNITTESTS/platform/ATCmdParser/unittest.cmake
+++ b/UNITTESTS/platform/ATCmdParser/unittest.cmake
@@ -11,6 +11,6 @@ set(unittest-sources
 set(unittest-test-sources
   platform/ATCmdParser/test_ATCmdParser.cpp
   stubs/FileHandle_stub.cpp
-  stubs/mbed_assert_stub.c
+  stubs/mbed_assert_stub.cpp
   stubs/mbed_poll_stub.cpp
 )

--- a/UNITTESTS/stubs/mbed_assert_stub.cpp
+++ b/UNITTESTS/stubs/mbed_assert_stub.cpp
@@ -17,9 +17,14 @@
 
 #include "platform/mbed_assert.h"
 #include <stdio.h>
+#include <stdbool.h>
 
-void mbed_assert_internal(const char *expr, const char *file, int line)
+bool mbed_assert_throw_errors = false;
+
+extern "C" void mbed_assert_internal(const char *expr, const char *file, int line)
 {
     fprintf(stderr, "mbed assertation failed: %s, file: %s, line %d \n", expr, file, line);
+    if (mbed_assert_throw_errors) {
+        throw 1;
+    }
 }
-

--- a/UNITTESTS/target_h/platform/mbed_assert.h
+++ b/UNITTESTS/target_h/platform/mbed_assert.h
@@ -50,6 +50,12 @@ void mbed_assert_internal(const char *expr, const char *file, int line);
 }
 #endif
 
+/**
+ * For unittests: Global flag to select whether MBED_ASSERT
+ * throws error. Default false.
+ */
+extern bool mbed_assert_throw_errors;
+
 /** MBED_ASSERT
  *  Declare runtime assertions: results in runtime error if condition is false
  *
@@ -63,18 +69,12 @@ void mbed_assert_internal(const char *expr, const char *file, int line);
  *  }
  *  @endcode
  */
-#if defined( NDEBUG ) && !defined (MBED_WDOG_ASSERT)
-#define MBED_ASSERT(expr) ((void)0)
-#else
 #define MBED_ASSERT(expr)                                \
 do {                                                     \
     if (!(expr)) {                                       \
         mbed_assert_internal(#expr, __FILE__, __LINE__); \
     }                                                    \
 } while (0)
-#endif
-
-
 
 /** MBED_STATIC_ASSERT
  *  Declare compile-time assertions, results in compile-time error if condition is false


### PR DESCRIPTION
### Description 
#### Summary of change <!-- Required -->

GoogleTest allows you to check whether certain function throws errors.
For example:
```
mbed_assert_throw_errors=true;
ASSERT_ANY_THROW(mbed::HeapBlockDevice one(3050, 100));
```
or
```
mbed_assert_throw_errors=true;
ASSERT_NO_THROW(bd.init());
```

As MBED_ERROR is now only function that can throw errors, there is
no need to check the type of thrown object.

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->
@AnttiKauppila 


----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
