### PR TITLE
Cellular: Mark AT_CellularBase as deprecated

### DIFF
--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -28,6 +28,7 @@ namespace mbed {
  */
 class AT_CellularBase {
 public:
+    MBED_DEPRECATED_SINCE("mbed-os-5.15", "This class will be refactored away, affected drivers if any will be updated accordingly.")
     AT_CellularBase(ATHandler &at);
     /** Getter for at handler. Common method for all AT-classes.
      *


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
#### Summary of change <!-- Required -->

Mark AT_CellularBase as to be deprecated. This class is not needed and will save about 2kB from binary size. The cellular properties this class is handling are (AT_)CellularDevice specific and will be moved there. Also getter for ATHandler and device_error will be moved most probably to (AT_)CellularDevice

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@AnttiKauppila 
<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->
AT_CellularBase has been marked to be deprecated and the class will actually be removed in Mbed OS 6. The functionality will be moved to (AT_)CellularDevice class and all drivers will be updated accordingly if affected.
<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes
AT_CellularBase has been marked to be deprecated and the class will actually be removed in Mbed OS 6. The functionality will be moved to (AT_)CellularDevice class and all drivers will be updated accordingly if affected.

#### Impact of changes
None

#### Migration actions required
None