### PR TITLE
Add MBED_FALLTHROUGH attribute

### DIFF
--- a/TESTS/mbedmicro-mbed/attributes/attributes.c
+++ b/TESTS/mbedmicro-mbed/attributes/attributes.c
@@ -145,6 +145,24 @@ int testNoReturn()
 }
 
 
+int testFallthrough1(int i)
+{
+    switch (i) {
+        case 1:
+        case 2:
+            i *= 2;
+            MBED_FALLTHROUGH;
+        default:
+            return i;
+    }
+}
+
+int testFallthrough()
+{
+    return testFallthrough1(0);
+}
+
+
 int testUnreachable1(int i)
 {
     switch (i) {

--- a/TESTS/mbedmicro-mbed/attributes/main.cpp
+++ b/TESTS/mbedmicro-mbed/attributes/main.cpp
@@ -33,6 +33,7 @@ extern "C" {
     int testPure();
     int testForceInline();
     int testNoReturn();
+    int testFallthrough();
     int testUnreachable();
     int testDeprecated();
 }
@@ -59,6 +60,7 @@ Case cases[] = {
     Case("Testing PURE attribute",          test_wrapper<testPure>),
     Case("Testing FORCEINLINE attribute",   test_wrapper<testForceInline>),
     Case("Testing NORETURN attribute",      test_wrapper<testNoReturn>),
+    Case("Testing FALLTHROUGH attribute",   test_wrapper<testFallthrough>),
     Case("Testing UNREACHABLE attribute",   test_wrapper<testUnreachable>),
     Case("Testing DEPRECATED attribute",    test_wrapper<testDeprecated>),
 };

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -340,6 +340,44 @@
 #endif
 #endif
 
+/** MBED_FALLTHROUGH
+ *  Marks a point in a switch statement where fallthrough can occur.
+ *  Should be placed as the last statement before a label.
+ *
+ *  @code
+ *  #include "mbed_toolchain.h"
+ *
+ *  int foo(int arg) {
+ *      switch (arg) {
+ *          case 1:
+ *          case 2:
+ *          case 3:
+ *              arg *= 2;
+ *              MBED_FALLTHROUGH;
+ *          default:
+ *              return arg;
+ *      }
+ *  }
+ *  @endcode
+ */
+#ifndef MBED_FALLTHROUGH
+#if __cplusplus >= 201703
+#define MBED_FALLTHROUGH [[fallthrough]]
+#elif defined(__clang__)
+#if __cplusplus >= 201103
+#define MBED_FALLTHROUGH [[clang::fallthrough]]
+#elif __has_attribute(fallthrough)
+#define MBED_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define MBED_FALLTHROUGH
+#endif
+#elif defined (__GNUC__) && !defined(__CC_ARM)
+#define MBED_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define MBED_FALLTHROUGH
+#endif
+#endif
+
 /** MBED_DEPRECATED("message string")
  *  Mark a function declaration as deprecated, if it used then a warning will be
  *  issued by the compiler possibly including the provided message. Note that not


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

C++17 standardised `[[fallthrough]]` for `switch` statements to suppress compiler warnings. Provide access to it, or compiler-specific alternatives.

#### Impact of changes <!-- Optional -->

`MBED_FALLTHROUGH` attribute added to `mbed_toolchain.h` - a portable equivalent for C++17's `[[fallthrough]]`.

#### Migration actions required <!-- Optional -->

None

### Documentation <!-- Required -->

Toolchain attributes not covered by docs

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JanneKiiskila 

----------------------------------------------------------------------------------------------------------------
