### PR TITLE
NANO130: Support dynamic heap configuration on IAR

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -11,7 +11,7 @@ define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20004000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_heap__   = 0xB00;
+define symbol __ICFEDIT_size_heap__   = 0x400;
 /**** End of ICF editor section. ###ICF###*/
 
 
@@ -21,7 +21,7 @@ define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFED
 
 define block ROMVEC    with alignment = 8                                   { readonly section .intvec };
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__ { };
 
 
 initialize by copy with packing = none { readwrite };


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR is continuation of #12047 and tries to fix static SRAM OOM further by supporting dynamic heap configuration on IAR. In this PR, for IAR toolchain, heap is configured to 1KiB at a minimum and expandable to available SRAM. This requires IAR 8.x.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@mprse @0xc0170 

----------------------------------------------------------------------------------------------------------------
