### PR TITLE
Fix LPC11U35_401 baremetal build

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/cmsis_nvic.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/cmsis_nvic.c
@@ -60,7 +60,8 @@ void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     
     // Copy and switch to dynamic vectors if first time called
     if((LPC_SYSCON->SYSMEMREMAP & 0x3) != 0x1) {     
-      uint32_t *old_vectors = (uint32_t *)0;         // FLASH vectors are at 0x0
+      // Add volatile qualifier to avoid armclang aggressive optimization
+      volatile uint32_t *old_vectors = (uint32_t *)0;         // FLASH vectors are at 0x0
       for(i = 0; i < NVIC_NUM_VECTORS; i++) {    
             vectors[i] = old_vectors[i];
         }

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/us_ticker.c
@@ -17,6 +17,8 @@
 #include "us_ticker_api.h"
 #include "PeripheralNames.h"
 
+#if DEVICE_USTICKER
+
 #define US_TICKER_TIMER          ((LPC_CTxxBx_Type *)LPC_CT32B1_BASE)
 #define US_TICKER_TIMER_IRQn     TIMER_32_1_IRQn
 
@@ -70,3 +72,5 @@ void us_ticker_free(void)
 {
 
 }
+
+#endif // DEVICE_USTICKER

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -374,8 +374,13 @@
             "SERIAL",
             "SLEEP",
             "SPI",
-            "SPISLAVE"
+            "SPISLAVE",
+            "USTICKER"
         ],
+        "overrides": {
+            "tickless-from-us-ticker"   : true,
+            "boot-stack-size"           : "0x400"
+        },
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "LPC11U35FBD48/401"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

The PR fix LPC11U35_401 baremetal build error and runtime error.
This should be now fixed: https://github.com/ARMmbed/mbed-os-example-blinky-baremetal/issues/15

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->


### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
Greentea test does not work for this target (Mbed 2 only target).
So, I verified this fix as below:

```
$ git clone https://github.com/ARMmbed/mbed-os-example-blinky-baremetal
$ cd mbed-os-example-blinky-baremetal
$ echo 'https://github.com/toyowata/mbed/#f9242d0b5c8ecc3a20e5a1f9813c2c1d93c61db9' > mbed-os.lib
$ mbed deploy
$ mbed ls
[mbed] Working path "/Users/toywat01/test/nxp/mbed-os-example-blinky-baremetal" (program)
mbed-os-example-blinky-baremetal (#11e65bf06a7a)
`- mbed-os (#f9242d0b5c8e)
$ mbed compile -m lpc11u35_401 -t arm -f
$ mbed compile -m lpc11u35_401 -t gcc_arm -f
```

* It was compiled without error
* No crash at runtime
* LED1 blinks as expected timing

I also put printf message in the main.cpp for debug and it worked fine.
    
----------------------------------------------------------------------------------------------------------------


### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
