### PR TITLE
TARGET_STM: fix flash api 64bit address alignment on L4 and WB

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
@@ -205,7 +205,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
 
     /*  HW needs an aligned address to program flash, which data
      *  parameters doesn't ensure  */
-    if ((uint32_t) data % 4 != 0) {
+    if ((uint32_t) data % 8 != 0) {
         volatile uint64_t data64;
         while ((address < (StartAddress + size)) && (status == 0)) {
             for (uint8_t i = 0; i < 8; i++) {

--- a/targets/TARGET_STM/TARGET_STM32WB/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32WB/flash_api.c
@@ -154,7 +154,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, 
     StartAddress = address;
 
     /*  HW needs an aligned address to program flash, which data parameters doesn't ensure */
-    if ((uint32_t) data % 4 != 0) { // Data is not aligned, copy data in a temp buffer before programming it
+    if ((uint32_t) data % 8 != 0) { // Data is not aligned, copy data in a temp buffer before programming it
         volatile uint64_t data64;
         while ((address < (StartAddress + size)) && (status == 0)) {
             for (uint8_t i = 0; i < 8; i++) {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

 fix flash api 64bit address alignment on L4 and WB

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

No test available with misaligned address.
    


----------------------------------------------------------------------------------------------------------------
