### PR TITLE
Fix build errors for bare metal greentea tests on NRF52840_DK

### DIFF
--- a/TESTS/configs/baremetal.json
+++ b/TESTS/configs/baremetal.json
@@ -1,12 +1,12 @@
-{ 
-    "requires": [ 
-        "bare-metal", 
+{
+    "requires": [
+        "bare-metal",
         "rtos-api",
-        "greentea-client", 
-        "utest", 
+        "greentea-client",
+        "utest",
         "unity",
         "psa",
-        "mbed-crypto",        
+        "mbed-crypto",
         "mbedtls",
         "psa-compliance-framework",
         "filesystem",
@@ -37,7 +37,6 @@
     ],
     "target_overrides": {
         "*": {
-            "target.device_has_remove": ["EMAC", "USBDEVICE"],
             "mbed-trace.fea-ipv6": false
         }
      }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

CI nightly tests are not building on NRF52840_DK with the following errors:

```
/usr/local/Cellar/arm-none-eabi-gcc/8-2018-q4-major/gcc/bin/../lib/gcc/arm-none-eabi/8.2.1/../../../../arm-none-eabi/bin/ld: 
BUILD/tests/NRF52840_DK/GCC_ARM/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/USBPhy_Nordic.o: in function `get_usb_phy()':
./targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/USBPhy_Nordic.cpp:53: multiple definition of `get_usb_phy()'; BUILD/tests/NRF52840_DK/GCC_ARM/hal/usb/mbed_usb_phy.o:
./hal/usb/mbed_usb_phy.cpp:25: first defined here

```

The solution is to fix the target override in baremetal.json which was wrongly removing USBDEVICE (similarly for EMAC).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
Covered by CI nightly tests.

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
