### PR TITLE
ONME-4433 SocketAddress::operator== should also check port

### DIFF
--- a/UNITTESTS/MODULETESTS/features/netsocket/IfaceDnsSocket/test_IfaceDnsSocket.cpp
+++ b/UNITTESTS/MODULETESTS/features/netsocket/IfaceDnsSocket/test_IfaceDnsSocket.cpp
@@ -499,7 +499,7 @@ TEST_F(Test_IfaceDnsSocket, async_cancel)
 
 TEST_F(Test_IfaceDnsSocket, add_server)
 {
-    SocketAddress server_address("1.2.3.4", 8000);
+    SocketAddress server_address("1.2.3.4", 53);
     EXPECT_EQ(NSAPI_ERROR_OK, nsapi_dns_add_server(server_address, NULL));
     EXPECT_EQ(NSAPI_ERROR_OK, nsapi_dns_add_server(server_address, NULL)); // Duplicate add - no error.
 
@@ -533,7 +533,7 @@ TEST_F(Test_IfaceDnsSocket, attempts)
     SocketAddress known_server_address[DNS_SERVER_SIZE];
     for (uint8_t i = DNS_SERVER_SIZE; i > 0; i--) {
         uint8_t bytes[NSAPI_IPv4_SIZE] = {i, i, i, i};
-        known_server_address[i - 1] = SocketAddress(bytes, NSAPI_IPv4);
+        known_server_address[i - 1] = SocketAddress(bytes, NSAPI_IPv4, 53);
         EXPECT_EQ(NSAPI_ERROR_OK, nsapi_dns_add_server(known_server_address[i - 1], NULL));
     }
 
@@ -573,7 +573,7 @@ TEST_F(Test_IfaceDnsSocket, retries_attempts)
     SocketAddress known_server_address[DNS_SERVER_SIZE];
     for (uint8_t i = DNS_SERVER_SIZE; i > 0; i--) {
         uint8_t bytes[NSAPI_IPv4_SIZE] = {i, i, i, i};
-        known_server_address[i - 1] = SocketAddress(bytes, NSAPI_IPv4);
+        known_server_address[i - 1] = SocketAddress(bytes, NSAPI_IPv4, 53);
         EXPECT_EQ(NSAPI_ERROR_OK, nsapi_dns_add_server(known_server_address[i - 1], NULL));
     }
 

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -182,6 +182,8 @@ bool operator==(const SocketAddress &a, const SocketAddress &b)
         return true;
     } else if (a._addr.version != b._addr.version) {
         return false;
+    } else if (a._port != b._port) {
+        return false;
     } else if (a._addr.version == NSAPI_IPv4) {
         return memcmp(a._addr.bytes, b._addr.bytes, NSAPI_IPv4_BYTES) == 0;
     } else if (a._addr.version == NSAPI_IPv6) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Currently SocketAddress::operator== does not check port number. Adding this check can be considered as a breaking change. Now SocketAddress::operator== checks port also. All greentests and unitests was checked and fixed.

### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@AnttiKauppila 
@kivaisan 
@michalpasztamobica 
----------------------------------------------------------------------------------------------------------------
