### PR TITLE
USB device HID test: remove duplicated define

### DIFF
--- a/TESTS/usb_device/hid/main.cpp
+++ b/TESTS/usb_device/hid/main.cpp
@@ -42,7 +42,6 @@
 
 #define MSG_VALUE_LEN 24
 #define MSG_KEY_LEN 24
-#define MSG_KEY_DEVICE_READY "ready"
 #define MSG_KEY_DEVICE_READY "dev_ready"
 #define MSG_KEY_HOST_READY "host_ready"
 #define MSG_KEY_SERIAL_NUMBER "usb_dev_sn"


### PR DESCRIPTION
### Description 
#### Summary of change <!-- Required -->

Fix #11977 

https://github.com/ARMmbed/mbed-os/blob/ffdd54315f98bda6021fec9076d271571dbe32e3/TESTS/usb_device/hid/main.cpp#L45-L46

MSG_KEY_DEVICE_READY  is defined twice


#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
