### PR TITLE
LWIP system mailbox overflow fix

### DIFF
--- a/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
@@ -116,9 +116,6 @@ u32_t sys_now(void) {
 /* CMSIS-RTOS implementation of the lwip operating system abstraction */
 #include "arch/sys_arch.h"
 
-/* modulus subtract: (a - b) mod m, where a, b belongs to mod m ring */
-#define SUB_MOD(a, b, m) ((a) >= (b) ? (a) - (b) : (m) - (b) + (a))
-
 /*---------------------------------------------------------------------------*
  * Routine:  sys_mbox_new
  *---------------------------------------------------------------------------*
@@ -181,7 +178,7 @@ void sys_mbox_post(sys_mbox_t *mbox, void *msg) {
     mbox->post_idx = (mbox->post_idx + 1) % MB_SIZE;
 
     osEventFlagsSet(mbox->id, SYS_MBOX_FETCH_EVENT);
-    if (SUB_MOD(mbox->post_idx, mbox->fetch_idx, MB_SIZE) >= MB_SIZE-1)
+    if ((mbox->post_idx + 1) % MB_SIZE == mbox->fetch_idx)
         osEventFlagsClear(mbox->id, SYS_MBOX_POST_EVENT);
 
     osKernelRestoreLock(state);
@@ -214,7 +211,7 @@ err_t sys_mbox_trypost(sys_mbox_t *mbox, void *msg) {
     mbox->post_idx = (mbox->post_idx + 1) % MB_SIZE;
 
     osEventFlagsSet(mbox->id, SYS_MBOX_FETCH_EVENT);
-    if (SUB_MOD(mbox->post_idx, mbox->fetch_idx, MB_SIZE) >= MB_SIZE-1)
+    if ((mbox->post_idx + 1) % MB_SIZE == mbox->fetch_idx)
         osEventFlagsClear(mbox->id, SYS_MBOX_POST_EVENT);
 
     osKernelRestoreLock(state);

--- a/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c
@@ -116,6 +116,9 @@ u32_t sys_now(void) {
 /* CMSIS-RTOS implementation of the lwip operating system abstraction */
 #include "arch/sys_arch.h"
 
+/* modulus subtract: (a - b) mod m, where a, b belongs to mod m ring */
+#define SUB_MOD(a, b, m) ((a) >= (b) ? (a) - (b) : (m) - (b) + (a))
+
 /*---------------------------------------------------------------------------*
  * Routine:  sys_mbox_new
  *---------------------------------------------------------------------------*
@@ -174,11 +177,11 @@ void sys_mbox_post(sys_mbox_t *mbox, void *msg) {
 
     int state = osKernelLock();
 
-    mbox->queue[mbox->post_idx % MB_SIZE] = msg;
-    mbox->post_idx += 1;
+    mbox->queue[mbox->post_idx] = msg;
+    mbox->post_idx = (mbox->post_idx + 1) % MB_SIZE;
 
     osEventFlagsSet(mbox->id, SYS_MBOX_FETCH_EVENT);
-    if (mbox->post_idx - mbox->fetch_idx == MB_SIZE-1)
+    if (SUB_MOD(mbox->post_idx, mbox->fetch_idx, MB_SIZE) >= MB_SIZE-1)
         osEventFlagsClear(mbox->id, SYS_MBOX_POST_EVENT);
 
     osKernelRestoreLock(state);
@@ -207,11 +210,11 @@ err_t sys_mbox_trypost(sys_mbox_t *mbox, void *msg) {
 
     int state = osKernelLock();
 
-    mbox->queue[mbox->post_idx % MB_SIZE] = msg;
-    mbox->post_idx += 1;
+    mbox->queue[mbox->post_idx] = msg;
+    mbox->post_idx = (mbox->post_idx + 1) % MB_SIZE;
 
     osEventFlagsSet(mbox->id, SYS_MBOX_FETCH_EVENT);
-    if (mbox->post_idx - mbox->fetch_idx == MB_SIZE-1)
+    if (SUB_MOD(mbox->post_idx, mbox->fetch_idx, MB_SIZE) >= MB_SIZE-1)
         osEventFlagsClear(mbox->id, SYS_MBOX_POST_EVENT);
 
     osKernelRestoreLock(state);
@@ -261,8 +264,8 @@ u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout) {
     int state = osKernelLock();
 
     if (msg)
-        *msg = mbox->queue[mbox->fetch_idx % MB_SIZE];
-    mbox->fetch_idx += 1;
+        *msg = mbox->queue[mbox->fetch_idx];
+    mbox->fetch_idx = (mbox->fetch_idx + 1) % MB_SIZE;
 
     osEventFlagsSet(mbox->id, SYS_MBOX_POST_EVENT);
     if (mbox->post_idx == mbox->fetch_idx)
@@ -297,8 +300,8 @@ u32_t sys_arch_mbox_tryfetch(sys_mbox_t *mbox, void **msg) {
     int state = osKernelLock();
 
     if (msg)
-        *msg = mbox->queue[mbox->fetch_idx % MB_SIZE];
-    mbox->fetch_idx += 1;
+        *msg = mbox->queue[mbox->fetch_idx];
+    mbox->fetch_idx = (mbox->fetch_idx + 1) % MB_SIZE;
 
     osEventFlagsSet(mbox->id, SYS_MBOX_POST_EVENT);
     if (mbox->post_idx == mbox->fetch_idx)


### PR DESCRIPTION
### Description

This is a bug fix for the LWIP mbed-os system mailbox overflow. The bug reveals during heavy network loads when a device is not able to handle all incoming network traffic in time, therefore the internal network buffers (including LWIP mailboxes and memory pools) work at their maximum capacities.

The bug was detected on K64F platform working as an UDP server flooded by large number of UDP packets for a long period of time. Description of encountered problems may be found here #11681.

##### Summary of change

Proposed patch constrains LWIP mbed-os system mailbox's post/fetch indexes value range from 0 to `MB_SIZE-1` (that is mod `MB_SIZE` integers). In the current implementation indexes are not constrained and wraps up at their maximum integer type value (255 for `uint8_t`) causing mailbox corruption.

##### Bug root cause

`sys_mbox_trypost()` and `sys_mbox_post()` defined in `features/lwipstack/lwip-sys/arch/lwip_sys_arch.c` have a common code as follows:

```c
1   int state = osKernelLock();
2
3   mbox->queue[mbox->post_idx % MB_SIZE] = msg;
4   mbox->post_idx += 1;
5
6   osEventFlagsSet(mbox->id, SYS_MBOX_FETCH_EVENT);
7   if (mbox->post_idx - mbox->fetch_idx == MB_SIZE-1)
8       osEventFlagsClear(mbox->id, SYS_MBOX_POST_EVENT);
9
10  osKernelRestoreLock(state);
```

Both `post_idx` and `fetch_idx` are `uint8_t` defined in `sys_mbox_t` (file `features/lwipstack/lwip-sys/arch/sys_arch.h`). Conditional check in line 7 protects the mailbox against overflow (anti-overflow check).

*Issue 1*

Let `MB_SIZE == 8` (default mailbox size value), `post_idx == 255`, `fetch_idx == 249`, then `post_idx - fetch_idx == 6`. So there is possible to post only 1 more message before entirely filling up the mailbox. But, after posting the message we have `post_idx == 0` (`uint8_t` wraps), so `post_idx -
 fetch_idx == -249 (0xffffff07)` (promotion from `uint8_t` to `int` in the anti-overflow check). This causes the anti-overflow check to return `false` and the mailbox will be filled with newly posted messages causing mailbox corruption (and memory leaks on the underlying memory pool where the messages are stored).

*Issue 2*

It will not happen for mailboxes where `255 mod MB_SIZE == MB_SIZE-1`, so will not reveal if `MB_SIZE` is 8, 16, 32, 64.... Therefore the default mailbox (size 8) is safe regarding this issue.

Let `MB_SIZE == 10`, `post_idx == 255`, `fetch_idx == 250`. The mailbox looks like:

```
 0   1   2   3   4   5   6   7   8   9
[X] [X] [X] [X] [X] [ ] [ ] [ ] [ ] [ ]
 F                   P

F - fetch_idx
P - post_idx 
X - slot with a message
```

After posting a new message, `post_idx == 0` (`uint8_t` wraps):

```
 0   1   2   3   4   5   6   7   8   9
[X] [X] [X] [X] [X] [X] [ ] [ ] [ ] [ ]
F,P
```

Next messages posted on the mailbox will overwrite the ones already stored in the mailbox (slots 0-5) causing mailbox corruption.

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [X] Patch update (Bug fix)
    [ ] Feature update (New feature / Functionality change / New API)
    [ ] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [ ] No Tests required for this change (E.g docs only update)
    [ ] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

* mbed-os unit tests passed (patch baseline on tag: mbed-os-5.14.2).
* GreenTea tests - not able to check due to some compilation issues on my building environment (not related to this patch).
* The fix was tested on the K64F setup, where the bug was detected. The tests have been performed for various sizes of the receiving mailbox and NETBUF / PBUF memory pools. After each test a memory pool statistics were verified against memory leaks and double frees. No problems found.