### PR TITLE
NRF5x: Fix baremetal linker error

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_11/libraries/util/nrf_assert.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_11/libraries/util/nrf_assert.c
@@ -40,7 +40,8 @@
 #include "app_error.h"
 #include "nordic_common.h"
 
-#if defined(DEBUG_NRF)
+#if !MBED_CONF_BLE_PRESENT
+#if defined(DEBUG_NRF) || defined(DEBUG_NRF_USER)
 void assert_nrf_callback(uint16_t line_num, const uint8_t * file_name)
 {
     assert_info_t assert_info =
@@ -52,4 +53,5 @@ void assert_nrf_callback(uint16_t line_num, const uint8_t * file_name)
 
     UNUSED_VARIABLE(assert_info);
 }
-#endif /* DEBUG_NRF */
+#endif /* defined(DEBUG_NRF) || defined(DEBUG_NRF_USER) */
+#endif // !MBED_CONF_BLE_PRESENT


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
`DEBUG_NRF_USER` gets defined for build profiles (develop, debug)
which do not define `NDEBUG` (see `nrf_assert.h`). Therefore the definition
of the function should be visible if `DEBUG_NRF_USER` is defined.
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
It is now possible to build NRF5x targets with the baremetal profile using the debug and develop build profiles.
i.e It is now possible to build `mbed-os-example-blinky-baremetal` with `$ mbed compile -t <TOOLCHAIN> -m NRF51_DONGLE`

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@pan- 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
