### PR TITLE
NUC472/M487: Limit EMAC receive frame length as 1518

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -262,6 +262,8 @@ void numaker_eth_init(uint8_t *mac_addr)
                     EMAC_CAMCTL_ABP_Msk;
     EMAC->CAMEN = 1;    // Enable CAM entry 0    
 
+    /* Limit the max receive frame length to 1514 + 4 */
+    EMAC->MRFL = 1518;    
     reset_phy();                    
                     
     EMAC_ENABLE_RX();

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.c
@@ -263,7 +263,7 @@ void numaker_eth_init(uint8_t *mac_addr)
     EMAC->CAMEN = 1;    // Enable CAM entry 0    
 
     /* Limit the max receive frame length to 1514 + 4 */
-    EMAC->MRFL = 1518;    
+    EMAC->MRFL = NU_ETH_MAX_FLEN;    
     reset_phy();                    
                     
     EMAC_ENABLE_RX();

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.h
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_M480/m480_eth.h
@@ -85,7 +85,7 @@
 #define RX_DESCRIPTOR_NUM       NU_RX_RING_LEN//4 //2    // 4: Max Number of Rx Frame Descriptors
 #define TX_DESCRIPTOR_NUM       NU_TX_RING_LEN//4 //2    // 4: Max number of Tx Frame Descriptors
 
-#define PACKET_BUFFER_SIZE      NU_ETH_MAX_FLEN//1520
+#define PACKET_BUFFER_SIZE      ( NU_ETH_MAX_FLEN + ((NU_ETH_MAX_FLEN%4) ? (4 - (NU_ETH_MAX_FLEN%4)) : 0) ) //For DMA 4 bytes alignment
 
 #define CONFIG_PHY_ADDR     1
 

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
@@ -228,6 +228,9 @@ void numaker_eth_init(uint8_t *mac_addr)
     init_rx_desc();
 
     numaker_set_mac_addr(mac_addr);  // need to reconfigure hardware address 'cos we just RESET emc...
+
+    /* Limit the max receive frame length to 1514 + 4 */
+    EMAC->MRFL = 1518;
     reset_phy();
 
     EMAC->CTL |= EMAC_CTL_STRIPCRC_Msk | EMAC_CTL_RXON_Msk | EMAC_CTL_TXON_Msk | EMAC_CTL_RMIIEN_Msk | EMAC_CTL_RMIIRXCTL_Msk;

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.c
@@ -230,7 +230,7 @@ void numaker_eth_init(uint8_t *mac_addr)
     numaker_set_mac_addr(mac_addr);  // need to reconfigure hardware address 'cos we just RESET emc...
 
     /* Limit the max receive frame length to 1514 + 4 */
-    EMAC->MRFL = 1518;
+    EMAC->MRFL = NU_ETH_MAX_FLEN;
     reset_phy();
 
     EMAC->CTL |= EMAC_CTL_STRIPCRC_Msk | EMAC_CTL_RXON_Msk | EMAC_CTL_TXON_Msk | EMAC_CTL_RMIIEN_Msk | EMAC_CTL_RMIIRXCTL_Msk;

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.h
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/TARGET_NUC472/nuc472_eth.h
@@ -84,7 +84,7 @@
 #define RX_DESCRIPTOR_NUM       NU_RX_RING_LEN//4 //2    // 4: Max Number of Rx Frame Descriptors
 #define TX_DESCRIPTOR_NUM       NU_TX_RING_LEN//4 //2    // 4: Max number of Tx Frame Descriptors
 
-#define PACKET_BUFFER_SIZE      NU_ETH_MAX_FLEN//1520
+#define PACKET_BUFFER_SIZE      ( NU_ETH_MAX_FLEN + ((NU_ETH_MAX_FLEN%4) ? (4 - (NU_ETH_MAX_FLEN%4)) : 0) ) //For DMA 4 bytes alignment
 
 #define CONFIG_PHY_ADDR     1
 

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
@@ -42,7 +42,7 @@
 #define NU_BUFF_ALIGNMENT       4
 #define PHY_LINKED_STATE        1
 #define PHY_UNLINKED_STATE      0
-#define PACKET_BUFFER_SIZE      NU_ETH_MAX_FLEN
+#define PACKET_BUFFER_SIZE      ( NU_ETH_MAX_FLEN + ((NU_ETH_MAX_FLEN%4) ? (4 - (NU_ETH_MAX_FLEN%4)) : 0) ) //For DMA 4 bytes alignment
 
 extern "C" void numaker_eth_rx_next(void);
 /* \brief Flags for worker thread */

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac_config.h
@@ -22,7 +22,7 @@
 #define NU_RX_RING_LEN              (8)
 #define NU_TX_RING_LEN              (4)
 
-#define NU_ETH_MAX_FLEN             (1520) 
+#define NU_ETH_MAX_FLEN             (1518) 
 
 #define NU_HWADDR_SIZE              (6)
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Limit the max receive frame length of EMAC to (1514 + 4) bytes.
According to the EMAC H/W design, this setting could avoid the risk of SRAM overwrite as while come-in some long packet over 1518 bytes.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
