### PR TITLE
TESTS-MBED_HAL-COMMON_TICKERS no more executed

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if !defined(MBED_RTOS_CONF_PRESENT)
+#if !defined(MBED_CONF_RTOS_PRESENT)
 #error [NOT_SUPPORTED] usticker test cases require a RTOS to run
 #else
 
@@ -611,4 +611,4 @@ int main()
     return !Harness::run(specification);
 }
 #endif // !DEVICE_USTICKER
-#endif // !defined(MBED_RTOS_CONF_PRESENT)
+#endif // !defined(MBED_CONF_RTOS_PRESENT)

--- a/TESTS/mbed_hal/common_tickers_freq/main.cpp
+++ b/TESTS/mbed_hal/common_tickers_freq/main.cpp
@@ -209,4 +209,4 @@ int main()
 }
 
 #endif // defined(SKIP_TIME_DRIFT_TESTS) || !DEVICE_USTICKER
-#endif // !defined(MBED_RTOS_CONF_PRESENT)
+#endif // !defined(MBED_CONF_RTOS_PRESENT)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

During 15.5 release non regression tests, I could see that
TESTS-MBED_HAL-COMMON_TICKERS is no more executed

I think it was some copy paste error... :-)

#### Impact of changes <!-- Optional -->

MBED_CONF_RTOS_PRESENT macro name corrected

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
