### PR TITLE
Fixing Systimer wake from deep sleep test case

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -27,9 +27,10 @@
 #define DELAY_DELTA_US 2500ULL
 
 /*  Use a specific delta value for deep sleep, as entry/exit adds up extra latency.
- *  Use deep sleep latency if defined and add 1ms extra delta */
+ *  Use deep sleep latency if defined and add 2ms extra delta works for both 
+ *  std and small library. */
 #if defined MBED_CONF_TARGET_DEEP_SLEEP_LATENCY
-#define DEEP_SLEEP_DELAY_DELTA_US ((MBED_CONF_TARGET_DEEP_SLEEP_LATENCY * 1000ULL) + 1000ULL)
+#define DEEP_SLEEP_DELAY_DELTA_US ((MBED_CONF_TARGET_DEEP_SLEEP_LATENCY * 1000ULL) + 2000ULL)
 #else
 #define DEEP_SLEEP_DELAY_DELTA_US 2500ULL
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -27,7 +27,7 @@
 #define DELAY_DELTA_US 2500ULL
 
 /*  Use a specific delta value for deep sleep, as entry/exit adds up extra latency.
- *  Use deep sleep latency if defined and add 2ms extra delta works for both 
+ *  Use deep sleep latency if defined and add 2ms extra delta works for both
  *  std and small library. */
 #if defined MBED_CONF_TARGET_DEEP_SLEEP_LATENCY
 #define DEEP_SLEEP_DELAY_DELTA_US ((MBED_CONF_TARGET_DEEP_SLEEP_LATENCY * 1000ULL) + 2000ULL)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).
-->

### Description 
#### Summary of change <!-- Required -->
Systimer wake from deep sleep test case having an extra delay of 1ms as a delta latency for entering and exit from a deep sleep when test case run with Mbed OS with std library at the same time when using small (microlib) library noticed that 1.5ms  delay as a delta latency for entering and exiting from a deep sleep so increased the delta latency from 1ms to 2ms in the test case to work for both std and small library.

<!-- Basic information about the change: what the change is for, why do we need it any implications -->

#### Documentation <!-- Optional, but most likely you need it -->

<!-- Details of any document updates required, including links to PR against the docs repository -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Required
    Provide all the information required, listing all the testing performed. For new targets please attach full test results
    for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@hugueskamba @evedon @jamesbeyond 
<!--
    Optional
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
### Release Notes <!-- Required for features, deprecations, breaking changes and other major PRs -->

<!--
    All 3 sections are compulsory for Major PR types. For Feature PRs only the summary section is required.
    This section is automatically added to release notes. Please fill in each sub-section with sufficient detail for a user.
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types). 
-->

#### Summary of changes

#### Impact of changes

#### Migration actions required
