### PR TITLE
Thread: remove methods deprecated in 5.10

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -46,34 +46,34 @@ struct Sync {
     Semaphore &sem_child;
 };
 
-template <int32_t signals, uint32_t timeout, int32_t test_val>
+template <int32_t signals, uint32_t timeout, uint32_t test_val>
 void run_signal_wait(void)
 {
-    osEvent ev = Thread::signal_wait(signals, timeout);
-    TEST_ASSERT_EQUAL(test_val, ev.status);
+    uint32_t ret = ThisThread::flags_wait_all_for(signals, timeout);
+    TEST_ASSERT_EQUAL(test_val, ret);
 }
 
-template <int32_t signals, uint32_t timeout, int32_t test_val>
+template <int32_t signals, uint32_t timeout, uint32_t test_val>
 void run_release_signal_wait(Semaphore *sem)
 {
     sem->release();
-    osEvent ev = Thread::signal_wait(signals, timeout);
-    TEST_ASSERT_EQUAL(test_val, ev.status);
+    uint32_t ret = ThisThread::flags_wait_all_for(signals, timeout);
+    TEST_ASSERT_EQUAL(test_val, ret);
 }
 
-template <int32_t signals, uint32_t timeout, int32_t test_val>
+template <int32_t signals, uint32_t timeout, uint32_t test_val>
 void run_release_wait_signal_wait(Sync *sync)
 {
     sync->sem_parent.release();
     sync->sem_child.acquire();
-    osEvent ev = Thread::signal_wait(signals, timeout);
-    TEST_ASSERT_EQUAL(test_val, ev.status);
+    uint32_t ret = ThisThread::flags_wait_all_for(signals, timeout);
+    TEST_ASSERT_EQUAL(test_val, ret);
 }
 
 template <int32_t signals, int32_t test_val>
 void run_clear(void)
 {
-    int32_t ret = Thread::signal_clr(signals);
+    int32_t ret = ThisThread::flags_clear(signals);
     TEST_ASSERT_EQUAL(test_val, ret);
 }
 
@@ -129,7 +129,7 @@ void test_clear_no_signals(void)
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
     t.start(callback(run_double_wait_clear<NO_SIGNALS, NO_SIGNALS, ALL_SIGNALS, ALL_SIGNALS>, &sync));
     sem_parent.acquire();
-    t.signal_set(ALL_SIGNALS);
+    t.flags_set(ALL_SIGNALS);
     sem_child.release();
     t.join();
 }
@@ -150,7 +150,7 @@ void test_init_state(void)
 /** Validate all signals set in one shot
 
     Given two threads A & B are started
-    When thread A call @a signal_set(ALL_SIGNALS) with all possible signals
+    When thread A call @a flags_set(ALL_SIGNALS) with all possible signals
     Then thread B @a signal_clr(NO_SIGNALS) status should be ALL_SIGNALS indicating all signals set correctly
  */
 void test_set_all(void)
@@ -164,17 +164,17 @@ void test_set_all(void)
     t.start(callback(run_wait_clear<NO_SIGNALS, ALL_SIGNALS>, &sync));
 
     sem_parent.acquire();
-    ret = t.signal_set(ALL_SIGNALS);
+    ret = t.flags_set(ALL_SIGNALS);
     TEST_ASSERT_EQUAL(ALL_SIGNALS, ret);
 
     sem_child.release();
     t.join();
 }
 
-/** Validate that call signal_set with prohibited signal doesn't change thread signals
+/** Validate that call flags_set with prohibited signal doesn't change thread signals
 
     Given two threads A & B are started, B with all signals set
-    When thread A executes @a signal_set(PROHIBITED_SIGNAL) with prohibited signal
+    When thread A executes @a flags_set(PROHIBITED_SIGNAL) with prohibited signal
     Then thread B @a signal_clr(NO_SIGNALS) status should be ALL_SIGNALS indicating that thread B signals are unchanged
 
     @note Each signal has up to 31 event flags 0x1, 0x2, 0x4, 0x8, ...,  0x40000000
@@ -191,10 +191,10 @@ void test_set_prohibited(void)
     t.start(callback(run_wait_clear<NO_SIGNALS, ALL_SIGNALS>, &sync));
 
     sem_parent.acquire();
-    t.signal_set(ALL_SIGNALS);
+    t.flags_set(ALL_SIGNALS);
 
 #if !MBED_TRAP_ERRORS_ENABLED
-    ret = t.signal_set(PROHIBITED_SIGNAL);
+    ret = t.flags_set(PROHIBITED_SIGNAL);
     TEST_ASSERT_EQUAL(osErrorParameter, ret);
 #endif
 
@@ -217,7 +217,7 @@ void test_clear_all(void)
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
     t.start(callback(run_double_wait_clear<ALL_SIGNALS, NO_SIGNALS, ALL_SIGNALS, NO_SIGNALS>, &sync));
     sem_parent.acquire();
-    t.signal_set(ALL_SIGNALS);
+    t.flags_set(ALL_SIGNALS);
     sem_child.release();
     t.join();
 }
@@ -225,7 +225,7 @@ void test_clear_all(void)
 /** Validate all signals set one by one in loop
 
     Given two threads A & B are started
-    When thread A executes @a signal_set(signal) in loop with all possible signals
+    When thread A executes @a flags_set(signal) in loop with all possible signals
  */
 void test_set_all_loop(void)
 {
@@ -241,7 +241,7 @@ void test_set_all_loop(void)
     for (int i = 0; i <= MAX_FLAG_POS; i++) {
         int32_t signal = 1 << i;
 
-        ret = t.signal_set(signal);
+        ret = t.flags_set(signal);
         signals |= signal;
         TEST_ASSERT_EQUAL(signals, ret);
         sem_child.release();
@@ -253,11 +253,10 @@ void test_set_all_loop(void)
 /** Validate signal_wait return status if timeout specified
 
     Given the thread is running
-    When thread executes @a signal_wait(signals, timeout) with specified signals and timeout
-    Then thread @a signal_wait status should be osEventTimeout indicating a timeout
-         thread @a signal_wait status should be osOK indicating 0[ms] timeout set
+    When thread executes @a flags_wait_all_for(signals, timeout) with specified signals and timeout
+    Then thread @a flags_wait_all_for return should be 0 indicating no flags set
  */
-template <int32_t signals, uint32_t timeout, int32_t status>
+template <int32_t signals, uint32_t timeout, uint32_t status>
 void test_wait_timeout(void)
 {
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
@@ -269,7 +268,7 @@ void test_wait_timeout(void)
 
     Given two threads A & B are started, B with all signals already set
     When thread B executes @a signal_wait(ALL_SIGNALS, osWaitForever),
-    Then thread B @a signal_wait return immediately with status osEventSignal indicating all wait signals was already set
+    Then thread B @a flags_wait_all_for return immediately with ALL_SIGNALS indicating all wait signals was already set
  */
 void test_wait_all_already_set(void)
 {
@@ -278,11 +277,11 @@ void test_wait_all_already_set(void)
     Sync sync(sem_parent, sem_child);
 
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
-    t.start(callback(run_release_wait_signal_wait<ALL_SIGNALS, osWaitForever, osEventSignal>, &sync));
+    t.start(callback(run_release_wait_signal_wait<ALL_SIGNALS, osWaitForever, ALL_SIGNALS>, &sync));
 
     sem_parent.acquire();
     TEST_ASSERT_EQUAL(Thread::WaitingSemaphore, t.get_state());
-    t.signal_set(ALL_SIGNALS);
+    t.flags_set(ALL_SIGNALS);
     sem_child.release();
     t.join();
 }
@@ -290,28 +289,28 @@ void test_wait_all_already_set(void)
 /** Validate if signal_wait return correctly when all signals set
 
     Given two threads A & B are started and B waiting for a thread flag to be set
-    When thread A executes @a signal_set(ALL_SIGNALS) with all possible signals
-    Then thread B @a signal_wait status is osEventSignal indicating all wait signals was set
+    When thread A executes @a flags_set(ALL_SIGNALS) with all possible signals
+    Then thread B @a flags_wait_all_for return is ALL_SIGNALS indicating all wait signals was set
  */
 void test_wait_all(void)
 {
     Semaphore sem(0, 1);
 
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
-    t.start(callback(run_release_signal_wait<ALL_SIGNALS, osWaitForever, osEventSignal>, &sem));
+    t.start(callback(run_release_signal_wait<ALL_SIGNALS, osWaitForever, ALL_SIGNALS>, &sem));
 
     sem.acquire();
     TEST_ASSERT_EQUAL(Thread::WaitingThreadFlag, t.get_state());
 
-    t.signal_set(ALL_SIGNALS);
+    t.flags_set(ALL_SIGNALS);
     t.join();
 }
 
 /** Validate if signal_wait accumulate signals and return correctly when all signals set
 
     Given two threads A & B are started and B waiting for a thread signals to be set
-    When thread A executes @a signal_set setting all signals in loop
-    Then thread B @a signal_wait status is osEventSignal indicating that all wait signals was set
+    When thread A executes @a flags_set setting all signals in loop
+    Then thread B @a flags_wait_all_for return is ALL_SIGNALS indicating that all wait signals was set
  */
 void test_wait_all_loop(void)
 {
@@ -319,16 +318,16 @@ void test_wait_all_loop(void)
     Semaphore sem(0, 1);
 
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
-    t.start(callback(run_release_signal_wait<ALL_SIGNALS, osWaitForever, osEventSignal>, &sem));
+    t.start(callback(run_release_signal_wait<ALL_SIGNALS, osWaitForever, ALL_SIGNALS>, &sem));
 
     sem.acquire();
     TEST_ASSERT_EQUAL(Thread::WaitingThreadFlag, t.get_state());
 
     for (int i = 0; i < MAX_FLAG_POS; i++) {
         int32_t signal = 1 << i;
-        ret = t.signal_set(signal);
+        ret = t.flags_set(signal);
     }
-    ret = t.signal_set(1 << MAX_FLAG_POS);
+    ret = t.flags_set(1 << MAX_FLAG_POS);
     TEST_ASSERT_EQUAL(NO_SIGNALS, ret);
     t.join();
 }
@@ -336,9 +335,9 @@ void test_wait_all_loop(void)
 /** Validate if setting same signal twice cause any unwanted behaviour
 
     Given two threads A & B are started and B waiting for a thread signals to be set
-    When thread A executes @a signal_set twice for the same signal
-    Then thread A @a signal_set status is current signal set
-         thread B @a signal_wait status is osEventSignal indicating that all wait signals was set
+    When thread A executes @a flags_set twice for the same signal
+    Then thread A @a flags_set status is current signal set
+         thread B @a flags_wait_all_for return indicates that all wait signals was set
  */
 void test_set_double(void)
 {
@@ -346,22 +345,22 @@ void test_set_double(void)
     Semaphore sem(0, 1);
 
     Thread t(osPriorityNormal, TEST_STACK_SIZE);
-    t.start(callback(run_release_signal_wait < SIGNAL1 | SIGNAL2 | SIGNAL3, osWaitForever, osEventSignal >, &sem));
+    t.start(callback(run_release_signal_wait < SIGNAL1 | SIGNAL2 | SIGNAL3, osWaitForever, SIGNAL1 | SIGNAL2 | SIGNAL3 >, &sem));
 
     sem.acquire();
     TEST_ASSERT_EQUAL(Thread::WaitingThreadFlag, t.get_state());
 
-    ret = t.signal_set(SIGNAL1);
+    ret = t.flags_set(SIGNAL1);
     TEST_ASSERT_EQUAL(SIGNAL1, ret);
 
-    ret = t.signal_set(SIGNAL2);
+    ret = t.flags_set(SIGNAL2);
     TEST_ASSERT_EQUAL(SIGNAL1 | SIGNAL2, ret);
 
-    ret = t.signal_set(SIGNAL2);
+    ret = t.flags_set(SIGNAL2);
     TEST_ASSERT_EQUAL(SIGNAL1 | SIGNAL2, ret);
     TEST_ASSERT_EQUAL(Thread::WaitingThreadFlag, t.get_state());
 
-    ret = t.signal_set(SIGNAL3);
+    ret = t.flags_set(SIGNAL3);
     TEST_ASSERT_EQUAL(NO_SIGNALS, ret);
     t.join();
 }
@@ -374,20 +373,20 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 }
 
 Case cases[] = {
-    Case("Validate that call signal_clr(NO_SIGNALS) doesn't change thread signals and return actual signals", test_clear_no_signals),
-    Case("Validate if any signals are set on just created thread", test_init_state),
-    Case("Validate all signals set in one shot", test_set_all),
-    Case("Validate that call signal_set with prohibited signal doesn't change thread signals", test_set_prohibited),
-    Case("Validate all signals clear in one shot", test_clear_all),
-    Case("Validate all signals set one by one in loop", test_set_all_loop),
-    Case("Validate signal_wait return status if timeout specified: 0[ms] no signals", test_wait_timeout<0, 0, osOK>),
-    Case("Validate signal_wait return status if timeout specified: 0[ms] all signals", test_wait_timeout<ALL_SIGNALS, 0, osOK>),
-    Case("Validate signal_wait return status if timeout specified: 1[ms] no signals", test_wait_timeout<0, 1, osEventTimeout>),
-    Case("Validate signal_wait return status if timeout specified: 1[ms] all signals", test_wait_timeout<ALL_SIGNALS, 1, osEventTimeout>),
-    Case("Validate that call of signal_wait return correctly when thread has all signals already set", test_wait_all_already_set),
-    Case("Validate if signal_wait return correctly when all signals set", test_wait_all),
-    Case("Validate if signal_wait accumulate signals and return correctly when all signals set", test_wait_all_loop),
-    Case("Validate if setting same signal twice cause any unwanted behaviour", test_set_double)
+    Case("Validate that call flags_clear(NO_SIGNALS) doesn't change thread flags and return actual flags", test_clear_no_signals),
+    Case("Validate if any flags are set on just created thread", test_init_state),
+    Case("Validate all flags set in one shot", test_set_all),
+    Case("Validate that call flags_set with prohibited flag doesn't change thread flags", test_set_prohibited),
+    Case("Validate all flags clear in one shot", test_clear_all),
+    Case("Validate all flags set one by one in loop", test_set_all_loop),
+    Case("Validate flags_wait return status if timeout specified: 0[ms] no flags", test_wait_timeout<0, 0, 0>),
+    Case("Validate flags_wait return status if timeout specified: 0[ms] all flags", test_wait_timeout<ALL_SIGNALS, 0, 0>),
+    Case("Validate flags_wait return status if timeout specified: 1[ms] no flags", test_wait_timeout<0, 1, 0>),
+    Case("Validate flags_wait return status if timeout specified: 1[ms] all flags", test_wait_timeout<ALL_SIGNALS, 1, 0>),
+    Case("Validate that call of flags_wait_all_for return correctly when thread has all flags already set", test_wait_all_already_set),
+    Case("Validate if flags_wait_all_for return correctly when all flags set", test_wait_all),
+    Case("Validate if flags_wait_all_for accumulate flags and return correctly when all flags set", test_wait_all_loop),
+    Case("Validate if setting same flag twice cause any unwanted behaviour", test_set_double)
 };
 
 utest::v1::Specification specification(test_setup, cases);

--- a/UNITTESTS/stubs/Thread_stub.cpp
+++ b/UNITTESTS/stubs/Thread_stub.cpp
@@ -21,11 +21,6 @@ using namespace rtos;
 
 osStatus Thread_stub::osStatus_value = osOK;
 
-osStatus Thread::wait_until(uint64_t millisec)
-{
-    return 0;
-}
-
 osStatus Thread::terminate()
 {
     return 0;

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -171,19 +171,6 @@ public:
     */
     uint32_t flags_set(uint32_t flags);
 
-    /** Set the specified Thread Flags for the thread.
-      @param   signals  specifies the signal flags of the thread that should be set.
-      @return  signal flags after setting or osFlagsError in case of incorrect parameters.
-
-      @note You may call this function from ISR context.
-      @deprecated Other signal_xxx methods have been deprecated in favour of ThisThread::flags functions.
-                  To match this naming scheme, derived from CMSIS-RTOS2, Thread::flags_set is now provided.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Other signal_xxx methods have been deprecated in favour of ThisThread::flags functions. "
-                          "To match this naming scheme, derived from CMSIS-RTOS2, Thread::flags_set is now provided.")
-    int32_t signal_set(int32_t signals);
-
     /** State of the Thread */
     enum State {
         Inactive,           /**< NOT USED */
@@ -255,112 +242,6 @@ public:
       @note You may call this function from ISR context.
      */
     osThreadId_t get_id() const;
-
-    /** Clears the specified Thread Flags of the currently running thread.
-      @param   signals  specifies the signal flags of the thread that should be cleared.
-      @return  signal flags before clearing or osFlagsError in case of incorrect parameters.
-
-      @note You cannot call this function from ISR context.
-      @deprecated Static methods only affecting current thread cause confusion. Replaced by ThisThread::flags_clear.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods only affecting current thread cause confusion. "
-                          "Replaced by ThisThread::flags_clear.")
-    static int32_t signal_clr(int32_t signals);
-
-    /** Wait for one or more Thread Flags to become signaled for the current RUNNING thread.
-      @param   signals   wait until all specified signal flags are set or 0 for any single signal flag.
-      @param   millisec  timeout value. (default: osWaitForever).
-      @return  event flag information or error code. @note if @a millisec is set to 0 and flag is no set the event carries osOK value.
-
-      @note You cannot call this function from ISR context.
-      @deprecated Static methods only affecting current thread cause confusion.
-                  Replaced by ThisThread::flags_wait_all, ThisThread::flags_wait_all_for, ThisThread::flags_wait_any and ThisThread:wait_any_for.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods only affecting current thread cause confusion. "
-                          "Replaced by ThisThread::flags_wait_all, ThisThread::flags_wait_all_for, ThisThread::flags_wait_any and ThisThread:wait_any_for.")
-    static osEvent signal_wait(int32_t signals, uint32_t millisec = osWaitForever);
-
-    /** Wait for a specified time period in milliseconds
-      Being tick-based, the delay will be up to the specified time - eg for
-      a value of 1 the system waits until the next millisecond tick occurs,
-      leading to a delay of 0-1 milliseconds.
-      @param   millisec  time delay value
-      @return  status code that indicates the execution status of the function.
-
-      @note You cannot call this function from ISR context.
-      @deprecated Static methods only affecting current thread cause confusion. Replaced by ThisThread::sleep_for.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods only affecting current thread cause confusion. "
-                          "Replaced by ThisThread::sleep_for.")
-    static osStatus wait(uint32_t millisec);
-
-    /** Wait until a specified time in millisec
-      The specified time is according to Kernel::get_ms_count().
-      @param   millisec absolute time in millisec
-      @return  status code that indicates the execution status of the function.
-      @note not callable from interrupt
-      @note if millisec is equal to or lower than the current tick count, this
-            returns immediately, either with an error or "osOK".
-      @note the underlying RTOS may have a limit to the maximum wait time
-            due to internal 32-bit computations, but this is guaranteed to work if the
-            delay is <= 0x7fffffff milliseconds (~24 days). If the limit is exceeded,
-            it may return with an immediate error, or wait for the maximum delay.
-
-      @note You cannot call this function from ISR context.
-      @deprecated Static methods only affecting current thread cause confusion. Replaced by ThisThread::sleep_until.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods only affecting current thread cause confusion. "
-                          "Replaced by ThisThread::sleep_until.")
-    static osStatus wait_until(uint64_t millisec);
-
-    /** Pass control to next thread that is in state READY.
-      @return  status code that indicates the execution status of the function.
-
-      @note You cannot call this function from ISR context.
-      @deprecated Static methods only affecting current thread cause confusion. Replaced by ThisThread::sleep_until.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods only affecting current thread cause confusion. "
-                          "Replaced by ThisThread::yield.")
-    static osStatus yield();
-
-    /** Get the thread id of the current running thread.
-      @return  thread ID for reference by other functions or nullptr in case of error.
-
-      @note You may call this function from ISR context.
-      @deprecated Static methods only affecting current thread cause confusion. Replaced by ThisThread::get_id.
-                  Use Thread::get_id for the ID of a specific Thread.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods only affecting current thread cause confusion. "
-                          "Replaced by ThisThread::get_id. Use Thread::get_id for the ID of a specific Thread.")
-    static osThreadId gettid();
-
-    /** Attach a function to be called by the RTOS idle task
-      @param   fptr  pointer to the function to be called
-
-      @note You may call this function from ISR context.
-      @deprecated Static methods affecting system cause confusion. Replaced by Kernel::attach_idle_hook.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods affecting system cause confusion. "
-                          "Replaced by Kernel::attach_idle_hook.")
-    static void attach_idle_hook(void (*fptr)(void));
-
-    /** Attach a function to be called when a task is killed
-      @param   fptr  pointer to the function to be called
-
-      @note You may call this function from ISR context.
-      @deprecated Static methods affecting system cause confusion. Replaced by Kernel::attach_thread_terminate_hook.
-    */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10",
-                          "Static methods affecting system cause confusion. "
-                          "Replaced by Kernel::attach_thread_terminate_hook.")
-    static void attach_terminate_hook(void (*fptr)(osThreadId id));
 
     /** Thread destructor
      *

--- a/rtos/source/Thread.cpp
+++ b/rtos/source/Thread.cpp
@@ -175,11 +175,6 @@ uint32_t Thread::flags_set(uint32_t flags)
     return flags;
 }
 
-int32_t Thread::signal_set(int32_t flags)
-{
-    return osThreadFlagsSet(_tid, flags);
-}
-
 Thread::State Thread::get_state() const
 {
     uint8_t state = osThreadTerminated;
@@ -321,77 +316,6 @@ const char *Thread::get_name() const
 osThreadId_t Thread::get_id() const
 {
     return _tid;
-}
-
-int32_t Thread::signal_clr(int32_t flags)
-{
-    return osThreadFlagsClear(flags);
-}
-
-osEvent Thread::signal_wait(int32_t signals, uint32_t millisec)
-{
-    uint32_t res;
-    osEvent evt;
-    uint32_t options = osFlagsWaitAll;
-    if (signals == 0) {
-        options = osFlagsWaitAny;
-        signals = 0x7FFFFFFF;
-    }
-    res = osThreadFlagsWait(signals, options, millisec);
-    if (res & osFlagsError) {
-        switch (res) {
-            case osFlagsErrorISR:
-                evt.status = osErrorISR;
-                break;
-            case osFlagsErrorResource:
-                evt.status = osOK;
-                break;
-            case osFlagsErrorTimeout:
-                evt.status = (osStatus)osEventTimeout;
-                break;
-            case osFlagsErrorParameter:
-            default:
-                evt.status = (osStatus)osErrorValue;
-                break;
-        }
-    } else {
-        evt.status = (osStatus)osEventSignal;
-        evt.value.signals = res;
-    }
-
-    return evt;
-}
-
-osStatus Thread::wait(uint32_t millisec)
-{
-    ThisThread::sleep_for(millisec);
-    return osOK;
-}
-
-osStatus Thread::wait_until(uint64_t millisec)
-{
-    ThisThread::sleep_until(millisec);
-    return osOK;
-}
-
-osStatus Thread::yield()
-{
-    return osThreadYield();
-}
-
-osThreadId Thread::gettid()
-{
-    return osThreadGetId();
-}
-
-void Thread::attach_idle_hook(void (*fptr)(void))
-{
-    rtos_attach_idle_hook(fptr);
-}
-
-void Thread::attach_terminate_hook(void (*fptr)(osThreadId_t id))
-{
-    rtos_attach_thread_terminate_hook(fptr);
 }
 
 Thread::~Thread()


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Remove various `Thread` methods that were deprecated in Mbed OS 5.10

#### Impact of changes <!-- Optional -->

Code using the old methods will no longer compile

#### Migration actions required <!-- Optional -->

Uses of the following removed `Thread` methods need to be replaced:
* `Thread::signal_set` -> `Thread::flags_set`
* `Thread::signal_clr` -> `ThisThread::flags_clear`
* `Thread::signal_wait` -> `ThisThread::flags_wait_xxx`
* `Thread::wait` -> `ThisThread::sleep_for`
* `Thread::wait_until` -> `ThisThread::sleep_until`
* `Thread::yield` -> `ThisThread::yield`
* `Thread::gettid` -> `Thread::get_id` or `ThisThread::get_id`
* `Thread::attach_idle_hook` -> `Kernel::attach_idle_hook`
* `Thread::attach_terminate_hook` -> `Kernel::attach_thread_terminate_hook`


### Documentation <!-- Required -->

None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
