### PR TITLE
TDBStore: Unlock the master mutex even after garbage_collect()

### DIFF
--- a/features/storage/kvstore/tdbstore/TDBStore.cpp
+++ b/features/storage/kvstore/tdbstore/TDBStore.cpp
@@ -663,16 +663,15 @@ int TDBStore::set_finalize(set_handle_t handle)
     }
 
 end:
-    if ((need_gc) && (ih->bd_base_offset != _master_record_offset)) {
-        garbage_collection();
-    }
-
     // mark handle as invalid by clearing magic field in header
     ih->header.magic = 0;
 
     _inc_set_mutex.unlock();
 
     if (ih->bd_base_offset != _master_record_offset) {
+        if (need_gc) {
+            garbage_collection();
+        }
         _mutex.unlock();
     }
     return ret;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
#### Summary of change <!-- Required -->

TDBStore::set() was leaving a mutex locked in case it failed to write a data, and then started a garbage collection phase.

Fixed the sequence so that mutex is always unlocked, regardless of whether we run the GC or not.

Fixes #11723 

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->
@VeijoPesonen 

