### PR TITLE
ONME-4366 - Fix UBLOX_EVK_ODIN_W2 fails in emac tests due to heap mem…

### DIFF
--- a/TESTS/network/emac/emac_util.cpp
+++ b/TESTS/network/emac/emac_util.cpp
@@ -92,7 +92,7 @@ static rtos::Semaphore link_status_semaphore;
 #if defined (__ICCARM__)
 #pragma location = ".ethusbram"
 #endif
-ETHMEM_SECTION static EventQueue worker_loop_event_queue(20 * EVENTS_EVENT_SIZE);
+ETHMEM_SECTION static EventQueue worker_loop_event_queue(50 * EVENTS_EVENT_SIZE);
 
 static void worker_loop_event_cb(int event);
 static Event<void(int)> worker_loop_event(&worker_loop_event_queue, worker_loop_event_cb);
@@ -434,7 +434,11 @@ void emac_if_link_state_change_cb(bool up)
 
 void emac_if_link_input_cb(void *buf)
 {
-    link_input_event.post(buf);
+    if (link_input_event.post(buf) == 0) {
+        if (buf) {
+            emac_m_mngr_get()->free(buf);
+        }
+    }
 }
 
 static void link_input_event_cb(void *buf)


### PR DESCRIPTION
…ory allocation failure. Increse event queue and free allocated buffer if cannot post packet to event queue.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

For huge traffic, rf board pass packets to emac test (Event queue) to fast. Queue was fully fill and cannot post new packets. Problem was there did't check if post was successful and if not nobody freed memory allocated by rf driver. To fix problem handling unposted packages and free memory. To improve handling incoming message event queue was increase from 20 to 50.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@AnttiKauppila 
@michalpasztamobica 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
