### PR TITLE
Expose target_offset and header_offset parameters in targets.json

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -33,6 +33,14 @@
                 "help": "Time in ms required to go to and wake up from deep sleep (max 10)",
                 "value": 0
             },
+            "app_offset": {
+                "help": "Application start offset in ROM",
+                "value": null
+            },
+            "header_offset": {
+                "help": "Application header offset in ROM",
+                "value": null
+            },
             "boot-stack-size": {
                 "help": "Define the boot stack size in bytes. This value must be a multiple of 8",
                 "value": "0x1000"


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The app_offset and header_offset parameters have always been a part of the target configuration parameters. However, they were intercepted by the tools and never exposed to the application. The new FOTA (update client next generation) functionality requires these parameters in the code as well now. So this PR adds them to targets.json file. The only result of this PR is the addition of these two macros into the code.
Note that the tools already expose the macros APPLICATION_ADDR and HEADER_ADDR having the same values. However, these macros are only available when the application is built with the bootloader. If it isn't, these macros aren't available, hence this PR.    
This change is required for new fota client. 

#### Impact of changes <!-- Optional -->
None

#### Migration actions required <!-- Optional -->
None

### Documentation <!-- Required -->
None
----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@alzix 
@donatieng 
----------------------------------------------------------------------------------------------------------------
