### PR TITLE
static pin-map: patch for SerialBase class

### DIFF
--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -356,12 +356,14 @@ protected:
     const PinName         _tx_pin;
     const PinName         _rx_pin;
     const serial_pinmap_t *_static_pinmap = NULL;
+    void (SerialBase::*_set_flow_control_dp_func)(Flow, PinName, PinName) = NULL;
 
 #if DEVICE_SERIAL_FC
     Flow                           _flow_type = Disabled;
     PinName                        _flow1 = NC;
     PinName                        _flow2 = NC;
     const serial_fc_pinmap_t       *_static_pinmap_fc = NULL;
+    void (SerialBase::*_set_flow_control_sp_func)(Flow, const serial_fc_pinmap_t &) = NULL;
 #endif
 
 #endif

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -330,6 +330,9 @@ protected:
     /** Initialize serial port
      */
     void _init();
+    void _init_direct();
+    /* Pointer to serial init function */
+    void (SerialBase::*_init_func)();
 
     /** Deinitialize serial port
      */
@@ -345,18 +348,20 @@ protected:
     bool _rx_asynch_set = false;
 #endif
 
-    serial_t         _serial {};
-    Callback<void()> _irq[IrqCnt];
-    int              _baud;
-    bool             _rx_enabled = true;
-    bool             _tx_enabled = true;
-    const PinName    _tx_pin;
-    const PinName    _rx_pin;
+    serial_t              _serial {};
+    Callback<void()>      _irq[IrqCnt];
+    int                   _baud;
+    bool                  _rx_enabled = true;
+    bool                  _tx_enabled = true;
+    const PinName         _tx_pin;
+    const PinName         _rx_pin;
+    const serial_pinmap_t *_static_pinmap = NULL;
 
 #if DEVICE_SERIAL_FC
-    Flow             _flow_type = Disabled;
-    PinName          _flow1 = NC;
-    PinName          _flow2 = NC;
+    Flow                           _flow_type = Disabled;
+    PinName                        _flow1 = NC;
+    PinName                        _flow2 = NC;
+    const serial_fc_pinmap_t       *_static_pinmap_fc = NULL;
 #endif
 
 #endif


### PR DESCRIPTION

### Summary of changes <!-- Required -->

Related PR: #10924

The above PR adds functions to disable/enable serial input/output. If both serial input and serial output are disabled, the peripheral is freed. If either serial input or serial output is re-enabled, the peripheral is reinitialized.

I missed this change while working on the static pin-map and unfortunately it has an impact on it. The reinitialization is a problem for static pin-map. Now the HAL `init()/init_direct()` function is called not only in the constructor (but also when re-enabling the peripheral). In the current version, even if static pin-map constructor was used to create an object (and `init_direct()` HAL API), when reinitialization is done it uses `init()` HAL API. This must be split.

If static pinmap constructor is used, then the peripheral must be always initialized using HAL `init_direct()` function. If the regular constructor is used, then the peripheral must be initialized using HAL `init()` function. The same split also must be done while setting flow control during reinitialization.


### Documentation <!-- Required -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jamesbeyond 
@kjbracey-arm 
@0xc0170 

----------------------------------------------------------------------------------------------------------------
