### PR TITLE
Fix for issue #10725 (tests-mbed_drivers-lp_timer failing nightly)

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -490,3 +490,29 @@ void ticker_resume(const ticker_data_t *const ticker)
 
     core_util_critical_section_exit();
 }
+
+void ticker_update_freq(const ticker_data_t *const ticker, uint32_t frequency)
+{
+    uint8_t frequency_shifts = 0;
+    for (uint8_t i = 31; i > 0; --i) {
+        if ((1U << i) == frequency) {
+            frequency_shifts = i;
+            break;
+        }
+    }
+
+    core_util_critical_section_enter();
+
+    if (!ticker->queue->initialized) {
+        initialize(ticker);
+    }
+
+    ticker->queue->frequency = frequency;
+    ticker->queue->frequency_shifts = frequency_shifts;
+    ticker->queue->tick_last_read = ticker->interface->read();
+
+    update_present_time(ticker);
+    schedule_interrupt(ticker);
+
+    core_util_critical_section_exit();
+}

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -208,6 +208,15 @@ void ticker_suspend(const ticker_data_t *const ticker);
  */
 void ticker_resume(const ticker_data_t *const ticker);
 
+/** Update ticker frequency
+ *
+ * Update ticker frequency.
+ *
+ * @param ticker        The ticker object.
+ * @param frequency     The new frequency
+ */
+void ticker_update_freq(const ticker_data_t *const ticker, uint32_t frequency);
+
 /* Private functions
  *
  * @cond PRIVATE


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

`tests-mbed_drivers-lp_timer` is failing on `UBLOX_C030_U201` (can't reproduce the failure locally).

According to the documentation of `STM32F437VG76` MCU:

The LSI RC acts as an low-power clock source that can be kept running in Stop and
Standby mode for the independent watchdog (IWDG) and Auto-wakeup unit (AWU). The
clock frequency is around 32 kHz. For more details, refer to the electrical characteristics
section of the datasheets.

It seems that typical LSI frequency is 32 kHz, but it may vary from 17 to 47 kHz!
This means that lp-timer test may fail on the same board because lp-ticker frequency is unstable.

The proposition is to add `ticker_update_freq()` function and modify the test to perform lp-ticker calibration if the target uses LSI RC for lp-ticker.
<!-- 
    Please provide the following information: 

    Description of the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
