### PR TITLE
Storage: fix kvstore-static_tests test case bugs

### DIFF
--- a/features/storage/TESTS/kvstore/static_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/static_tests/main.cpp
@@ -34,7 +34,7 @@ static const size_t data_size = 5;
 static size_t       actual_size = 0;
 static const size_t buffer_size = 20;
 static const int    num_of_threads = 3;
-static const char   num_of_keys = 3;
+static const char num_of_keys = 11;
 #if defined(MBED_CONF_RTOS_PRESENT)
 /* Forked 3 threads plus misc, so minimum (4 * OS_STACK_SIZE) heap are required. */
 static const int heap_alloc_threshold_size = 4 * OS_STACK_SIZE;
@@ -42,7 +42,9 @@ static const int heap_alloc_threshold_size = 4 * OS_STACK_SIZE;
 /* Bare metal does not require memory for threads, so use just minimum for test */
 static const int heap_alloc_threshold_size = MBED_CONF_TARGET_BOOT_STACK_SIZE;
 #endif
-static const char *keys[] = {"key1", "key2", "key3"};
+static const char *keys[num_of_keys] = { "key1", "key2", "key3", "key4", "key5", "key6", "key7", "key8", "key9",
+                                         "key10", "key11"
+                                       };
 
 static int init_res = MBED_ERROR_NOT_READY;
 
@@ -298,14 +300,14 @@ static void set_several_key_value_sizes()
 
     name[6] = 0;
 
-    for (i = 0; i < 26; i++) {
+    for (i = 0; i < num_of_keys; i++) {
         c = i + 'a';
         name[5] = c;
         res = kv_set(name, name, sizeof(name), 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     }
 
-    for (i = 0; i < 26; i++) {
+    for (i = 0; i < num_of_keys; i++) {
         c = i + 'a';
         name[5] = c;
         res = kv_get(name, buffer, sizeof(buffer), &actual_size);
@@ -328,7 +330,7 @@ static void set_several_unvalid_key_names()
 
     name[6] = 0;
 
-    for (i = 0; i < 11; i++) {
+    for (i = 0; i < num_of_keys; i++) {
         name[5] = unvalid[i];
         res = kv_set(name, name, sizeof(name), 0);
         if (unvalid[i] != '/') {
@@ -817,7 +819,7 @@ static void iterator_next_full_list()
     res = kv_iterator_close(kvstore_it);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
 
-    for (i = 0; i < num_of_threads; i++) {
+    for (i = 0; i < num_of_keys; i++) {
         res = kv_remove(keys[i]);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     }
@@ -855,7 +857,7 @@ static void iterator_next_remove_while_iterating()
 
     int i = 0, res = 0;
 
-    for (i = 0; i < num_of_keys; i++) {
+    for (i = 0; i < 3; i++) {
         int res = kv_set(keys[i], data, data_size, 0);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);
     }


### PR DESCRIPTION
### Description 
At least with LPC55S69's default TDBStore configuration it's impossible to run storage Greentea tests without exhausting the memory reserved for storing keys.

Fixes an issue where number of keys were removed based on number of threads which didn't have anything to do with the test case.

Fixes an issue where number of keys were assumed to be constant but variable number was used for configuration.

#### Summary of change <!-- Required -->

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@SeppoTakalo 
<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
