### PR TITLE
Fixed possible double deletion of SecurityManager database object

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
@@ -138,10 +138,10 @@ ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::setData
 template<template<class> class TPalSecurityManager, template<class> class SigningMonitor>
 ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::reset_(void) {
 
-	delete _db; // Close the database
-	_db = NULL;
+    delete _db; // Close the database
+    _db = NULL;
 
-	_pal.reset();
+    _pal.reset();
     SecurityManager::reset_();
 
     return BLE_ERROR_NONE;
@@ -213,8 +213,8 @@ ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::request
 
     initiator_distribution.set_signing(
         cb->signing_override_default ?
-            cb->signing_requested :
-            _default_key_distribution.get_signing()
+                cb->signing_requested :
+                _default_key_distribution.get_signing()
     );
 
     /* if requested the initiator may send all the default keys for later
@@ -836,12 +836,6 @@ template<template<class> class TPalSecurityManager, template<class> class Signin
 ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::init_database(
     const char *db_path
 ) {
-	// Close the old database if it still exists
-	if(_db != NULL) {
-		delete _db;
-		_db = NULL;
-	}
-
     FILE* db_file = FileSecurityDb::open_db_file(db_path);
 
     if (db_file) {
@@ -1139,8 +1133,8 @@ void GenericSecurityManager<TPalSecurityManager, SigningMonitor>::on_connected_(
 
 #if BLE_FEATURE_SIGNING
     const bool signing = cb->signing_override_default ?
-	                         cb->signing_requested :
-	                         _default_key_distribution.get_signing();
+                    cb->signing_requested :
+                    _default_key_distribution.get_signing();
 
     if (signing && flags->csrk_stored) {
         _db->get_entry_peer_csrk(
@@ -1333,8 +1327,8 @@ void GenericSecurityManager<TPalSecurityManager, SigningMonitor>::on_signed_writ
     }
 
     const bool signing = cb->signing_override_default ?
-	                         cb->signing_requested :
-	                         _default_key_distribution.get_signing();
+                    cb->signing_requested :
+                    _default_key_distribution.get_signing();
 
     if (signing) {
         cb->csrk_failures++;

--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.tpp
@@ -137,8 +137,11 @@ ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::setData
 
 template<template<class> class TPalSecurityManager, template<class> class SigningMonitor>
 ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::reset_(void) {
-    delete _db;
-    _pal.reset();
+
+	delete _db; // Close the database
+	_db = NULL;
+
+	_pal.reset();
     SecurityManager::reset_();
 
     return BLE_ERROR_NONE;
@@ -833,7 +836,11 @@ template<template<class> class TPalSecurityManager, template<class> class Signin
 ble_error_t GenericSecurityManager<TPalSecurityManager, SigningMonitor>::init_database(
     const char *db_path
 ) {
-    delete _db;
+	// Close the old database if it still exists
+	if(_db != NULL) {
+		delete _db;
+		_db = NULL;
+	}
 
     FILE* db_file = FileSecurityDb::open_db_file(db_path);
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Fixing possible scenario where dynamically-allocated SecurityManager database object could be deleted multiple times, possibly causing stack corruption and subsequent hard faults.

Related to issue #11768 and MR #11831 

Calling `SecurityManager::reset` now checks to see if the database object has already been deleted before attempting to delete it.

Subsequently, when reinitialized, the call to `SecurityManager::init_database` also tries to delete the database object without checking if it's NULL.

I'm not sure why deleting the database object in reset and then reinitializing it allows the file to be flushed to non-volatile storage (see #11768 ), while deleting it in the `init_database` call and then reinitializing it does not appear to flush the database to disk first...

However, this patch fixes both issues for me. 

I think we need need to refactor the SecurityManager to address this issue from an architectural standpoint very soon.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Related to issue #11768 and MR #11831 

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@paul-szczepanek-arm 

----------------------------------------------------------------------------------------------------------------
