### PR TITLE
Bare metal greentea tests compilation fixes

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -16,6 +16,7 @@
         "storage_tdb_internal",
         "storage_filesystem",
         "storage_tdb_external",
+        "fat_chan",
         "lora",
         "nfc",
         "network-emac",

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if !MBED_CONF_RTOS_PRESENT
+#error [NOT_SUPPORTED] Watchdog reset test cases require a RTOS to run.
+#else
+
 #if !DEVICE_WATCHDOG
 #error [NOT_SUPPORTED] Watchdog not supported for this target
 #else
@@ -334,3 +338,4 @@ int main()
 }
 
 #endif // !DEVICE_WATCHDOG
+#endif // !MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
#### Summary of change <!-- Required -->

Two recent PRs introduced compilation errors when building greentea tests with bare metal profile:

- https://github.com/ARMmbed/mbed-os/pull/11851 We need to include fat_chan to build bare metal greentea tests due to this PR.
- https://github.com/ARMmbed/mbed-os/pull/11773 We need to excluse watchdog reset test cases because they now rely on a thread running in the background.

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
   
----------------------------------------------------------------------------------------------------------------

These errors were found because we are introducing nightly CI for bare metal greentea tests.

### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------

@SeppoTakalo @fkjagodzinski 

### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
