### PR TITLE
increased qspi size for cypress integration fs tests

### DIFF
--- a/TESTS/integration/COMMON/target_extended.json
+++ b/TESTS/integration/COMMON/target_extended.json
@@ -226,6 +226,15 @@
             "spif-driver.SPI_CS"                        : "PC_12",
             "no_led"                                    : "1",
             "tests-fs-size"                             : "2*1024*1024"
+        },
+        "MCU_PSOC6": {
+            "tests-fs-size"                             : "8*1024*1024"
+        },
+        "CY8PROTO_062_4343W": {
+            "no_led"                                    : "1"
+        },
+        "_CY8CPROTO_062S3_4343W": {
+            "no_led"                                    : "1"
         }
     },
     "config": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The fs integration tests requires about 10 little fs blocks.
The qspi device used cypress has erase size of 256KB, with a default size of 2MB, the test only
allocates 8 little fs blocks. The tests need about 10 little fs blocks to
work.
Also Added no-led tags to cypress board that only have 1 LED. The
fs integration tests blinks 2 LEDs.

Fixed issue:
https://github.com/ARMmbed/mbed-os/issues/11451

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
[CY8CPROTO_062_4343W_GT_Test_Results.txt](https://github.com/ARMmbed/mbed-os/files/3933321/CY8CPROTO_062_4343W_GT_Test_Results.txt)

    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@ARMmbed/team-cypress
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
