### PR TITLE
Split integration tests in fs/net

### DIFF
--- a/TESTS/integration/COMMON/common_defines_fs_test.h
+++ b/TESTS/integration/COMMON/common_defines_fs_test.h
@@ -1,0 +1,64 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2006-2019 ARM Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed_trace.h"
+
+#define TRACE_GROUP "GRNT"
+
+#define FS_FAT 1
+#define FS_LFS 2
+
+#if COMPONENT_SPIF
+#define TEST_BLOCK_DEVICE_TYPE "SPIF"
+#elif COMPONENT_QSPIF
+#define TEST_BLOCK_DEVICE_TYPE "QSPIF"
+#elif COMPONENT_DATAFLASH
+#define TEST_BLOCK_DEVICE_TYPE "DATAFLASH"
+#elif COMPONENT_SD
+#define TEST_BLOCK_DEVICE_TYPE "SD"
+#define TEST_USE_FILESYSTEM FS_FAT
+#elif COMPONENT_SDIO
+#define TEST_BLOCK_DEVICE_TYPE "SDIO"
+#elif COMPONENT_NUSD
+#define TEST_BLOCK_DEVICE_TYPE "NUSD"
+#define TEST_USE_FILESYSTEM FS_FAT
+#elif COMPONENT_FLASHIAP && MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE
+#define TEST_BLOCK_DEVICE_TYPE "FLASHIAP"
+#else
+#define TEST_BLOCK_DEVICE_TYPE "UNKNOWN"
+#error [NOT_SUPPORTED] no valid block device enabled for this target
+#endif
+
+#if !defined(TEST_USE_FILESYSTEM)
+#define TEST_USE_FILESYSTEM FS_LFS
+#endif
+
+#if TEST_USE_FILESYSTEM == FS_FAT
+#define TEST_FILESYSTEM_TYPE "FAT"
+#elif TEST_USE_FILESYSTEM == FS_LFS
+#define TEST_FILESYSTEM_TYPE "LFS"
+#else
+#define TEST_FILESYSTEM_TYPE "UNKNOWN"
+#endif
+
+#define TEST_MEMORY_SIZE_10K 10240
+#define TEST_MEMORY_SIZE_20K 20480
+#define TEST_MEMORY_SIZE_40K 40960
+#define TEST_MEMORY_SIZE_60K 61440
+#define TEST_MEMORY_SIZE_80K 81920
+#define TEST_MEMORY_SIZE_100K 102400

--- a/TESTS/integration/COMMON/common_defines_net_test.h
+++ b/TESTS/integration/COMMON/common_defines_net_test.h
@@ -16,9 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_trace.h"
-
-#define TRACE_GROUP "GRNT"
 
 #define ETHERNET 1
 #define WIFI 2
@@ -38,47 +35,6 @@
 #elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
 #define TEST_NETWORK_TYPE "Cellular"
 #else
+#define TEST_NETWORK_TYPE "Unknown"
 #error [NOT_SUPPORTED] Either WiFi, Ethernet or Cellular network interface need to be enabled
 #endif
-
-#define FS_FAT 1
-#define FS_LFS 2
-
-#if COMPONENT_SPIF
-#define TEST_BLOCK_DEVICE_TYPE "SPIF"
-#elif COMPONENT_QSPIF
-#define TEST_BLOCK_DEVICE_TYPE "QSPIF"
-#elif COMPONENT_DATAFLASH
-#define TEST_BLOCK_DEVICE_TYPE "DATAFLASH"
-#elif COMPONENT_SD
-#define TEST_BLOCK_DEVICE_TYPE "SD"
-#define TEST_USE_FILESYSTEM FS_FAT
-#elif COMPONENT_FLASHIAP
-#define TEST_BLOCK_DEVICE_TYPE "FLASHIAP"
-#elif COMPONENT_SDIO
-#define TEST_BLOCK_DEVICE_TYPE "SDIO"
-#elif COMPONENT_NUSD
-#define TEST_BLOCK_DEVICE_TYPE "NUSD"
-#define TEST_USE_FILESYSTEM FS_FAT
-#else
-#define TEST_BLOCK_DEVICE_TYPE "UNKNOWN"
-#endif
-
-#if !defined(TEST_USE_FILESYSTEM)
-#define TEST_USE_FILESYSTEM FS_LFS
-#endif
-
-#if TEST_USE_FILESYSTEM == FS_FAT
-#define TEST_FILESYSTEM_TYPE "FAT"
-#elif TEST_USE_FILESYSTEM == FS_LFS
-#define TEST_FILESYSTEM_TYPE "LFS"
-#else
-#define TEST_FILESYSTEM_TYPE "UNKNOWN"
-#endif
-
-#define TEST_MEMORY_SIZE_10K 10240
-#define TEST_MEMORY_SIZE_20K 20480
-#define TEST_MEMORY_SIZE_40K 40960
-#define TEST_MEMORY_SIZE_60K 61440
-#define TEST_MEMORY_SIZE_80K 81920
-#define TEST_MEMORY_SIZE_100K 102400

--- a/TESTS/integration/fs-single/main.cpp
+++ b/TESTS/integration/fs-single/main.cpp
@@ -31,7 +31,7 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
-#include "common_defines_test.h"
+#include "common_defines_fs_test.h"
 #include "file_test.h"
 
 #ifdef MBED_CONF_APP_BASICS_TEST_FILENAME

--- a/TESTS/integration/fs-threaded/main.cpp
+++ b/TESTS/integration/fs-threaded/main.cpp
@@ -31,7 +31,7 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
-#include "common_defines_test.h"
+#include "common_defines_fs_test.h"
 #include "file_test.h"
 
 #ifdef MBED_CONF_APP_BASICS_TEST_FILENAME

--- a/TESTS/integration/net-single/main.cpp
+++ b/TESTS/integration/net-single/main.cpp
@@ -29,7 +29,7 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
-#include "common_defines_test.h"
+#include "common_defines_net_test.h"
 #include "download_test.h"
 #include <string>
 

--- a/TESTS/integration/net-threaded/main.cpp
+++ b/TESTS/integration/net-threaded/main.cpp
@@ -29,7 +29,7 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
-#include "common_defines_test.h"
+#include "common_defines_net_test.h"
 #include "download_test.h"
 #include <string>
 

--- a/TESTS/integration/stress-net-fs/main.cpp
+++ b/TESTS/integration/stress-net-fs/main.cpp
@@ -31,7 +31,8 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
-#include "common_defines_test.h"
+#include "common_defines_fs_test.h"
+#include "common_defines_net_test.h"
 #include "download_test.h"
 #include "file_test.h"
 #include <string>


### PR DESCRIPTION
### Description

This PR splits integration tests to let developers run individual tests for filesystem, network or stress (fs+net) depending on what the platform supports.

This is an example of platforms and tests that can be run:

|                   |fs-single|net-single|stress (fs+net)|
|-------------|-------------|-------------|-------------|
|K64F (sd+eth)         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
|NUCLEO_F429ZI (eth) |:x:|:heavy_check_mark:|:x:|
|DISCO_L496AG (qspi) |:heavy_check_mark:|:x:|:x:|

The way to run the integration tests has not changed, but no valid test cases are now skipped.
`mbed test -t <toolchain> -m <target> -DINTEGRATION_TESTS`

This is another attempt to merge after these ones: https://github.com/ARMmbed/mbed-os/pull/11703 https://github.com/ARMmbed/mbed-os/pull/11858

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

### Reviewers

@0xc0170 
