### PR TITLE
LPC55S69_NS: Fix baremetal compilation error

### DIFF
--- a/components/TARGET_PSA/mbed_lib.json
+++ b/components/TARGET_PSA/mbed_lib.json
@@ -1,3 +1,6 @@
 {
-    "name": "psa"
+    "name": "psa",
+    "config": {
+        "present": 1
+    }
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/cmsis_nvic_virtual.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/cmsis_nvic_virtual.c
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#if MBED_CONF_PSA_PRESENT
+
 #include "cmsis_nvic_virtual.h"
 #include "mbed_toolchain.h"
 
@@ -25,3 +27,5 @@ void __NVIC_TFMSystemReset(void)
 {
     mbed_psa_system_reset();
 }
+
+#endif // MBED_CONF_PSA_PRESENT

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/cmsis_nvic_virtual.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/cmsis_nvic_virtual.h
@@ -37,15 +37,22 @@ extern "C" {
 #define NVIC_GetActive              __NVIC_GetActive
 #define NVIC_SetPriority            __NVIC_SetPriority
 #define NVIC_GetPriority            __NVIC_GetPriority
+#if MBED_CONF_PSA_PRESENT
 #define NVIC_SystemReset            __NVIC_TFMSystemReset
+#else
+#define NVIC_SystemReset            __NVIC_SystemReset
+#endif // MBED_CONF_PSA_PRESENT
 
 
+#if MBED_CONF_PSA_PRESENT
 /**
  * \brief Overriding the default CMSIS system reset implementation by calling
  *        secure TFM service.
  *
  */
 void __NVIC_TFMSystemReset(void);
+
+#endif // MBED_CONF_PSA_PRESENT
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
#### Summary of change <!-- Required -->
As the `psa` library is not included in the baremetal profile, perform
a TFM system reset only if the `psa` library is included in
the build otherwise perform a normal CMSIS system reset.

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->
https://os.mbed.com/docs/mbed-os/v5.14/reference/mbed-os-bare-metal.html
<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    

There is an on-going effort to enable automated CI testing for baremetal. Until then it can be tested by manually building `mbed-os-example-blinky-baremetal` with the following command:
`$ mbed compile -t gcc_arm -m lpc55s69_ns`

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->
@Patater @evedon 

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
