### PR TITLE
PPPinterface: remove faulty address getter check for invalid pointer

### DIFF
--- a/features/netsocket/PPPInterface.cpp
+++ b/features/netsocket/PPPInterface.cpp
@@ -94,10 +94,6 @@ const char *PPPInterface::get_ip_address()
 
 nsapi_error_t PPPInterface::get_ip_address(SocketAddress *address)
 {
-    if (address) {
-        return NSAPI_ERROR_PARAMETER;
-    }
-
     if (_interface && _interface->get_ip_address(address) == NSAPI_ERROR_OK) {
         strncpy(_ip_address, address->get_ip_address(), sizeof(_ip_address));
         return NSAPI_ERROR_OK;


### PR DESCRIPTION
### Description 
#### Summary of change <!-- Required -->

(edited after Seppo's remark)
`PPPInterface` address [getter had reversed logic of the check](https://github.com/ARMmbed/mbed-os/pull/11941#discussion_r351784683) - this is fixed now, by removing the check entirely.

#### Documentation <!-- Optional, but most likely you need it -->

### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
   
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@kivaisan 
