### PR TITLE
Valgrind support added for unittests

### DIFF
--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -82,6 +82,10 @@ if (COVERAGE)
 
 endif(COVERAGE)
 
+if (VALGRIND)
+  find_program(MEMORYCHECK_COMMAND valgrind)
+endif(VALGRIND)
+
 ####################
 # UNIT TESTS
 ####################
@@ -196,6 +200,7 @@ foreach(testfile ${unittest-file-list})
   if (unittest-test-sources)
     # Create the executable.
     add_executable(${TEST_SUITE_NAME} ${unittest-test-sources})
+
     target_include_directories(${TEST_SUITE_NAME} PRIVATE
       ${unittest-includes})
     target_compile_options(${TEST_SUITE_NAME} PRIVATE

--- a/UNITTESTS/mbed_unittest.py
+++ b/UNITTESTS/mbed_unittest.py
@@ -76,13 +76,15 @@ def _mbed_unittest_test(options, cwd, pwd):
         tool.create_makefiles(path_to_src=src_path,
                               generator=options.cmake_generator,
                               coverage_output_type=options.coverage,
-                              debug=options.debug_build)
+                              debug=options.debug_build,
+                              valgrind=options.valgrind)
 
         # Build tests
         tool.build_tests()
 
     if options.run_only:
-        tool.run_tests(filter_regex=options.test_regex)
+        tool.run_tests(filter_regex=options.test_regex,
+                       valgrind=options.valgrind)
 
         # If code coverage generation:
         if options.coverage:

--- a/UNITTESTS/moduletests/storage/blockdevice/SlicingBlockDevice/moduletest.cpp
+++ b/UNITTESTS/moduletests/storage/blockdevice/SlicingBlockDevice/moduletest.cpp
@@ -120,6 +120,8 @@ TEST_F(SlicingBlockModuleTest, slice_in_middle)
     EXPECT_EQ(0, memcmp(buf, magic, BLOCK_SIZE));
     bd.read(buf, BLOCK_SIZE * 3, BLOCK_SIZE);
     EXPECT_EQ(0, memcmp(buf, magic, BLOCK_SIZE));
+
+    delete[] program;
 }
 
 TEST_F(SlicingBlockModuleTest, slice_at_the_end)
@@ -143,6 +145,8 @@ TEST_F(SlicingBlockModuleTest, slice_at_the_end)
     //Verify that blocks before and after the slicing blocks are not touched
     bd.read(buf, BLOCK_SIZE * 7, BLOCK_SIZE);
     EXPECT_EQ(0, memcmp(buf, magic, BLOCK_SIZE));
+
+    delete[] program;
 }
 
 TEST_F(SlicingBlockModuleTest, over_write)
@@ -163,6 +167,8 @@ TEST_F(SlicingBlockModuleTest, over_write)
 
     //Program a test value to address that is one pass the device size
     EXPECT_EQ(slice.program(program, 2 * BLOCK_SIZE, BLOCK_SIZE), BD_ERROR_DEVICE_ERROR);
+
+    delete[] buf;
     delete[] program;
 }
 

--- a/UNITTESTS/unit_test/get_tools.py
+++ b/UNITTESTS/unit_test/get_tools.py
@@ -53,6 +53,13 @@ def get_cmake_tool():
 
     return _get_program(["cmake"])
 
+def get_valgrind_tool():
+    """
+    Get Valgrind program
+    """
+
+    return _get_program(["valgrind"])
+
 def get_cxx_tool():
     """
     Get C++ compiler

--- a/UNITTESTS/unit_test/options.py
+++ b/UNITTESTS/unit_test/options.py
@@ -103,6 +103,11 @@ def get_options_parser():
                         help="Build directory. Default: UNITTESTS/build/",
                         dest="build")
 
+    parser.add_argument("--valgrind",
+                        help="Use Valgrind when running executables",
+                        action="store_true",
+                        dest="valgrind")
+
     parser.add_argument("--new",
                         action="append",
                         help="Source file from which to generate test files. E.g. rtos/Semaphore.cpp",

--- a/UNITTESTS/unit_test/test.py
+++ b/UNITTESTS/unit_test/test.py
@@ -28,7 +28,8 @@ from .utils import execute_program
 from .get_tools import get_make_tool, \
                        get_cmake_tool, \
                        get_cxx_tool, \
-                       get_c_tool
+                       get_c_tool, \
+                       get_valgrind_tool
 from .settings import DEFAULT_CMAKE_GENERATORS
 
 class UnitTestTool(object):
@@ -96,6 +97,11 @@ class UnitTestTool(object):
             args.append("-DCOVERAGE:STRING=%s" % coverage_output_type)
 
         if valgrind:
+            valgrind = get_valgrind_tool()
+            if valgrind is None:
+                logging.error(
+                    "No Valgrind found in Path. Install all the required tools.\n")
+                sys.exit(1)
             args.append("-DVALGRIND=1")
             args.append("-DMEMORYCHECK_COMMAND_OPTIONS=\"--track-origins=yes\" \"--leak-check=full\" \"--show-reachable=yes\" \"--error-exitcode=1\"")
         else:


### PR DESCRIPTION
Added an option to select Valgrind to be used for unittests from command line

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Added an option to select Valgrind to be used for unittests from command line
can be used by calling `mbed test --unittest --valgrind`

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
Tool specific help is part of this PR, mbed-cli must be updated also to add same option hint.

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-wan @ARMmbed/mbed-os-ipcore 
----------------------------------------------------------------------------------------------------------------
