### PR TITLE
Move get_ip_address_if() to NetworkStack and include it in multihoming test

### DIFF
--- a/TESTS/network/multihoming/main.cpp
+++ b/TESTS/network/multihoming/main.cpp
@@ -37,6 +37,7 @@
 #include "utest.h"
 #include "utest/utest_stack_trace.h"
 #include "multihoming_tests.h"
+#include "LWIPStack.h"
 
 using namespace utest::v1;
 
@@ -77,6 +78,10 @@ static void _ifup()
     SocketAddress eth_ip_address;
     eth->get_ip_address(&eth_ip_address);
     printf("MBED: IP address is '%s' interface name %s\n", eth_ip_address.get_ip_address(), interface_name[interface_num]);
+    SocketAddress eth_ip_address_if;
+    LWIP::get_instance().get_ip_address_if(&eth_ip_address_if, interface_name[interface_num]);
+    printf("IP_if: %s\n", eth_ip_address.get_ip_address());
+    TEST_ASSERT_EQUAL(eth_ip_address_if, eth_ip_address);
     interface_num++;
 
     wifi = WiFiInterface::get_default_instance();
@@ -104,6 +109,10 @@ static void _ifup()
         SocketAddress wifi_ip_address;
         wifi->get_ip_address(&wifi_ip_address);
         printf("IP: %s\n", STRING_VERIFY(wifi_ip_address.get_ip_address()));
+        SocketAddress wifi_ip_address_if;
+        LWIP::get_instance().get_ip_address_if(&wifi_ip_address_if, interface_name[interface_num]);
+        printf("IP_if: %s\n", STRING_VERIFY(wifi_ip_address_if.get_ip_address()));
+        TEST_ASSERT_EQUAL(wifi_ip_address_if, wifi_ip_address);
         SocketAddress wifi_netmask;
         wifi->get_netmask(&wifi_netmask);
         printf("Netmask: %s\n", STRING_VERIFY(wifi_netmask.get_ip_address()));

--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -349,36 +349,6 @@ char *LWIP::Interface::get_ip_address(char *buf, nsapi_size_t buflen)
 #endif
 }
 
-nsapi_error_t LWIP::Interface::get_ip_address_if(const char *interface_name, SocketAddress *address)
-{
-    if (!address) {
-        return NSAPI_ERROR_PARAMETER;
-    }
-
-    const ip_addr_t *addr;
-
-    if (interface_name == NULL) {
-        addr = LWIP::get_ip_addr(true, &netif);
-    } else {
-        addr = LWIP::get_ip_addr(true, netif_find(interface_name));
-    }
-#if LWIP_IPV6
-    if (IP_IS_V6(addr)) {
-        char buf[NSAPI_IPv6_SIZE];
-        address->set_ip_address(ip6addr_ntoa_r(ip_2_ip6(addr), buf, NSAPI_IPv6_SIZE));
-        return NSAPI_ERROR_OK;
-    }
-#endif
-#if LWIP_IPV4
-    if (IP_IS_V4(addr)) {
-        char buf[NSAPI_IPv4_SIZE];
-        address->set_ip_address(ip4addr_ntoa_r(ip_2_ip4(addr), buf, NSAPI_IPv4_SIZE));
-        return NSAPI_ERROR_OK;
-    }
-#endif
-    return NSAPI_ERROR_UNSUPPORTED;
-}
-
 char *LWIP::Interface::get_ip_address_if(char *buf, nsapi_size_t buflen, const char *interface_name)
 {
     const ip_addr_t *addr;

--- a/features/lwipstack/LWIPInterface.cpp
+++ b/features/lwipstack/LWIPInterface.cpp
@@ -349,33 +349,6 @@ char *LWIP::Interface::get_ip_address(char *buf, nsapi_size_t buflen)
 #endif
 }
 
-char *LWIP::Interface::get_ip_address_if(char *buf, nsapi_size_t buflen, const char *interface_name)
-{
-    const ip_addr_t *addr;
-
-    if (interface_name == NULL) {
-        addr = LWIP::get_ip_addr(true, &netif);
-    } else {
-        addr = LWIP::get_ip_addr(true, netif_find(interface_name));
-    }
-    if (!addr) {
-        return NULL;
-    }
-#if LWIP_IPV6
-    if (IP_IS_V6(addr)) {
-        return ip6addr_ntoa_r(ip_2_ip6(addr), buf, buflen);
-    }
-#endif
-#if LWIP_IPV4
-    if (IP_IS_V4(addr)) {
-        return ip4addr_ntoa_r(ip_2_ip4(addr), buf, buflen);
-    }
-#endif
-#if LWIP_IPV6 && LWIP_IPV4
-    return NULL;
-#endif
-}
-
 nsapi_error_t LWIP::Interface::get_netmask(SocketAddress *address)
 {
     if (!address) {

--- a/features/lwipstack/LWIPStack.cpp
+++ b/features/lwipstack/LWIPStack.cpp
@@ -217,6 +217,36 @@ const char *LWIP::get_ip_address()
 #endif
 }
 
+nsapi_error_t LWIP::get_ip_address_if(SocketAddress *address, const char *interface_name)
+{
+    if (!address) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+    const ip_addr_t *addr;
+
+    if (interface_name == NULL) {
+        addr = get_ip_addr(true, &default_interface->netif);
+    } else {
+        addr = get_ip_addr(true, netif_find(interface_name));
+    }
+#if LWIP_IPV6
+    if (IP_IS_V6(addr)) {
+        char buf[NSAPI_IPv6_SIZE];
+        address->set_ip_address(ip6addr_ntoa_r(ip_2_ip6(addr), buf, NSAPI_IPv6_SIZE));
+        return NSAPI_ERROR_OK;
+    }
+#endif
+#if LWIP_IPV4
+    if (IP_IS_V4(addr)) {
+        char buf[NSAPI_IPv4_SIZE];
+        address->set_ip_address(ip4addr_ntoa_r(ip_2_ip4(addr), buf, NSAPI_IPv4_SIZE));
+        return NSAPI_ERROR_OK;
+    }
+#endif
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
 nsapi_error_t LWIP::socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto)
 {
     // check if network is connected

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -106,9 +106,6 @@ public:
          */
         virtual nsapi_error_t get_ipv6_link_local_address(SocketAddress *address);
 
-        MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
-        virtual char *get_ip_address_if(char *buf, nsapi_size_t buflen, const char *interface_name);
-
         /** Copies netmask of the network interface to user supplied buffer
          *
          * @param    buf        buffer to which netmask will be copied as "W:X:Y:Z"

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -106,15 +106,6 @@ public:
          */
         virtual nsapi_error_t get_ipv6_link_local_address(SocketAddress *address);
 
-        /** Copies IP address of the name based network interface to user supplied buffer
-         *
-         * @param    buf        buffer to which IP address will be copied as "W:X:Y:Z"
-         * @param    buflen     size of supplied buffer
-         * @param    interface_name     naame of the interface
-         * @return              Pointer to a buffer, or NULL if the buffer is too small
-         */
-        virtual nsapi_error_t get_ip_address_if(const char *interface_name, SocketAddress *address);
-
         MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
         virtual char *get_ip_address_if(char *buf, nsapi_size_t buflen, const char *interface_name);
 
@@ -323,6 +314,15 @@ public:
      *                  or null if not yet connected
      */
     virtual const char *get_ip_address();
+
+    /** Copies IP address of the name based network interface to user supplied buffer
+     *
+     * @param    address        SocketAddress object pointer to store the address
+     * @param    interface_name name of the interface
+     * @return                  Pointer to a buffer, or NULL if the buffer is too small
+     */
+    virtual nsapi_error_t get_ip_address_if(SocketAddress *address, const char *interface_name);
+
     /** Set the network interface as default one
       */
     virtual void set_default_interface(OnboardNetworkStack::Interface *interface);

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -121,18 +121,6 @@ public:
             return NSAPI_ERROR_UNSUPPORTED;
         }
 
-        /** @copydoc NetworkStack::get_ip_address_if */
-        virtual nsapi_error_t get_ip_address_if(SocketAddress *address, const char *interface_name)
-        {
-            return NSAPI_ERROR_UNSUPPORTED;
-        }
-
-        MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
-        virtual char *get_ip_address_if(char *buf, nsapi_size_t buflen, const char *interface_name)
-        {
-            return NULL;
-        };
-
         /** @copydoc NetworkStack::get_netmask */
         virtual nsapi_error_t get_netmask(SocketAddress *address) = 0;
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

When working on multihoming feature, `get_ip_address_if()` was wrongly put into `OnboardNetworkStack::Interface`. This is incorrect, because every of those interfaces only knows its own address, so it could only return and empty address in case the name doesn't match its name or it actual address if it does. Further more, the `OnboardNetworkStack::Interface::get_ip_address_if()` was not internally connected to any public API.

Instead `get_ip_address_if()` should only be an API of `NetworkStack` and implemented in `LWIP` class. This way we can make best use of the feature: the stack holding multiple interfaces will find the one with a matching name and return its address.

We haven't noticed this, because, the function was never called in our greentea tests. I don't think it deserves its own dedicated test, but at least I added checks confirming that the API returns the same addresses that the eth/wifi interfaces do, based on their string name identifiers.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

No real impact - the `NetworkStack::get_ip_address_if()` function will become usable.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
Already in place

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@kjbracey-arm 
@AnttiKauppila 
@tymoteuszblochmobica 

----------------------------------------------------------------------------------------------------------------
