### PR TITLE
LWIP: Remove unused MBOX configs

### DIFF
--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -84,11 +84,6 @@
 #define LWIP_RAW                    MBED_CONF_LWIP_RAW_SOCKET_ENABLED
 
 #define MEMP_NUM_TCPIP_MSG_INPKT    MBED_CONF_LWIP_MEMP_NUM_TCPIP_MSG_INPKT
-#define TCPIP_MBOX_SIZE             MBED_CONF_LWIP_TCPIP_MBOX_SIZE
-#define DEFAULT_TCP_RECVMBOX_SIZE   MBED_CONF_LWIP_DEFAULT_TCP_RECVMBOX_SIZE
-#define DEFAULT_UDP_RECVMBOX_SIZE   8
-#define DEFAULT_RAW_RECVMBOX_SIZE   8
-#define DEFAULT_ACCEPTMBOX_SIZE     8
 
 // Thread stacks use 8-byte alignment
 #define LWIP_ALIGN_UP(pos, align) ((pos) % (align) ? (pos) +  ((align) - (pos) % (align)) : (pos))

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -90,14 +90,6 @@
             "help": "TCP Maximum segment size, see LWIP opt.h for more information. Current default is 536.",
             "value": 536
         },
-        "tcpip-mbox-size": {
-            "help": "TCPIP mailbox size",
-            "value": 8
-        },
-        "default-tcp-recvmbox-size": {
-            "help": "Default TCPIP receive mailbox size",
-            "value": 8
-        },
         "mbox-size": {
             "help": "mailbox size",
             "value": 8


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Remove the two MBOX config options which were ignored by LWIP. The configs have never been used (`sys_mbox_new()` [silently ignores them](https://github.com/ARMmbed/mbed-os/blob/d128ff488235d806bbefb21ebb00aea0f55a4bb7/features/lwipstack/lwip-sys/arch/lwip_sys_arch.c#L130)), so I doubt this is a breaking change and did not mark it as such.
Fixes https://github.com/ARMmbed/mbed-os/issues/12046


#### Impact of changes <!-- Optional -->

Some `mbed_app.json` files may not compile if they used the removed options.

### Documentation <!-- Required -->

Not required

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@pstolarz 
@kjbracey-arm 
@AnttiKauppila 

----------------------------------------------------------------------------------------------------------------
