### PR TITLE
Add pytest test case to validate PSA target mandatory attributes

### DIFF
--- a/features/FEATURE_PSA/supporting_psa_in_mbed-os.md
+++ b/features/FEATURE_PSA/supporting_psa_in_mbed-os.md
@@ -19,19 +19,18 @@ Please note that Mbed OS exporters are currently **NOT** supported for PSA dual-
 To help with the creation of PSA targets, a couple of generic targets have been added to `targets/targets.json`.
 * `PSA_Target` (Root level PSA target)
 * `PSA_V7_M_NSPE` (Single v7-M NSPE generic target)
-* `PSA_V7_M_SPE` (Single v7-M SPE generic target)
 * `PSA_DUAL_CORE_NSPE` (Dual-core NSPE generic target)
-* `PSA_DUAL_CORE_SPE` (Dual-core SPE generic target)
 * `PSA_V8_M_NSPE` (v8-M NSPE generic target)
-* `PSA_V8_M_SPE` (v8-M SPE generic target)
 
-A single-core PSA target doesn't employ hardware isolation between the NSPE and the SPE. Therefore for single-core PSA targets only NSPE target is defined. PSA secure service emulation enables PSA API compatibility.
+A single-core PSA target doesn't employ hardware isolation between the NSPE and the SPE. PSA secure service emulation enables PSA API compatibility.
 
-A dual-core PSA target will have at least two cores that are either Armv7-M or Armv6-M. One core will be used for the SPE and another for the NSPE. Hardware isolation between the cores enables PSA compliance. On dual-core targets, TF-M runs on the SPE and provides PSA services. Therefore, it is **MANDATORY** to define both the SPE and the NSPE target for dual-core PSA targets.
+A dual-core PSA target will have at least two cores that are either Armv7-M or Armv6-M. One core will be used for the SPE and another for the NSPE. Hardware isolation between the cores enables PSA compliance. On dual-core targets, TF-M runs on the SPE and provides PSA services and Mbed OS runs on the NSPE.
 
-An Armv8-M PSA target employs hardware to isolate the NSPE from the SPE. On Armv8-M targets, TF-M runs on the SPE and provides PSA services. Therefore, it is **MANDATORY** to define both the SPE and the NSPE target for Armv8-M PSA targets.
+An Armv8-M PSA target employs hardware to isolate the NSPE from the SPE. On Armv8-M targets, TF-M runs on the SPE and provides PSA services and Mbed OS runs on the NSPE.
 
-PSA targets **MUST** inherit from the generic PSA target that corresponds to that target's architecture. Also, in case of dual-core and v8-M targets, SPE and NSPE targets **MUST** inherit from the respective SPE and NSPE PSA generic targets.
+PSA targets **MUST** inherit from the generic PSA target that corresponds to that target's architecture.
+
+Only PSA NSPE generic targets have been defined for dual-core and Armv7-M targets because TF-M build tools are used to generate SPE binary instead of Mbed OS build tools. Therefore, it is not necessary to define SPE target while adding a new PSA target to Mbed OS, only defining NSPE target is sufficient.
 
 *Note*  
 The examples in this document are taken from `targets/targets.json`.
@@ -45,10 +44,7 @@ Example single-core PSA target:
 
 Example dual-core PSA target:
 ```json
-    "CY8CPROTO_064_SB_S": {
-        "inherits": ["PSA_DUAL_CORE_SPE"],
-    },
-    "CY8CPROTO_064_SB_NS": {
+    "CY8CPROTO_064_SB": {
         "inherits": ["PSA_DUAL_CORE_NSPE", "MCU_PSOC6_M4"],
     }
 ```
@@ -65,14 +61,6 @@ Example:
         "inherits": ["PSA_V7_M_NSPE", "FAMILY_STM32"],
     }
 ```
-
-## Naming convention for dual-core and Armv8-M target names
-As described in previous paragraphs, both SPE and NSPE target names **MUST** be defined for dual-core and Armv8-M targets. This section defines the naming convention for the same.
-
-`TargetName_S`       : PSA secure target (SPE)  
-`TargetName_NS`      : PSA non-secure target (NSPE)  
-`TargetName_NPSA_S`  : Non-PSA secure target  
-`TargetName_NPSA_NS` : Non-PSA non-secure target  
 
 ## Adding single-core PSA targets
 Mbed OS's PSA service emulation provides PSA compatibility for single-core PSA targets. The following example shows a PSA-enabled single-core target, `K64F`.
@@ -139,34 +127,23 @@ Please pay attention to the config options `extra_labels_add` and `device_has_ad
 Check [extra_labels](https://os.mbed.com/docs/mbed-os/v5.14/reference/adding-and-configuring-targets.html), [device_has](https://os.mbed.com/docs/mbed-os/v5.14/reference/adding-and-configuring-targets.html) and [features](https://os.mbed.com/docs/mbed-os/v5.14/reference/adding-and-configuring-targets.html) for more information.
 
 ## Adding dual-core PSA targets
-A target can be categorized as a dual-core target if it has at least two cores that are either Armv7-M or Armv6-M. On dual-core PSA targets, TF-M runs on the SPE and provides PSA services. Therefore, it is **MANDATORY** to define both the SPE and the NSPE target for dual-core PSA targets.
+A target can be categorized as a dual-core target if it has at least two cores that are either Armv7-M or Armv6-M. On dual-core PSA targets, TF-M runs on the SPE and provides PSA services.
 
-The SPE target **MUST** contain the following attributes:
+The NSPE target **MUST** contain the following attributes along with Mbed OS specific attributes:
 
-* `inherits`: PSA generic target PSA_DUAL_CORE_SPE
 * `tfm_target_name`: Target name in TF-M
 * `tfm_bootloader_supported`: If TF-M bootloader is supported by the target. Values supported are "true" and "false"
 * `tfm_default_toolchain`: Default TF-M toolchain supported. Values supported are `ARMCLANG` and `GNUARM`
 * `tfm_supported_toolchains`: Supported TF-M toolchains. Values supported are `ARMCLANG` and `GNUARM`
-* `delivery_dir`: The directory to which TF-M binary will be copied to
+* `tfm_delivery_dir`: The directory to which TF-M binary will be copied to
 
 The following example shows a PSA enabled dual-core target, `PSoC64`,
 
 ```json
-    "CY8CPROTO_064_SB_S": {
-        "inherits": ["PSA_DUAL_CORE_SPE"],
-        "tfm_target_name": "psoc64_1m",
-        "tfm_bootloader_supported": false,
-        "tfm_default_toolchain": "ARMCLANG",
-        "tfm_supported_toolchains": ["ARMCLANG", "GNUARM"],
-        "delivery_dir": "TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB",
-        "OUTPUT_EXT": "hex"
-    },
-    "CY8CPROTO_064_SB_NS": {
+    "CY8CPROTO_064_SB": {
         "inherits": ["PSA_DUAL_CORE_NSPE", "MCU_PSOC6_M4"],
         "components_remove": ["QSPIF"],
         "device_has_remove": ["QSPI"],
-        "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["PSOC6_01", "MXCRYPTO_01"],
         "macros_add": ["CYB06447BZI_D54",
                        "PSOC6_DYNSRM_DISABLE=1",
@@ -177,14 +154,20 @@ The following example shows a PSA enabled dual-core target, `PSoC64`,
         "reset_method": "default",
         "post_binary_hook": {
             "function": "PSOC6Code.sign_image"
-        }
-    },
+        },
+        "tfm_target_name": "psoc64_1m",
+        "tfm_bootloader_supported": false,
+        "tfm_default_toolchain": "ARMCLANG",
+        "tfm_supported_toolchains": ["ARMCLANG", "GNUARM"],
+        "tfm_delivery_dir": "TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB",
+        "TFM_OUTPUT_EXT": "hex"
+    }
 ```
 
 Please pay attention to the config options `extra_labels_add` and `device_has_remove`. If needed, a PSA target definition **MUST** use [extra_labels/device_has]`_add` or [extra_labels/device_has]`_remove` (not `extra_labels` or `device_has`) to add/remove either `extra_labels` or target capabilities. Also, use `feature_`[add/remove] to add/remove a feature.
 Check [extra_labels](https://os.mbed.com/docs/mbed-os/v5.14/reference/adding-and-configuring-targets.html), [device_has](https://os.mbed.com/docs/mbed-os/v5.14/reference/adding-and-configuring-targets.html) and [features](https://os.mbed.com/docs/mbed-os/v5.14/reference/adding-and-configuring-targets.html) for more information.
 
-By default TF-M build generates a `bin` file. If the target requires a `hex` file then the attribute `"OUTPUT_EXT": "hex"` should be added to the target definition.
+By default TF-M build generates a `bin` file. If the target requires a `hex` file then the attribute `"TFM_OUTPUT_EXT": "hex"` should be added to the target definition.
 
 ## Adding Armv8-M PSA targets
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -72,18 +72,10 @@
         "device_has": ["TRNG"],
         "public": false
     },
-    "PSA_V7_M_SPE": {
-        "inherits": ["PSA_Target"],
-        "public": false
-    },
     "PSA_DUAL_CORE_NSPE": {
         "inherits": ["PSA_Target"],
         "extra_labels": ["TFM", "TARGET_TFM_TWINCPU"],
         "device_has_add": ["TRNG"],
-        "public": false
-    },
-    "PSA_DUAL_CORE_SPE": {
-        "inherits": ["PSA_Target"],
         "tfm_target_name": "",
         "tfm_bootloader_supported": "",
         "tfm_default_toolchain": "ARMCLANG",
@@ -95,10 +87,6 @@
         "inherits": ["PSA_Target"],
         "extra_labels": ["TFM", "TARGET_TFM_V8M"],
         "device_has_add": ["TRNG"],
-        "public": false
-    },
-    "PSA_V8_M_SPE": {
-        "inherits": ["PSA_Target"],
         "tfm_target_name": "",
         "tfm_bootloader_supported": "",
         "tfm_default_toolchain": "ARMCLANG",
@@ -8841,7 +8829,7 @@
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "core": "Cortex-M4F",
         "OUTPUT_EXT": "hex",
-        "device_has": [
+        "device_has_add": [
             "ANALOGIN",
             "ANALOGOUT",
             "CRC",
@@ -8871,7 +8859,7 @@
             "WATCHDOG"
         ],
         "release_versions": ["5"],
-        "extra_labels": ["Cypress", "PSOC6", "MXCRYPTO"],
+        "extra_labels_add": ["Cypress", "PSOC6", "MXCRYPTO"],
         "components_add": ["SOFTFP", "RTX"],
         "public": false,
         "overrides" : {
@@ -9046,16 +9034,7 @@
         "sectors": [[268443648, 512]],
         "bootloader_supported": false
     },
-    "CY8CPROTO_064_SB_S": {
-        "inherits": ["PSA_DUAL_CORE_SPE"],
-        "tfm_target_name": "psoc64_1m",
-        "tfm_bootloader_supported": false,
-        "tfm_default_toolchain": "ARMCLANG",
-        "tfm_supported_toolchains": ["ARMCLANG", "GNUARM"],
-        "delivery_dir": "TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB",
-        "OUTPUT_EXT": "hex"
-    },
-    "CY8CPROTO_064_SB_NS": {
+    "CY8CPROTO_064_SB": {
         "inherits": ["PSA_DUAL_CORE_NSPE", "MCU_PSOC6_M4"],
         "components_remove": ["QSPIF"],
         "device_has_remove": ["QSPI"],
@@ -9069,7 +9048,13 @@
         "reset_method": "default",
         "post_binary_hook": {
             "function": "PSOC6Code.sign_image"
-        }
+        },
+        "tfm_target_name": "psoc64_1m",
+        "tfm_bootloader_supported": false,
+        "tfm_default_toolchain": "ARMCLANG",
+        "tfm_supported_toolchains": ["ARMCLANG", "GNUARM"],
+        "tfm_delivery_dir": "TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CPROTO_064_SB",
+        "TFM_OUTPUT_EXT": "hex"
     },
     "CYW9P62S1_43438EVB_01": {
         "inherits": ["MCU_PSOC6_M4"],

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -600,11 +600,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         into_dir, extra_artifacts = toolchain.config.deliver_into()
         if into_dir:
             copy_when_different(res[0], into_dir)
-            if not extra_artifacts:
-                if toolchain.target.is_TrustZone_secure_target:
-                    cmse_lib = join(dirname(res[0]), "cmse_lib.o")
-                    copy_when_different(cmse_lib, into_dir)
-            else:
+            if extra_artifacts:
                 for tc, art in extra_artifacts:
                     if toolchain_name == tc:
                         copy_when_different(join(build_path, art), into_dir)

--- a/tools/psa/build_tfm.py
+++ b/tools/psa/build_tfm.py
@@ -263,7 +263,7 @@ def _get_target_info(target, toolchain=None):
         raise Exception(msg)
 
     delivery_dir = join(ROOT, 'targets',
-                        TARGET_MAP[target].delivery_dir)
+                        TARGET_MAP[target].tfm_delivery_dir)
 
     if not os.path.exists(delivery_dir):
         msg = "Delivery directory (delivery_dir) missing for %s" % target
@@ -393,7 +393,7 @@ def _copy_binaries(source, destination, toolchain, target):
     shutil.copy2(tfm_secure_axf, output_dir)
 
     try:
-        out_ext = TARGET_MAP[target].OUTPUT_EXT
+        out_ext = TARGET_MAP[target].TFM_OUTPUT_EXT
     except AttributeError:
         tfm_secure_bin = join(source, 'tfm_s.bin')
         logger.info("Copying %s to %s" % (relpath(tfm_secure_bin, ROOT),

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -390,24 +390,13 @@ class Target(namedtuple(
         else:
             return self.core
 
-    # Mechanism for specifying TrustZone is subject to change - see
-    # discussion on https://github.com/ARMmbed/mbed-os/issues/9460
-    # In the interim, we follow heuristics that support existing
-    # documentation for ARMv8-M TF-M integration (check the "TFM" label),
-    # plus an extra "trustzone" flag set by M2351, and looking at the "-NS"
-    # suffix. This now permits non-TrustZone ARMv8 builds if
-    # having trustzone = false (default), no TFM flag, and no -NS suffix.
-    @property
-    def is_TrustZone_secure_target(self):
-        return (getattr(self, 'trustzone', False) or 'TFM' in self.labels) and not self.core.endswith('-NS')
-
     @property
     def is_TrustZone_non_secure_target(self):
         return self.core.endswith('-NS')
 
     @property
     def is_TrustZone_target(self):
-        return self.is_TrustZone_secure_target or self.is_TrustZone_non_secure_target
+        return self.is_TrustZone_non_secure_target
 
     @property
     def is_PSA_secure_target(self):

--- a/tools/test/psa/psa_test.py
+++ b/tools/test/psa/psa_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""
+Copyright (c) 2019 ARM Limited. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import pytest
+
+from tools.targets import TARGETS
+
+def test_psa_target_attributes():
+    psa_targets = (tar for tar in TARGETS
+                   if tar.is_TFM_target)
+
+    for tar in psa_targets:
+        msg = "tfm_target_name attribute cannot be empty"
+        assert(tar.tfm_target_name != ""), msg
+        msg = "tfm_bootloader_supported attribute cannot be empty"
+        assert(tar.tfm_bootloader_supported != ""), msg
+        msg = "tfm_default_toolchain attribute cannot be empty"
+        assert(tar.tfm_default_toolchain != ""), msg
+        msg = "tfm_supported_toolchains attribute cannot be empty"
+        assert(tar.tfm_supported_toolchains != ""), msg
+        msg = "delivery_dir attribute cannot be empty"
+        assert(tar.tfm_delivery_dir != ""), msg
+

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -572,17 +572,6 @@ class ARMC6(ARM_STD):
 
         self.check_and_add_minimal_printf(target)
 
-        if target.is_TrustZone_secure_target:
-            if kwargs.get('build_dir', False):
-                # Output secure import library
-                build_dir = kwargs['build_dir']
-                secure_file = join(build_dir, "cmse_lib.o")
-                self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
-
-            # Enable compiler security extensions
-            self.flags['cxx'].append("-mcmse")
-            self.flags['c'].append("-mcmse")
-
         if target.is_TrustZone_non_secure_target:
             # Add linking time preprocessor macro DOMAIN_NS
             # (DOMAIN_NS is passed to compiler and assembler via CORTEX_SYMBOLS

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -79,15 +79,6 @@ class GCC(mbedToolchain):
                     self.flags["ld"].append(minimal_printf_wrap)
 
         self.cpu = []
-        if target.is_TrustZone_secure_target:
-            # Enable compiler security extensions
-            self.cpu.append("-mcmse")
-            # Output secure import library
-            self.flags["ld"].extend([
-                "-Wl,--cmse-implib",
-                "-Wl,--out-implib=%s" % join(build_dir, "cmse_lib.o")
-            ])
-
         if target.is_TrustZone_non_secure_target:
             # Add linking time preprocessor macro DOMAIN_NS
             # (DOMAIN_NS is passed to compiler and assembler via CORTEX_SYMBOLS

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -54,14 +54,6 @@ class IAR(mbedToolchain):
             build_profile=build_profile
         )
 
-        if target.is_TrustZone_secure_target:
-            # Enable compiler security extensions
-            self.flags["asm"] += ["--cmse"]
-            self.flags["common"] += ["--cmse"]
-            # Output secure import library
-            secure_file = join(build_dir, "cmse_lib.o")
-            self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
-
         if target.is_TrustZone_non_secure_target:
             # Add linking time preprocessor macro DOMAIN_NS
             # (DOMAIN_NS is passed to compiler and assembler via CORTEX_SYMBOLS


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
The following attributes are mandatory for dual-core and Armv8-M PSA targets:

```
inherits: PSA generic target PSA_DUAL_V7_M_SPE
tfm_target_name: Target name in TF-M
tfm_bootloader_supported: If TF-M bootloader is supported by the target.
Values supported are "true" and "false"
tfm_default_toolchain: Default TF-M toolchain supported. Values supported
are "ARMCLANG" and "GNUARM"
tfm_supported_toolchains: Supported TF-M toolchains. Values supported
are "ARMCLANG" and "GNUARM"
delivery_dir: The directory to which TF-M binary will be copied to
```

The pytest test case ensures that dual-core and Armv8-M PSA targets have these mandatory attributes.

Depends on https://github.com/ARMmbed/mbed-os/pull/11964. The commit relevant for this PR is https://github.com/ARMmbed/mbed-os/commit/dc978f13d1e3745a3dbbdd70e802e8f29ac561b9.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
If either a dual-core or Armv8-M target is added without mandatory parameters then the PR checks will fail.
```
inherits: PSA generic target PSA_DUAL_V7_M_SPE
tfm_target_name: Target name in TF-M
tfm_bootloader_supported: If TF-M bootloader is supported by the target.
Values supported are "true" and "false"
tfm_default_toolchain: Default TF-M toolchain supported. Values supported
are "ARMCLANG" and "GNUARM"
tfm_supported_toolchains: Supported TF-M toolchains. Values supported
are "ARMCLANG" and "GNUARM"
delivery_dir: The directory to which TF-M binary will be copied to
```
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
Currently everything is documented at https://github.com/ARMmbed/mbed-os/blob/feature_twincpu/features/FEATURE_PSA/supporting_psa_in_mbed-os.md. When we are ready to merge this feature branch to master then online docs will be updated with relevant information.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@Patater @jainvikas8 

----------------------------------------------------------------------------------------------------------------
