### PR TITLE
GCC: remove -fno-delete-null-pointer-checks

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -4,7 +4,7 @@
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
                    "-fmessage-length=0", "-fno-exceptions",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
-                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-MMD",
                    "-fomit-frame-pointer", "-Og", "-g3", "-DMBED_DEBUG",
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -4,7 +4,7 @@
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
                    "-fmessage-length=0", "-fno-exceptions",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
-                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-MMD",
                    "-fomit-frame-pointer", "-Os", "-g", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu11"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -4,7 +4,7 @@
                    "-Wno-unused-parameter", "-Wno-missing-field-initializers",
                    "-fmessage-length=0", "-fno-exceptions",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
-                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-MMD",
                    "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu11"],


### PR DESCRIPTION
### Summary of changes <!-- Required -->

For GCC we're being cautious by passing the `-fno-delete-null-pointer-checks`. This option prevents some optimisation opportunities, so removing it can reduce code size.

One particular optimisation loss occurs in `Callback` where a test similar to this occurs:

    extern void myfunc();

    inline void foo(void (*fnptr)())
    {
        if (fnptr) {
            do A;
        } else {
            do B;
        }
    };

    foo(myfunc);

With `-fno-delete-null-pointer-checks`, the compiler does not assume that `&myfunc` is non-null, and inserts the "null check" - seeing if the address is 0. But performing that test of the address is incorrect anyway - if myfunc actually could be at address 0, we'd still want to doA.

Anyway, we do not have an equivalent option enabled for either Clang or IAR, and we have performed clean-ups avoiding issues with apparently-null vector tables in Clang already, for example #10534.

Therefore it should(TM) be safe to remove the option for GCC. We do not have general data or code at address 0, only vectors are likely to be there, so it does not make sense to be globally restricting code generation for that.

#### Impact of changes <!-- Optional -->

Will reduce image size. Particularly when `Callback` is in use. Increased optimisation may require code adjustments, exposing undefined behaviour

#### Migration actions required <!-- Optional -->

If code fails, address undefined behaviour. Eg this null check may now be removed:

      int foo(int *ptr)
      {
           int a = ptr[0];
           if (!ptr) {  // may be optimised out - compiler can assume non-null because already accessed
                return -1;
           }
           return bar(a);
      }

Correct to:

      int foo(int *ptr)
      {
           if (!ptr) {
                return -1;
           }
           int a = ptr[0];
           return bar(a);
      }

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
