### PR TITLE
Add deep-debug build profile for GCC ARM

### DIFF
--- a/tools/profiles/deep-debug.json
+++ b/tools/profiles/deep-debug.json
@@ -1,0 +1,63 @@
+{
+    "GCC_ARM": {
+        "common": ["-c", "-Wall", "-Wextra",
+                   "-Wno-unused-parameter", "-Wno-missing-field-initializers",
+                   "-fmessage-length=0", "-fno-exceptions",
+                   "-ffunction-sections", "-fdata-sections", "-funsigned-char",
+                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": ["-x", "assembler-with-cpp"],
+        "c": ["-std=gnu11"],
+        "cxx": ["-std=gnu++14", "-fno-rtti", "-Wvla"],
+        "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
+               "-Wl,-n"]
+    },
+    "ARMC6": {
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
+                   "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-Wno-reserved-user-defined-literal", "-Wno-deprecated-register",
+                   "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
+                   "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
+                   "-fshort-enums", "-fshort-wchar", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": [],
+        "c": ["-D__ASSERT_MSG", "-std=gnu11"],
+        "cxx": ["-fno-rtti", "-std=gnu++14"],
+        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign",
+               "--any_contingency", "--keep=os_cb_sections"]
+    },
+    "ARM": {
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O0", "-g", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
+        "ld": ["--show_full_path", "--any_contingency", "--keep=os_cb_sections"]
+    },
+    "uARM": {
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O0", "-D__MICROLIB", "-g",
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp11", "--no_rtti", "--no_vla"],
+        "ld": ["--library_type=microlib"]
+    },
+    "IAR": {
+        "common": [
+            "--no_wrap_diagnostics",  "-e",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082,Pe540", "-Ol", "-r", "-DMBED_DEBUG",
+            "-DMBED_TRAP_ERRORS_ENABLED=1", "--enable_restrict"],
+        "asm": [],
+        "c": ["--vla", "--diag_suppress=Pe546"],
+        "cxx": ["--guard_calls", "--no_static_destruction"],
+        "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
+    }
+}


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Even with the `debug.json` build profile in master, sometimes debugging can be difficult due to optimized-out symbols and out-of-order execution.

This adds an additional build profile called `deep-debug.json` that (for GCC ARM toolchain) disables all optimization (-O0 as opposed to -Og in `debug.json`).

I don't have access to the other toolchains so I don't know what options need to be set for those.

The aforementioned debugging difficulty caused me some head-scratching for a while before I realized the optimization flag for GCC ARM had changed at some point in the default `debug.json` build profile.

This may help other users who experience the same confusion.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

Any documentation concerning build profiles and debugging

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
