### PR TITLE
Linker script changes for the TARGET - CY8CPROTO_064_SB

### DIFF
--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xx7_cm4_dual.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xx7_cm4_dual.sct
@@ -27,6 +27,7 @@
 ;*******************************************************************************
 ;* \copyright
 ;* Copyright 2016-2019 Cypress Semiconductor Corporation
+;* Copyright (c) 2019 ARM Limited
 ;* SPDX-License-Identifier: Apache-2.0
 ;*
 ;* Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,8 +43,10 @@
 ;* limitations under the License.
 ;******************************************************************************/
 
+#include "../../../partition/region_defs.h"
+
 #if !defined(MBED_ROM_START)
-  #define MBED_ROM_START    0x10000400
+  #define MBED_ROM_START    NS_CODE_START
 #endif
 
 ;* MBED_APP_START is being  used by the bootloader build script and
@@ -55,7 +58,7 @@
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-  #define MBED_ROM_SIZE     0x000CFC00
+  #define MBED_ROM_SIZE     NS_CODE_SIZE
 #endif
 
 ;* MBED_APP_SIZE is being  used by the bootloader build script and
@@ -67,19 +70,20 @@
 #endif
 
 #if !defined(MBED_RAM_START)
-  #define MBED_RAM_START    0x08000000
+  #define MBED_RAM_START    NS_DATA_START
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-  #define MBED_RAM_SIZE     0x00020000
+  #define MBED_RAM_SIZE     NS_DATA_SIZE
 #endif
 
+; Size of the stack section in CM4 SRAM area
 #if !defined(MBED_BOOT_STACK_SIZE)
-  #define MBED_BOOT_STACK_SIZE 0x400
+    #define MBED_BOOT_STACK_SIZE    NS_MSP_STACK_SIZE
 #endif
 
-; Size of the stack section at the end of CM4 SRAM
-#define STACK_SIZE MBED_BOOT_STACK_SIZE
+; Shared memory area between Non-Secure and Secure
+#define MBED_DATA_SHARED_SIZE       NS_DATA_SHARED_SIZE
 
 ; The defines below describe the location and size of blocks of memory in the target.
 ; Use these defines to specify the memory regions available for allocation.
@@ -168,14 +172,25 @@ LR_IROM1 FLASH_START FLASH_SIZE
     }
 
     ; Application heap area (HEAP)
-    ARM_LIB_HEAP  +0 EMPTY RAM_START+RAM_SIZE-STACK_SIZE-ImageLimit(RW_IRAM1)
+    ARM_LIB_HEAP  +0 ALIGN 4 EMPTY RAM_START+RAM_SIZE-MBED_BOOT_STACK_SIZE-MBED_DATA_SHARED_SIZE-ImageLimit(RW_IRAM1)
     { 
     }
-    
-    ; Stack region growing down
-    ARM_LIB_STACK RAM_START+RAM_SIZE EMPTY -STACK_SIZE 
+
+    ; Stack region
+    ARM_LIB_STACK RAM_START+RAM_SIZE-MBED_DATA_SHARED_SIZE ALIGN 4 EMPTY -MBED_BOOT_STACK_SIZE 
     {
     }
+
+    ; Stack area overflowed within RAM
+    ScatterAssert(ImageBase(ARM_LIB_STACK) + ImageLength(ARM_LIB_STACK) == RAM_START+RAM_SIZE-MBED_DATA_SHARED_SIZE)
+
+    ; Shared region
+    ARM_LIB_SHARED RAM_START+RAM_SIZE-MBED_DATA_SHARED_SIZE ALIGN 4 EMPTY MBED_DATA_SHARED_SIZE 
+    {
+    }
+
+    ; Shared area overflowed within RAM
+    ScatterAssert(ImageBase(ARM_LIB_SHARED) + ImageLength(ARM_LIB_SHARED) == RAM_START+RAM_SIZE)
 
     ; Used for the digital signature of the secure application and the
     ; Bootloader SDK application. The size of the section depends on the required
@@ -271,7 +286,7 @@ CYMETA 0x90500000
 /* The following symbols used by the cymcuelftool. */
 /* Flash */
 #define __cy_memory_0_start 0x10000000
-#define __cy_memory_0_length  0x000D0000
+#define __cy_memory_0_length  0x00100000
 #define __cy_memory_0_row_size 0x200
 
 /* Emulated EEPROM Flash area */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xx7_cm4_dual.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xx7_cm4_dual.ld
@@ -20,6 +20,7 @@
 ********************************************************************************
 * \copyright
 * Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright (c) 2019 ARM Limited
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,8 +41,10 @@ SEARCH_DIR(.)
 GROUP(-lgcc -lc -lnosys)
 ENTRY(Reset_Handler)
 
+#include "../../../partition/region_defs.h"
+
 #if !defined(MBED_ROM_START)
-  #define MBED_ROM_START    0x10000400
+  #define MBED_ROM_START    NS_CODE_START
 #endif
 
 /* MBED_APP_START is being  used by the bootloader build script and
@@ -49,11 +52,11 @@ ENTRY(Reset_Handler)
 * is equal to MBED_ROM_START
 */
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START MBED_ROM_START
+  #define MBED_APP_START    MBED_ROM_START
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-  #define MBED_ROM_SIZE     0x000CFC00
+  #define MBED_ROM_SIZE     NS_CODE_SIZE
 #endif
 
 /* MBED_APP_SIZE is being  used by the bootloader build script and
@@ -61,23 +64,24 @@ ENTRY(Reset_Handler)
 * is equal to MBED_ROM_SIZE
 */
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE MBED_ROM_SIZE
+  #define MBED_APP_SIZE     MBED_ROM_SIZE
 #endif
 
 #if !defined(MBED_RAM_START)
-  #define MBED_RAM_START    0x08000000
+  #define MBED_RAM_START    NS_DATA_START
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-  #define MBED_RAM_SIZE     0x00020000
+  #define MBED_RAM_SIZE     NS_DATA_SIZE
 #endif
 
+/* Size of the stack section in CM4 SRAM area */
 #if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
+    #define MBED_BOOT_STACK_SIZE    NS_MSP_STACK_SIZE
 #endif
 
-/* Size of the stack section at the end of CM4 SRAM */
-STACK_SIZE = MBED_BOOT_STACK_SIZE;
+/* Shared memory area between Non-Secure and Secure*/
+#define MBED_DATA_SHARED_SIZE       NS_DATA_SHARED_SIZE
 
 /* Force symbol to be entered in the output file as an undefined symbol. Doing
 * this may, for example, trigger linking of additional modules from standard
@@ -331,20 +335,28 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        . = ORIGIN(ram) + LENGTH(ram) - STACK_SIZE;
+        . = ORIGIN(ram) + LENGTH(ram) - MBED_BOOT_STACK_SIZE - MBED_DATA_SHARED_SIZE;
+        . = ALIGN(4);
+        __StackLimit = .;
         __HeapLimit = .;
     } > ram
 
 
-    /* Set stack top to end of RAM, and stack limit move down by
-     * size of stack_dummy section */
-    __StackTop = ORIGIN(ram) + LENGTH(ram);
-    __StackLimit = __StackTop - STACK_SIZE;
+    __StackTop = (__StackLimit + MBED_BOOT_STACK_SIZE + 3) & 0xFFFFFFFC;
     PROVIDE(__stack = __StackTop);
 
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 
+    .shared __StackTop (NOLOAD):
+    {
+        __SharedStart = .;
+        . += MBED_DATA_SHARED_SIZE;
+        KEEP(*(.shared*))
+        __SharedLimit = .;
+    } > ram
+
+
+    /* Check if Shared area overflowed within RAM*/
+    ASSERT(__SharedLimit == ORIGIN(ram) + LENGTH(ram), "Shared area overflowed within RAM")
 
     /* Used for the digital signature of the secure application and the Bootloader SDK application.
     * The size of the section depends on the required data size. */
@@ -422,7 +434,7 @@ SECTIONS
 /* The following symbols used by the cymcuelftool. */
 /* Flash */
 __cy_memory_0_start    = 0x10000000;
-__cy_memory_0_length   = 0x000D0000;
+__cy_memory_0_length   = 0x00100000;
 __cy_memory_0_row_size = 0x200;
 
 /* Emulated EEPROM Flash area */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/partition/flash_layout.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/partition/flash_layout.h
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2017-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2019, Cypress Semiconductor Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FLASH_LAYOUT_H__
+#define __FLASH_LAYOUT_H__
+
+/* Flash layout with BL2:
+ *
+ * TBD
+ *
+ *
+ * Flash layout if BL2 not defined:
+ *
+ * 0x1000_0000 Non-secure image primary (256 KB)
+ * 0x1004_0000 Secure/Non-secure image secondary (256 KB)
+ *  Note that only one image can be upgraded per boot
+ * 0x1008_0000 Secure     image primary (256 KB)
+ * 0x100c_0000 Secure Storage Area (20 KB)
+ * 0x100c_5000 NV counters area (24 Bytes)
+ * 0x100c_5018 Unused (almost 44 KB)
+ * 0x100d_0000 Reserved (192 KB)
+ *
+ */
+
+#define MAX(X, Y)                       (((X) > (Y)) ? (X) : (Y))
+
+/* This header file is included from linker scatter file as well, where only a
+ * limited C constructs are allowed. Therefore it is not possible to include
+ * here the platform_base_address.h to access flash related defines. To resolve
+ * this some of the values are redefined here with different names, these are
+ * marked with comment.
+ */
+
+/* The size of S partition */
+#define FLASH_S_PARTITION_SIZE          0x40000      /* 256 KB */
+/* The size of NS partition */
+#define FLASH_NS_PARTITION_SIZE         0x40000      /* 256 KB */
+
+/*
+ * Each FLASH_AREA_IMAGE contains NS and S partitions.
+ * See Flash layout above.
+ */
+#define FLASH_PARTITION_SIZE            (FLASH_S_PARTITION_SIZE + \
+                                         FLASH_NS_PARTITION_SIZE)
+#define FLASH_MAX_PARTITION_SIZE        MAX(FLASH_S_PARTITION_SIZE, \
+                                            FLASH_NS_PARTITION_SIZE)
+
+/* Sector size of the flash hardware; same as FLASH0_SECTOR_SIZE */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE    (0x200)      /* 512 B */
+/* Same as FLASH0_SIZE */
+#define FLASH_TOTAL_SIZE                (0x00100000) /* 1 MB */
+
+/* Flash layout info for BL2 bootloader */
+#define FLASH_BASE_ADDRESS              (0x10000000U) /* same as FLASH0_BASE */
+
+#ifdef BL2
+/* Offset and size definitions of the flash partitions that are handled by the
+ * bootloader. The image swapping is done between IMAGE_PRIMARY and
+ * IMAGE_SECONDARY.
+ * SCRATCH is used as a temporary storage during image swapping.
+ */
+#define FLASH_AREA_BL2_OFFSET           (0x0)
+#define FLASH_AREA_BL2_SIZE             (0x20000)  /* 128 kB */
+
+#if !defined(MCUBOOT_IMAGE_NUMBER) || (MCUBOOT_IMAGE_NUMBER == 1)
+/* Secure + Non-secure image primary slot */
+#define FLASH_AREA_0_ID                 (1)
+#define FLASH_AREA_0_OFFSET             (FLASH_AREA_BL2_OFFSET + \
+                                         FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE               FLASH_PARTITION_SIZE
+
+/* Secure + Non-secure secondary slot */
+#define FLASH_AREA_2_ID                 (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_2_OFFSET             (FLASH_AREA_0_OFFSET + \
+                                         FLASH_AREA_0_SIZE)
+#define FLASH_AREA_2_SIZE               FLASH_PARTITION_SIZE
+
+/* Scratch area */
+#define FLASH_AREA_SCRATCH_ID           (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET       (FLASH_AREA_2_OFFSET + \
+                                         FLASH_AREA_2_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE         (0x8000)   /* 32 KB */
+
+/* Maximum number of status entries supported by the bootloader. */
+#define BOOT_STATUS_MAX_ENTRIES         MAX(2, FLASH_PARTITION_SIZE / \
+                                               FLASH_AREA_SCRATCH_SIZE)
+
+/** Maximum number of image sectors supported by the bootloader. */
+#define BOOT_MAX_IMG_SECTORS            (FLASH_PARTITION_SIZE / \
+                                         FLASH_AREA_IMAGE_SECTOR_SIZE)
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+
+/* Secure image primary slot */
+#define FLASH_AREA_0_ID                 (1)
+#define FLASH_AREA_0_OFFSET             (FLASH_AREA_BL2_OFFSET + \
+                                         FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE               (FLASH_S_PARTITION_SIZE)
+
+/* Non-secure image primary slot */
+#define FLASH_AREA_1_ID                 (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_1_OFFSET             (FLASH_AREA_0_OFFSET + \
+                                         FLASH_AREA_0_SIZE)
+#define FLASH_AREA_1_SIZE               (FLASH_NS_PARTITION_SIZE)
+
+/* Secure image secondary slot */
+#define FLASH_AREA_2_ID                 (FLASH_AREA_1_ID + 1)
+#define FLASH_AREA_2_OFFSET             (FLASH_AREA_1_OFFSET + \
+                                         FLASH_AREA_1_SIZE)
+#define FLASH_AREA_2_SIZE               (FLASH_S_PARTITION_SIZE)
+
+/* Non-secure image secondary slot */
+#define FLASH_AREA_3_ID                 (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_3_OFFSET             (FLASH_AREA_2_OFFSET + \
+                                         FLASH_AREA_2_SIZE)
+#define FLASH_AREA_3_SIZE               (FLASH_NS_PARTITION_SIZE)
+
+/* Scratch area */
+#define FLASH_AREA_SCRATCH_ID           (FLASH_AREA_3_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET       (FLASH_AREA_3_OFFSET + \
+                                         FLASH_AREA_3_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE         (0x8000)   /* 32 KB */
+
+/* The maximum number of status entries supported by the bootloader. */
+/* The maximum number of status entries must be at least 2. For more
+ * information see the MCUBoot issue:
+ * https://github.com/JuulLabs-OSS/mcuboot/issues/427.
+ */
+#define BOOT_STATUS_MAX_ENTRIES         MAX(2, FLASH_MAX_PARTITION_SIZE / \
+                                               FLASH_AREA_SCRATCH_SIZE)
+/* Maximum number of image sectors supported by the bootloader. */
+#define BOOT_MAX_IMG_SECTORS            (FLASH_MAX_PARTITION_SIZE / \
+                                         FLASH_AREA_IMAGE_SECTOR_SIZE)
+#else /* MCUBOOT_IMAGE_NUMBER > 2 */
+#error "Only MCUBOOT_IMAGE_NUMBER 1 and 2 are supported!"
+#endif /* MCUBOOT_IMAGE_NUMBER */
+
+#else /* BL2 */
+/* SST area follows scratch area */
+#define FLASH_AREA_SCRATCH_OFFSET       (SECURE_IMAGE_OFFSET + \
+                                         FLASH_S_PARTITION_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE         (0)   /* None */
+#endif /* BL2 */
+
+#define FLASH_SST_AREA_OFFSET           (FLASH_AREA_SCRATCH_OFFSET + \
+                                         FLASH_AREA_SCRATCH_SIZE)
+#define FLASH_SST_AREA_SIZE             (0x5000)   /* 20 KB */
+
+#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_SST_AREA_OFFSET + \
+                                         FLASH_SST_AREA_SIZE)
+#define FLASH_NV_COUNTERS_AREA_SIZE     (0x18)     /* 24 Bytes */
+
+/* Offset and size definition in flash area, used by assemble.py */
+#ifdef BL2
+#define SECURE_IMAGE_OFFSET             0x0
+#else
+#define SECURE_IMAGE_OFFSET             (NON_SECURE_IMAGE_OFFSET + \
+                                         FLASH_NS_PARTITION_SIZE + \
+                                         FLASH_MAX_PARTITION_SIZE)
+#endif
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
+
+#ifdef BL2
+#define NON_SECURE_IMAGE_OFFSET         (SECURE_IMAGE_OFFSET + \
+                                         SECURE_IMAGE_MAX_SIZE)
+#else
+#define NON_SECURE_IMAGE_OFFSET         0x0
+#endif
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
+
+/* Flash device name used by BL2 and SST
+ * Name is defined in flash driver file: Driver_Flash.c
+ */
+#define FLASH_DEV_NAME Driver_FLASH0
+
+/* Secure Storage (SST) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M SST Integration Guide.
+ */
+#define SST_FLASH_DEV_NAME Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define SST_FLASH_AREA_ADDR     FLASH_SST_AREA_OFFSET
+/* Dedicated flash area for SST */
+#define SST_FLASH_AREA_SIZE     FLASH_SST_AREA_SIZE
+#define SST_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of SST_SECTOR_SIZE per block */
+#define SST_SECTORS_PER_BLOCK   0x8
+/* Specifies the smallest flash programmable unit in bytes */
+#define SST_FLASH_PROGRAM_UNIT  0x1
+/* The maximum asset size to be stored in the SST area */
+#define SST_MAX_ASSET_SIZE      2048
+/* The maximum number of assets to be stored in the SST area */
+#define SST_NUM_ASSETS          10
+
+/* NV Counters definitions */
+#define TFM_NV_COUNTERS_AREA_ADDR    FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_AREA_SIZE    FLASH_NV_COUNTERS_AREA_SIZE
+#define TFM_NV_COUNTERS_SECTOR_ADDR  FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_SECTOR_SIZE  FLASH_AREA_IMAGE_SECTOR_SIZE
+
+/* Use Flash to store Code data */
+#define S_ROM_ALIAS_BASE  (0x10000000)
+#define NS_ROM_ALIAS_BASE (0x10000000)
+
+/* Use SRAM to store RW data */
+#define S_RAM_ALIAS_BASE  (0x08000000)
+#define NS_RAM_ALIAS_BASE (0x08000000)
+
+#endif /* __FLASH_LAYOUT_H__ */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/partition/region_defs.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB/partition/region_defs.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2017-2019 ARM Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_DEFS_H__
+#define __REGION_DEFS_H__
+
+#include "flash_layout.h"
+
+#define TOTAL_ROM_SIZE FLASH_TOTAL_SIZE
+/* 2KB of RAM (at the end of the SRAM) are reserved for system use. Using
+ * this memory region for other purposes will lead to unexpected behavior.
+ * 94KB of RAM (just before the memory reserved for system use) are
+ * allocated and protected by Cypress Bootloader */
+#define TOTAL_RAM_SIZE (0x00030000) /* CY_SRAM0_SIZE - 96KB */
+
+#define BL2_HEAP_SIZE           0x0001000
+#define BL2_MSP_STACK_SIZE      0x0001000
+
+#define S_HEAP_SIZE             0x0001000
+#define S_MSP_STACK_SIZE_INIT   0x0000400
+#define S_MSP_STACK_SIZE        0x0000800
+#define S_PSP_STACK_SIZE        0x0000800
+
+#define NS_HEAP_SIZE            0x0001000
+#define NS_MSP_STACK_SIZE       0x0000400
+#define NS_PSP_STACK_SIZE       0x0000C00
+
+/* Relocation of vectors to RAM support */
+/* #define RAM_VECTORS_SUPPORT */
+
+/*
+ * This size of buffer is big enough to store an attestation
+ * token produced by initial attestation service
+ */
+#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   0x250
+
+/*
+ * MPC granularity is 128 KB on AN519 MPS2 FPGA image. Alignment
+ * of partitions is defined in accordance with this constraint.
+ */
+
+#ifdef BL2
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET    (FLASH_AREA_0_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET  (FLASH_AREA_2_OFFSET)
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET + \
+                                           FLASH_S_PARTITION_SIZE)
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET    (FLASH_AREA_2_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET  (FLASH_AREA_0_OFFSET)
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET + \
+                                           FLASH_S_PARTITION_SIZE)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET  SECURE_IMAGE_OFFSET
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET NON_SECURE_IMAGE_OFFSET
+#endif /* BL2 */
+
+/* TFM PSoC6 CY8CKIT_064 RAM layout:
+ *
+ * 0x0800_0000 Non-secure data (NS_DATA_SIZE, 63KB)
+ * 0x0800_FC00 Shared memory (NS_DATA_SHARED_SIZE, 1KB)
+ * 0x0801_0000 Secure unprivileged data (S_UNPRIV_DATA_SIZE, 32KB)
+ * 0x0801_8000 Secure priviliged data (S_PRIV_DATA_SIZE, 92KB)
+ * 0x0802_F000 Secure priv code executable from RAM (S_RAM_CODE_SIZE, 4KB)
+ * 0x0803_0000 System reserved memory (96KB)
+ * 0x0804_8000 End of RAM
+ */
+
+/*
+ * Boot partition structure if MCUBoot is used:
+ * 0x0_0000 Bootloader header
+ * 0x0_0400 Image area
+ * 0x1_FC00 Trailer
+ */
+/* Image code size is the space available for the software binary image.
+ * It is less than the FLASH_S_PARTITION_SIZE and FLASH_NS_PARTITION_SIZE
+ * because we reserve space for the image header and trailer introduced by the
+ * bootloader.
+ */
+#ifdef BL2
+#define BL2_HEADER_SIZE      (0x400)
+#define BL2_TRAILER_SIZE     (0x400)
+#else
+/* Even though TFM BL2 is excluded from the build,
+ * CY BL built externally is used and it needs offsets for header and trailer
+ * to be taken in account.
+ * */
+#define BL2_HEADER_SIZE      (0x400)
+#define BL2_TRAILER_SIZE     (0x400)
+
+#endif /* BL2 */
+
+#define IMAGE_S_CODE_SIZE \
+            (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+#define IMAGE_NS_CODE_SIZE \
+            (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+
+/* Alias definitions for secure and non-secure areas*/
+#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + (x))
+
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
+
+/* Secure regions */
+#define S_IMAGE_PRIMARY_AREA_OFFSET \
+             (S_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define S_CODE_START    (S_ROM_ALIAS(S_IMAGE_PRIMARY_AREA_OFFSET))
+#define S_CODE_SIZE     IMAGE_S_CODE_SIZE
+#define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
+
+#define S_DATA_START    (S_RAM_ALIAS(NS_DATA_SIZE))
+#define S_UNPRIV_DATA_SIZE  0x8000
+#define S_PRIV_DATA_SIZE    0x17000
+/* Reserve 4KB for RAM-based executable code */
+#define S_RAM_CODE_SIZE     0x1000
+
+/* Secure data area */
+#define S_DATA_SIZE  (S_UNPRIV_DATA_SIZE + S_PRIV_DATA_SIZE + S_RAM_CODE_SIZE)
+#define S_DATA_LIMIT (S_DATA_START + S_DATA_SIZE - 1)
+
+/* We need the privileged data area to be aligned so that an SMPU
+ * region can cover it.
+ */
+/* TODO It would be nice to figure this out automatically.
+ * In theory, in the linker script, we could determine the amount
+ * of secure data space available after all the unprivileged data,
+ * round that down to a power of 2 to get the actual size we want
+ * to use for privileged data, and then determine this value from
+ * that. We'd also potentially have to update the configs for SMPU9
+ * and SMPU10.
+ * Leave the SMPU alignment check in SMPU configuration file.
+ */
+#define S_DATA_PRIV_OFFSET       (NS_DATA_SIZE + S_UNPRIV_DATA_SIZE)
+#define S_DATA_PRIV_START        S_RAM_ALIAS(S_DATA_PRIV_OFFSET)
+
+/* Reserve area for RAM-based executable code right after secure unprivilaged
+ * and privilaged data areas*/
+#define S_RAM_CODE_START (S_DATA_START + S_UNPRIV_DATA_SIZE + S_PRIV_DATA_SIZE)
+
+/* Non-secure regions */
+#define NS_IMAGE_PRIMARY_AREA_OFFSET \
+                        (NS_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define NS_CODE_START   (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_AREA_OFFSET))
+#define NS_CODE_SIZE    IMAGE_NS_CODE_SIZE
+#define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
+
+#define NS_DATA_START   (S_RAM_ALIAS(0))
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE)
+#define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
+
+/* Shared memory */
+#define NS_DATA_SHARED_SIZE  0x400
+#define NS_DATA_SHARED_START (NS_DATA_START + NS_DATA_SIZE - \
+                              NS_DATA_SHARED_SIZE)
+#define NS_DATA_SHARED_LIMIT (NS_DATA_SHARED_START + NS_DATA_SHARED_SIZE - 1)
+
+/* Shared variables addresses */
+/* ipcWaitMessageStc, cy_flash.c */
+#define IPC_WAIT_MESSAGE_STC_ADDR NS_DATA_SHARED_START
+#define IPC_WAIT_MESSAGE_STC_SIZE 4
+
+/* NS partition information is used for MPC and SAU configuration */
+#define NS_PARTITION_START \
+            (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_PARTITION_OFFSET))
+
+#define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
+
+/* Secondary partition for new images in case of firmware upgrade */
+#define SECONDARY_PARTITION_START \
+            (NS_ROM_ALIAS(S_IMAGE_SECONDARY_PARTITION_OFFSET))
+
+#define SECONDARY_PARTITION_SIZE   FLASH_PARTITION_SIZE
+
+#ifdef BL2
+/* Bootloader regions */
+#define BL2_CODE_START    (S_ROM_ALIAS(FLASH_AREA_BL2_OFFSET))
+#define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
+#define BL2_CODE_LIMIT    (BL2_CODE_START + BL2_CODE_SIZE - 1)
+
+#define BL2_DATA_START    (S_RAM_ALIAS(S_DATA_PRIV_OFFSET))
+#define BL2_DATA_SIZE     (S_PRIV_DATA_SIZE)
+#define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
+#endif /* BL2 */
+
+/* Shared data area between bootloader and runtime firmware.
+ * Shared data area is allocated at the beginning of the privileged data area,
+ * it is overlapping with TF-M Secure code's MSP stack
+ */
+#define BOOT_TFM_SHARED_DATA_BASE (S_RAM_ALIAS(S_DATA_PRIV_OFFSET))
+#define BOOT_TFM_SHARED_DATA_SIZE 0x400
+
+#endif /* __REGION_DEFS_H__ */
+


### PR DESCRIPTION
### Description 
#### Summary of change <!-- Required -->

Linker script changes for the **ARM** and **GCC** compiler for the target to align with TF-M flash partition and region definitions.

This impacts the memory map of the following regions:
* RAM START, SIZE.
* STACK SIZE (MSP).
* ROM START, SIZE.
* DATA_SHARED (new region).

The files are directly leveraged from the TF-M target (psoc64_1m).
Folder structure:
* TARGET_CY8CPROTO_064_SB
  - device
    - TFM_partition
      - flash_layout.h
      - region_defs.h

Further, this PR contains merge/rebase from **master** of mbed-os to **feature_twincpu**

NOTE: **IAR** Linker scripts are not changed and would not work with TF-M integration at the moment.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
----------------------------------------------------------------------------------------------------------------
### Validation <!-- Required -->

The changes are validated in the following way.
* [mbed-os-blinky-example](https://github.com/ARMmbed/mbed-os-example-blinky) is used to compare the memory map changes.
* These files are the memory map from the external TFM Non-secure build used as a reference for the changes in this PR.
  - [external-TFM-NS-ARMC6.txt](https://github.com/ARMmbed/mbed-os/files/3911210/external-TFM-NS-ARMC6.txt)
  - [external-TFM-NS-GCCARM.txt](https://github.com/ARMmbed/mbed-os/files/3911211/external-TFM-NS-GCCARM.txt)
* Memory map of [mbed-os-blinky-example](https://github.com/ARMmbed/mbed-os-example-blinky) Non-Secure build **without** linker file changes.
  - [mbed-os-example-blinky-ARMC6-Base.txt](https://github.com/ARMmbed/mbed-os/files/3911212/mbed-os-example-blinky-ARMC6-Base.txt)
  - [mbed-os-example-blinky-GCC-Base.txt](https://github.com/ARMmbed/mbed-os/files/3911214/mbed-os-example-blinky-GCC-Base.txt)
* Memory map of [mbed-os-blinky-example](https://github.com/ARMmbed/mbed-os-example-blinky)  Non-Secure build **with** linker file changes.
  - [mbed-os-example-blinky-ARMC6-PR.txt](https://github.com/ARMmbed/mbed-os/files/3911213/mbed-os-example-blinky-ARMC6-PR.txt)
  - [mbed-os-example-blinky-GCC-PR.txt](https://github.com/ARMmbed/mbed-os/files/3911215/mbed-os-example-blinky-GCC-PR.txt)

Comparing the memory maps of [mbed-os-blinky-example](https://github.com/ARMmbed/mbed-os-example-blinky) we can see the difference in changes of regions and partitions similar to external TF-M Non-secure builds.
At the moment this the only we could think of to validate these changes, as the integration work is in progress.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@Patater @devran01 
<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of change <!-- Required -->

Linker script changes for the **ARM** and **GCC** compiler for the target to align with TF-M flash partition and region definitions.

This impacts the memory map of:
* RAM START, SIZE.
* STACK SIZE (MSP).
* ROM START, SIZE.
* DATA_SHARED (new region).

The files are directly leveraged from the TF-M target (psoc64_1m).
Folder structure:
* TARGET_CY8CPROTO_064_SB
  - device
    - TFM_partition
      - flash_layout.h
      - region_defs.h

NOTE: **IAR** Linker scripts are not changed and would not work with TF-M integration.

#### Impact of changes

There is **NO** impact if standalone Non-Secure image is run on the target.
If the user intends to run a Secure image (Non-TF-M version) on this target, then only the IAR compiler needs to be used for building it.
**IAR** compiler is not supported at the moment on TF-M for this particular target. Therefore changes are not synced.

**Further, this integration work is in progress only for this target.**
 