### PR TITLE
Thread: remove constructors deprecated in 5.1

### DIFF
--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -125,135 +125,6 @@ public:
     }
 
 
-    /** Create a new thread, and start it executing the specified function.
-      @param   task           function to be executed by this thread.
-      @param   priority       initial priority of the thread function. (default: osPriorityNormal).
-      @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
-      @param   stack_mem      pointer to the stack area to be used by this thread (default: nullptr).
-      @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(task).
-
-        @code
-        Thread thread(priority, stack_size, stack_mem);
-
-        osStatus status = thread.start(task);
-        if (status != osOK) {
-            error("oh no!");
-        }
-        @endcode
-
-      @note You cannot call this function from ISR context.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Thread-spawning constructors hide errors. "
-                          "Replaced by thread.start(task).")
-    Thread(mbed::Callback<void()> task,
-           osPriority priority = osPriorityNormal,
-           uint32_t stack_size = OS_STACK_SIZE,
-           unsigned char *stack_mem = nullptr)
-    {
-        constructor(task, priority, stack_size, stack_mem);
-    }
-
-    /** Create a new thread, and start it executing the specified function.
-      @param   argument       pointer that is passed to the thread function as start argument. (default: nullptr).
-      @param   task           argument to task.
-      @param   priority       initial priority of the thread function. (default: osPriorityNormal).
-      @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
-      @param   stack_mem      pointer to the stack area to be used by this thread (default: nullptr).
-      @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(task, argument)).
-
-        @code
-        Thread thread(priority, stack_size, stack_mem);
-
-        osStatus status = thread.start(callback(task, argument));
-        if (status != osOK) {
-            error("oh no!");
-        }
-        @endcode
-
-        @note You cannot call this function from ISR context.
-    */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Thread-spawning constructors hide errors. "
-                          "Replaced by thread.start(callback(task, argument)).")
-    Thread(T *argument, void (T::*task)(),
-           osPriority priority = osPriorityNormal,
-           uint32_t stack_size = OS_STACK_SIZE,
-           unsigned char *stack_mem = nullptr)
-    {
-        constructor(mbed::callback(task, argument),
-                    priority, stack_size, stack_mem);
-    }
-
-    /** Create a new thread, and start it executing the specified function.
-      @param   argument       pointer that is passed to the thread function as start argument. (default: nullptr).
-      @param   task           argument to task.
-      @param   priority       initial priority of the thread function. (default: osPriorityNormal).
-      @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
-      @param   stack_mem      pointer to the stack area to be used by this thread (default: nullptr).
-      @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(task, argument)).
-
-        @code
-        Thread thread(priority, stack_size, stack_mem);
-
-        osStatus status = thread.start(callback(task, argument));
-        if (status != osOK) {
-            error("oh no!");
-        }
-        @endcode
-
-      @note You cannot call this function from ISR context.
-    */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Thread-spawning constructors hide errors. "
-                          "Replaced by thread.start(callback(task, argument)).")
-    Thread(T *argument, void (*task)(T *),
-           osPriority priority = osPriorityNormal,
-           uint32_t stack_size = OS_STACK_SIZE,
-           unsigned char *stack_mem = nullptr)
-    {
-        constructor(mbed::callback(task, argument),
-                    priority, stack_size, stack_mem);
-    }
-
-    /** Create a new thread, and start it executing the specified function.
-        Provided for backwards compatibility
-      @param   task           function to be executed by this thread.
-      @param   argument       pointer that is passed to the thread function as start argument. (default: nullptr).
-      @param   priority       initial priority of the thread function. (default: osPriorityNormal).
-      @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
-      @param   stack_mem      pointer to the stack area to be used by this thread (default: nullptr).
-      @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(task, argument)).
-
-        @code
-        Thread thread(priority, stack_size, stack_mem);
-
-        osStatus status = thread.start(callback(task, argument));
-        if (status != osOK) {
-            error("oh no!");
-        }
-        @endcode
-
-        @note You cannot call this function from ISR context.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "Thread-spawning constructors hide errors. "
-                          "Replaced by thread.start(callback(task, argument)).")
-    Thread(void (*task)(void const *argument), void *argument = nullptr,
-           osPriority priority = osPriorityNormal,
-           uint32_t stack_size = OS_STACK_SIZE,
-           unsigned char *stack_mem = nullptr)
-    {
-        constructor(mbed::callback((void (*)(void *))task, argument),
-                    priority, stack_size, stack_mem);
-    }
-
     /** Starts a thread executing the specified function.
       @param   task           function to be executed by this thread.
       @return  status code that indicates the execution status of the function.
@@ -262,24 +133,6 @@ public:
       @note You cannot call this function ISR context.
     */
     osStatus start(mbed::Callback<void()> task);
-
-    /** Starts a thread executing the specified function.
-      @param   obj            argument to task
-      @param   method         function to be executed by this thread.
-      @return  status code that indicates the execution status of the function.
-      @deprecated
-          The start function does not support cv-qualifiers. Replaced by start(callback(obj, method)).
-
-      @note You cannot call this function from ISR context.
-    */
-    template <typename T, typename M>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-                          "The start function does not support cv-qualifiers. "
-                          "Replaced by thread.start(callback(obj, method)).")
-    osStatus start(T *obj, M method)
-    {
-        return start(mbed::callback(obj, method));
-    }
 
     /** Wait for thread to terminate
       @return  status code that indicates the execution status of the function.
@@ -519,11 +372,6 @@ private:
     // Required to share definitions without
     // delegated constructors
     void constructor(osPriority priority = osPriorityNormal,
-                     uint32_t stack_size = OS_STACK_SIZE,
-                     unsigned char *stack_mem = nullptr,
-                     const char *name = nullptr);
-    void constructor(mbed::Callback<void()> task,
-                     osPriority priority = osPriorityNormal,
                      uint32_t stack_size = OS_STACK_SIZE,
                      unsigned char *stack_mem = nullptr,
                      const char *name = nullptr);

--- a/rtos/source/Thread.cpp
+++ b/rtos/source/Thread.cpp
@@ -69,25 +69,6 @@ void Thread::constructor(osPriority priority,
     constructor(MBED_TZ_DEFAULT_ACCESS, priority, stack_size, stack_mem, name);
 }
 
-void Thread::constructor(mbed::Callback<void()> task,
-                         osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name)
-{
-    constructor(MBED_TZ_DEFAULT_ACCESS, priority, stack_size, stack_mem, name);
-
-    switch (start(task)) {
-        case osErrorResource:
-            MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_RESOURCES), "OS ran out of threads!\n", task);
-            break;
-        case osErrorParameter:
-            MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_ALREADY_IN_USE), "Thread already running!\n", task);
-            break;
-        case osErrorNoMemory:
-            MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory\n", task);
-        default:
-            break;
-    }
-}
-
 osStatus Thread::start(mbed::Callback<void()> task)
 {
     _mutex.lock();


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Remove the immediate-start constructors deprecated in Mbed OS 5.1.

#### Impact of changes <!-- Optional -->

Code using the old constructors will no longer compile

#### Migration actions required <!-- Optional -->

Code using immediate-start `Thread` constructors must be changed to use the `Thread::start` method.

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
