### PR TITLE
Fix for Dragonfly nano and registration for LTE-M plans

### DIFF
--- a/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
+++ b/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
@@ -22,9 +22,9 @@ using namespace mbed;
 using namespace events;
 
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
-    AT_CellularNetwork::RegistrationModeDisable,// C_EREG
-    AT_CellularNetwork::RegistrationModeLAC,    // C_GREG
-    AT_CellularNetwork::RegistrationModeLAC,    // C_REG
+    AT_CellularNetwork::RegistrationModeLAC, // C_EREG
+    AT_CellularNetwork::RegistrationModeDisable, // C_GREG
+    AT_CellularNetwork::RegistrationModeDisable, // C_REG
     0,  // AT_CGSN_WITH_TYPE
     0,  // AT_CGDATA
     1,  // AT_CGAUTH

--- a/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
+++ b/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
@@ -23,7 +23,7 @@ using namespace events;
 
 static const intptr_t cellular_properties[AT_CellularBase::PROPERTY_MAX] = {
     AT_CellularNetwork::RegistrationModeLAC, // C_EREG
-    AT_CellularNetwork::RegistrationModeDisable, // C_GREG
+    AT_CellularNetwork::RegistrationModeLAC, // C_GREG
     AT_CellularNetwork::RegistrationModeDisable, // C_REG
     0,  // AT_CGSN_WITH_TYPE
     0,  // AT_CGDATA


### PR DESCRIPTION
### Description 
#### Summary of change 

The cellular_properties object for the SARA4_PPP instance did not allow CEREG to be used for registration checks.  LTE-M plans require that CEREG is used to check for registration as its separate from 3G or 2G service (CREG/CGREG respectively).  CGREG is left in because the radio has 2G fallback.

In current LTE-M dataplans in the US (on Verizon and AT&T at least) CEREG will report a successful registration while CGREG and CREG will not.  This means that the cellular connection will not be established as mbed does not think the modem is registered.

#### Documentation  
None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes
Changed cellular_properties object for Dragonfly Nano.
#### Impact of changes
Registration with LTE-M only data plans should now work.
#### Migration actions required
None