### PR TITLE
Add static pin-map support: SDBlockDevice, kvstore, system storage (reduce ROM used by Mbed Cloud Client example)

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -27,6 +27,7 @@
 #include "drivers/DigitalOut.h"
 #include "platform/platform.h"
 #include "platform/PlatformMutex.h"
+#include "hal/static_pinmap.h"
 
 /** SDBlockDevice class
  *
@@ -34,7 +35,7 @@
  */
 class SDBlockDevice : public mbed::BlockDevice {
 public:
-    /** Creates an SDBlockDevice on a SPI bus specified by pins
+    /** Creates an SDBlockDevice on a SPI bus specified by pins (using dynamic pin-map)
      *
      *  @param mosi     SPI master out, slave in pin
      *  @param miso     SPI master in, slave out pin
@@ -44,6 +45,15 @@ public:
      *  @param crc_on   Enable cyclic redundancy check (defaults to disabled)
      */
     SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz = 1000000, bool crc_on = 0);
+
+    /** Creates an SDBlockDevice on a SPI bus specified by pins (using static pin-map)
+     *
+     *  @param spi_pinmap Static SPI pin-map
+     *  @param hz         Clock speed of the SPI bus (defaults to 1MHz)
+     *  @param crc_on     Enable cyclic redundancy check (defaults to disabled)
+     */
+    SDBlockDevice(const spi_pinmap_t &spi_pinmap, PinName cs, uint64_t hz = 1000000, bool crc_on = 0);
+
     virtual ~SDBlockDevice();
 
     /** Initialize a block device

--- a/features/storage/kvstore/conf/kv_config.cpp
+++ b/features/storage/kvstore/conf/kv_config.cpp
@@ -49,6 +49,10 @@
 
 #if COMPONENT_SD
 #include "components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h"
+
+#if (STATIC_PINMAP_READY)
+constexpr spi_pinmap_t static_spi_pinmap = get_spi_pinmap(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, NC);
+#endif
 #endif
 
 /**
@@ -564,12 +568,19 @@ BlockDevice *_get_blockdevice_SD(bd_addr_t start_address, bd_size_t size)
     bd_addr_t aligned_end_address;
     bd_addr_t aligned_start_address;
 
+#if (STATIC_PINMAP_READY)
+    static SDBlockDevice bd(
+        static_spi_pinmap,
+        MBED_CONF_SD_SPI_CS
+    );
+#else
     static SDBlockDevice bd(
         MBED_CONF_SD_SPI_MOSI,
         MBED_CONF_SD_SPI_MISO,
         MBED_CONF_SD_SPI_CLK,
         MBED_CONF_SD_SPI_CS
     );
+#endif
 
     if (bd.init() != MBED_SUCCESS) {
         tr_error("KV Config: SDBlockDevice init fail");

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -38,6 +38,10 @@
 
 #if COMPONENT_SD
 #include "components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h"
+
+#if (STATIC_PINMAP_READY)
+constexpr spi_pinmap_t static_spi_pinmap = get_spi_pinmap(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, NC);
+#endif
 #endif
 
 #if COMPONENT_FLASHIAP
@@ -110,12 +114,19 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
 #elif COMPONENT_SD
 
+#if (STATIC_PINMAP_READY)
+    static SDBlockDevice default_bd(
+        static_spi_pinmap,
+        MBED_CONF_SD_SPI_CS
+    );
+#else
     static SDBlockDevice default_bd(
         MBED_CONF_SD_SPI_MOSI,
         MBED_CONF_SD_SPI_MISO,
         MBED_CONF_SD_SPI_CLK,
         MBED_CONF_SD_SPI_CS
     );
+#endif
 
     return &default_bd;
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR adds static pin-map support to:
- `SDBlockDevice` component,
- `kvstore` feature,
- `system storage` feature.

This is done to reduce ROM used by the Mbed Cloud Client Example.

Related PR https://github.com/ARMmbed/mbed-os/pull/12033 (fixes pin-map for `SerialBase` class and ensures that serial flow control functions/pinmaps are not pulled into the image if flow control is not used).

Memory usage details `GCC 9.0/Cloud Client Example` below.

```
mbed-os-5.15 vs mbed-os-5.15 + PR #12033 + this PR

| Module                                                                                                                   |         .text |    .data |      .bss |
|--------------------------------------------------------------------------------------------------------------------------|---------------|----------|-----------|
| [fill]                                                                                                                   |       743(-3) |   19(+0) | 2697(-32) |
| mbed-os\drivers\source\SPI.o                                                                                             |      940(-26) |    0(+0) |  1096(+0) |
| mbed-os\drivers\source\SerialBase.o                                                                                      |      1092(-2) |    0(+0) |     0(+0) |
| mbed-os\features\storage\kvstore\conf\kv_config.o                                                                        |     1755(+28) |    0(+0) |  1269(+0) |
| mbed-os\features\storage\system_storage\SystemStorage.o                                                                  |      236(+28) |    0(+0) |   309(+0) |
| mbed-os\hal\mbed_pinmap_common.o                                                                                         |       0(-185) |    0(+0) |     0(+0) |
| mbed-os\targets\TARGET_Freescale\TARGET_MCUXpresso_MCUS\TARGET_MCU_K64F\TARGET_FRDM\PeripheralPins.o                     |      0(-1032) |    0(+0) |     0(+0) |
| mbed-os\targets\TARGET_Freescale\TARGET_MCUXpresso_MCUS\TARGET_MCU_K64F\serial_api.o                                     |    1270(-344) |    0(+0) |   220(+0) |
| mbed-os\targets\TARGET_Freescale\TARGET_MCUXpresso_MCUS\TARGET_MCU_K64F\spi_api.o                                        |     644(-272) |    0(+0) |     0(+0) |
| Subtotals                                                                                                                | 416646(-1808) | 3368(+0) | 56392(+0) |


```

Example output:
```
Mbed Bootloader
No Update image
[DBG ] Active firmware up-to-date
booting...

Start Device Management Client
Using hardcoded Root of Trust, not suitable for production use.
Starting developer flow
Developer credentials already exist, continuing..
Application ready. Build at: Dec  9 2019 12:29:00
Mbed OS version 5.15.0
mcc_platform_interface_connect()
Connecting with interface: Ethernet
NSAPI_STATUS_CONNECTING
NSAPI_STATUS_GLOBAL_UP
IP: 192.168.70.19
Network initialized, registering...
Client registered
Endpoint Name: 016eeaaaf361000000000001001dccb8
Device ID: 016eeaaaf361000000000001001dccb8
```


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jamesbeyond 
@bulislaw 
@0xc0170 

----------------------------------------------------------------------------------------------------------------
