### PR TITLE
Improve reliability of KVStore general tests

### DIFF
--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -78,6 +78,12 @@ static inline uint32_t align_up(uint32_t val, uint32_t size)
 //init the blockdevice
 static void kvstore_init()
 {
+    // This directly corresponds to the pages allocated for each of the SecureStore block devices
+    // For the others it may not match exactly to the space that is used, but it is expected to
+    // be a close enough approximation to act as a guideline for how much of the block device we
+    // need to erase in order to ensure a stable initial condition.
+    const size_t PAGES_ESTIMATE = 40;
+
     int res;
     size_t program_size, erase_size, ul_bd_size, rbp_bd_size;
     BlockDevice *sec_bd;
@@ -85,6 +91,11 @@ static void kvstore_init()
     res = bd->init();
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
     int erase_val = bd->get_erase_value();
+    // Clear out any stale data that might be left from a previous test
+    // Multiply by 2 because SecureStore requires two underlying block devices of this size
+    size_t bytes_to_erase = align_up(2 * PAGES_ESTIMATE * bd->get_program_size(), bd->get_erase_size());
+
+    bd->erase(0, bytes_to_erase);
     res = bd->deinit();
     TEST_ASSERT_EQUAL_ERROR_CODE(0, res);
 
@@ -121,8 +132,8 @@ static void kvstore_init()
         erase_size = sec_bd->get_erase_size();
         // We must be able to hold at least 10 small keys (20 program sectors) and master record + internal data
         // but minimum of 2 erase sectors, so that the garbage collection way work
-        ul_bd_size  = align_up(program_size * 40, erase_size * 2);
-        rbp_bd_size = align_up(program_size * 40, erase_size * 2);
+        ul_bd_size  = align_up(program_size * PAGES_ESTIMATE, erase_size * 2);
+        rbp_bd_size = align_up(program_size * PAGES_ESTIMATE, erase_size * 2);
 
         res = sec_bd->deinit();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, res);


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
In kvstore_init, prior to initializing the kvstore, erase the underlying block storage device. This ensures that each test run starts from a consistent state and avoids failures that can result if a previous test run left the storage in an inconsistent state. 

This change resolves cases we have seen where the SecureStore init fails with `TDBSTORE: Unable to read record at init` because the existing memory contents are sufficiently recognizeable to not trigger a reinitialization of the storage, but not enough for init to find the key that it expects. 

This mostly occurs on boards with no external flash storage and internal flash with a 1:1 ratio of program to erase size - which increases the chance of old values remaining in flash because fewer areas are erased as a "side effect". However, the fix conceptually applies to all storage types and is therefore not conditioned on internal storage or low program to erase size ratio.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
        
[CY8CKIT_062_BLE-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942381/CY8CKIT_062_BLE-GCC_ARM.txt)
[CYW9P62S1_43012EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942387/CYW9P62S1_43012EVB_01-GCC_ARM.txt)
[CYW9P62S1_43438EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942388/CYW9P62S1_43438EVB_01-GCC_ARM.txt)
[CYW943012P6EVB_01-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942389/CYW943012P6EVB_01-GCC_ARM.txt)
[CY8CKIT_062_WIFI_BT-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942382/CY8CKIT_062_WIFI_BT-GCC_ARM.txt)
[CY8CKIT_062S2_43012-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942383/CY8CKIT_062S2_43012-GCC_ARM.txt)
[CY8CPROTO_062_4343W_GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942384/CY8CPROTO_062_4343W_GCC_ARM.txt)
[CY8CPROTO_062S3_4343W-GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942385/CY8CPROTO_062S3_4343W-GCC_ARM.txt)
[CY8CPROTO_063_BLE_GCC_ARM.txt](https://github.com/ARMmbed/mbed-os/files/3942386/CY8CPROTO_063_BLE_GCC_ARM.txt)

Note 1: The failure of tests-mbed_drivers-timeout on CY8CPROTO_063_BLE appears to be a spurious failure. The test passed when re-run on its own, and this PR does not modify that test file (nor any other non-test code).
Note 2: To avoid false failures, testing was performed with the changes from #12050 applied (but the changes from that PR are not included in the commits for this PR, nor is there a dependency between the two).

----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
