### PR TITLE
Add FlashIAP to NUCLEO_L4R5ZI

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -8396,6 +8396,7 @@
         "inherits": ["FAMILY_STM32"],
         "supported_form_factors": ["ARDUINO", "MORPHO"],
         "core": "Cortex-M4F",
+        "components_add": ["FLASHIAP"],
         "extra_labels_add": [
             "STM32L4",
             "STM32L4R5ZI",


### PR DESCRIPTION
### Description 

It is supported and we need it.

@jeromecoutant  has run the tests.

```
| target                | platform_name   | test suite                                               | result | elapsed_time (sec) | copy_method |
|-----------------------|-----------------|----------------------------------------------------------|--------|--------------------|-------------|
| NUCLEO_L4R5ZI_P-ARMC6 | NUCLEO_L4R5ZI_P | features-storage-tests-blockdevice-flashsim_block_device | OK     | 14.23              | default     |
| NUCLEO_L4R5ZI_P-ARMC6 | NUCLEO_L4R5ZI_P | tests-mbed_drivers-flashiap                              | OK     | 16.78              | default     |
| NUCLEO_L4R5ZI_P-ARMC6 | NUCLEO_L4R5ZI_P | tests-mbed_hal-flash                                     | OK     | 16.16              | default     |
| NUCLEO_L4R5ZI_P-ARMC6 | NUCLEO_L4R5ZI_P | features-device_key-tests-device_key-functionality          | OK     | 31.49              | default     |
| NUCLEO_L4R5ZI_P-ARMC6 | NUCLEO_L4R5ZI_P | features-storage-tests-kvstore-direct_access_devicekey_test | OK     | 16.06              | default     |
```

Client has been enabled too and it works.

### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
### Reviewers <!-- Optional -->

@ARMmbed/team-st-mcd  @jeromecoutant 


### Release Notes
#### Summary of changes

Add FlashIAP component to NUCLEO_L4RZI.

#### Impact of changes

#### Migration actions required
