### PR TITLE
NANO130: Fix OOM with packing algorithm at IAR linking

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -11,7 +11,7 @@ define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20004000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_heap__   = 0xC00;
+define symbol __ICFEDIT_size_heap__   = 0xB00;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -24,7 +24,7 @@ define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
 
-initialize by copy { readwrite };
+initialize by copy with packing = none { readwrite };
 do not initialize  { section .noinit };
 
 place at address mem:__ICFEDIT_intvec_start__ { block ROMVEC };


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR tries to address https://github.com/ARMmbed/mbed-os/pull/12033#issuecomment-562565568 for **NUMAKER_PFM_NANO130** target: 
1. At IAR linking, the default method of `initialize by copy` is `auto`, which will estimate different packing algorithms, including complex `lz77`, for smallest memory footprint. But the algorithm itself can require some SRAM overhead and cause OOM at linking stage for small SRAM target like NANO130, which just has 16KiB SRAM. To avoid this error on NANO130, always choose `none` packing algorithm.
1. On IAR, heap configuration is hard-coded and cannot be adjusted according to static SRAM usage. Reduce heap configuration to spare more SRAM for static allocation.
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@mprse @0xc0170 