### PR TITLE
SharedPtr: add nullptr constructor

### DIFF
--- a/TESTS/mbed_platform/SharedPtr/main.cpp
+++ b/TESTS/mbed_platform/SharedPtr/main.cpp
@@ -65,7 +65,7 @@ void test_single_sharedptr_lifetime()
  */
 void test_instance_sharing()
 {
-    SharedPtr<TestStruct> s_ptr1(NULL);
+    SharedPtr<TestStruct> s_ptr1(nullptr);
 
     // Sanity-check value of counter
     TEST_ASSERT_EQUAL(0, TestStruct::s_count);
@@ -80,7 +80,7 @@ void test_instance_sharing()
 
     TEST_ASSERT_EQUAL(1, TestStruct::s_count);
 
-    s_ptr1 = NULL;
+    s_ptr1 = nullptr;
 
     // Destroy shared pointer
     TEST_ASSERT_EQUAL(0, TestStruct::s_count);

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -76,6 +76,13 @@ public:
     }
 
     /**
+     * @brief Create empty SharedPtr not pointing to anything.
+     */
+    constexpr SharedPtr(std::nullptr_t) : SharedPtr()
+    {
+    }
+
+    /**
      * @brief Create new SharedPtr
      * @param ptr Pointer to take control over
      */


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

For consistency with `std::shared_ptr`, and `mbed::Callback`, and as a
potential optimisation aid, give `SharedPtr` a distinct constructor for
`nullptr`.

#### Impact of changes <!-- Optional -->

* Optimise clearing by adding `nullptr` overload. 

#### Migration actions required <!-- Optional -->
* The added `nullptr` overload means `SharedPtr(NULL)` or `SharedPtr(0)` will no longer work; users must use `SharedPtr(nullptr)` or `SharedPtr()`.

### Documentation <!-- Required -->

Docs example updated in https://github.com/ARMmbed/mbed-os-5-docs/pull/1183

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
