### PR TITLE
STM32 USB : Add __HAL_RCC_PWR_CLK_ENABLE

### DIFF
--- a/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -228,6 +228,8 @@ void USBPhyHw::init(USBPhyEvents *events)
         map++;
     }
 
+    __HAL_RCC_PWR_CLK_ENABLE();
+
 #if !defined(TARGET_STM32WB)
     __HAL_RCC_SYSCFG_CLK_ENABLE();
 #endif


### PR DESCRIPTION
### Description 

USB tests are failed within the master branch

#### Summary of change <!-- Required -->

Miss to enable one clock during #11675 

#### Documentation <!-- Optional, but most likely you need it -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

| DISCO_L475VG_IOT01A-ARMC6 | DISCO_L475VG_IOT01A | tests-usb_device-hid | OK     | 25.34              | default     |

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
