### PR TITLE
Fix TDBStore sizes for SecureStore tests

### DIFF
--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -120,8 +120,11 @@ static void kvstore_init()
         program_size  = sec_bd->get_program_size();
         erase_size = sec_bd->get_erase_size();
         // We must be able to hold at least 10 small keys (20 program sectors) and master record + internal data
-        ul_bd_size  = align_up(program_size * 40, erase_size);
-        rbp_bd_size = align_up(program_size * 40, erase_size);
+        // but minimum of 2 erase sectors, so that the garbage collection way work
+        ul_bd_size  = align_up(program_size * 40, erase_size * 2);
+        rbp_bd_size = align_up(program_size * 40, erase_size * 2);
+
+        TEST_ASSERT((ul_bd_size + rbp_bd_size) < sec_bd->size());
 
         res = sec_bd->deinit();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -120,8 +120,9 @@ static void kvstore_init()
         program_size  = sec_bd->get_program_size();
         erase_size = sec_bd->get_erase_size();
         // We must be able to hold at least 10 small keys (20 program sectors) and master record + internal data
-        ul_bd_size  = align_up(program_size * 40, erase_size);
-        rbp_bd_size = align_up(program_size * 40, erase_size);
+        // but minimum of 2 erase sectors, so that the garbage collection way work
+        ul_bd_size  = align_up(program_size * 40, erase_size * 2);
+        rbp_bd_size = align_up(program_size * 40, erase_size * 2);
 
         res = sec_bd->deinit();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Tests must require at least 2 erase sectors per TDBStore,
so that the garbage collection may work.

Fixes #12031 


----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    

