### PR TITLE
fpga tests: clear uart fix

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/uart/main.cpp
@@ -133,6 +133,9 @@ static void uart_test_common(int baudrate, int data_bits, SerialParity parity, i
             serial_set_flow_control_direct(&serial, FlowControlRTSCTS, &pinmap);
 #else
             //skip this test case if static pinmap is not supported
+            // Cleanup uart to be able execute next test case
+            serial_free(&serial);
+            tester.reset();
             return;
 #endif
         } else {

--- a/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/src/cyhal_uart.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/psoc6csp/hal/src/cyhal_uart.c
@@ -720,10 +720,12 @@ void cyhal_uart_enable_event(cyhal_uart_t *obj, cyhal_uart_event_t event, uint8_
         obj->irq_cause &= ~event;
         if (event & CYHAL_UART_IRQ_RX_NOT_EMPTY)
         {
+            Cy_SCB_ClearRxInterrupt(obj->base, CY_SCB_RX_INTR_NOT_EMPTY);
             Cy_SCB_SetRxInterruptMask(obj->base, Cy_SCB_GetRxInterruptMask(obj->base) & ~CY_SCB_RX_INTR_NOT_EMPTY);
         }
         if (event & CYHAL_UART_IRQ_TX_EMPTY)
         {
+            Cy_SCB_ClearTxInterrupt(obj->base, CY_SCB_UART_TX_EMPTY);
             Cy_SCB_SetTxInterruptMask(obj->base, Cy_SCB_GetTxInterruptMask(obj->base) & ~CY_SCB_UART_TX_EMPTY);
         }
     }


### PR DESCRIPTION

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
1. Clear UART events before enabling
2. Reset device before return from test case

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
[CY8CKIT_062_WIFI_BT_FPGA.txt](https://github.com/ARMmbed/mbed-os/files/3939367/CY8CKIT_062_WIFI_BT_FPGA.txt)

| target                      | platform_name       | test suite                                  | result | elapsed_time (sec) | copy_method |
|-----------------------------|---------------------|---------------------------------------------|--------|--------------------|-------------|
| CY8CKIT_062_WIFI_BT-GCC_ARM | CY8CKIT_062_WIFI_BT | tests-mbed_hal_fpga_ci_test_shield-gpio     | OK     | 28.29              | default     |
| CY8CKIT_062_WIFI_BT-GCC_ARM | CY8CKIT_062_WIFI_BT | tests-mbed_hal_fpga_ci_test_shield-gpio_irq | OK     | 27.04              | default     |
| CY8CKIT_062_WIFI_BT-GCC_ARM | CY8CKIT_062_WIFI_BT | tests-mbed_hal_fpga_ci_test_shield-i2c      | OK     | 31.48              | default     |
| CY8CKIT_062_WIFI_BT-GCC_ARM | CY8CKIT_062_WIFI_BT | tests-mbed_hal_fpga_ci_test_shield-pwm      | OK     | 74.84              | default     |
| CY8CKIT_062_WIFI_BT-GCC_ARM | CY8CKIT_062_WIFI_BT | tests-mbed_hal_fpga_ci_test_shield-spi      | OK     | 34.02              | default     |
| CY8CKIT_062_WIFI_BT-GCC_ARM | CY8CKIT_062_WIFI_BT | tests-mbed_hal_fpga_ci_test_shield-uart     | OK     | 35.87              | default     |
mbedgt: test suite results: 6 OK
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
