### PR TITLE
Fix for ARMC5 compilation errors for some targets

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
 #include "AT_CellularContext.h"
 #include "AT_CellularNetwork.h"
 #include "AT_CellularStack.h"

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include "QUECTEL/BG96/QUECTEL_BG96_CellularStack.h"
 #include "CellularLog.h"


### PR DESCRIPTION
### Description 
#### Summary of change 

the following compilation error is seen for a number of targets when compiling using ARMC5
`tools.utils.ToolException: "./mbed-os/features/cellular/framework/AT/AT_CellularContext.cpp", line 247: Error:  #20: identifier "sprintf" is undefined`

Failing command:
> 5.06u6/bin/armcc -c --gnu -Ospace --split_sections --apcs=interwork --brief_diagnostics --restrict --multibyte_chars -O3 -DMBED_TRAP_ERRORS_ENABLED=1 --cpu=Cortex-M4.fp.sp --md --no_depend_system_headers --c99 -D__ASSERT_MSG --cpp11 --no_rtti --no_vla -DDEVICE_SERIAL_ASYNCH=1 -D__MBED__=1 -D__CORTEX_M4 -DTOOLCHAIN_ARM -DMBED_BUILD_TIMESTAMP=1574735332.2275832 -DTARGET_RELEASE -DTARGET_GigaDevice -DDEVICE_SERIAL_FC=1 -DARM_MATH_CM4 -DTARGET_LIKE_MBED -DTARGET_GD32E10X -D__FPU_PRESENT=1 -DTARGET_GD32_Target -DTARGET_M4 -DDEVICE_RTC=1 -DDEVICE_INTERRUPTIN=1 -DCOMPONENT_PSA_SRV_EMUL=1 -D__CMSIS_RTOS -DTOOLCHAIN_ARMC5 -DDEVICE_SPISLAVE=1 -DTARGET_GD32_E103VB -DTARGET_CORTEX -DDEVICE_PORTIN=1 -DDEVICE_ANALOGOUT=1 -DDEVICE_I2C=1 -DDEVICE_ANALOGIN=1 -DDEVICE_FLASH=1 -DDEVICE_SLEEP=1 -DCOMPONENT_NSPE=1 -DDEVICE_SERIAL=1 -DDEVICE_PORTOUT=1 -DTARGET_GD32E103VB -DDEVICE_CAN=1 -DTARGET_NAME=GD32_E103VB -DTARGET_CORTEX_M -D__MBED_CMSIS_RTOS_CM -DDEVICE_PWMOUT=1 -DTARGET_FF_ARDUINO -DGD32E10X -DDEVICE_USTICKER=1 -DTARGET_RTOS_M4_M7 -DDEVICE_PORTINOUT=1 -DTOOLCHAIN_ARM_STD -DCOMPONENT_PSA_SRV_IMPL=1 -DDEVICE_SPI=1 -DTARGET_LIKE_CORTEX_M4 -DDEVICE_I2CSLAVE=1 --preinclude=./BUILD/GD32_E103VB/ARMC5/mbed_config.h --via ./BUILD/GD32_E103VB/ARMC5/.includes_022feb5c2e44b9896df9a82c69438bc9.txt --depend BUILD/GD32_E103VB/ARMC5/mbed-os/features/cellular/framework/AT/AT_CellularContext.d -o BUILD/GD32_E103VB/ARMC5/mbed-os/features/cellular/framework/AT/AT_CellularContext.o ./mbed-os/features/cellular/framework/AT/AT_CellularContext.cpp
[Error] AT_CellularContext.cpp@247,0:  #20: identifier "sprintf" is undefined


#### Documentation
Included the libc header for sprintf

### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)


### Test results 

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    

#### Impact of changes

None
