### PR TITLE
Updated 113 targets with missing detect_codes

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -206,7 +206,10 @@
         "supported_toolchains": [
             "uARM"
         ],
-        "default_lib": "small"
+        "default_lib": "small",
+        "detect_code": [
+            "9992"
+        ]
     },
     "CM4_ARM": {
         "inherits": [
@@ -216,6 +219,9 @@
         "public": false,
         "supported_toolchains": [
             "ARM"
+        ],
+        "detect_code": [
+            "9993"
         ]
     },
     "CM4F_UARM": {
@@ -228,7 +234,10 @@
         "supported_toolchains": [
             "uARM"
         ],
-        "default_lib": "small"
+        "default_lib": "small",
+        "detect_code": [
+            "9990"
+        ]
     },
     "CM4F_ARM": {
         "inherits": [
@@ -238,6 +247,9 @@
         "public": false,
         "supported_toolchains": [
             "ARM"
+        ],
+        "detect_code": [
+            "9991"
         ]
     },
     "LPCTarget": {
@@ -328,7 +340,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC1114FN28/102"
+        "device_name": "LPC1114FN28/102",
+        "detect_code": [
+            "1114"
+        ]
     },
     "LPC11U24": {
         "inherits": [
@@ -412,6 +427,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "1080"
         ]
     },
     "LPC11U24_301": {
@@ -502,7 +520,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC11U34FBD48/311"
+        "device_name": "LPC11U34FBD48/311",
+        "detect_code": [
+            "1034"
+        ]
     },
     "LPC11U35_401": {
         "inherits": [
@@ -547,7 +568,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC11U35FBD48/401"
+        "device_name": "LPC11U35FBD48/401",
+        "detect_code": [
+            "1061"
+        ]
     },
     "MCU_LPC11U35_501": {
         "inherits": [
@@ -593,6 +617,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "9007"
         ]
     },
     "LPC11U35_501_IBDAP": {
@@ -609,6 +636,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "9008"
         ]
     },
     "LPC11U35_Y5_MBUG": {
@@ -617,6 +647,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "4000"
         ]
     },
     "LPC11U37_501": {
@@ -704,7 +737,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC11U37FBD64/501"
+        "device_name": "LPC11U37FBD64/501",
+        "detect_code": [
+            "9010"
+        ]
     },
     "LPC11U68": {
         "supported_form_factors": [
@@ -779,7 +815,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC1347FBD48"
+        "device_name": "LPC1347FBD48",
+        "detect_code": [
+            "9003"
+        ]
     },
     "LPC1549": {
         "supported_form_factors": [
@@ -949,7 +988,10 @@
         "bootloader_supported": true,
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "detect_code": [
+            "9004"
+        ]
     },
     "UBLOX_C027": {
         "supported_form_factors": [
@@ -1009,7 +1051,10 @@
         "bootloader_supported": true,
         "overrides": {
             "network-default-interface-type": "CELLULAR"
-        }
+        },
+        "detect_code": [
+            "1235"
+        ]
     },
     "XBED_LPC1768": {
         "inherits": [
@@ -1089,7 +1134,10 @@
             "SPISLAVE"
         ],
         "default_lib": "small",
-        "device_name": "LPC810M021FN8"
+        "device_name": "LPC810M021FN8",
+        "detect_code": [
+            "1020"
+        ]
     },
     "LPC812": {
         "supported_form_factors": [
@@ -1164,7 +1212,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC824M201JDH20"
+        "device_name": "LPC824M201JDH20",
+        "detect_code": [
+            "0824"
+        ]
     },
     "SSCI824": {
         "inherits": [
@@ -1195,6 +1246,9 @@
         "default_lib": "small",
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "1018"
         ]
     },
     "MCU_LPC4088": {
@@ -1250,6 +1304,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "1060"
         ]
     },
     "LPC4088_DM": {
@@ -1259,6 +1316,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "1062"
         ]
     },
     "LPC4330_M4": {
@@ -1295,7 +1355,10 @@
             "STDIO_MESSAGES",
             "MPU"
         ],
-        "device_name": "LPC4330"
+        "device_name": "LPC4330",
+        "detect_code": [
+            "1605"
+        ]
     },
     "LPC4330_M0": {
         "inherits": [
@@ -1365,7 +1428,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "LPC4337"
+        "device_name": "LPC4337",
+        "detect_code": [
+            "4337"
+        ]
     },
     "LPC1800": {
         "inherits": [
@@ -1488,7 +1554,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "MKL05Z32xxx4"
+        "device_name": "MKL05Z32xxx4",
+        "detect_code": [
+            "0210"
+        ]
     },
     "KL25Z": {
         "supported_form_factors": [
@@ -1779,6 +1848,9 @@
         ],
         "extra_labels_add": [
             "FRDM"
+        ],
+        "detect_code": [
+            "0231"
         ]
     },
     "KL27Z": {
@@ -2387,7 +2459,10 @@
             "STDIO_MESSAGES",
             "FLASH"
         ],
-        "device_name": "MK64FN1M0xxx12"
+        "device_name": "MK64FN1M0xxx12",
+        "detect_code": [
+            "0300"
+        ]
     },
     "HEXIWEAR": {
         "inherits": [
@@ -3115,7 +3190,10 @@
             "init-us-ticker-at-boot": true
         },
         "OUTPUT_EXT": "hex",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0236"
+        ]
     },
     "LPC55S69_S": {
         "inherits": [
@@ -3157,12 +3235,20 @@
             "secure-ram-start": "0x30000000",
             "secure-ram-size": "0x22000"
         }
-    },    
+    },
     "HANI_IOT": {
-        "inherits": ["LPC55S69_NS"],
-        "detect_code": ["0360"],
-        "components_add": ["SPIF"],
-        "extra_labels_remove": ["LPCXpresso"]
+        "inherits": [
+            "LPC55S69_NS"
+        ],
+        "detect_code": [
+            "0360"
+        ],
+        "components_add": [
+            "SPIF"
+        ],
+        "extra_labels_remove": [
+            "LPCXpresso"
+        ]
     },
     "NUCLEO_F030R8": {
         "inherits": [
@@ -3942,7 +4028,10 @@
         },
         "overrides": {
             "network-default-interface-type": "WIFI"
-        }
+        },
+        "detect_code": [
+            "0451"
+        ]
     },
     "USI_WM_BN_BM_22": {
         "inherits": [
@@ -4008,6 +4097,9 @@
         ],
         "inherits": [
             "USI_WM_BN_BM_22"
+        ],
+        "detect_code": [
+            "0462"
         ]
     },
     "MTB_ADV_WISE_1530": {
@@ -4022,7 +4114,10 @@
         "overrides": {
             "stdio_uart_tx": "PB_10",
             "stdio_uart_rx": "PC_11"
-        }
+        },
+        "detect_code": [
+            "0459"
+        ]
     },
     "DISCO_F413ZH": {
         "components_add": [
@@ -5642,7 +5737,10 @@
         "overrides": {
             "lse_available": 0,
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "detect_code": [
+            "9011"
+        ]
     },
     "WIO_3G": {
         "inherits": [
@@ -5834,7 +5932,10 @@
         "device_has_remove": [
             "LPTICKER"
         ],
-        "device_name": "STM32F303VC"
+        "device_name": "STM32F303VC",
+        "detect_code": [
+            "0746"
+        ]
     },
     "DISCO_F334C8": {
         "inherits": [
@@ -5909,7 +6010,10 @@
             "2",
             "5"
         ],
-        "device_name": "STM32F407VG"
+        "device_name": "STM32F407VG",
+        "detect_code": [
+            "0830"
+        ]
     },
     "OLIMEX_STM32E407_F407ZG": {
         "inherits": [
@@ -5993,7 +6097,10 @@
             "5"
         ],
         "device_name": "STM32F429ZI",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0795"
+        ]
     },
     "DISCO_F469NI": {
         "components_add": [
@@ -6128,7 +6235,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "STM32L053C8"
+        "device_name": "STM32L053C8",
+        "detect_code": [
+            "0805"
+        ]
     },
     "DISCO_L072CZ_LRWAN1": {
         "inherits": [
@@ -6582,7 +6692,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "STM32F405RG"
+        "device_name": "STM32F405RG",
+        "detect_code": [
+            "0305"
+        ]
     },
     "MTS_MDOT_F411RE": {
         "inherits": [
@@ -6617,7 +6730,10 @@
             "2",
             "5"
         ],
-        "device_name": "STM32F411RE"
+        "device_name": "STM32F411RE",
+        "detect_code": [
+            "0320"
+        ]
     },
     "MTS_DRAGONFLY_F411RE": {
         "inherits": [
@@ -6659,7 +6775,10 @@
             "5"
         ],
         "device_name": "STM32F411RE",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0454"
+        ]
     },
     "MTS_DRAGONFLY_F413RH": {
         "inherits": [
@@ -6807,7 +6926,10 @@
             "5"
         ],
         "device_name": "STM32F411RE",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0454"
+        ]
     },
     "XDOT_L151CC": {
         "inherits": [
@@ -6842,7 +6964,10 @@
             "5"
         ],
         "device_name": "STM32L151CC",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0350"
+        ]
     },
     "FF1705_L151CC": {
         "inherits": [
@@ -6889,7 +7014,10 @@
             "5"
         ],
         "device_name": "STM32L151CC",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0453"
+        ]
     },
     "MTB_RAK811": {
         "inherits": [
@@ -6918,7 +7046,10 @@
             "5"
         ],
         "device_name": "STM32L151CBxxA",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0457"
+        ]
     },
     "MOTE_L152RC": {
         "inherits": [
@@ -7063,7 +7194,10 @@
         "overrides": {
             "stdio_uart_tx": "D8",
             "stdio_uart_rx": "D2"
-        }
+        },
+        "detect_code": [
+            "1236"
+        ]
     },
     "MBED_CONNECT_ODIN": {
         "inherits": [
@@ -7083,7 +7217,10 @@
         "overrides": {
             "stdio_uart_tx": "PA_9",
             "stdio_uart_rx": "PA_10"
-        }
+        },
+        "detect_code": [
+            "2410"
+        ]
     },
     "MTB_UBLOX_ODIN_W2": {
         "inherits": [
@@ -7094,6 +7231,9 @@
         },
         "release_versions": [
             "5"
+        ],
+        "detect_code": [
+            "0450"
         ]
     },
     "OKDO_ODIN_W2": {
@@ -7106,6 +7246,9 @@
         },
         "release_versions": [
             "5"
+        ],
+        "detect_code": [
+            "1280"
         ]
     },
     "UBLOX_C030": {
@@ -7161,6 +7304,9 @@
         "macros_add": [
             "UBX_MDM_SARA_U2XX",
             "UBX_MDM_SARA_U201"
+        ],
+        "detect_code": [
+            "C030"
         ]
     },
     "UBLOX_C030_N211": {
@@ -7173,6 +7319,9 @@
         "macros_add": [
             "UBX_MDM_SARA_N2XX",
             "UBX_MDM_SARA_N211"
+        ],
+        "detect_code": [
+            "C031"
         ]
     },
     "UBLOX_C030_R41XM": {
@@ -7206,6 +7355,9 @@
         "macros_add": [
             "UBX_MDM_SARA_R41XM",
             "UBX_MDM_SARA_R412M"
+        ],
+        "detect_code": [
+            "C036"
         ]
     },
     "NZ32_SC151": {
@@ -7320,8 +7472,8 @@
             "USTICKER"
         ],
         "overrides": {
-            "tickless-from-us-ticker"   : true,
-            "boot-stack-size"           : "0x400"
+            "tickless-from-us-ticker": true,
+            "boot-stack-size": "0x400"
         }
     },
     "MCU_NRF51_16K_BASE": {
@@ -7501,7 +7653,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "1070"
+        ]
     },
     "NRF51822_BOOT": {
         "inherits": [
@@ -7525,6 +7680,9 @@
         ],
         "macros_add": [
             "TARGET_NRF51822_MKIT"
+        ],
+        "detect_code": [
+            "1075"
         ]
     },
     "ARCH_BLE": {
@@ -7537,7 +7695,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "9009"
+        ]
     },
     "ARCH_BLE_BOOT": {
         "supported_form_factors": [
@@ -7579,6 +7740,9 @@
         ],
         "macros_add": [
             "TARGET_ARCH_BLE"
+        ],
+        "detect_code": [
+            "9013"
         ]
     },
     "ARCH_LINK_BOOT": {
@@ -7620,7 +7784,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "9012"
+        ]
     },
     "SEEED_TINY_BLE_BOOT": {
         "inherits": [
@@ -7654,7 +7821,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "1017"
+        ]
     },
     "HRM1017_BOOT": {
         "inherits": [
@@ -7690,7 +7860,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "1090"
+        ]
     },
     "RBLAB_NRF51822_BOOT": {
         "supported_form_factors": [
@@ -7726,6 +7899,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "1095"
         ]
     },
     "RBLAB_BLENANO_BOOT": {
@@ -7774,11 +7950,17 @@
             "NRF52_PAN_62",
             "NRF52_PAN_63",
             "NRF52_PAN_64"
+        ],
+        "detect_code": [
+            "1093"
         ]
     },
     "NRF51822_Y5_MBUG": {
         "inherits": [
             "MCU_NRF51_16K"
+        ],
+        "detect_code": [
+            "4005"
         ]
     },
     "WALLBOT_BLE": {
@@ -7787,6 +7969,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "1140"
         ]
     },
     "WALLBOT_BLE_BOOT": {
@@ -7836,7 +8021,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "4500"
+        ]
     },
     "DELTA_DFCM_NNN40_BOOT": {
         "inherits": [
@@ -7890,7 +8078,10 @@
             "SPI_ASYNCH",
             "SPISLAVE"
         ],
-        "device_name": "nRF51822_xxAC"
+        "device_name": "nRF51822_xxAC",
+        "detect_code": [
+            "4502"
+        ]
     },
     "DELTA_DFCM_NNN50_BOOT": {
         "supported_form_factors": [
@@ -7957,6 +8148,9 @@
         ],
         "macros_add": [
             "TARGET_NRF51_DK"
+        ],
+        "detect_code": [
+            "1105"
         ]
     },
     "NRF51_DONGLE_LEGACY": {
@@ -8007,6 +8201,9 @@
         "supported_toolchains": [
             "ARMC5",
             "GCC_ARM"
+        ],
+        "detect_code": [
+            "9900"
         ]
     },
     "NRF51_MICROBIT_BOOT": {
@@ -8079,7 +8276,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "C005"
+        ]
     },
     "MTM_MTCONNECT04S_BOOT": {
         "inherits": [
@@ -8150,7 +8350,10 @@
         },
         "overrides": {
             "uart_hwfc": 0
-        }
+        },
+        "detect_code": [
+            "0452"
+        ]
     },
     "TY51822R3": {
         "inherits": [
@@ -8501,6 +8704,9 @@
         ],
         "release_versions": [
             "2"
+        ],
+        "detect_code": [
+            "5001"
         ]
     },
     "ARM_CM3DS_MPS2": {
@@ -8550,7 +8756,10 @@
         "reset_method": "reboot.txt",
         "overrides": {
             "target.network-default-interface-type": "ETHERNET"
-        }
+        },
+        "detect_code": [
+            "5004"
+        ]
     },
     "ARM_MUSCA_A1": {
         "public": false,
@@ -8716,9 +8925,17 @@
         ],
         "device_name": "R7S72100",
         "bootloader_supported": true,
-        "mbed_rom_start"        : "0x18000000",
-        "mbed_rom_size"         : "0x800000",
-        "sectors": [[402653184,4096]]
+        "mbed_rom_start": "0x18000000",
+        "mbed_rom_size": "0x800000",
+        "sectors": [
+            [
+                402653184,
+                4096
+            ]
+        ],
+        "detect_code": [
+            "5500"
+        ]
     },
     "VK_RZ_A1H": {
         "inherits": [
@@ -8735,6 +8952,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "C002"
         ]
     },
     "GR_LYCHEE": {
@@ -8767,12 +8987,20 @@
         ],
         "device_name": "R7S72103",
         "bootloader_supported": true,
-        "mbed_rom_start"        : "0x18000000",
-        "mbed_rom_size"         : "0x800000",
-        "sectors": [[402653184,4096]],
+        "mbed_rom_start": "0x18000000",
+        "mbed_rom_size": "0x800000",
+        "sectors": [
+            [
+                402653184,
+                4096
+            ]
+        ],
         "overrides": {
             "network-default-interface-type": null
-        }
+        },
+        "detect_code": [
+            "5501"
+        ]
     },
     "MAXWSNENV": {
         "inherits": [
@@ -8809,7 +9037,10 @@
         "features": [
             "BLE"
         ],
-        "release_versions": []
+        "release_versions": [],
+        "detect_code": [
+            "0400"
+        ]
     },
     "MAX32600MBED": {
         "inherits": [
@@ -8847,6 +9078,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "0405"
         ]
     },
     "MAX32620HSP": {
@@ -8881,7 +9115,10 @@
         "features": [
             "BLE"
         ],
-        "release_versions": []
+        "release_versions": [],
+        "detect_code": [
+            "0407"
+        ]
     },
     "MAX32620FTHR": {
         "inherits": [
@@ -8923,6 +9160,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "0418"
         ]
     },
     "SDT32620B": {
@@ -9019,6 +9259,9 @@
         ],
         "extra_labels_add": [
             "MAX32625_NO_BOOT"
+        ],
+        "detect_code": [
+            "0415"
         ]
     },
     "SDT32625B": {
@@ -9039,11 +9282,17 @@
         "extra_labels_add": [
             "MAX32625_BOOT"
         ],
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "detect_code": [
+            "0444"
+        ]
     },
     "MAX32625NEXPAQ": {
         "inherits": [
             "MAX32625_BASE"
+        ],
+        "detect_code": [
+            "0408"
         ]
     },
     "MAX32630FTHR": {
@@ -9090,6 +9339,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "0409"
         ]
     },
     "EFM32": {
@@ -9206,7 +9458,10 @@
                 "value": "PF7",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2015"
+        ]
     },
     "EFM32LG990F256": {
         "inherits": [
@@ -9304,7 +9559,10 @@
                 "value": "PF7",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2020"
+        ]
     },
     "EFM32WG990F256": {
         "inherits": [
@@ -9404,7 +9662,10 @@
                 "value": "PF7",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2010"
+        ]
     },
     "EFM32ZG222F32": {
         "inherits": [
@@ -9496,7 +9757,10 @@
                 "value": "PA9",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2030"
+        ]
     },
     "EFM32HG322F64": {
         "inherits": [
@@ -9588,7 +9852,10 @@
                 "value": "PA9",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2005"
+        ]
     },
     "EFM32PG1B100F256GM32": {
         "inherits": [
@@ -9685,7 +9952,10 @@
                 "value": "PA5",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2035"
+        ]
     },
     "EFR32MG1P132F256GM48": {
         "inherits": [
@@ -9985,7 +10255,10 @@
                 "value": "PA5",
                 "macro_name": "EFM_BC_EN"
             }
-        }
+        },
+        "detect_code": [
+            "2040"
+        ]
     },
     "EFR32MG12P332F1024GL125": {
         "inherits": [
@@ -10085,7 +10358,10 @@
         },
         "overrides": {
             "network-default-interface-type": "MESH"
-        }
+        },
+        "detect_code": [
+            "2041"
+        ]
     },
     "EFM32GG11B820F2048GL192": {
         "inherits": [
@@ -10196,7 +10472,10 @@
         },
         "overrides": {
             "network-default-interface-type": "ETHERNET"
-        }
+        },
+        "detect_code": [
+            "2042"
+        ]
     },
     "WIZWIKI_W7500": {
         "supported_form_factors": [
@@ -10238,6 +10517,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "2201"
         ]
     },
     "WIZWIKI_W7500P": {
@@ -10280,6 +10562,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "2203"
         ]
     },
     "WIZWIKI_W7500ECO": {
@@ -10319,6 +10604,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "2202"
         ]
     },
     "SAMR21G18A": {
@@ -10365,7 +10653,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "ATSAMR21G18A"
+        "device_name": "ATSAMR21G18A",
+        "detect_code": [
+            "0900"
+        ]
     },
     "SAMD21J18A": {
         "inherits": [
@@ -10411,7 +10702,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "ATSAMD21J18A"
+        "device_name": "ATSAMD21J18A",
+        "detect_code": [
+            "0915"
+        ]
     },
     "SAMD21G18A": {
         "inherits": [
@@ -10457,7 +10751,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "ATSAMD21G18A"
+        "device_name": "ATSAMD21G18A",
+        "detect_code": [
+            "0905"
+        ]
     },
     "SAML21J18A": {
         "inherits": [
@@ -10500,7 +10797,10 @@
             "SPISLAVE",
             "SPI_ASYNCH"
         ],
-        "device_name": "ATSAML21J18A"
+        "device_name": "ATSAML21J18A",
+        "detect_code": [
+            "0910"
+        ]
     },
     "SAMG55J19": {
         "inherits": [
@@ -10546,7 +10846,10 @@
             "MPU"
         ],
         "default_lib": "std",
-        "device_name": "ATSAMG55J19"
+        "device_name": "ATSAMG55J19",
+        "detect_code": [
+            "0920"
+        ]
     },
     "MCU_NRF51_UNIFIED": {
         "inherits": [
@@ -10693,7 +10996,10 @@
             "2",
             "5"
         ],
-        "device_name": "nRF51822_xxAA"
+        "device_name": "nRF51822_xxAA",
+        "detect_code": [
+            "1100"
+        ]
     },
     "SDT51822B": {
         "inherits": [
@@ -10754,6 +11060,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "1120"
         ]
     },
     "OSHCHIP": {
@@ -10899,6 +11208,9 @@
             "NRF52_PAN_62",
             "NRF52_PAN_63",
             "NRF52_PAN_64"
+        ],
+        "detect_code": [
+            "1101"
         ]
     },
     "RIOT_MICRO_MODULE": {
@@ -10965,6 +11277,9 @@
             "NRF52_PAN_62",
             "NRF52_PAN_63",
             "NRF52_PAN_64"
+        ],
+        "detect_code": [
+            "1238"
         ]
     },
     "UBLOX_EVK_NINA_B1": {
@@ -10997,7 +11312,10 @@
         ],
         "overrides": {
             "console-uart-flow-control": "RTSCTS"
-        }
+        },
+        "detect_code": [
+            "1237"
+        ]
     },
     "MTB_UBLOX_NINA_B1": {
         "inherits": [
@@ -11023,6 +11341,9 @@
             "NRF52_PAN_62",
             "NRF52_PAN_63",
             "NRF52_PAN_64"
+        ],
+        "detect_code": [
+            "0455"
         ]
     },
     "MTB_LAIRD_BL652": {
@@ -11053,7 +11374,10 @@
         "overrides": {
             "lf_clock_src": "NRF_LF_SRC_RC",
             "console-uart-flow-control": null
-        }
+        },
+        "detect_code": [
+            "0461"
+        ]
     },
     "MTB_MURATA_WSM_BL241": {
         "inherits": [
@@ -11095,7 +11419,10 @@
         "release_versions": [
             "5"
         ],
-        "device_name": "nRF52832_xxAA"
+        "device_name": "nRF52832_xxAA",
+        "detect_code": [
+            "0472"
+        ]
     },
     "DELTA_DFBM_NQ620": {
         "supported_form_factors": [
@@ -11132,7 +11459,10 @@
             "lf_clock_src": "NRF_LF_SRC_RC",
             "lf_clock_rc_calib_timer_interval": 16,
             "lf_clock_rc_calib_mode_config": 0
-        }
+        },
+        "detect_code": [
+            "4501"
+        ]
     },
     "MCU_NRF52840": {
         "inherits": [
@@ -11413,7 +11743,10 @@
             "network-default-interface-type": "ETHERNET",
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
-        }
+        },
+        "detect_code": [
+            "1302"
+        ]
     },
     "NCS36510": {
         "inherits": [
@@ -11486,6 +11819,9 @@
         "release_versions": [
             "2",
             "5"
+        ],
+        "detect_code": [
+            "1200"
         ]
     },
     "NUMAKER_PFM_M453": {
@@ -11573,7 +11909,10 @@
         "overrides": {
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
-        }
+        },
+        "detect_code": [
+            "1303"
+        ]
     },
     "NUMAKER_PFM_NANO130": {
         "core": "Cortex-M0",
@@ -11655,7 +11994,10 @@
         "overrides": {
             "deep-sleep-latency": 1,
             "tickless-from-us-ticker": true
-        }
+        },
+        "detect_code": [
+            "1306"
+        ]
     },
     "HI2110": {
         "inherits": [
@@ -12168,7 +12510,9 @@
         "bootloader_supported": true
     },
     "NUCLEO_L552ZE_Q": {
-        "inherits": ["FAMILY_STM32"],
+        "inherits": [
+            "FAMILY_STM32"
+        ],
         "core": "Cortex-M33FE",
         "extra_labels_add": [
             "STM32L5",
@@ -12197,22 +12541,28 @@
                 "value": 1
             }
         },
-        "overrides": { "lpticker_delay_ticks": 0 },
+        "overrides": {
+            "lpticker_delay_ticks": 0
+        },
         "device_has_add": [
-	          "ANALOGOUT",
-	          "CRC",
-	          "MPU",
-	          "SERIAL_ASYNCH",
-	          "TRNG",
-	          "FLASH"
+            "ANALOGOUT",
+            "CRC",
+            "MPU",
+            "SERIAL_ASYNCH",
+            "TRNG",
+            "FLASH"
         ],
-        "detect_code": ["0854"],
+        "detect_code": [
+            "0854"
+        ],
         "bootloader_supported": true,
         "mbed_rom_start": "0x08000000",
         "mbed_rom_size": "0x80000",
         "mbed_ram_start": "0x20000000",
         "mbed_ram_size": "0x40000",
-        "release_versions": [ "5" ]
+        "release_versions": [
+            "5"
+        ]
     },
     "VBLUNO52": {
         "supported_form_factors": [
@@ -12339,7 +12689,10 @@
         "components_add": [
             "FLASHIAP"
         ],
-        "device_name": "M487JIDAE"
+        "device_name": "M487JIDAE",
+        "detect_code": [
+            "1304"
+        ]
     },
     "NUMAKER_IOT_M487": {
         "inherits": [
@@ -12348,7 +12701,10 @@
         "components_add": [
             "FLASHIAP"
         ],
-        "device_name": "M487JIDAE"
+        "device_name": "M487JIDAE",
+        "detect_code": [
+            "1308"
+        ]
     },
     "TMPM066": {
         "inherits": [
@@ -12435,7 +12791,10 @@
         "release_versions": [
             "2"
         ],
-        "device_name": "STM32F411RE"
+        "device_name": "STM32F411RE",
+        "detect_code": [
+            "C008"
+        ]
     },
     "TMPM46B": {
         "inherits": [
@@ -12698,7 +13057,10 @@
         "mbed_rom_start": "0x10010000",
         "mbed_rom_size": "0x70000",
         "mbed_ram_start": "0x30002000",
-        "mbed_ram_size": "0x16000"
+        "mbed_ram_size": "0x16000",
+        "detect_code": [
+            "1305"
+        ]
     },
     "NU_PFM_M2351_NPSA_S": {
         "overrides": {
@@ -12757,17 +13119,19 @@
         "components_add": [
             "FLASHIAP"
         ],
-        "post_binary_hook": {"function": "M2351Code.merge_secure"},
+        "post_binary_hook": {
+            "function": "M2351Code.merge_secure"
+        },
         "secure_image_filename": "tfm.hex",
         "overrides": {
-            "secure-rom-start"      : "0x0",
-            "secure-rom-size"       : "0x3C000",
-            "secure-ram-start"      : "0x20000000",
-            "secure-ram-size"       : "0x10000",
-            "non-secure-rom-start"  : "0x1003C000",
-            "non-secure-rom-size"   : "0x44000",
-            "non-secure-ram-start"  : "0x30010000",
-            "non-secure-ram-size"   : "0x8000"
+            "secure-rom-start": "0x0",
+            "secure-rom-size": "0x3C000",
+            "secure-ram-start": "0x20000000",
+            "secure-ram-size": "0x10000",
+            "non-secure-rom-start": "0x1003C000",
+            "non-secure-rom-size": "0x44000",
+            "non-secure-ram-start": "0x30010000",
+            "non-secure-ram-size": "0x8000"
         }
     },
     "NU_PFM_M2351_S": {
@@ -12802,14 +13166,14 @@
         "deliver_to_target": "NU_PFM_M2351_NS",
         "delivery_dir": "TARGET_NUVOTON/TARGET_M2351/TARGET_M23_NS/TARGET_NU_PFM_M2351_NS/TARGET_NU_PREBUILD_SECURE",
         "overrides": {
-            "secure-rom-start"      : "0x0",
-            "secure-rom-size"       : "0x3C000",
-            "secure-ram-start"      : "0x20000000",
-            "secure-ram-size"       : "0x10000",
-            "non-secure-rom-start"  : "0x1003C000",
-            "non-secure-rom-size"   : "0x44000",
-            "non-secure-ram-start"  : "0x30010000",
-            "non-secure-ram-size"   : "0x8000"
+            "secure-rom-start": "0x0",
+            "secure-rom-size": "0x3C000",
+            "secure-ram-start": "0x20000000",
+            "secure-ram-size": "0x10000",
+            "non-secure-rom-start": "0x1003C000",
+            "non-secure-rom-size": "0x44000",
+            "non-secure-ram-start": "0x30010000",
+            "non-secure-ram-size": "0x8000"
         }
     },
     "NUMAKER_M252KG": {
@@ -13998,6 +14362,9 @@
         "supported_form_factors": [],
         "macros_add": [
             "CONFIG_GPIO_AS_PINRESET"
+        ],
+        "detect_code": [
+            "2600"
         ]
     },
     "IM880B": {
@@ -14344,12 +14711,26 @@
         "bootloader_supported": true
     },
     "S5JS100": {
-        "inherits": ["Target"],
+        "inherits": [
+            "Target"
+        ],
         "core": "Cortex-M7",
-        "supported_toolchains": ["GCC_ARM", "IAR", "ARMC6"],
+        "supported_toolchains": [
+            "GCC_ARM",
+            "IAR",
+            "ARMC6"
+        ],
         "default_toolchain": "GCC_ARM",
-        "extra_labels": ["Samsung", "SIDK_S5JS100"],
-        "macros": ["CMSDK_CM7", "MBED_MPU_CUSTOM",  "CMSIS_NVIC_VIRTUAL", "MBEDTLS_CONFIG_HW_SUPPORT"],
+        "extra_labels": [
+            "Samsung",
+            "SIDK_S5JS100"
+        ],
+        "macros": [
+            "CMSDK_CM7",
+            "MBED_MPU_CUSTOM",
+            "CMSIS_NVIC_VIRTUAL",
+            "MBEDTLS_CONFIG_HW_SUPPORT"
+        ],
         "device_has": [
             "INTERRUPTIN",
             "USTICKER",
@@ -14357,7 +14738,12 @@
             "SLEEP",
             "TRNG"
         ],
-        "release_versions": ["5"]
+        "release_versions": [
+            "5"
+        ],
+        "detect_code": [
+            "3701"
+        ]
     },
     "__build_tools_metadata__": {
         "version": "1",


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

This PR includes formatting changes as the `targets.json` file was re-generated from a script.
The missing data was drawn from the mbed.com target database APIs.

### Summary of changes <!-- Required -->

Updated `targets.json` file to include 113 `detect_codes` which were missing

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
