### PR TITLE
Blockdevice config changes to make it possible to run littlefs filesystem tests

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -23,6 +23,21 @@
 #include "drivers/SPI.h"
 #include "drivers/DigitalOut.h"
 
+#ifndef MBED_CONF_DATAFLASH_SPI_MOSI
+#define MBED_CONF_DATAFLASH_SPI_MOSI NC
+#endif
+#ifndef MBED_CONF_DATAFLASH_SPI_MISO
+#define MBED_CONF_DATAFLASH_SPI_MISO NC
+#endif
+#ifndef MBED_CONF_DATAFLASH_SPI_CLK
+#define MBED_CONF_DATAFLASH_SPI_CLK NC
+#endif
+#ifndef MBED_CONF_DATAFLASH_SPI_CS
+#define MBED_CONF_DATAFLASH_SPI_CS NC
+#endif
+#ifndef MBED_CONF_DATAFLASH_SPI_FREQ
+#define MBED_CONF_DATAFLASH_SPI_FREQ 40000000
+#endif
 
 /** BlockDevice for DataFlash flash devices
  *
@@ -72,13 +87,14 @@ public:
      *  @param csel     SPI chip select pin
      *  @param nowp     GPIO not-write-protect
      *  @param freq     Clock speed of the SPI bus (defaults to 40MHz)
+     *  @param nwp      Not-write-protected pin
      */
-    DataFlashBlockDevice(PinName mosi,
-                         PinName miso,
-                         PinName sclk,
-                         PinName csel,
+    DataFlashBlockDevice(PinName mosi = MBED_CONF_DATAFLASH_SPI_MOSI,
+                         PinName miso = MBED_CONF_DATAFLASH_SPI_MISO,
+                         PinName sclk = MBED_CONF_DATAFLASH_SPI_CLK,
+                         PinName csel = MBED_CONF_DATAFLASH_SPI_CS,
                          int freq = MBED_CONF_DATAFLASH_SPI_FREQ,
-                         PinName nowp = NC);
+                         PinName nwp = NC);
 
     /** Initialize a block device
      *

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -19,6 +19,31 @@
 #include "drivers/QSPI.h"
 #include "features/storage/blockdevice/BlockDevice.h"
 
+#ifndef MBED_CONF_QSPIF_QSPI_IO0
+#define MBED_CONF_QSPIF_QSPI_IO0 NC
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_IO1
+#define MBED_CONF_QSPIF_QSPI_IO1 NC
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_IO2
+#define MBED_CONF_QSPIF_QSPI_IO2 NC
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_IO3
+#define MBED_CONF_QSPIF_QSPI_IO3 NC
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_SCK
+#define MBED_CONF_QSPIF_QSPI_SCK NC
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_CSN
+#define MBED_CONF_QSPIF_QSPI_CSN NC
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_POLARITY_MODE
+#define MBED_CONF_QSPIF_QSPI_POLARITY_MODE 0
+#endif
+#ifndef MBED_CONF_QSPIF_QSPI_FREQ
+#define MBED_CONF_QSPIF_QSPI_FREQ 40000000
+#endif
+
 /** Enum qspif standard error codes
  *
  *  @enum qspif_bd_error
@@ -98,10 +123,15 @@ public:
      *  @param clock_mode specifies the QSPI Clock Polarity mode (QSPIF_POLARITY_MODE_0/QSPIF_POLARITY_MODE_1)
      *         default value = 0
      *  @param freq Clock frequency of the QSPI bus (defaults to 40MHz)
-     *
      */
-    QSPIFBlockDevice(PinName io0, PinName io1, PinName io2, PinName io3, PinName sclk, PinName csel,
-                     int clock_mode, int freq = MBED_CONF_QSPIF_QSPI_FREQ);
+    QSPIFBlockDevice(PinName io0 = MBED_CONF_QSPIF_QSPI_IO0,
+                     PinName io1 = MBED_CONF_QSPIF_QSPI_IO1,
+                     PinName io2 = MBED_CONF_QSPIF_QSPI_IO2,
+                     PinName io3 = MBED_CONF_QSPIF_QSPI_IO3,
+                     PinName sclk = MBED_CONF_QSPIF_QSPI_SCK,
+                     PinName csel = MBED_CONF_QSPIF_QSPI_CSN,
+                     int clock_mode = MBED_CONF_QSPIF_QSPI_POLARITY_MODE,
+                     int freq = MBED_CONF_QSPIF_QSPI_FREQ);
 
     /** Initialize a block device
      *

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
@@ -20,6 +20,22 @@
 #include "drivers/DigitalOut.h"
 #include "features/storage/blockdevice/BlockDevice.h"
 
+#ifndef MBED_CONF_RSPIF_DRIVER_SPI_MOSI
+#define MBED_CONF_RSPIF_DRIVER_SPI_MOSI NC
+#endif
+#ifndef MBED_CONF_RSPIF_DRIVER_SPI_MISO
+#define MBED_CONF_RSPIF_DRIVER_SPI_MISO NC
+#endif
+#ifndef MBED_CONF_RSPIF_DRIVER_SPI_CLK
+#define MBED_CONF_RSPIF_DRIVER_SPI_CLK NC
+#endif
+#ifndef MBED_CONF_RSPIF_DRIVER_SPI_CS
+#define MBED_CONF_RSPIF_DRIVER_SPI_CS NC
+#endif
+#ifndef MBED_CONF_RSPIF_DRIVER_SPI_FREQ
+#define MBED_CONF_RSPIF_DRIVER_SPI_FREQ 40000000
+#endif
+
 /** Reduced BlockDevice for SPI based flash devices
  *  *Should only be used by Boot Loader*
  *
@@ -66,7 +82,11 @@ public:
      *  @param csel     SPI chip select pin
      *  @param freq     Clock speed of the SPI bus (defaults to 40MHz)
      */
-    SPIFReducedBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName csel, int freq = 40000000);
+    SPIFReducedBlockDevice(PinName mosi = MBED_CONF_RSPIF_DRIVER_SPI_MOSI,
+                           PinName miso = MBED_CONF_RSPIF_DRIVER_SPI_MISO,
+                           PinName sclk = MBED_CONF_RSPIF_DRIVER_SPI_CLK,
+                           PinName csel = MBED_CONF_RSPIF_DRIVER_SPI_CS,
+                           int freq = MBED_CONF_RSPIF_DRIVER_SPI_FREQ);
 
     /** Initialize a block device
      *

--- a/components/storage/blockdevice/COMPONENT_RSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/mbed_lib.json
@@ -1,11 +1,11 @@
 {
   "name": "rspif-driver",
   "config": {
-    "SPI_MOSI": "NC",
-    "SPI_MISO": "NC",
-    "SPI_CLK":  "NC",
-    "SPI_CS":   "NC",
-    "SPI_FREQ": "40000000"
+    "SPI_MOSI": "SPI_MOSI",
+    "SPI_MISO": "SPI_MISO",
+    "SPI_CLK":  "SPI_SCK",
+    "SPI_CS":   "SPI_CS",
+    "SPI_FREQ":"40000000"
   },
   "target_overrides": {
     "K82F": {

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -29,6 +29,28 @@
 #include "platform/PlatformMutex.h"
 #include "hal/static_pinmap.h"
 
+#ifndef MBED_CONF_SD_SPI_MOSI
+#define MBED_CONF_SD_SPI_MOSI NC
+#endif
+#ifndef MBED_CONF_SD_SPI_MISO
+#define MBED_CONF_SD_SPI_MISO NC
+#endif
+#ifndef MBED_CONF_SD_SPI_CLK
+#define MBED_CONF_SD_SPI_CLK NC
+#endif
+#ifndef MBED_CONF_SD_SPI_CS
+#define MBED_CONF_SD_SPI_CS NC
+#endif
+#ifndef MBED_CONF_SD_INIT_FREQUENCY
+#define MBED_CONF_SD_INIT_FREQUENCY 100000
+#endif
+#ifndef MBED_CONF_SD_TRX_FREQUENCY
+#define MBED_CONF_SD_TRX_FREQUENCY  1000000
+#endif
+#ifndef MBED_CONF_SD_CRC_ENABLED
+#define MBED_CONF_SD_CRC_ENABLED 0
+#endif
+
 /** SDBlockDevice class
  *
  * Access an SD Card using SPI bus
@@ -44,7 +66,12 @@ public:
      *  @param hz       Clock speed of the SPI bus (defaults to 1MHz)
      *  @param crc_on   Enable cyclic redundancy check (defaults to disabled)
      */
-    SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz = 1000000, bool crc_on = 0);
+    SDBlockDevice(PinName mosi = MBED_CONF_SD_SPI_MOSI,
+                  PinName miso = MBED_CONF_SD_SPI_MISO,
+                  PinName sclk = MBED_CONF_SD_SPI_CLK,
+                  PinName cs = MBED_CONF_SD_SPI_CS,
+                  uint64_t hz = MBED_CONF_SD_TRX_FREQUENCY,
+                  bool crc_on = MBED_CONF_SD_CRC_ENABLED);
 
     /** Creates an SDBlockDevice on a SPI bus specified by pins (using static pin-map)
      *
@@ -52,7 +79,10 @@ public:
      *  @param hz         Clock speed of the SPI bus (defaults to 1MHz)
      *  @param crc_on     Enable cyclic redundancy check (defaults to disabled)
      */
-    SDBlockDevice(const spi_pinmap_t &spi_pinmap, PinName cs, uint64_t hz = 1000000, bool crc_on = 0);
+    SDBlockDevice(const spi_pinmap_t &spi_pinmap,
+                  PinName cs = MBED_CONF_SD_SPI_CS,
+                  uint64_t hz = MBED_CONF_SD_TRX_FREQUENCY,
+                  bool crc_on = MBED_CONF_SD_CRC_ENABLED);
 
     virtual ~SDBlockDevice();
 

--- a/components/storage/blockdevice/COMPONENT_SD/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/mbed_lib.json
@@ -9,7 +9,8 @@
         "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
         "INIT_FREQUENCY": 100000,
-        "CRC_ENABLED": 1,
+        "TRX_FREQUENCY": 1000000,
+        "CRC_ENABLED": 0,
         "TEST_BUFFER": 8192
     },
     "target_overrides": {

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -21,6 +21,22 @@
 #include "drivers/DigitalOut.h"
 #include "features/storage/blockdevice/BlockDevice.h"
 
+#ifndef MBED_CONF_SPIF_DRIVER_SPI_MOSI
+#define MBED_CONF_SPIF_DRIVER_SPI_MOSI NC
+#endif
+#ifndef MBED_CONF_SPIF_DRIVER_SPI_MISO
+#define MBED_CONF_SPIF_DRIVER_SPI_MISO NC
+#endif
+#ifndef MBED_CONF_SPIF_DRIVER_SPI_CLK
+#define MBED_CONF_SPIF_DRIVER_SPI_CLK NC
+#endif
+#ifndef MBED_CONF_SPIF_DRIVER_SPI_CS
+#define MBED_CONF_SPIF_DRIVER_SPI_CS NC
+#endif
+#ifndef MBED_CONF_SPIF_DRIVER_SPI_FREQ
+#define MBED_CONF_SPIF_DRIVER_SPI_FREQ 40000000
+#endif
+
 /** Enum spif standard error codes
  *
  *  @enum spif_bd_error
@@ -82,8 +98,14 @@ public:
      *  @param sclk     SPI clock pin
      *  @param csel     SPI chip select pin
      *  @param freq     Clock speed of the SPI bus (defaults to 40MHz)
+     *
+     *
      */
-    SPIFBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName csel, int freq = 40000000);
+    SPIFBlockDevice(PinName mosi = MBED_CONF_SPIF_DRIVER_SPI_MOSI,
+                    PinName miso = MBED_CONF_SPIF_DRIVER_SPI_MISO,
+                    PinName sclk = MBED_CONF_SPIF_DRIVER_SPI_CLK,
+                    PinName csel = MBED_CONF_SPIF_DRIVER_SPI_CS,
+                    int freq = MBED_CONF_SPIF_DRIVER_SPI_FREQ);
 
     /** Initialize a block device
      *

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -82,12 +82,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
 #elif COMPONENT_DATAFLASH
 
-    static DataFlashBlockDevice default_bd(
-        MBED_CONF_DATAFLASH_SPI_MOSI,
-        MBED_CONF_DATAFLASH_SPI_MISO,
-        MBED_CONF_DATAFLASH_SPI_CLK,
-        MBED_CONF_DATAFLASH_SPI_CS
-    );
+    static DataFlashBlockDevice default_bd;
 
     return &default_bd;
 

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -120,12 +120,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_SD_SPI_CS
     );
 #else
-    static SDBlockDevice default_bd(
-        MBED_CONF_SD_SPI_MOSI,
-        MBED_CONF_SD_SPI_MISO,
-        MBED_CONF_SD_SPI_CLK,
-        MBED_CONF_SD_SPI_CS
-    );
+    static SDBlockDevice default_bd;
 #endif
 
     return &default_bd;

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -70,13 +70,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
 #elif COMPONENT_RSPIF
 
-    static SPIFReducedBlockDevice default_bd(
-        MBED_CONF_RSPIF_DRIVER_SPI_MOSI,
-        MBED_CONF_RSPIF_DRIVER_SPI_MISO,
-        MBED_CONF_RSPIF_DRIVER_SPI_CLK,
-        MBED_CONF_RSPIF_DRIVER_SPI_CS,
-        MBED_CONF_RSPIF_DRIVER_SPI_FREQ
-    );
+    static SPIFReducedBlockDevice default_bd;
 
     return &default_bd;
 

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -64,13 +64,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 {
 #if COMPONENT_SPIF
 
-    static SPIFBlockDevice default_bd(
-        MBED_CONF_SPIF_DRIVER_SPI_MOSI,
-        MBED_CONF_SPIF_DRIVER_SPI_MISO,
-        MBED_CONF_SPIF_DRIVER_SPI_CLK,
-        MBED_CONF_SPIF_DRIVER_SPI_CS,
-        MBED_CONF_SPIF_DRIVER_SPI_FREQ
-    );
+    static SPIFBlockDevice default_bd;
 
     return &default_bd;
 

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -88,16 +88,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
 #elif COMPONENT_QSPIF
 
-    static QSPIFBlockDevice default_bd(
-        MBED_CONF_QSPIF_QSPI_IO0,
-        MBED_CONF_QSPIF_QSPI_IO1,
-        MBED_CONF_QSPIF_QSPI_IO2,
-        MBED_CONF_QSPIF_QSPI_IO3,
-        MBED_CONF_QSPIF_QSPI_SCK,
-        MBED_CONF_QSPIF_QSPI_CSN,
-        MBED_CONF_QSPIF_QSPI_POLARITY_MODE,
-        MBED_CONF_QSPIF_QSPI_FREQ
-    );
+    static QSPIFBlockDevice default_bd;
 
     return &default_bd;
 

--- a/tools/test_configs/QSPIFBlockDeviceAndHeapBlockDevice.json
+++ b/tools/test_configs/QSPIFBlockDeviceAndHeapBlockDevice.json
@@ -1,0 +1,19 @@
+{
+    "config": {
+        "sim-blockdevice": {
+            "help": "Simulated block device, requires sufficient heap",
+            "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",
+            "value": "HeapBlockDevice"
+        },
+        "test-blockdevice": {
+            "help": "Used blockdevice",
+            "macro_name": "MBED_TEST_BLOCKDEVICE",
+            "value": "QSPIFBlockDevice"
+        },
+        "test-filesystem": {
+            "help": "Used filesystem",
+            "macro_name": "MBED_TEST_FILESYSTEM",
+            "value": "LittleFileSystem"
+        }
+    }
+}

--- a/tools/test_configs/RSPIFBlockDeviceAndHeapBlockDevice.json
+++ b/tools/test_configs/RSPIFBlockDeviceAndHeapBlockDevice.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "sim-blockdevice": {
+            "help": "Simulated block device, requires sufficient heap",
+            "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",
+            "value": "HeapBlockDevice"
+        },
+        "test-blockdevice": {
+            "help": "Used blockdevice",
+            "macro_name": "MBED_TEST_BLOCKDEVICE",
+            "value": "SPIFReducedBlockDevice"
+        },
+        "test-filesystem": {
+            "help": "Used filesystem",
+            "macro_name": "MBED_TEST_FILESYSTEM",
+            "value": "LittleFileSystem"
+        }
+    },
+    "target_overrides": {
+        "NRF52840_DK": {
+            "target.components_remove": ["QSPI", "QSPIF"],
+            "target.components_add"   : ["SPI", "RSPIF"]
+        }
+    }
+}

--- a/tools/test_configs/SDBlockDeviceAndHeapBlockDevice.json
+++ b/tools/test_configs/SDBlockDeviceAndHeapBlockDevice.json
@@ -1,0 +1,19 @@
+{
+    "config": {
+        "sim-blockdevice": {
+            "help": "Simulated block device, requires sufficient heap",
+            "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",
+            "value": "HeapBlockDevice"
+        },
+        "test-blockdevice": {
+            "help": "Used blockdevice",
+            "macro_name": "MBED_TEST_BLOCKDEVICE",
+            "value": "SDBlockDevice"
+        },
+        "test-filesystem": {
+            "help": "Used filesystem",
+            "macro_name": "MBED_TEST_FILESYSTEM",
+            "value": "LittleFileSystem"
+        }
+    }
+}

--- a/tools/test_configs/SPIFBlockDeviceAndHeapBlockDevice.json
+++ b/tools/test_configs/SPIFBlockDeviceAndHeapBlockDevice.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "sim-blockdevice": {
+            "help": "Simulated block device, requires sufficient heap",
+            "macro_name": "MBED_TEST_SIM_BLOCKDEVICE",
+            "value": "HeapBlockDevice"
+        },
+        "test-blockdevice": {
+            "help": "Used blockdevice",
+            "macro_name": "MBED_TEST_BLOCKDEVICE",
+            "value": "SPIFBlockDevice"
+        },
+        "test-filesystem": {
+            "help": "Used filesystem",
+            "macro_name": "MBED_TEST_FILESYSTEM",
+            "value": "LittleFileSystem"
+        }
+    },
+    "target_overrides": {
+        "NRF52840_DK": {
+            "target.components_remove": ["QSPI", "QSPIF"],
+            "target.components_add"   : ["SPI", "SPIF"]
+        }
+    }
+}


### PR DESCRIPTION

### Summary of changes <!-- Required -->
Moves BlockDevice configurations used by SystemStorage as BlockDevice defaults. This makes it possible to use the defaults to execute littlefs filesystem tests.

Adds SPIF/QSPIF/SPIFReduced- and SDBlockDevice specific app configs for making it possible to run the forementioned tests.

#### Impact of changes <!-- Optional -->
none

#### Migration actions required <!-- Optional -->

### Documentation <!-- Required -->
Q/SPI based BlockDevice drivers have pins set by default

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR

#### SPIFBlockDevice
```
mbedgt: shuffle seed: 0.6225077270
mbedgt: test suite report:
| target              | platform_name | test suite                                                                           | result | elapsed_time (sec) | copy_method |
|---------------------|---------------|--------------------------------------------------------------------------------------|--------|--------------------|-------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 156.62             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 64.45              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 25.76              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 133.16             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 39.98              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 61.76              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 76.37              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 120.33             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 158.09             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 62.83              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 26.68              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 155.31             | default     |
mbedgt: test suite results: 12 OK
mbedgt: test case report:
| target              | platform_name | test suite                                                                           | test case                                                                            | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------|--------|--------|--------------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory creation                                                                   | 1      | 0      | OK     | 0.22               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory failures                                                                   | 1      | 0      | OK     | 0.1                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory iteration                                                                  | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory remove                                                                     | 1      | 0      | OK     | 17.85              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory rename                                                                     | 1      | 0      | OK     | 64.42              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory tests                                                                      | 1      | 0      | OK     | 0.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | File creation                                                                        | 1      | 0      | OK     | 0.16               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Multi-block directory                                                                | 1      | 0      | OK     | 48.68              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Nested directories                                                                   | 1      | 0      | OK     | 0.64               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Root directory                                                                       | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Dir check                                                                            | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | File tests                                                                           | 1      | 0      | OK     | 0.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Large file test                                                                      | 1      | 0      | OK     | 31.92              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Medium file test                                                                     | 1      | 0      | OK     | 1.35               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Non-overlap check                                                                    | 1      | 0      | OK     | 7.02               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Simple file test                                                                     | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Small file test                                                                      | 1      | 0      | OK     | 0.35               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel file test                                                                   | 1      | 0      | OK     | 1.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel remove file test                                                            | 1      | 0      | OK     | 0.73               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel tests                                                                       | 1      | 0      | OK     | 0.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Remove inconveniently test                                                           | 1      | 0      | OK     | 0.79               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Boundary seek and write                                                              | 1      | 0      | OK     | 4.74               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large dir seek                                                                       | 1      | 0      | OK     | 0.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek                                                                      | 1      | 0      | OK     | 0.19               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek and write                                                            | 1      | 0      | OK     | 1.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Out-of-bounds seek                                                                   | 1      | 0      | OK     | 1.12               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Seek tests                                                                           | 1      | 0      | OK     | 99.71              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple dir seek                                                                      | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek                                                                     | 1      | 0      | OK     | 0.16               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek and write                                                           | 1      | 0      | OK     | 1.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount                                                                       | 1      | 0      | OK     | 16.6               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount than reformat                                                         | 1      | 0      | OK     | 0.24               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test format                                                                          | 1      | 0      | OK     | 0.3                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test good mount than reformat                                                        | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test mount                                                                           | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | test resilience                                                                      | 1      | 0      | OK     | 37.32              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | 1      | 0      | OK     | 76.37              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | test wear leveling                                                                   | 1      | 0      | OK     | 95.74              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory creation                                                                   | 1      | 0      | OK     | 0.23               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory failures                                                                   | 1      | 0      | OK     | 0.09               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory iteration                                                                  | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory remove                                                                     | 1      | 0      | OK     | 17.87              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory rename                                                                     | 1      | 0      | OK     | 64.45              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory tests                                                                      | 1      | 0      | OK     | 0.3                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | File creation                                                                        | 1      | 0      | OK     | 0.16               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Multi-block directory                                                                | 1      | 0      | OK     | 49.33              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Nested directories                                                                   | 1      | 0      | OK     | 0.66               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Root directory                                                                       | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Dir check                                                                            | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | File tests                                                                           | 1      | 0      | OK     | 0.3                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Large file test                                                                      | 1      | 0      | OK     | 29.7               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Medium file test                                                                     | 1      | 0      | OK     | 1.25               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Non-overlap check                                                                    | 1      | 0      | OK     | 6.59               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Simple file test                                                                     | 1      | 0      | OK     | 0.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Small file test                                                                      | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel file test                                                                   | 1      | 0      | OK     | 1.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel remove file test                                                            | 1      | 0      | OK     | 0.73               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel tests                                                                       | 1      | 0      | OK     | 0.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Remove inconveniently test                                                           | 1      | 0      | OK     | 0.8                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Boundary seek and write                                                              | 1      | 0      | OK     | 2.51               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large dir seek                                                                       | 1      | 0      | OK     | 0.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large file seek                                                                      | 1      | 0      | OK     | 0.22               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large file seek and write                                                            | 1      | 0      | OK     | 1.35               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Out-of-bounds seek                                                                   | 1      | 0      | OK     | 1.3                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Seek tests                                                                           | 1      | 0      | OK     | 122.95             |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple dir seek                                                                      | 1      | 0      | OK     | 0.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple file seek                                                                     | 1      | 0      | OK     | 0.24               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple file seek and write                                                           | 1      | 0      | OK     | 1.19               |
mbedgt: test case results: 68 OK
mbedgt: completed in 1081.95 sec
```

#### QSPIFBlockDevice
```
mbedgt: shuffle seed: 0.8888232791
mbedgt: test suite report:
| target              | platform_name | test suite                                                                           | result | elapsed_time (sec) | copy_method |
|---------------------|---------------|--------------------------------------------------------------------------------------|--------|--------------------|-------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | OK     | 59.58              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK     | 38.38              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK     | 24.57              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK     | 67.45              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK     | 27.49              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK     | 62.11              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK     | 75.49              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK     | 120.06             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | OK     | 59.67              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK     | 34.93              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK     | 25.55              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK     | 76.08              | default     |
mbedgt: test suite results: 12 OK
mbedgt: test case report:
| target              | platform_name | test suite                                                                           | test case                                                                            | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------|--------|--------|--------------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory creation                                                                   | 1      | 0      | OK     | 0.15               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory failures                                                                   | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory iteration                                                                  | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory remove                                                                     | 1      | 0      | OK     | 2.91               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory rename                                                                     | 1      | 0      | OK     | 10.97              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory tests                                                                      | 1      | 0      | OK     | 0.19               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | File creation                                                                        | 1      | 0      | OK     | 0.12               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Multi-block directory                                                                | 1      | 0      | OK     | 20.09              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Nested directories                                                                   | 1      | 0      | OK     | 0.36               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Root directory                                                                       | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Dir check                                                                            | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | File tests                                                                           | 1      | 0      | OK     | 0.21               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Large file test                                                                      | 1      | 0      | OK     | 12.74              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Medium file test                                                                     | 1      | 0      | OK     | 0.6                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Non-overlap check                                                                    | 1      | 0      | OK     | 1.15               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Simple file test                                                                     | 1      | 0      | OK     | 0.22               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Small file test                                                                      | 1      | 0      | OK     | 0.21               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel file test                                                                   | 1      | 0      | OK     | 0.65               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel remove file test                                                            | 1      | 0      | OK     | 0.43               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel tests                                                                       | 1      | 0      | OK     | 0.21               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Remove inconveniently test                                                           | 1      | 0      | OK     | 0.45               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Boundary seek and write                                                              | 1      | 0      | OK     | 1.7                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large dir seek                                                                       | 1      | 0      | OK     | 0.12               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek                                                                      | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek and write                                                            | 1      | 0      | OK     | 0.42               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Out-of-bounds seek                                                                   | 1      | 0      | OK     | 0.36               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Seek tests                                                                           | 1      | 0      | OK     | 40.07              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple dir seek                                                                      | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek                                                                     | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek and write                                                           | 1      | 0      | OK     | 0.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount                                                                       | 1      | 0      | OK     | 4.24               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount than reformat                                                         | 1      | 0      | OK     | 0.22               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test format                                                                          | 1      | 0      | OK     | 0.21               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test good mount than reformat                                                        | 1      | 0      | OK     | 0.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test mount                                                                           | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | test resilience                                                                      | 1      | 0      | OK     | 37.47              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | 1      | 0      | OK     | 75.49              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | test wear leveling                                                                   | 1      | 0      | OK     | 95.51              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory creation                                                                   | 1      | 0      | OK     | 0.15               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory failures                                                                   | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory iteration                                                                  | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory remove                                                                     | 1      | 0      | OK     | 2.9                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory rename                                                                     | 1      | 0      | OK     | 10.96              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory tests                                                                      | 1      | 0      | OK     | 0.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | File creation                                                                        | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Multi-block directory                                                                | 1      | 0      | OK     | 19.79              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Nested directories                                                                   | 1      | 0      | OK     | 0.36               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Root directory                                                                       | 1      | 0      | OK     | 0.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Dir check                                                                            | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | File tests                                                                           | 1      | 0      | OK     | 0.21               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Large file test                                                                      | 1      | 0      | OK     | 9.0                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Medium file test                                                                     | 1      | 0      | OK     | 0.47               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Non-overlap check                                                                    | 1      | 0      | OK     | 0.76               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Simple file test                                                                     | 1      | 0      | OK     | 0.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Small file test                                                                      | 1      | 0      | OK     | 0.2                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel file test                                                                   | 1      | 0      | OK     | 0.72               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel remove file test                                                            | 1      | 0      | OK     | 0.42               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel tests                                                                       | 1      | 0      | OK     | 0.21               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Remove inconveniently test                                                           | 1      | 0      | OK     | 0.49               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Boundary seek and write                                                              | 1      | 0      | OK     | 0.91               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large dir seek                                                                       | 1      | 0      | OK     | 0.13               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large file seek                                                                      | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large file seek and write                                                            | 1      | 0      | OK     | 0.41               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Out-of-bounds seek                                                                   | 1      | 0      | OK     | 0.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Seek tests                                                                           | 1      | 0      | OK     | 48.54              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple dir seek                                                                      | 1      | 0      | OK     | 0.11               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple file seek                                                                     | 1      | 0      | OK     | 0.08               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple file seek and write                                                           | 1      | 0      | OK     | 0.4                |
mbedgt: test case results: 68 OK
mbedgt: completed in 674.49 sec
```

#### SDBlockDevice
```
mbedgt: shuffle seed: 0.6718887376
mbedgt: test suite report:
| target       | platform_name | test suite                                                                           | result  | elapsed_time (sec) | copy_method |
|--------------|---------------|--------------------------------------------------------------------------------------|---------|--------------------|-------------|
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | TIMEOUT | 497.41             | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK      | 408.24             | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK      | 30.29              | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK      | 231.89             | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK      | 19.96              | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK      | 39.53              | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK      | 74.95              | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK      | 277.48             | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | FAIL    | 17.94              | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK      | 408.29             | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | OK      | 26.13              | default     |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | OK      | 257.65             | default     |
mbedgt: test suite results: 1 FAIL / 10 OK / 1 TIMEOUT
mbedgt: test case report:
| target       | platform_name | test suite                                                                           | test case                                                                            | passed | failed | result  | elapsed_time (sec) |
|--------------|---------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------|--------|---------|--------------------|
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory creation                                                                   | 1      | 0      | OK      | 1.06               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory failures                                                                   | 1      | 0      | OK      | 1.37               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory iteration                                                                  | 1      | 0      | OK      | 0.33               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory remove                                                                     | 1      | 0      | OK      | 187.71             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory rename                                                                     | 0      | 0      | ERROR   | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Directory tests                                                                      | 1      | 0      | OK      | 0.46               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | File creation                                                                        | 1      | 0      | OK      | 1.05               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Multi-block directory                                                                | 1      | 0      | OK      | 95.04              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Nested directories                                                                   | 1      | 0      | OK      | 3.1                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | Root directory                                                                       | 1      | 0      | OK      | 0.29               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | Dir check                                                                            | 1      | 0      | OK      | 0.31               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | File tests                                                                           | 1      | 0      | OK      | 0.45               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | Large file test                                                                      | 1      | 0      | OK      | 225.75             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | Medium file test                                                                     | 1      | 0      | OK      | 5.62               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | Non-overlap check                                                                    | 1      | 0      | OK      | 155.36             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | Simple file test                                                                     | 1      | 0      | OK      | 1.4                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-files                          | Small file test                                                                      | 1      | 0      | OK      | 1.61               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel file test                                                                   | 1      | 0      | OK      | 3.25               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel remove file test                                                            | 1      | 0      | OK      | 2.25               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel tests                                                                       | 1      | 0      | OK      | 0.47               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Remove inconveniently test                                                           | 1      | 0      | OK      | 2.52               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Boundary seek and write                                                              | 1      | 0      | OK      | 19.6               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large dir seek                                                                       | 1      | 0      | OK      | 2.21               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek                                                                      | 1      | 0      | OK      | 1.01               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek and write                                                            | 1      | 0      | OK      | 15.24              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Out-of-bounds seek                                                                   | 1      | 0      | OK      | 15.0               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Seek tests                                                                           | 1      | 0      | OK      | 142.75             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple dir seek                                                                      | 1      | 0      | OK      | 0.64               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek                                                                     | 1      | 0      | OK      | 1.02               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek and write                                                           | 1      | 0      | OK      | 15.87              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount                                                                       | 1      | 0      | OK      | 0.33               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount than reformat                                                         | 1      | 0      | OK      | 0.79               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test format                                                                          | 1      | 0      | OK      | 0.46               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test good mount than reformat                                                        | 1      | 0      | OK      | 0.73               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test mount                                                                           | 1      | 0      | OK      | 0.18               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | test resilience                                                                      | 1      | 0      | OK      | 22.16              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | 1      | 0      | OK      | 74.95              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | test wear leveling                                                                   | 1      | 0      | OK      | 259.35             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory creation                                                                   | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory failures                                                                   | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory iteration                                                                  | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory remove                                                                     | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory rename                                                                     | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Directory tests                                                                      | 0      | 1      | FAIL    | 0.09               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | File creation                                                                        | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Multi-block directory                                                                | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Nested directories                                                                   | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | Root directory                                                                       | 0      | 0      | SKIPPED | 0.0                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Dir check                                                                            | 1      | 0      | OK      | 0.31               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | File tests                                                                           | 1      | 0      | OK      | 0.45               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Large file test                                                                      | 1      | 0      | OK      | 225.69             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Medium file test                                                                     | 1      | 0      | OK      | 5.59               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Non-overlap check                                                                    | 1      | 0      | OK      | 155.24             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Simple file test                                                                     | 1      | 0      | OK      | 1.38               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Small file test                                                                      | 1      | 0      | OK      | 1.6                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel file test                                                                   | 1      | 0      | OK      | 3.24               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel remove file test                                                            | 1      | 0      | OK      | 2.26               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Parallel tests                                                                       | 1      | 0      | OK      | 0.46               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | Remove inconveniently test                                                           | 1      | 0      | OK      | 2.48               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Boundary seek and write                                                              | 1      | 0      | OK      | 18.81              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large dir seek                                                                       | 1      | 0      | OK      | 2.2                |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large file seek                                                                      | 1      | 0      | OK      | 1.05               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Large file seek and write                                                            | 1      | 0      | OK      | 15.32              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Out-of-bounds seek                                                                   | 1      | 0      | OK      | 14.86              |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Seek tests                                                                           | 1      | 0      | OK      | 168.44             |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple dir seek                                                                      | 1      | 0      | OK      | 0.65               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple file seek                                                                     | 1      | 0      | OK      | 1.33               |
| K64F-GCC_ARM | K64F          | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | Simple file seek and write                                                           | 1      | 0      | OK      | 16.31              |
mbedgt: test case results: 1 FAIL / 9 SKIPPED / 57 OK / 1 ERROR
mbedgt: completed in 2293.58 sec
```

#### SPIFReducedBlockDevice
```
mbedgt: shuffle seed: 0.1523948239
mbedgt: test suite report:
| target              | platform_name | test suite                                                                           | result  | elapsed_time (sec) | copy_method |
|---------------------|---------------|--------------------------------------------------------------------------------------|---------|--------------------|-------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | TIMEOUT | 384.67             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | OK      | 59.53              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | OK      | 23.74              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | OK      | 122.02             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | OK      | 32.7               | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | OK      | 50.93              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | OK      | 81.09              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | OK      | 313.49             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | TIMEOUT | 384.05             | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | OK      | 58.87              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | TIMEOUT | 88.18              | default     |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | TIMEOUT | 508.43             | default     |
mbedgt: test suite results: 8 OK / 4 TIMEOUT
mbedgt: test case report:
| target              | platform_name | test suite                                                                           | test case                                                                            | passed | failed | result | elapsed_time (sec) |
|---------------------|---------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------|--------|--------|--------------------|
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | features-storage-filesystem-littlefs-tests-filesystem-dirs                           | 0      | 1      | ERROR  | 384.67             |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Dir check                                                                            | 1      | 0      | OK     | 0.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | File tests                                                                           | 1      | 0      | OK     | 0.28               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Large file test                                                                      | 1      | 0      | OK     | 27.95              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Medium file test                                                                     | 1      | 0      | OK     | 1.24               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Non-overlap check                                                                    | 1      | 0      | OK     | 7.04               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Simple file test                                                                     | 1      | 0      | OK     | 0.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-files                          | Small file test                                                                      | 1      | 0      | OK     | 0.34               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel file test                                                                   | 1      | 0      | OK     | 1.17               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel remove file test                                                            | 1      | 0      | OK     | 0.72               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Parallel tests                                                                       | 1      | 0      | OK     | 0.32               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-interspersed                   | Remove inconveniently test                                                           | 1      | 0      | OK     | 0.79               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Boundary seek and write                                                              | 1      | 0      | OK     | 4.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large dir seek                                                                       | 1      | 0      | OK     | 0.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek                                                                      | 1      | 0      | OK     | 0.18               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Large file seek and write                                                            | 1      | 0      | OK     | 1.28               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Out-of-bounds seek                                                                   | 1      | 0      | OK     | 1.05               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Seek tests                                                                           | 1      | 0      | OK     | 90.94              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple dir seek                                                                      | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek                                                                     | 1      | 0      | OK     | 0.15               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem-seek                           | Simple file seek and write                                                           | 1      | 0      | OK     | 1.06               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount                                                                       | 1      | 0      | OK     | 8.4                |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test bad mount than reformat                                                         | 1      | 0      | OK     | 0.24               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test format                                                                          | 1      | 0      | OK     | 0.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test good mount than reformat                                                        | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_integration-format             | Test mount                                                                           | 1      | 0      | OK     | 0.07               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience            | test resilience                                                                      | 1      | 0      | OK     | 26.6               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | features-storage-filesystem-littlefs-tests-filesystem_recovery-resilience_functional | 1      | 0      | OK     | 81.09              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_recovery-wear_leveling         | test wear leveling                                                                   | 1      | 0      | OK     | 70.31              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | features-storage-filesystem-littlefs-tests-filesystem_retarget-dirs                  | 0      | 1      | ERROR  | 384.05             |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Dir check                                                                            | 1      | 0      | OK     | 0.04               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | File tests                                                                           | 1      | 0      | OK     | 0.31               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Large file test                                                                      | 1      | 0      | OK     | 28.11              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Medium file test                                                                     | 1      | 0      | OK     | 1.22               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Non-overlap check                                                                    | 1      | 0      | OK     | 6.61               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Simple file test                                                                     | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-files                 | Small file test                                                                      | 1      | 0      | OK     | 0.33               |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | features-storage-filesystem-littlefs-tests-filesystem_retarget-interspersed          | 0      | 1      | ERROR  | 88.18              |
| NRF52840_DK-GCC_ARM | NRF52840_DK   | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | features-storage-filesystem-littlefs-tests-filesystem_retarget-seek                  | 0      | 1      | ERROR  | 508.43             |
mbedgt: test case results: 35 OK / 4 ERROR
```    
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@SeppoTakalo 

----------------------------------------------------------------------------------------------------------------
