### PR TITLE
MCU_NRF52840 target configuration fixes

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7850,11 +7850,9 @@
     },
     "ARDUINO_NANO33BLE": {
         "inherits": ["MCU_NRF52840"],
-        "features_add": ["BLE", "STORAGE"],
+        "features_add": ["STORAGE"],
         "components_remove": ["QSPIF"],
-        "components_add": ["FLASHIAP"],
         "device_has_remove": ["QSPI", "ITM"],
-        "device_has_add": ["FLASH"],
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"
         ]
@@ -7875,8 +7873,7 @@
         "detect_code": ["1026"],
         "device_has_remove": ["ITM"],
         "macros_add": [
-            "CONFIG_GPIO_AS_PINRESET",
-            "NRF52_ERRATA_20"
+            "CONFIG_GPIO_AS_PINRESET"
         ]
     },
     "BLUEPILL_F103C8": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7844,6 +7844,7 @@
     "NRF52840_DK": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52840"],
+        "detect_code": ["1102"],
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"
         ]

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7831,6 +7831,8 @@
         "overrides": {
             "mpu-rom-end": "0x1fffffff"
         },
+        "release_versions": ["5"],
+        "device_name": "nRF52840_xxAA",
         "OUTPUT_EXT": "hex",
         "is_disk_virtual": true,
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
@@ -7842,16 +7844,12 @@
     "NRF52840_DK": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52840"],
-        "release_versions": ["5"],
-        "device_name": "nRF52840_xxAA",
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"
         ]
     },
     "ARDUINO_NANO33BLE": {
         "inherits": ["MCU_NRF52840"],
-        "release_versions": ["5"],
-        "device_name": "nRF52840_xxAA",
         "features_add": ["BLE", "STORAGE"],
         "components_remove": ["QSPIF"],
         "components_add": ["FLASHIAP"],
@@ -7863,8 +7861,6 @@
     },
     "MTB_LAIRD_BL654": {
         "inherits": ["MCU_NRF52840"],
-        "release_versions": ["5"],
-        "device_name": "nRF52840_xxAA",
         "detect_code": ["0465"],
         "features_remove": ["CRYPTOCELL310"],
         "macros_remove": ["MBEDTLS_CONFIG_HW_SUPPORT"],
@@ -7876,8 +7872,6 @@
     },
     "MAKERDIARY_NRF52840_MDK": {
         "inherits": ["MCU_NRF52840"],
-        "release_versions": ["5"],
-        "device_name": "nRF52840_xxAA",
         "detect_code": ["1026"],
         "device_has_remove": ["ITM"],
         "macros_add": [
@@ -9633,7 +9627,6 @@
     },
     "EP_AGORA": {
         "inherits": ["MCU_NRF52840"],
-        "device_name": "nRF52840_xxAA",
         "supported_form_factors": [],
         "config": {
             "modem_is_on_board": {
@@ -9649,7 +9642,6 @@
         },
         "components_add": ["SPIF"],
         "components_remove": ["QSPIF"],
-        "release_versions": ["5"],
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"
         ]


### PR DESCRIPTION
### Description 
#### Summary of change <!-- Required -->
Fixes NRF52840_DK target configuration and removes redundancies between all MCU_NRF52840_DK based boards.

NRF52840_DK target code fixed, should be `1102`

Moved configurations shared by all the boards MCU_NRF52840_DK based boards under MCU_NRF52840_DK.

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
```
mbedgt: test on hardware with target id: 11023602442031204c503243323038313831303597969903
mbedgt: test suite 'tests-network-l3ip' .............................................................. OK in 18.12 sec
	test case: 'L3IP_START' ...................................................................... OK in 0.06 sec
	test case: 'L3IP_STOP' ....................................................................... OK in 0.05 sec
mbedgt: test case summary: 2 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.3332229894
mbedgt: test suite report:
| target              | platform_name | test suite                                                                   | result  | elapsed_time (sec) | copy_method |
|---------------------|---------------|------------------------------------------------------------------------------|---------|--------------------|-------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-device_key-tests-device_key-functionality                           | OK      | 30.79              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-feature_ble-targets-target_cordio-tests-cordio_hci-driver           | OK      | 38.61              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-basic_test                        | OK      | 17.83              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-basic_test_default                | OK      | 17.85              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-case_async_validate               | OK      | 19.82              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-case_control_async                | OK      | 25.98              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-case_control_repeat               | OK      | 19.98              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-case_selection                    | OK      | 17.91              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-case_setup_failure                | OK      | 18.45              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | OK      | 18.56              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-control_type                      | OK      | 19.11              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | OK      | 18.97              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | OK      | 19.35              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | OK      | 17.48              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | OK      | 17.64              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-test_setup_failure                | OK      | 17.78              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-frameworks-utest-tests-unit_tests-test_skip                         | OK      | 17.85              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-nvstore-tests-nvstore-functionality                         | OK      | 29.36              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-buffered_block_device                     | OK      | 19.66              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-flashsim_block_device                     | OK      | 17.93              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-general_block_device                      | OK      | 47.11              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-heap_block_device                         | OK      | 21.41              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-mbr_block_device                          | OK      | 20.53              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-blockdevice-util_block_device                         | OK      | 20.06              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-direct_access_devicekey_test                  | OK      | 26.98              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-static_tests                                  | OK      | 42.32              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-tests-kvstore-tdbstore_whitebox                             | OK      | 18.44              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-events-queue                                                           | OK      | 27.68              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-events-timing                                                          | OK      | 80.13              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-c_strings                                                 | OK      | 19.85              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-crc                                                       | OK      | 19.59              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-dev_null                                                  | OK      | 19.49              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-echo                                                      | OK      | 19.58              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-flashiap                                                  | OK      | 21.1               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-generic_tests                                             | OK      | 19.38              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-lp_ticker                                                 | OK      | 24.17              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-lp_timeout                                                | OK      | 40.37              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-lp_timer                                                  | OK      | 23.1               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-race_test                                                 | OK      | 19.07              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-sleep_lock                                                | OK      | 17.86              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-stl_features                                              | OK      | 19.19              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-ticker                                                    | OK      | 23.52              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-timeout                                                   | OK      | 37.55              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-timer                                                     | OK      | 25.8               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_drivers-timerevent                                                | OK      | 19.78              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_functional-callback                                               | OK      | 20.2               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_functional-callback_big                                           | OK      | 20.32              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_functional-callback_small                                         | OK      | 20.04              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_functional-functionpointer                                        | OK      | 17.87              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-critical_section                                              | OK      | 17.77              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-flash                                                         | OK      | 20.25              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-gpio                                                          | OK      | 17.44              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-lp_ticker                                                     | OK      | 18.21              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-minimum_requirements                                          | OK      | 17.71              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-pinmap                                                        | OK      | 19.87              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-qspi                                                          | OK      | 41.08              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-rtc_time                                                      | OK      | 23.34              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-rtc_time_conv                                                 | OK      | 35.61              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-sleep                                                         | OK      | 19.51              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-sleep_manager                                                 | OK      | 22.05              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-sleep_manager_racecondition                                   | OK      | 30.85              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-stack_size_unification                                        | OK      | 17.44              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-ticker                                                        | OK      | 32.02              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-trng                                                          | OK      | 22.16              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_hal-us_ticker                                                     | OK      | 17.44              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-atomic                                                   | OK      | 32.6               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-circularbuffer                                           | OK      | 24.57              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-crash_reporting                                          | OK      | 30.17              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-critical_section                                         | OK      | 19.74              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-error_handling                                           | OK      | 18.41              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-filehandle                                               | OK      | 22.94              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-minimal-printf                                           | OK      | 25.67              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-sharedptr                                                | OK      | 18.44              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-singletonptr                                             | OK      | 17.75              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-stream                                                   | OK      | 21.81              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-system_reset                                             | OK      | 18.05              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-transaction                                              | OK      | 18.61              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbed_platform-wait_ns                                                  | OK      | 20.13              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-mbed-attributes                                              | OK      | 19.65              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-mbed-call_before_main                                        | OK      | 16.91              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-mbed-cpp                                                     | OK      | 17.86              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-mbed-div                                                     | OK      | 17.87              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-mbed-static_assert                                           | OK      | 17.4               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-condition_variable                                 | OK      | 18.34              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-event_flags                                        | OK      | 21.17              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-heap_and_stack                                     | OK      | 19.62              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-kernel_tick_count                                  | OK      | 20.34              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-mail                                               | OK      | 23.27              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-malloc                                             | OK      | 41.09              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-memorypool                                         | OK      | 26.32              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-mutex                                              | OK      | 22.53              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-queue                                              | OK      | 21.47              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-rtostimer                                          | OK      | 20.1               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-semaphore                                          | OK      | 22.88              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-signals                                            | OK      | 24.74              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-systimer                                           | OK      | 19.9               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedmicro-rtos-mbed-threads                                            | OK      | 30.78              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedtls-multi                                                          | OK      | 21.78              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-mbedtls-selftest                                                       | OK      | 26.19              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-network-l3ip                                                           | OK      | 18.12              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-usb_device-basic                                                       | FAIL    | 200.24             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-usb_device-hid                                                         | ERROR   | 24.39              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-usb_device-msd                                                         | FAIL    | 52.81              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | tests-usb_device-serial                                                      | TIMEOUT | 69.55              | default     |
mbedgt: test suite results: 2 FAIL / 100 OK / 1 TIMEOUT / 1 ERROR
```
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@0xc0170 
@AnttiKauppila 
@SeppoTakalo 

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
