### PR TITLE
Fix issues in setting radio access technology

### DIFF
--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -161,6 +161,13 @@ public:
         NWModeManualAutomatic   // if manual fails, fallback to automatic
     };
 
+    /// Operator name format
+    enum OperatorNameFormat {
+        OperatorNameAlphaLong = 0,    // alphanumeric long form
+        OperatorNameAlphaShort,       // alphanumeric short form
+        OperatorNameNumeric           // numeric digits
+    };
+
     /// Network registration information
     struct registration_params_t {
         RegistrationType _type;

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -48,7 +48,7 @@ class FileHandle;
 extern const char *OK;
 extern const char *CRLF;
 
-#define BUFF_SIZE 32
+#define BUFF_SIZE 128
 
 /* AT Error types enumeration */
 enum DeviceErrorType {

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -48,7 +48,7 @@ class FileHandle;
 extern const char *OK;
 extern const char *CRLF;
 
-#define BUFF_SIZE 128
+#define BUFF_SIZE 32
 
 /* AT Error types enumeration */
 enum DeviceErrorType {

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -42,21 +42,22 @@ public:
      *       to the end (just before PROPERTY_MAX). Do not modify any of the existing fields.
      */
     enum CellularProperty {
-        PROPERTY_C_EREG,            // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
-        PROPERTY_C_GREG,            // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
-        PROPERTY_C_REG,             // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
-        PROPERTY_AT_CGSN_WITH_TYPE, // 0 = not supported, 1 = supported. AT+CGSN without type is likely always supported similar to AT+GSN.
-        PROPERTY_AT_CGDATA,         // 0 = not supported, 1 = supported. Alternative is to support only ATD*99***<cid>#
-        PROPERTY_AT_CGAUTH,         // 0 = not supported, 1 = supported. APN authentication AT commands supported
-        PROPERTY_AT_CNMI,           // 0 = not supported, 1 = supported. New message (SMS) indication AT command
-        PROPERTY_AT_CSMP,           // 0 = not supported, 1 = supported. Set text mode AT command
-        PROPERTY_AT_CMGF,           // 0 = not supported, 1 = supported. Set preferred message format AT command
-        PROPERTY_AT_CSDH,           // 0 = not supported, 1 = supported. Show text mode AT command
-        PROPERTY_IPV4_PDP_TYPE,     // 0 = not supported, 1 = supported. Does modem support IPV4?
-        PROPERTY_IPV6_PDP_TYPE,     // 0 = not supported, 1 = supported. Does modem support IPV6?
-        PROPERTY_IPV4V6_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support IPV4 and IPV6 simultaneously?
-        PROPERTY_NON_IP_PDP_TYPE,   // 0 = not supported, 1 = supported. Does modem support Non-IP?
-        PROPERTY_AT_CGEREP,         // 0 = not supported, 1 = supported. Does modem support AT command AT+CGEREP.
+        PROPERTY_C_EREG,                // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
+        PROPERTY_C_GREG,                // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
+        PROPERTY_C_REG,                 // AT_CellularNetwork::RegistrationMode. What support modem has for this registration type.
+        PROPERTY_AT_CGSN_WITH_TYPE,     // 0 = not supported, 1 = supported. AT+CGSN without type is likely always supported similar to AT+GSN.
+        PROPERTY_AT_CGDATA,             // 0 = not supported, 1 = supported. Alternative is to support only ATD*99***<cid>#
+        PROPERTY_AT_CGAUTH,             // 0 = not supported, 1 = supported. APN authentication AT commands supported
+        PROPERTY_AT_CNMI,               // 0 = not supported, 1 = supported. New message (SMS) indication AT command
+        PROPERTY_AT_CSMP,               // 0 = not supported, 1 = supported. Set text mode AT command
+        PROPERTY_AT_CMGF,               // 0 = not supported, 1 = supported. Set preferred message format AT command
+        PROPERTY_AT_CSDH,               // 0 = not supported, 1 = supported. Show text mode AT command
+        PROPERTY_IPV4_PDP_TYPE,         // 0 = not supported, 1 = supported. Does modem support IPV4?
+        PROPERTY_IPV6_PDP_TYPE,         // 0 = not supported, 1 = supported. Does modem support IPV6?
+        PROPERTY_IPV4V6_PDP_TYPE,       // 0 = not supported, 1 = supported. Does modem support IPV4 and IPV6 simultaneously?
+        PROPERTY_NON_IP_PDP_TYPE,       // 0 = not supported, 1 = supported. Does modem support Non-IP?
+        PROPERTY_AT_CGEREP,             // 0 = not supported, 1 = supported. Does modem support AT command AT+CGEREP.
+        PROPERTY_AT_COPS_FALLBACK_AUTO, // 0 = not supported, 1 = supported. Does modem support mode 4 of AT+COPS= ?
 
         PROPERTY_MAX
     };

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -222,7 +222,7 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
     } else {
         tr_debug("Manual network registration to %s", plmn);
         if (_op_act != RAT_UNKNOWN) {
-            return _at.at_cmd_discard("+COPS", "=1,2,", "%s%d", plmn, _op_act);
+            return _at.at_cmd_discard("+COPS", "=4,2,", "%s%d", plmn, _op_act);
         } else {
             return _at.at_cmd_discard("+COPS", "=1,2,", "%s", plmn);
         }

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -209,9 +209,10 @@ nsapi_error_t AT_CellularNetwork::get_network_registering_mode(NWRegisteringMode
 nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
 {
 
+    NWRegisteringMode mode = NWModeAutomatic;
+
     if (!plmn) {
         tr_debug("Automatic network registration");
-        NWRegisteringMode mode;
         if (get_network_registering_mode(mode) != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
@@ -221,10 +222,17 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
         return NSAPI_ERROR_OK;
     } else {
         tr_debug("Manual network registration to %s", plmn);
+        mode = NWModeManual;
+        OperatorNameFormat format = OperatorNameNumeric;
+#ifdef MBED_CONF_CELLULAR_PLMN_FALLBACK_AUTO
+        if (_device.get_property(AT_CellularDevice::PROPERTY_AT_COPS_FALLBACK_AUTO)) {
+            mode = NWModeManualAutomatic;
+        }
+#endif
         if (_op_act != RAT_UNKNOWN) {
-            return _at.at_cmd_discard("+COPS", "=4,2,", "%s%d", plmn, _op_act);
+            return _at.at_cmd_discard("+COPS", "=", "%d%d%s%d", mode, format, plmn, _op_act);
         } else {
-            return _at.at_cmd_discard("+COPS", "=1,2,", "%s", plmn);
+            return _at.at_cmd_discard("+COPS", "=", "%d%d%s", mode, format, plmn);
         }
     }
 }

--- a/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
+++ b/features/cellular/framework/targets/GENERIC/GENERIC_AT3GPP/GENERIC_AT3GPP.cpp
@@ -37,6 +37,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 GENERIC_AT3GPP::GENERIC_AT3GPP(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
+++ b/features/cellular/framework/targets/MultiTech/DragonflyNano/PPP/SARA4_PPP.cpp
@@ -37,6 +37,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 SARA4_PPP::SARA4_PPP(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -43,7 +43,8 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
-    0,  // PROPERTY_AT_CGEREP
+    0,  // PROPERTY_AT_CGEREP,
+    0,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 QUECTEL_BC95::QUECTEL_BC95(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -60,7 +60,8 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     1,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_CGEREP,
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 QUECTEL_BG96::QUECTEL_BG96(FileHandle *fh, PinName pwr, bool active_high, PinName rst)

--- a/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
+++ b/features/cellular/framework/targets/QUECTEL/EC2X/QUECTEL_EC2X.cpp
@@ -61,7 +61,8 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV6_STACK
     1,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_CGEREP,
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 QUECTEL_EC2X::QUECTEL_EC2X(FileHandle *fh, PinName pwr, bool active_high, PinName rst)

--- a/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
+++ b/features/cellular/framework/targets/QUECTEL/M26/QUECTEL_M26.cpp
@@ -40,6 +40,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 QUECTEL_M26::QUECTEL_M26(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.cpp
@@ -42,7 +42,8 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_CGEREP,
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 QUECTEL_UG96::QUECTEL_UG96(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/RiotMicro/AT/RM1000_AT.cpp
+++ b/features/cellular/framework/targets/RiotMicro/AT/RM1000_AT.cpp
@@ -44,6 +44,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     0,  // PROPERTY_AT_CGEREP
+    0,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 RM1000_AT::RM1000_AT(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
@@ -36,7 +36,8 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
-    1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_CGEREP,
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 TELIT_HE910::TELIT_HE910(FileHandle *fh) : AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.cpp
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.cpp
@@ -17,6 +17,7 @@
 
 #include "TELIT_ME910.h"
 #include "TELIT_ME910_CellularContext.h"
+#include "TELIT_ME910_CellularNetwork.h"
 #include "AT_CellularNetwork.h"
 #include "PinNames.h"
 #include "rtos/ThisThread.h"
@@ -186,4 +187,9 @@ nsapi_error_t TELIT_ME910::hard_power_off()
 nsapi_error_t TELIT_ME910::soft_power_off()
 {
     return AT_CellularDevice::soft_power_off();
+}
+
+AT_CellularNetwork *TELIT_ME910::open_network_impl(ATHandler &at)
+{
+    return new TELIT_ME910_CellularNetwork(at);
 }

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.cpp
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.cpp
@@ -58,6 +58,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 //the delay between sending AT commands
@@ -191,5 +192,5 @@ nsapi_error_t TELIT_ME910::soft_power_off()
 
 AT_CellularNetwork *TELIT_ME910::open_network_impl(ATHandler &at)
 {
-    return new TELIT_ME910_CellularNetwork(at);
+    return new TELIT_ME910_CellularNetwork(at, *this);
 }

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.h
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910.h
@@ -48,6 +48,8 @@ protected: // AT_CellularDevice
     virtual nsapi_error_t hard_power_off();
     virtual nsapi_error_t soft_power_on();
     virtual nsapi_error_t soft_power_off();
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+
 private:
     bool _active_high;
     DigitalOut _pwr_key;

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TELIT_ME910_CellularNetwork.h"
+
+using namespace mbed;
+
+TELIT_ME910_CellularNetwork::TELIT_ME910_CellularNetwork(ATHandler &atHandler) : AT_CellularNetwork(atHandler)
+{
+}
+
+TELIT_ME910_CellularNetwork::~TELIT_ME910_CellularNetwork()
+{
+}
+
+nsapi_error_t TELIT_ME910_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opsAct)
+{
+    switch (opsAct) {
+        case RAT_GSM:
+        case RAT_CATM1:
+        case RAT_NB1:
+            _op_act = opsAct;
+            return NSAPI_ERROR_OK;
+
+        default:
+            _op_act = RAT_UNKNOWN;
+            return NSAPI_ERROR_UNSUPPORTED;
+    }
+}
+
+

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.cpp
@@ -19,7 +19,7 @@
 
 using namespace mbed;
 
-TELIT_ME910_CellularNetwork::TELIT_ME910_CellularNetwork(ATHandler &atHandler) : AT_CellularNetwork(atHandler)
+TELIT_ME910_CellularNetwork::TELIT_ME910_CellularNetwork(ATHandler &atHandler, AT_CellularDevice &device) : AT_CellularNetwork(atHandler, device)
 {
 }
 

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.h
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TELIT_ME910_CELLULAR_NETWORK_H_
+#define TELIT_ME910_CELLULAR_NETWORK_H_
+
+#include "AT_CellularNetwork.h"
+
+namespace mbed {
+
+class TELIT_ME910_CellularNetwork : public AT_CellularNetwork {
+public:
+    TELIT_ME910_CellularNetwork(ATHandler &atHandler);
+    virtual ~ TELIT_ME910_CellularNetwork();
+
+protected:
+    virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology opRat);
+
+};
+
+} // namespace mbed
+
+#endif // TELIT_ME910_CELLULAR_NETWORK_H_

--- a/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.h
+++ b/features/cellular/framework/targets/TELIT/ME910/TELIT_ME910_CellularNetwork.h
@@ -24,7 +24,7 @@ namespace mbed {
 
 class TELIT_ME910_CellularNetwork : public AT_CellularNetwork {
 public:
-    TELIT_ME910_CellularNetwork(ATHandler &atHandler);
+    TELIT_ME910_CellularNetwork(ATHandler &atHandler, AT_CellularDevice &device);
     virtual ~ TELIT_ME910_CellularNetwork();
 
 protected:

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -37,6 +37,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 #elif defined(UBX_MDM_SARA_U2XX) || defined(UBX_MDM_SARA_G3XX)
 static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {

--- a/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.cpp
+++ b/features/cellular/framework/targets/UBLOX/N2XX/UBLOX_N2XX.cpp
@@ -34,6 +34,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     1,  // PROPERTY_IPV4_STACK
     0,  // PROPERTY_IPV6_STACK
     0,  // PROPERTY_IPV4V6_STACK
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 
 UBLOX_N2XX::UBLOX_N2XX(FileHandle *fh): AT_CellularDevice(fh)

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -38,6 +38,7 @@ static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {
     0,  // PROPERTY_IPV4V6_STACK
     0,  // PROPERTY_NON_IP_PDP_TYPE
     1,  // PROPERTY_AT_CGEREP
+    1,  // PROPERTY_AT_COPS_FALLBACK_AUTO
 };
 #elif defined(UBX_MDM_SARA_U2XX) || defined(UBX_MDM_SARA_G3XX)
 static const intptr_t cellular_properties[AT_CellularDevice::PROPERTY_MAX] = {

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -36,6 +36,10 @@
         "max-cp-data-recv-len" : {
             "help": "Max length of the buffer storing data received over control plane",
             "value": 1358
+        },
+        "plmn-fallback-auto" : {
+            "help": "If manual PLMN is selected, use mode 4 manual/automatic in AT+COPS to try automatic mode if manual selection fails. Set to null to disable",
+            "value": null
         }
     }
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Fix a missing comma when radio access technology is specified. This missing comma causes modem to return syntax error.
Add implementation for setting radio access technology for Telit ME910. Without this, RAT is set back to UNKNOWN.
Add configuration in JSON to allow PLMN fallback to auto if manual selection fails.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
