### PR TITLE
Moved CP Max recv len into mbed_lib.json

### DIFF
--- a/features/cellular/framework/AT/AT_ControlPlane_netif.h
+++ b/features/cellular/framework/AT/AT_ControlPlane_netif.h
@@ -32,7 +32,7 @@ protected:
 private:
     void (*_cb)(void *);
     void *_data;
-    char _recv_buffer[MAX_CP_DATA_RECV_LEN];
+    char _recv_buffer[MBED_CONF_CELLULAR_MAX_CP_DATA_RECV_LEN];
     size_t _recv_len;
     // Called on receiving URC: +CRTDCP
     void urc_cp_recv();

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -32,6 +32,10 @@
         "clear-on-connect" : {
             "help": "Clear modem to a known default state on connect() before SIM pin is entered, null to disable",
             "value": null
+        },
+        "max-cp-data-recv-len" : {
+            "help": "Max length of the buffer storing data received over control plane",
+            "value": 1358
         }
     }
 }

--- a/features/netsocket/cellular/ControlPlane_netif.h
+++ b/features/netsocket/cellular/ControlPlane_netif.h
@@ -27,9 +27,10 @@
 namespace mbed {
 
 /* Length of the buffer storing data received over control plane */
-#define MAX_CP_DATA_RECV_LEN 2048
+#ifndef MBED_CONF_CELLULAR_MAX_CP_DATA_RECV_LEN
+#define MBED_CONF_CELLULAR_MAX_CP_DATA_RECV_LEN 1358
+#endif
 
-// TODO: need to make this l3ip compatible
 
 /**
  * @addtogroup cellular


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Moved CP Max recv len into mbed_lib.json so it can be configured by end developer when needed.
According to [3GPP-TS_24.008] the maximum size for Non-IP link MTU is 1358 octets to prevent fragmentation in the backbone network. Therefore reduced the maximum size to follow the standard. 

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
mbed_lib.json has a specific help for the value
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@ARMmbed/mbed-os-wan 
----------------------------------------------------------------------------------------------------------------
