### PR TITLE
[RFC] Use minimal printf by default inside the OS

### DIFF
--- a/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.c
+++ b/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.c
@@ -39,6 +39,16 @@ int mbed_snprintf(char *buffer, size_t length, const char *format, ...)
     return result;
 }
 
+int mbed_sprintf(char *buffer, const char *format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+    va_end(arguments);
+
+    return result;
+}
+
 int mbed_vprintf(const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);

--- a/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.h
+++ b/TESTS/mbed_platform/minimal-printf/compliance/mbed_printf.h
@@ -39,6 +39,13 @@ int mbed_printf(const char *format, ...);
 int mbed_snprintf(char *buffer, size_t length, const char *format, ...);
 
 /**
+ * Minimal snprintf
+ *
+ * Prints directly to buffer without using malloc.
+ */
+int mbed_sprintf(char *buffer, const char *format, ...);
+
+/**
  * Minimal printf
  *
  * Prints directly to stdio/UART without using malloc.

--- a/UNITTESTS/platform/ATCmdParser/unittest.cmake
+++ b/UNITTESTS/platform/ATCmdParser/unittest.cmake
@@ -5,6 +5,8 @@
 # Source files
 set(unittest-sources
   ../platform/source/ATCmdParser.cpp
+  ../platform/source/minimal-printf/mbed_printf.c
+  ../platform/source/minimal-printf/mbed_printf_implementation.c
 )
 
 # Test files

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -44,7 +44,7 @@ using namespace mbed;
 #endif /* DATAFLASH_DEBUG */
 
 #if DATAFLASH_DEBUG
-#define DEBUG_PRINTF(...) printf(__VA_ARGS__)
+#define DEBUG_PRINTF(...) mbed_printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINTF(...)
 #endif

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -38,24 +38,24 @@
  *  DataFlashBlockDevice dataflash2(PTE2, PTE4, PTE1, PTE5, PTE6);
  *
  *  int main() {
- *      printf("dataflash test\n");
+ *      mbed_printf("dataflash test\n");
  *
  *      // Initialize the SPI flash device and print the memory layout
  *      dataflash.init();
- *      printf("dataflash size: %llu\n", dataflash.size());
- *      printf("dataflash read size: %llu\n", dataflash.get_read_size());
- *      printf("dataflash program size: %llu\n", dataflash.get_program_size());
- *      printf("dataflash erase size: %llu\n", dataflash.get_erase_size());
+ *      mbed_printf("dataflash size: %llu\n", dataflash.size());
+ *      mbed_printf("dataflash read size: %llu\n", dataflash.get_read_size());
+ *      mbed_printf("dataflash program size: %llu\n", dataflash.get_program_size());
+ *      mbed_printf("dataflash erase size: %llu\n", dataflash.get_erase_size());
  *
  *      // Write "Hello World!" to the first block
  *      char *buffer = (char*)malloc(dataflash.get_erase_size());
- *      sprintf(buffer, "Hello World!\n");
+ *      mbed_sprintf(buffer, "Hello World!\n");
  *      dataflash.erase(0, dataflash.get_erase_size());
  *      dataflash.program(buffer, 0, dataflash.get_erase_size());
  *
  *      // Read back what was stored
  *      dataflash.read(buffer, 0, dataflash.get_erase_size());
- *      printf("%s", buffer);
+ *      mbed_printf("%s", buffer);
  *
  *      // Deinitialize the device
  *      dataflash.deinit();

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/COMMON/fslittle_debug.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/COMMON/fslittle_debug.h
@@ -41,7 +41,7 @@
 #define FSLITTLE_LOG(_fmt, ...)                          \
   do                                                    \
   {                                                     \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
   }while(0);
 
 #define noFSLITTLE_DEBUG
@@ -64,7 +64,7 @@ extern uint32_t fslittle_optLogLevel_g;
   {                                                     \
     if(fslittle_optDebug_g && (fslittle_optLogLevel_g >= FSLITTLE_LOG_DEBUG))  \
     {                                                   \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
     }                                                   \
   }while(0);
 
@@ -74,7 +74,7 @@ extern uint32_t fslittle_optLogLevel_g;
   {                                                     \
     if(fslittle_optDebug_g && (fslittle_optLogLevel_g >= FSLITTLE_LOG_ERR))  \
     {                                                   \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
     }                                                   \
   }while(0);
 
@@ -84,7 +84,7 @@ extern uint32_t fslittle_optLogLevel_g;
   {                                                     \
     if(fslittle_optDebug_g && (fslittle_optLogLevel_g >= FSLITTLE_LOG_FENTRY))  \
     {                                                   \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
     }                                                   \
   }while(0);
 

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/COMMON/fslittle_test.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/COMMON/fslittle_test.h
@@ -47,7 +47,7 @@ extern "C" {
 #define FSLITTLE_TEST_UTEST_MESSAGE(_buf, _max_len, _fmt, ...)   \
   do                                                            \
   {                                                             \
-      snprintf((_buf), (_max_len), (_fmt), __VA_ARGS__);        \
+      mbed_snprintf((_buf), (_max_len), (_fmt), __VA_ARGS__);        \
   }while(0);
 
 

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -31,7 +31,7 @@ using namespace mbed;
 #endif
 
 #if FLASHIAP_DEBUG
-#define DEBUG_PRINTF(...) printf(__VA_ARGS__)
+#define DEBUG_PRINTF(...) mbed_printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINTF(...)
 #endif

--- a/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/I2CEEBlockDevice.h
@@ -31,24 +31,24 @@
  *  I2CEEBlockDevice i2cee(D14, D15, 0xa0, 32*1024);
  *
  *  int main() {
- *      printf("i2cee test\n");
+ *      mbed_printf("i2cee test\n");
  *
  *      // Initialize the device and print the memory layout
  *      i2cee.init();
- *      printf("i2cee size: %llu\n",         i2cee.size());
- *      printf("i2cee read size: %llu\n",    i2cee.get_read_size());
- *      printf("i2cee program size: %llu\n", i2cee.get_program_size());
- *      printf("i2cee erase size: %llu\n",   i2cee.get_erase_size());
+ *      mbed_printf("i2cee size: %llu\n",         i2cee.size());
+ *      mbed_printf("i2cee read size: %llu\n",    i2cee.get_read_size());
+ *      mbed_printf("i2cee program size: %llu\n", i2cee.get_program_size());
+ *      mbed_printf("i2cee erase size: %llu\n",   i2cee.get_erase_size());
  *
  *      // Write "Hello World!" to the first block
  *      char *buffer = (char*)malloc(i2cee.get_erase_size());
- *      sprintf(buffer, "Hello World!\n");
+ *      mbed_sprintf(buffer, "Hello World!\n");
  *      i2cee.erase(0, i2cee.get_erase_size());
  *      i2cee.program(buffer, 0, i2cee.get_erase_size());
  *
  *      // Read back what was stored
  *      i2cee.read(buffer, 0, i2cee.get_erase_size());
- *      printf("%s", buffer);
+ *      mbed_printf("%s", buffer);
  *
  *      // Deinitialize the device
  *      i2cee.deinit();

--- a/components/storage/blockdevice/COMPONENT_I2CEE/README.md
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/README.md
@@ -20,24 +20,24 @@ https://en.wikipedia.org/wiki/EEPROM
 I2CEEBlockDevice i2cee(D14, D15, 0xa0, 32*1024);
 
 int main() {
-    printf("i2cee test\n");
+    mbed_printf("i2cee test\n");
 
     // Initialize the device and print the memory layout
     i2cee.init();
-    printf("i2cee size: %llu\n",         i2cee.size());
-    printf("i2cee read size: %llu\n",    i2cee.get_read_size());
-    printf("i2cee program size: %llu\n", i2cee.get_program_size());
-    printf("i2cee erase size: %llu\n",   i2cee.get_erase_size());
+    mbed_printf("i2cee size: %llu\n",         i2cee.size());
+    mbed_printf("i2cee read size: %llu\n",    i2cee.get_read_size());
+    mbed_printf("i2cee program size: %llu\n", i2cee.get_program_size());
+    mbed_printf("i2cee erase size: %llu\n",   i2cee.get_erase_size());
 
     // Write "Hello World!" to the first block
     char *buffer = (char*)malloc(i2cee.get_erase_size());
-    sprintf(buffer, "Hello World!\n");
+    mbed_sprintf(buffer, "Hello World!\n");
     i2cee.erase(0, i2cee.get_erase_size());
     i2cee.program(buffer, 0, i2cee.get_erase_size());
 
     // Read back what was stored
     i2cee.read(buffer, 0, i2cee.get_erase_size());
-    printf("%s", buffer);
+    mbed_printf("%s", buffer);
 
     // Deinitialize the device
     i2cee.deinit();
@@ -66,7 +66,7 @@ struct t_setting {
 };
 
 int main() {
-    printf("i2cee struct test\n");
+    mbed_printf("i2cee struct test\n");
 
      // No. of bytes to be stored, but topped up to be multiplied by block size
     unsigned int setting_block_size = ceil(sizeof(setting)/(double)BLOCK_SIZE)*BLOCK_SIZE;
@@ -78,7 +78,7 @@ int main() {
     i2cee.init();
 
     // Save struct to EEPROM
-    printf("\nSaving struct version: %u, name: %s\n", setting.version, setting.name);
+    mbed_printf("\nSaving struct version: %u, name: %s\n", setting.version, setting.name);
     memcpy(buffer, &setting, sizeof(setting));
     i2cee.program(buffer, 0, setting_block_size);
 
@@ -89,9 +89,9 @@ int main() {
     if (i2cee.read(buffer, 0, setting_block_size ) == 0){ // get data into buffer
         // Convert what we read into struct
         memcpy(&tmp, buffer, sizeof(tmp)); // copy only size of struct not setting_block_size
-        printf("\nTemporary struct version: %u, name: %s\n", tmp.version, tmp.name);
+        mbed_printf("\nTemporary struct version: %u, name: %s\n", tmp.version, tmp.name);
     } else {
-        printf("Error when reading\n");
+        mbed_printf("Error when reading\n");
     }
 
     // Deinitialize the device

--- a/components/storage/blockdevice/COMPONENT_I2CEE/TESTS/block_device/i2cee/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_I2CEE/TESTS/block_device/i2cee/main.cpp
@@ -42,7 +42,7 @@ void test_read_write()
             bd_size_t size = (bd.*ATTRS[a].method)();
 
             if (size >= (1ULL << 10 * i)) {
-                printf("%s: %llu%sbytes (%llubytes)\n",
+                mbed_printf("%s: %llu%sbytes (%llubytes)\n",
                        ATTRS[a].name, size >> 10 * i, prefixes[i], size);
                 break;
             }
@@ -71,7 +71,7 @@ void test_read_write()
         }
 
         // Write, sync, and read the block
-        printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
+        mbed_printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
 
         err = bd.erase(block, block_size);
         TEST_ASSERT_EQUAL(0, err);
@@ -79,32 +79,32 @@ void test_read_write()
         err = bd.program(write_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
-        printf("write %0*llx:%llu ", addrwidth, block, block_size);
+        mbed_printf("write %0*llx:%llu ", addrwidth, block, block_size);
 
         for (int i = 0; i < block_size && i < 16; i++) {
-            printf("%02x", write_block[i]);
+            mbed_printf("%02x", write_block[i]);
         }
 
         if (block_size > 16) {
-            printf("...\n");
+            mbed_printf("...\n");
         }
 
-        printf("\n");
+        mbed_printf("\n");
 
         err = bd.read(read_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
-        printf("read  %0*llx:%llu ", addrwidth, block, block_size);
+        mbed_printf("read  %0*llx:%llu ", addrwidth, block, block_size);
 
         for (int i = 0; i < block_size && i < 16; i++) {
-            printf("%02x", read_block[i]);
+            mbed_printf("%02x", read_block[i]);
         }
 
         if (block_size > 16) {
-            printf("...");
+            mbed_printf("...");
         }
 
-        printf("\n");
+        mbed_printf("\n");
 
         // Find error mask for debugging
         memset(error_mask, 0, TEST_ERROR_MASK);
@@ -120,13 +120,13 @@ void test_read_write()
             }
         }
 
-        printf("error %0*llx:%llu ", addrwidth, block, block_size);
+        mbed_printf("error %0*llx:%llu ", addrwidth, block, block_size);
 
         for (int i = 0; i < TEST_ERROR_MASK; i++) {
-            printf("%02x", error_mask[i]);
+            mbed_printf("%02x", error_mask[i]);
         }
 
-        printf("\n");
+        mbed_printf("\n");
 
         // Check that the data was unmodified
         srand(seed);

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -59,26 +59,26 @@ enum qspif_polarity_mode {
  *
  *  int main()
  *  {
- *      printf("QSPI SFDP Flash Block Device example\n");
+ *      mbed_printf("QSPI SFDP Flash Block Device example\n");
  *
  *      // Initialize the SPI flash device and print the memory layout
  *      block_device.init();
  *      bd_size_t sector_size_at_address_0 = block_device.get_erase_size(0);
  *
- *      printf("QSPIF BD size: %llu\n",         block_device.size());
- *      printf("QSPIF BD read size: %llu\n",    block_device.get_read_size());
- *      printf("QSPIF BD program size: %llu\n", block_device.get_program_size());
- *      printf("QSPIF BD erase size (at address 0): %llu\n", sector_size_at_address_0);
+ *      mbed_printf("QSPIF BD size: %llu\n",         block_device.size());
+ *      mbed_printf("QSPIF BD read size: %llu\n",    block_device.get_read_size());
+ *      mbed_printf("QSPIF BD program size: %llu\n", block_device.get_program_size());
+ *      mbed_printf("QSPIF BD erase size (at address 0): %llu\n", sector_size_at_address_0);
  *
  *      // Write "Hello World!" to the first block
  *      char *buffer = (char *) malloc(sector_size_at_address_0);
- *      sprintf(buffer, "Hello World!\n");
+ *      mbed_sprintf(buffer, "Hello World!\n");
  *      block_device.erase(0, sector_size_at_address_0);
  *      block_device.program(buffer, 0, sector_size_at_address_0);
  *
  *      // Read back what was stored
  *      block_device.read(buffer, 0, sector_size_at_address_0);
- *      printf("%s", buffer);
+ *      mbed_printf("%s", buffer);
  *
  *      // Deinitialize the device
  *      block_device.deinit();

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -157,22 +157,22 @@ void SPIFReducedBlockDevice::_cmdread(
     _cs = 1;
 
     if (SPIF_DEBUG) {
-        printf("spif <- %02x", op);
+        mbed_printf("spif <- %02x", op);
         for (uint32_t i = 0; i < addrc; i++) {
             if (i < addrc) {
-                printf("%02lx", 0xff & (addr >> 8 * (addrc - 1 - i)));
+                mbed_printf("%02lx", 0xff & (addr >> 8 * (addrc - 1 - i)));
             } else {
-                printf("  ");
+                mbed_printf("  ");
             }
         }
-        printf(" ");
+        mbed_printf(" ");
         for (uint32_t i = 0; i < 16 && i < retc; i++) {
-            printf("%02x", rets[i]);
+            mbed_printf("%02x", rets[i]);
         }
         if (retc > 16) {
-            printf("...");
+            mbed_printf("...");
         }
-        printf("\n");
+        mbed_printf("\n");
     }
 }
 
@@ -193,22 +193,22 @@ void SPIFReducedBlockDevice::_cmdwrite(
     _cs = 1;
 
     if (SPIF_DEBUG) {
-        printf("spif -> %02x", op);
+        mbed_printf("spif -> %02x", op);
         for (uint32_t i = 0; i < addrc; i++) {
             if (i < addrc) {
-                printf("%02lx", 0xff & (addr >> 8 * (addrc - 1 - i)));
+                mbed_printf("%02lx", 0xff & (addr >> 8 * (addrc - 1 - i)));
             } else {
-                printf("  ");
+                mbed_printf("  ");
             }
         }
-        printf(" ");
+        mbed_printf(" ");
         for (uint32_t i = 0; i < 16 && i < argc; i++) {
-            printf("%02x", args[i]);
+            mbed_printf("%02x", args[i]);
         }
         if (argc > 16) {
-            printf("...");
+            mbed_printf("...");
         }
-        printf("\n");
+        mbed_printf("\n");
     }
 }
 

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
@@ -32,24 +32,24 @@
  *  SPIFReducedBlockDevice rspif(PTE2, PTE4, PTE1, PTE5);
  *
  *  int main() {
- *      printf("reduced spif test\n");
+ *      mbed_printf("reduced spif test\n");
  *
  *      // Initialize the Reduced SPI flash device and print the memory layout
  *      rspif.init();
- *      printf("rspif size: %llu\n",         rspif.size());
- *      printf("rspif read size: %llu\n",    rspif.get_read_size());
- *      printf("rspif program size: %llu\n", rspif.get_program_size());
- *      printf("rspif erase size: %llu\n",   rspif.get_erase_size());
+ *      mbed_printf("rspif size: %llu\n",         rspif.size());
+ *      mbed_printf("rspif read size: %llu\n",    rspif.get_read_size());
+ *      mbed_printf("rspif program size: %llu\n", rspif.get_program_size());
+ *      mbed_printf("rspif erase size: %llu\n",   rspif.get_erase_size());
  *
  *      // Write "Hello World!" to the first block
  *      char *buffer = (char*)malloc(rspif.get_erase_size());
- *      sprintf(buffer, "Hello World!\n");
+ *      mbed_sprintf(buffer, "Hello World!\n");
  *      rspif.erase(0, rspif.get_erase_size());
  *      rspif.program(buffer, 0, rspif.get_erase_size());
  *
  *      // Read back what was stored
  *      rspif.read(buffer, 0, rspif.get_erase_size());
- *      printf("%s", buffer);
+ *      mbed_printf("%s", buffer);
  *
  *      // Deinitialize the device
  *      rspif.deinit();

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/COMMON/fsfat_debug.h
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/COMMON/fsfat_debug.h
@@ -41,7 +41,7 @@
 #define FSFAT_LOG(_fmt, ...)                          \
   do                                                    \
   {                                                     \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
   }while(0);
 
 #define noFSFAT_DEBUG
@@ -64,7 +64,7 @@ extern uint32_t fsfat_optLogLevel_g;
   {                                                     \
     if(fsfat_optDebug_g && (fsfat_optLogLevel_g >= FSFAT_LOG_DEBUG))  \
     {                                                   \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
     }                                                   \
   }while(0);
 
@@ -74,7 +74,7 @@ extern uint32_t fsfat_optLogLevel_g;
   {                                                     \
     if(fsfat_optDebug_g && (fsfat_optLogLevel_g >= FSFAT_LOG_ERR))  \
     {                                                   \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
     }                                                   \
   }while(0);
 
@@ -84,7 +84,7 @@ extern uint32_t fsfat_optLogLevel_g;
   {                                                     \
     if(fsfat_optDebug_g && (fsfat_optLogLevel_g >= FSFAT_LOG_FENTRY))  \
     {                                                   \
-        printf(_fmt, __VA_ARGS__);                      \
+        mbed_printf(_fmt, __VA_ARGS__);                      \
     }                                                   \
   }while(0);
 

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/COMMON/fsfat_test.h
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/COMMON/fsfat_test.h
@@ -47,7 +47,7 @@ extern "C" {
 #define FSFAT_TEST_UTEST_MESSAGE(_buf, _max_len, _fmt, ...)   \
   do                                                            \
   {                                                             \
-      snprintf((_buf), (_max_len), (_fmt), __VA_ARGS__);        \
+      mbed_snprintf((_buf), (_max_len), (_fmt), __VA_ARGS__);        \
   }while(0);
 
 

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/dirs/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/dirs/main.cpp
@@ -265,7 +265,7 @@ void test_multi_block_directory()
         res = fs.mkdir("cactus", 0777);
         TEST_ASSERT_EQUAL(0, res);
         for (int i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "cactus/test%d", i);
+            mbed_sprintf((char *)buffer, "cactus/test%d", i);
             res = fs.mkdir((char *)buffer, 0777);
             TEST_ASSERT_EQUAL(0, res);
         }
@@ -285,7 +285,7 @@ void test_multi_block_directory()
 #endif
 
         for (int i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "test%d", i);
+            mbed_sprintf((char *)buffer, "test%d", i);
             res = dir[0].read(&ent);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ent.d_name, (char *)buffer);

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/fopen/fopen.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/fopen/fopen.cpp
@@ -258,9 +258,9 @@ static int32_t fsfat_filepath_make_dirs(char *filepath, bool do_asserts)
      * Skip creating dir for "/sd" which must be present */
     buf = (char *) malloc(strlen(filepath) + 1);
     memset(buf, 0, strlen(filepath) + 1);
-    pos = sprintf(buf, "/%s", parts[0]);
+    pos = mbed_sprintf(buf, "/%s", parts[0]);
     for (i = 1; i < num_parts - 1; i++) {
-        pos += sprintf(buf + pos, "/%s", parts[i]);
+        pos += mbed_sprintf(buf + pos, "/%s", parts[i]);
         FSFAT_DBGLOG("mkdir(%s)\n", buf);
         ret = mkdir(buf, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
         if (do_asserts == true) {
@@ -651,7 +651,7 @@ control_t fsfat_fopen_test_05(const size_t call_count)
 
             /* set the start, mid, last character of the name to the test char code */
             for (pos = (uint32_t) fsfat_fopen_kv_name_pos_start; pos < (uint32_t) fsfat_fopen_kv_name_pos_max; pos++) {
-                len = snprintf(filename, filename_len + 1, "%s/%s.%s", mnt_pt, basename, extname);
+                len = mbed_snprintf(filename, filename_len + 1, "%s/%s.%s", mnt_pt, basename, extname);
                 /* overwrite a char at the pos start, mid, end of the filename with an ascii char code (both illegal and legal)*/
                 switch (pos) {
                     case fsfat_fopen_kv_name_pos_start:
@@ -779,13 +779,13 @@ control_t fsfat_fopen_test_06(const size_t call_count)
     /* generate a number of illegal filenames */
     for (j = 0; i < FSFAT_MAX_FILE_BASENAME; j++) {
         /* generate a kv name of illegal chars*/
-        len = snprintf(filename, filename_len + 1, "%s/", mnt_pt);
+        len = mbed_snprintf(filename, filename_len + 1, "%s/", mnt_pt);
         for (i = 0; i < FSFAT_MAX_FILE_BASENAME; i++) {
             pos = rand() % (buf_data_max + 1);
-            len += snprintf(filename + len, filename_len + 1, "%c", fsfat_fopen_ascii_illegal_buf_g[pos]);
+            len += mbed_snprintf(filename + len, filename_len + 1, "%c", fsfat_fopen_ascii_illegal_buf_g[pos]);
 
         }
-        len += snprintf(filename + len, filename_len + 1, ".%s", extname);
+        len += mbed_snprintf(filename + len, filename_len + 1, ".%s", extname);
         ret = fsfat_test_create(filename, filename, len);
         FSFAT_TEST_UTEST_MESSAGE(fsfat_fopen_utest_msg_g, FSFAT_UTEST_MSG_BUF_SIZE,
                                  "%s:Error: created file when filename contains invalid characters (filename=%s, ret=%d).\n", __func__, filename,

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/parallel/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/parallel/main.cpp
@@ -107,7 +107,7 @@ void write_file_data(char count)
     uint8_t wbuffer[MBED_TEST_BUFFER];
     int res;
 
-    sprintf(filename, "%s%d", "data", count);
+    mbed_sprintf(filename, "%s%d", "data", count);
     res = file[count].open(&fs, filename, O_WRONLY | O_CREAT);
     TEST_ASSERT_EQUAL(0, res);
 
@@ -134,7 +134,7 @@ void read_file_data(char count)
     uint8_t rbuffer[MBED_TEST_BUFFER];
     int res;
 
-    sprintf(filename, "%s%d", "data", count);
+    mbed_sprintf(filename, "%s%d", "data", count);
     res = file[count].open(&fs, filename, O_RDONLY);
     TEST_ASSERT_EQUAL(0, res);
 

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/seek/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/seek/main.cpp
@@ -90,7 +90,7 @@ void test_seek_tests()
         res = fs.mkdir("hello", 0777);
         TEST_ASSERT_EQUAL(0, res);
         for (int i = 0; i < 132; i++) {
-            sprintf((char *)buffer, "hello/kitty%d", i);
+            mbed_sprintf((char *)buffer, "hello/kitty%d", i);
             res = file[0].open(&fs, (char *)buffer,
                                O_WRONLY | O_CREAT | O_APPEND);
             TEST_ASSERT_EQUAL(0, res);
@@ -135,7 +135,7 @@ void test_simple_dir_seek()
         off_t pos;
         int i;
         for (i = 0; i < 4; i++) {
-            sprintf((char *)buffer, "kitty%d", i);
+            mbed_sprintf((char *)buffer, "kitty%d", i);
             res = dir[0].read(&ent);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ent.d_name, (char *)buffer);
@@ -146,14 +146,14 @@ void test_simple_dir_seek()
         TEST_ASSERT_EQUAL(1, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].rewind();
-        sprintf((char *)buffer, "kitty%d", 0);
+        mbed_sprintf((char *)buffer, "kitty%d", 0);
 #if (MBED_TEST_FILESYSTEM != FATFileSystem)
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
@@ -170,7 +170,7 @@ void test_simple_dir_seek()
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);
@@ -209,7 +209,7 @@ void test_large_dir_seek()
         off_t pos;
         int i;
         for (i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "kitty%d", i);
+            mbed_sprintf((char *)buffer, "kitty%d", i);
             res = dir[0].read(&ent);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ent.d_name, (char *)buffer);
@@ -220,14 +220,14 @@ void test_large_dir_seek()
         TEST_ASSERT_EQUAL(1, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].rewind();
-        sprintf((char *)buffer, "kitty%d", 0);
+        mbed_sprintf((char *)buffer, "kitty%d", 0);
 #if (MBED_TEST_FILESYSTEM != FATFileSystem)
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
@@ -244,7 +244,7 @@ void test_large_dir_seek()
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -49,24 +49,24 @@ enum spif_bd_error {
  *  SPIFBlockDevice spif(PTE2, PTE4, PTE1, PTE5);
  *
  *  int main() {
- *      printf("spif test\n");
+ *      mbed_printf("spif test\n");
  *
  *      // Initialize the SPI flash device and print the memory layout
  *      spif.init();
- *      printf("spif size: %llu\n",         spif.size());
- *      printf("spif read size: %llu\n",    spif.get_read_size());
- *      printf("spif program size: %llu\n", spif.get_program_size());
- *      printf("spif erase size: %llu\n",   spif.get_erase_size());
+ *      mbed_printf("spif size: %llu\n",         spif.size());
+ *      mbed_printf("spif read size: %llu\n",    spif.get_read_size());
+ *      mbed_printf("spif program size: %llu\n", spif.get_program_size());
+ *      mbed_printf("spif erase size: %llu\n",   spif.get_erase_size());
  *
  *      // Write "Hello World!" to the first block
  *      char *buffer = (char*)malloc(spif.get_erase_size());
- *      sprintf(buffer, "Hello World!\n");
+ *      mbed_sprintf(buffer, "Hello World!\n");
  *      spif.erase(0, spif.get_erase_size());
  *      spif.program(buffer, 0, spif.get_erase_size());
  *
  *      // Read back what was stored
  *      spif.read(buffer, 0, spif.get_erase_size());
- *      printf("%s", buffer);
+ *      mbed_printf("%s", buffer);
  *
  *      // Deinitialize the device
  *      spif.deinit();

--- a/drivers/AnalogIn.h
+++ b/drivers/AnalogIn.h
@@ -57,7 +57,7 @@ namespace mbed {
  * int main() {
  *     while(1) {
  *         if(temperature > 0.5) {
- *             printf("Too hot! (%f)", temperature.read());
+ *             mbed_printf("Too hot! (%f)", temperature.read());
  *         }
  *     }
  * }

--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -140,7 +140,7 @@ public:
      *
      * void send() {
      *     if(can1.write(CANMessage(1337U, &counter, 1))) {
-     *         printf("Message sent: %d\n", counter);
+     *         mbed_printf("Message sent: %d\n", counter);
      *         counter++;
      *     }
      *     led1 = !led1;
@@ -151,7 +151,7 @@ public:
      *     CANMessage msg;
      *     while(1) {
      *         if(can2.read(msg)) {
-     *             printf("Message received: %d\n\n", msg.data[0]);
+     *             mbed_printf("Message received: %d\n\n", msg.data[0]);
      *             led2 = !led2;
      *         }
      *         wait(0.2);

--- a/drivers/Ethernet.h
+++ b/drivers/Ethernet.h
@@ -56,9 +56,9 @@ namespace mbed {
  *         int size = eth.receive();
  *         if(size > 0) {
  *             eth.read(buf, size);
- *             printf("Destination:  %02X:%02X:%02X:%02X:%02X:%02X\n",
+ *             mbed_printf("Destination:  %02X:%02X:%02X:%02X:%02X:%02X\n",
  *                     buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
- *             printf("Source: %02X:%02X:%02X:%02X:%02X:%02X\n",
+ *             mbed_printf("Source: %02X:%02X:%02X:%02X:%02X:%02X\n",
  *                     buf[6], buf[7], buf[8], buf[9], buf[10], buf[11]);
  *         }
  *
@@ -187,9 +187,9 @@ public:
      * int main() {
      *     wait(1); // Needed after startup.
      *     if (eth.link()) {
-     *          printf("online\n");
+     *          mbed_printf("online\n");
      *     } else {
-     *          printf("offline\n");
+     *          mbed_printf("offline\n");
      *     }
      * }
      * @endcode

--- a/drivers/I2C.h
+++ b/drivers/I2C.h
@@ -74,7 +74,7 @@ namespace mbed {
  *         i2c.read( addr8bit, cmd, 2);
  *
  *         float tmp = (float((cmd[0]<<8)|cmd[1]) / 256.0);
- *         printf("Temp = %.2f\n", tmp);
+ *         mbed_printf("Temp = %.2f\n", tmp);
  *   }
  * }
  * @endcode

--- a/drivers/I2CSlave.h
+++ b/drivers/I2CSlave.h
@@ -51,18 +51,18 @@ namespace mbed {
  *             case I2CSlave::ReadAddressed:
  *                 int status = slave.write(message, sizeof(message));
  *                 if (status == 0) {
- *                     printf("Written message: %s\n", message);
+ *                     mbed_printf("Written message: %s\n", message);
  *                 } else {
- *                     printf("Failed to write message.\n");
+ *                     mbed_printf("Failed to write message.\n");
  *                 }
  *                 break;
  *             case I2CSlave::WriteGeneral:
  *                 int byte_read = slave.read();
- *                 printf("Read General: %c (%d)\n", byte_read, byte_read);
+ *                 mbed_printf("Read General: %c (%d)\n", byte_read, byte_read);
  *                 break;
  *             case I2CSlave::WriteAddressed:
  *                 int byte_read = slave.read();
- *                 printf("Read Addressed: %c (%d)\n", byte_read, byte_read);
+ *                 mbed_printf("Read Addressed: %c (%d)\n", byte_read, byte_read);
  *                 break;
  *         }
  *     }

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -49,7 +49,7 @@ namespace mbed {
  * DigitalOut led(LED1);
  *
  * void trigger() {
- *     printf("triggered!\n");
+ *     mbed_printf("triggered!\n");
  * }
  *
  * int main() {

--- a/drivers/MbedCRC.h
+++ b/drivers/MbedCRC.h
@@ -116,11 +116,11 @@ constexpr CrcMode choose_crc_mode(uint32_t polynomial, uint8_t width, CrcMode mo
  *      char  test[] = "123456789";
  *      uint32_t crc = 0;
  *
- *      printf("\nPolynomial = 0x%lx  Width = %d \n", ct.get_polynomial(), ct.get_width());
+ *      mbed_printf("\nPolynomial = 0x%lx  Width = %d \n", ct.get_polynomial(), ct.get_width());
  *
  *      ct.compute((void *)test, strlen((const char*)test), &crc);
  *
- *      printf("The CRC of data \"123456789\" is : 0x%lx\n", crc);
+ *      mbed_printf("The CRC of data \"123456789\" is : 0x%lx\n", crc);
  *      return 0;
  *  }
  * @endcode
@@ -134,12 +134,12 @@ constexpr CrcMode choose_crc_mode(uint32_t polynomial, uint8_t width, CrcMode mo
  *      char  test[] = "123456789";
  *      uint32_t crc = 0;
  *
- *      printf("\nPolynomial = 0x%lx  Width = %d \n", ct.get_polynomial(), ct.get_width());
+ *      mbed_printf("\nPolynomial = 0x%lx  Width = %d \n", ct.get_polynomial(), ct.get_width());
  *      ct.compute_partial_start(&crc);
  *      ct.compute_partial((void *)&test, 4, &crc);
  *      ct.compute_partial((void *)&test[4], 5, &crc);
  *      ct.compute_partial_stop(&crc);
- *      printf("The CRC of data \"123456789\" is : 0x%lx\n", crc);
+ *      mbed_printf("The CRC of data \"123456789\" is : 0x%lx\n", crc);
  *      return 0;
  *  }
  * @endcode

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -73,11 +73,11 @@ typedef int qspi_inst_t;
  *
  *     qspi_status_t result = qspi_device.write(CMD_WRITE, 0, ADDRESS, tx_buf, &buf_len);
  *     if (result != QSPI_STATUS_OK) {
- *        printf("Write failed");
+ *        mbed_printf("Write failed");
  *     }
  *     result = qspi_device.read(CMD_READ, 0, ADDRESS, rx_buf, &buf_len);
  *     if (result != QSPI_STATUS_OK) {
- *        printf("Read failed");
+ *        mbed_printf("Read failed");
  *     }
  *
  * }

--- a/drivers/ResetReason.h
+++ b/drivers/ResetReason.h
@@ -47,7 +47,7 @@ public:
      *  const reset_reason_t reason = ResetReason::get();
      *
      *  if (reason == RESET_REASON_WATCHDOG) {
-     *      printf("Watchdog reset\n");
+     *      mbed_printf("Watchdog reset\n");
      *      rollback();
      *  }
      *  @endcode

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -47,7 +47,7 @@ namespace mbed {
  *     begin = timer.read_us();
  *     led = !led;
  *     end = timer.read_us();
- *     printf("Toggle the led takes %d us", end - begin);
+ *     mbed_printf("Toggle the led takes %d us", end - begin);
  * }
  * @endcode
  */

--- a/drivers/USBAudio.h
+++ b/drivers/USBAudio.h
@@ -55,7 +55,7 @@
 *
 *     USBAudio audio(true, 44100, 2, 44100, 2);
 *
-*     printf("Looping audio\r\n");
+*     mbed_printf("Looping audio\r\n");
 *     static uint8_t buf[128];
 *     while (true) {
 *         if (!audio.read(buf, sizeof(buf))) {

--- a/drivers/source/RawSerial.cpp
+++ b/drivers/source/RawSerial.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "drivers/RawSerial.h"
+#include "platform/mbed_printf.h"
 #include <stdio.h>
 
 
@@ -74,14 +75,14 @@ int RawSerial::vprintf(const char *format, std::va_list arg)
     // ARMCC microlib does not properly handle a size of 0.
     // As a workaround supply a dummy buffer with a size of 1.
     char dummy_buf[1];
-    int len = vsnprintf(dummy_buf, sizeof(dummy_buf), format, arg);
+    int len = mbed_vsnprintf(dummy_buf, sizeof(dummy_buf), format, arg);
     if (len < STRING_STACK_LIMIT) {
         char temp[STRING_STACK_LIMIT];
-        vsprintf(temp, format, arg);
+        mbed_vsprintf(temp, format, arg);
         puts(temp);
     } else {
         char *temp = new char[len + 1];
-        vsprintf(temp, format, arg);
+        mbed_vsprintf(temp, format, arg);
         puts(temp);
         delete[] temp;
     }

--- a/drivers/source/usb/USBCDC_ECM.cpp
+++ b/drivers/source/usb/USBCDC_ECM.cpp
@@ -277,7 +277,7 @@ void USBCDC_ECM::callback_request(const setup_packet_t *setup)
     uint32_t size = 0;
 
     if (setup->bmRequestType.Type == CLASS_TYPE) {
-        //printf("In USBCallback_request: CLASS specific Request: %02x\n", setup->bRequest);
+        //mbed_printf("In USBCallback_request: CLASS specific Request: %02x\n", setup->bRequest);
         switch (setup->bRequest) {
             case SET_ETHERNET_MULTICAST_FILTERS:
                 /* TODO: Support is optional, not implemented here */

--- a/drivers/source/usb/USBDevice.cpp
+++ b/drivers/source/usb/USBDevice.cpp
@@ -23,6 +23,7 @@
 #include "usb_phy_api.h"
 #include "mbed_assert.h"
 #include "platform/mbed_error.h"
+#include "platform/mbed_printf.h"
 
 //#define DEBUG
 
@@ -64,7 +65,7 @@ bool USBDevice::_request_get_descriptor()
 
     bool success = false;
 #ifdef DEBUG
-    printf("get descr: type: %d\r\n", DESCRIPTOR_TYPE(_transfer.setup.wValue));
+    mbed_printf("get descr: type: %d\r\n", DESCRIPTOR_TYPE(_transfer.setup.wValue));
 #endif
     switch (DESCRIPTOR_TYPE(_transfer.setup.wValue)) {
         case DEVICE_DESCRIPTOR: {
@@ -72,7 +73,7 @@ bool USBDevice::_request_get_descriptor()
                 if ((device_desc()[0] == DEVICE_DESCRIPTOR_LENGTH) \
                         && (device_desc()[1] == DEVICE_DESCRIPTOR)) {
 #ifdef DEBUG
-                    printf("device descr\r\n");
+                    mbed_printf("device descr\r\n");
 #endif
                     _transfer.remaining = DEVICE_DESCRIPTOR_LENGTH;
                     _transfer.ptr = (uint8_t *)device_desc();
@@ -88,7 +89,7 @@ bool USBDevice::_request_get_descriptor()
                 if ((configuration_desc(idx)[0] == CONFIGURATION_DESCRIPTOR_LENGTH) \
                         && (configuration_desc(idx)[1] == CONFIGURATION_DESCRIPTOR)) {
 #ifdef DEBUG
-                    printf("conf descr request\r\n");
+                    mbed_printf("conf descr request\r\n");
 #endif
                     /* Get wTotalLength */
                     _transfer.remaining = configuration_desc(idx)[2] \
@@ -103,12 +104,12 @@ bool USBDevice::_request_get_descriptor()
         }
         case STRING_DESCRIPTOR: {
 #ifdef DEBUG
-            printf("str descriptor\r\n");
+            mbed_printf("str descriptor\r\n");
 #endif
             switch (DESCRIPTOR_INDEX(_transfer.setup.wValue)) {
                 case STRING_OFFSET_LANGID:
 #ifdef DEBUG
-                    printf("1\r\n");
+                    mbed_printf("1\r\n");
 #endif
                     _transfer.remaining = string_langid_desc()[0];
                     _transfer.ptr = (uint8_t *)string_langid_desc();
@@ -117,7 +118,7 @@ bool USBDevice::_request_get_descriptor()
                     break;
                 case STRING_OFFSET_IMANUFACTURER:
 #ifdef DEBUG
-                    printf("2\r\n");
+                    mbed_printf("2\r\n");
 #endif
                     _transfer.remaining =  string_imanufacturer_desc()[0];
                     _transfer.ptr = (uint8_t *)string_imanufacturer_desc();
@@ -126,7 +127,7 @@ bool USBDevice::_request_get_descriptor()
                     break;
                 case STRING_OFFSET_IPRODUCT:
 #ifdef DEBUG
-                    printf("3\r\n");
+                    mbed_printf("3\r\n");
 #endif
                     _transfer.remaining = string_iproduct_desc()[0];
                     _transfer.ptr = (uint8_t *)string_iproduct_desc();
@@ -135,7 +136,7 @@ bool USBDevice::_request_get_descriptor()
                     break;
                 case STRING_OFFSET_ISERIAL:
 #ifdef DEBUG
-                    printf("4\r\n");
+                    mbed_printf("4\r\n");
 #endif
                     _transfer.remaining = string_iserial_desc()[0];
                     _transfer.ptr = (uint8_t *)string_iserial_desc();
@@ -144,7 +145,7 @@ bool USBDevice::_request_get_descriptor()
                     break;
                 case STRING_OFFSET_ICONFIGURATION:
 #ifdef DEBUG
-                    printf("5\r\n");
+                    mbed_printf("5\r\n");
 #endif
                     _transfer.remaining = string_iconfiguration_desc()[0];
                     _transfer.ptr = (uint8_t *)string_iconfiguration_desc();
@@ -153,7 +154,7 @@ bool USBDevice::_request_get_descriptor()
                     break;
                 case STRING_OFFSET_IINTERFACE:
 #ifdef DEBUG
-                    printf("6\r\n");
+                    mbed_printf("6\r\n");
 #endif
                     _transfer.remaining = string_iinterface_desc()[0];
                     _transfer.ptr = (uint8_t *)string_iinterface_desc();
@@ -165,20 +166,20 @@ bool USBDevice::_request_get_descriptor()
         }
         case INTERFACE_DESCRIPTOR: {
 #ifdef DEBUG
-            printf("interface descr\r\n");
+            mbed_printf("interface descr\r\n");
 #endif
             break;
         }
         case ENDPOINT_DESCRIPTOR: {
 #ifdef DEBUG
-            printf("endpoint descr\r\n");
+            mbed_printf("endpoint descr\r\n");
 #endif
             /* TODO: Support is optional, not implemented here */
             break;
         }
         default: {
 #ifdef DEBUG
-            printf("ERROR\r\n");
+            mbed_printf("ERROR\r\n");
 #endif
             break;
         }
@@ -678,7 +679,7 @@ void USBDevice::_control_setup()
     _transfer.user_callback = Request;
 
 #ifdef DEBUG
-    printf("dataTransferDirection: %d\r\nType: %d\r\nRecipient: %d\r\nbRequest: %d\r\nwValue: %d\r\nwIndex: %d\r\nwLength: %d\r\n", _transfer.setup.bmRequestType.dataTransferDirection,
+    mbed_printf("dataTransferDirection: %d\r\nType: %d\r\nRecipient: %d\r\nbRequest: %d\r\nwValue: %d\r\nwIndex: %d\r\nwLength: %d\r\n", _transfer.setup.bmRequestType.dataTransferDirection,
            _transfer.setup.bmRequestType.Type,
            _transfer.setup.bmRequestType.Recipient,
            _transfer.setup.bRequest,
@@ -945,7 +946,7 @@ void USBDevice::ep0_in()
     }
 
 #ifdef DEBUG
-    printf("ep0_in\r\n");
+    mbed_printf("ep0_in\r\n");
 #endif
     if (_transfer.stage == Status) {
         // No action needed on status stage

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -287,7 +287,7 @@ public:
      *         EventQueue queue;
      *
      *         // events are simple callbacks
-     *         queue.call(printf, "called immediately\n");
+     *         queue.call(mbed_printf, "called immediately\n");
      *
      *         // the dispatch method executes events
      *         queue.dispatch();
@@ -323,7 +323,7 @@ public:
      *         EventHandler(int id) : _id(id) { }
      *
      *         void handler(int c) {
-     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *             mbed_printf("ID: %d Param: %d\r\n", _id, c);
      *         }
      *     };
      *
@@ -371,7 +371,7 @@ public:
      *         EventQueue queue;
      *
      *         // events are simple callbacks
-     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_in(2000, mbed_printf, "called in 2 seconds\n");
      *
      *         // the dispatch methods executes events
      *         queue.dispatch();
@@ -406,7 +406,7 @@ public:
      *         EventHandler(int id) : _id(id) { }
      *
      *         void handler(int c) {
-     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *             mbed_printf("ID: %d Param: %d\r\n", _id, c);
      *         }
      *     };
      *
@@ -459,7 +459,7 @@ public:
      *         EventHandler(int id) : _id(id) { }
      *
      *         void handler(int c) {
-     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *             mbed_printf("ID: %d Param: %d\r\n", _id, c);
      *         }
      *     };
      *
@@ -468,7 +468,7 @@ public:
      *         EventQueue queue;
      *
      *         // events are simple callbacks, call every 2 seconds
-     *         queue.call_every(2000, printf, "Calling every 2 seconds\n");
+     *         queue.call_every(2000, mbed_printf, "Calling every 2 seconds\n");
      *
      *         // the dispatch method executes events
      *         queue.dispatch();
@@ -503,7 +503,7 @@ public:
      *         EventHandler(int id) : _id(id) { }
      *
      *         void handler(int c) {
-     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *             mbed_printf("ID: %d Param: %d\r\n", _id, c);
      *         }
      *     };
      *
@@ -543,7 +543,7 @@ public:
      *     #include "mbed.h"
      *
      *     void handler(int c) {
-     *         printf("Param: %d\r\n", c);
+     *         mbed_printf("Param: %d\r\n", c);
      *     }
      *
      *     int main()
@@ -596,7 +596,7 @@ public:
      *         EventHandler(int id) : _id(id) { }
      *
      *         void handler(int c) {
-     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *             mbed_printf("ID: %d Param: %d\r\n", _id, c);
      *         }
      *     };
      *
@@ -637,7 +637,7 @@ public:
      *     #include "mbed.h"
      *
      *     void handler(int c) {
-     *         printf("Param: %d\r\n", c);
+     *         mbed_printf("Param: %d\r\n", c);
      *     }
      *
      *     int main()

--- a/events/README.md
+++ b/events/README.md
@@ -11,9 +11,9 @@ int main() {
     EventQueue queue;
 
     // events are simple callbacks
-    queue.call(printf, "called immediately\n");
-    queue.call_in(2000, printf, "called in 2 seconds\n");
-    queue.call_every(1000, printf, "called every 1 seconds\n");
+    queue.call(mbed_printf, "called immediately\n");
+    queue.call_in(2000, mbed_printf, "called in 2 seconds\n");
+    queue.call_every(1000, mbed_printf, "called every 1 seconds\n");
 
     // events are executed by the dispatch method
     queue.dispatch();
@@ -43,7 +43,7 @@ EventQueue queue(32*EVENTS_EVENT_SIZE);
 
 // Events can be posted to the underlying event queue with dynamic
 // context allocated from the specified buffer
-queue.call(printf, "hello %d %d %d %d\n", 1, 2, 3, 4);
+queue.call(mbed_printf, "hello %d %d %d %d\n", 1, 2, 3, 4);
 queue.call(&serial, &Serial::printf, "hi\n");
 
 // The dispatch function provides the context for the running the queue
@@ -60,17 +60,17 @@ for moving events out of interrupt contexts.
 ``` cpp
 // Simple call function registers events to be called as soon as possible
 queue.call(doit);
-queue.call(printf, "called immediately\n");
+queue.call(mbed_printf, "called immediately\n");
 
 // The call_in function registers events to be called after a delay
 // specified in milliseconds
 queue.call_in(2000, doit_in_two_seconds);
-queue.call_in(300, printf, "called in 0.3 seconds\n");
+queue.call_in(300, mbed_printf, "called in 0.3 seconds\n");
 
 // The call_every function registers events to be called repeatedly
 // with a period specified in milliseconds
 queue.call_every(2000, doit_every_two_seconds);
-queue.call_every(400, printf, "called every 0.4 seconds\n");
+queue.call_every(400, mbed_printf, "called every 0.4 seconds\n");
 ```
 
 The call functions return an ID that uniquely represents the event in the 
@@ -79,7 +79,7 @@ an in-flight event.
 
 ``` cpp
 // The event id uniquely represents the event in the queue
-int id = queue.call_in(100, printf, "will this work?\n");
+int id = queue.call_in(100, mbed_printf, "will this work?\n");
 
 // If there was not enough memory necessary to allocate the event,
 // an id of 0 is returned from the call functions
@@ -113,7 +113,7 @@ queue.dispatch();
 
 // Events can also pass arguments to the underlying callback when both
 // initially constructed and posted.
-Event<void(int, int)> event(&queue, printf, "received %d and %d\n");
+Event<void(int, int)> event(&queue, mbed_printf, "received %d and %d\n");
 
 // Events can be posted multiple times and enqueue gracefully until
 // the dispatch function is called.
@@ -132,13 +132,13 @@ use independent event queues but still be composed through the
 ``` cpp
 // Create some event queues with pending events
 EventQueue a;
-a.call(printf, "hello from a!\n");
+a.call(mbed_printf, "hello from a!\n");
 
 EventQueue b;
-b.call(printf, "hello from b!\n");
+b.call(mbed_printf, "hello from b!\n");
 
 EventQueue c;
-c.call(printf, "hello from c!\n");
+c.call(mbed_printf, "hello from c!\n");
 
 // Chain c and b onto a's event queue. Both c and b will be dispatched
 // in the context of a's dispatch function.

--- a/events/internal/equeue_platform.h
+++ b/events/internal/equeue_platform.h
@@ -35,7 +35,7 @@ extern "C" {
 // Try to infer a platform if none was manually selected
 #if !defined(EQUEUE_PLATFORM_POSIX)     \
  && !defined(EQUEUE_PLATFORM_MBED)
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
 #define EQUEUE_PLATFORM_POSIX
 #elif defined(__MBED__)
 #define EQUEUE_PLATFORM_MBED

--- a/features/storage/TESTS/blockdevice/buffered_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/buffered_block_device/main.cpp
@@ -46,7 +46,7 @@ void functionality_test()
         bd_size_t heap_read_size = sizes[i].read_size;
         bd_size_t heap_prog_size = sizes[i].prog_size;
 
-        printf("Testing read size of %lld, prog size of %lld\n", heap_read_size, heap_prog_size);
+        mbed_printf("Testing read size of %lld, prog size of %lld\n", heap_read_size, heap_prog_size);
 
         uint8_t *read_buf, *write_buf;
         read_buf = new (std::nothrow) uint8_t[heap_erase_size];

--- a/features/storage/TESTS/blockdevice/general_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/general_block_device/main.cpp
@@ -54,7 +54,7 @@
 #endif
 
 #if MODE_DEBUG
-#define DEBUG_PRINTF(...) printf(__VA_ARGS__)
+#define DEBUG_PRINTF(...) mbed_printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINTF(...)
 #endif
@@ -786,7 +786,7 @@ int main()
     for (int j = 0; j < bd_count; j++) {
         for (size_t i = 0; i < num_cases; i++) {
             char desc[128], *desc_ptr;
-            sprintf(desc, "%s%s", prefix[bd_arr[j]], template_cases[i].description);
+            mbed_sprintf(desc, "%s%s", prefix[bd_arr[j]], template_cases[i].description);
             desc_ptr = new char[strlen(desc) + 1];
             strcpy(desc_ptr, desc);
             new (&cases[total_num_cases]) Case((const char *) desc_ptr, template_cases[i].case_handler,
@@ -797,7 +797,7 @@ int main()
         //Add test_get_type_functionality once, runs on default blockdevice
         if (j == bd_count - 1) {
             char desc[128], *desc_ptr;
-            sprintf(desc, "%s%s", prefix[default_bd], def_template_case.description);
+            mbed_sprintf(desc, "%s%s", prefix[default_bd], def_template_case.description);
             desc_ptr = new char[strlen(desc) + 1];
             strcpy(desc_ptr, desc);
             new (&cases[total_num_cases]) Case((const char *) desc_ptr, def_template_case.case_handler,

--- a/features/storage/TESTS/blockdevice/heap_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/heap_block_device/main.cpp
@@ -61,7 +61,7 @@ void test_read_write()
         for (int i = 3; i >= 0; i--) {
             bd_size_t size = (bd.*ATTRS[a].method)();
             if (size >= (1ULL << 10 * i)) {
-                printf("%s: %llu%sbytes (%llubytes)\n",
+                mbed_printf("%s: %llu%sbytes (%llubytes)\n",
                        ATTRS[a].name, size >> 10 * i, prefixes[i], size);
                 break;
             }
@@ -75,7 +75,7 @@ void test_read_write()
     uint8_t *read_block = new (std::nothrow) uint8_t[block_size];
     uint8_t *error_mask = new (std::nothrow) uint8_t[TEST_ERROR_MASK];
     if (!write_block || !read_block || !error_mask) {
-        printf("Not enough memory for test");
+        mbed_printf("Not enough memory for test");
         goto end;
     }
 
@@ -95,7 +95,7 @@ void test_read_write()
         }
 
         // erase, program, and read the block
-        printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
+        mbed_printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
 
         err = bd.erase(block, block_size);
         TEST_ASSERT_EQUAL(0, err);
@@ -103,20 +103,20 @@ void test_read_write()
         err = bd.program(write_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
-        printf("write %0*llx:%llu ", addrwidth, block, block_size);
+        mbed_printf("write %0*llx:%llu ", addrwidth, block, block_size);
         for (int i = 0; i < 16; i++) {
-            printf("%02x", write_block[i]);
+            mbed_printf("%02x", write_block[i]);
         }
-        printf("...\n");
+        mbed_printf("...\n");
 
         err = bd.read(read_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
-        printf("read  %0*llx:%llu ", addrwidth, block, block_size);
+        mbed_printf("read  %0*llx:%llu ", addrwidth, block, block_size);
         for (int i = 0; i < 16; i++) {
-            printf("%02x", read_block[i]);
+            mbed_printf("%02x", read_block[i]);
         }
-        printf("...\n");
+        mbed_printf("...\n");
 
         // Find error mask for debugging
         memset(error_mask, 0, TEST_ERROR_MASK);
@@ -131,11 +131,11 @@ void test_read_write()
             }
         }
 
-        printf("error %0*llx:%llu ", addrwidth, block, block_size);
+        mbed_printf("error %0*llx:%llu ", addrwidth, block, block_size);
         for (int i = 0; i < 16; i++) {
-            printf("%02x", error_mask[i]);
+            mbed_printf("%02x", error_mask[i]);
         }
-        printf("\n");
+        mbed_printf("\n");
 
         // Check that the data was unmodified
         srand(seed);

--- a/features/storage/TESTS/blockdevice/mbr_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/mbr_block_device/main.cpp
@@ -86,14 +86,14 @@ void test_mbr_attr()
     TEST_ASSERT_EQUAL(0, err);
 
     // Test attributes on partitions
-    printf("partition 1 partition number: %d\n",        part1.get_partition_number());
-    printf("partition 1 partition start: 0x%llx\n",     part1.get_partition_start());
-    printf("partition 1 partition stop: 0x%llx\n",      part1.get_partition_stop());
-    printf("partition 1 partition type: 0x%02x\n",      part1.get_partition_type());
-    printf("partition 1 read size: %llu bytes\n",       part1.get_read_size());
-    printf("partition 1 program size: %llu bytes\n",    part1.get_program_size());
-    printf("partition 1 erase size: %llu bytes\n",      part1.get_erase_size());
-    printf("partition 1 size: %llu bytes\n",            part1.size());
+    mbed_printf("partition 1 partition number: %d\n",        part1.get_partition_number());
+    mbed_printf("partition 1 partition start: 0x%llx\n",     part1.get_partition_start());
+    mbed_printf("partition 1 partition stop: 0x%llx\n",      part1.get_partition_stop());
+    mbed_printf("partition 1 partition type: 0x%02x\n",      part1.get_partition_type());
+    mbed_printf("partition 1 read size: %llu bytes\n",       part1.get_read_size());
+    mbed_printf("partition 1 program size: %llu bytes\n",    part1.get_program_size());
+    mbed_printf("partition 1 erase size: %llu bytes\n",      part1.get_erase_size());
+    mbed_printf("partition 1 size: %llu bytes\n",            part1.size());
     TEST_ASSERT_EQUAL(1,                                part1.get_partition_number());
     TEST_ASSERT_EQUAL(1 * BLOCK_SIZE,                     part1.get_partition_start());
     TEST_ASSERT_EQUAL((BLOCK_COUNT / 2)*BLOCK_SIZE,       part1.get_partition_stop());
@@ -103,14 +103,14 @@ void test_mbr_attr()
     TEST_ASSERT_EQUAL(BLOCK_SIZE,                       part1.get_erase_size());
     TEST_ASSERT_EQUAL(((BLOCK_COUNT / 2) - 1)*BLOCK_SIZE,   part1.size());
 
-    printf("partition 2 partition number: %d\n",        part2.get_partition_number());
-    printf("partition 2 partition start: 0x%llx\n",     part2.get_partition_start());
-    printf("partition 2 partition stop: 0x%llx\n",      part2.get_partition_stop());
-    printf("partition 2 partition type: 0x%02x\n",      part2.get_partition_type());
-    printf("partition 2 read size: %llu bytes\n",       part2.get_read_size());
-    printf("partition 2 program size: %llu bytes\n",    part2.get_program_size());
-    printf("partition 2 erase size: %llu bytes\n",      part2.get_erase_size());
-    printf("partition 2 size: %llu bytes\n",            part2.size());
+    mbed_printf("partition 2 partition number: %d\n",        part2.get_partition_number());
+    mbed_printf("partition 2 partition start: 0x%llx\n",     part2.get_partition_start());
+    mbed_printf("partition 2 partition stop: 0x%llx\n",      part2.get_partition_stop());
+    mbed_printf("partition 2 partition type: 0x%02x\n",      part2.get_partition_type());
+    mbed_printf("partition 2 read size: %llu bytes\n",       part2.get_read_size());
+    mbed_printf("partition 2 program size: %llu bytes\n",    part2.get_program_size());
+    mbed_printf("partition 2 erase size: %llu bytes\n",      part2.get_erase_size());
+    mbed_printf("partition 2 size: %llu bytes\n",            part2.size());
     TEST_ASSERT_EQUAL(2,                                part2.get_partition_number());
     TEST_ASSERT_EQUAL((BLOCK_COUNT / 2)*BLOCK_SIZE,       part2.get_partition_start());
     TEST_ASSERT_EQUAL(BLOCK_COUNT * BLOCK_SIZE,           part2.get_partition_stop());
@@ -150,7 +150,7 @@ void test_mbr_read_write()
     uint8_t *write_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
     uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
     if (!write_block || !read_block) {
-        printf("Not enough memory for test");
+        mbed_printf("Not enough memory for test");
         goto end;
     }
 

--- a/features/storage/TESTS/blockdevice/util_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/util_block_device/main.cpp
@@ -60,7 +60,7 @@ void test_slicing()
     uint8_t *write_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
     uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
     if (!write_block || !read_block) {
-        printf("Not enough memory for test");
+        mbed_printf("Not enough memory for test");
         goto end;
     }
 
@@ -161,7 +161,7 @@ void test_chaining()
     uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
 
     if (!write_block || !read_block) {
-        printf("Not enough memory for test");
+        mbed_printf("Not enough memory for test");
         goto end;
     }
 
@@ -236,7 +236,7 @@ void test_profiling()
     uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
 
     if (!write_block || !read_block) {
-        printf("Not enough memory for test");
+        mbed_printf("Not enough memory for test");
         goto end;
     }
 

--- a/features/storage/TESTS/filesystem/fat_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/fat_filesystem/main.cpp
@@ -138,7 +138,7 @@ void test_read_dir()
     bool test_file_found = true;
 
     while ((de = readdir(&dir))) {
-        printf("d_name: %.32s, d_type: %x\n", de->d_name, de->d_type);
+        mbed_printf("d_name: %.32s, d_type: %x\n", de->d_name, de->d_type);
 
         if (strcmp(de->d_name, ".") == 0) {
             test_dir_found = true;
@@ -154,7 +154,7 @@ void test_read_dir()
             TEST_ASSERT_EQUAL(DT_REG, de->d_type);
         } else {
             char *buf = new char[NAME_MAX];
-            snprintf(buf, NAME_MAX, "Unexpected file \"%s\"", de->d_name);
+            mbed_snprintf(buf, NAME_MAX, "Unexpected file \"%s\"", de->d_name);
             TEST_ASSERT_MESSAGE(false, buf);
         }
     }

--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -1411,7 +1411,7 @@ static void FS_fscanf_valid_flow()
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
-    res = fprintf(fd[0], "%d %s", 123, write_buf);
+    res = mbed_fprintf(fd[0], "%d %s", 123, write_buf);
     TEST_ASSERT_EQUAL(3 + sizeof(write_buf), res);
 
     res = fclose(fd[0]);
@@ -1463,7 +1463,7 @@ static void FS_fscanf_more_fields_than_exist()
     int res = !((fd[0] = fopen("/default/" "filename", "wb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
-    res = fprintf(fd[0], "%d %s", 123, write_buf);
+    res = mbed_fprintf(fd[0], "%d %s", 123, write_buf);
     TEST_ASSERT_EQUAL(3 + sizeof(write_buf), res);
 
     res = fclose(fd[0]);
@@ -1504,7 +1504,7 @@ static void FS_fprintf_read_mode()
     res = !((fd[0] = fopen("/default/" "filename", "rb")) != NULL);
     TEST_ASSERT_EQUAL(0, res);
 
-    res = fprintf(fd[0], "%d", 123);
+    res = mbed_fprintf(fd[0], "%d", 123);
     TEST_ASSERT_NOT_EQUAL(1, res);
 
     res = fclose(fd[0]);
@@ -1932,7 +1932,7 @@ static void FS_write_read_random_data()
 
     for (i = 0; i < medium_buf_size; i++) {
         write_buf[i] = rand() % 0XFF;
-        res = fprintf(fd[0], "%c", write_buf[i]);
+        res = mbed_fprintf(fd[0], "%c", write_buf[i]);
         TEST_ASSERT_EQUAL(1, res);
     }
 

--- a/features/storage/TESTS/filesystem/multipart_fat_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/multipart_fat_filesystem/main.cpp
@@ -246,7 +246,7 @@ void test_with_other_fs()
         FileSystem *fs;
 
         if (stage == 1) {
-            printf("Stage %d: FAT FS\n", stage + 1);
+            mbed_printf("Stage %d: FAT FS\n", stage + 1);
             err = MBRBlockDevice::partition(bd, 1, 0x83, 0, BLOCK_COUNT * BLOCK_SIZE);
             TEST_ASSERT_EQUAL(0, err);
 
@@ -258,7 +258,7 @@ void test_with_other_fs()
 
             fs = new FATFileSystem("fat");
         } else {
-            printf("Stage %d: Little FS\n", stage + 1);
+            mbed_printf("Stage %d: Little FS\n", stage + 1);
             part = bd;
             fs = new LittleFileSystem("lfs");
         }

--- a/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/filesystemstore_tests/main.cpp
@@ -60,7 +60,7 @@ static void test_set_thread_job(void *data)
     FileSystemStore *thread_fsst = (FileSystemStore *)(thread_data->fsst);
 
     utest_printf("\n Thread %d Started\n", thread_num);
-    sprintf(thread_str, "%d", thread_num);
+    mbed_sprintf(thread_str, "%d", thread_num);
     strcat(kv_value, thread_str);
     strcat(kv_key, thread_str);
     err = thread_fsst->set(kv_key, kv_value, strlen(kv_value) + 1, 0);
@@ -477,7 +477,7 @@ void test_file_system_store_multi_threads()
 
     for (i_ind = 1; i_ind < (FSST_TEST_NUM_OF_THREADS + 1); i_ind++) {
         memset(kv_buf, 0, 64);
-        sprintf(thread_str, "%d", i_ind);
+        mbed_sprintf(thread_str, "%d", i_ind);
         strcpy(&kv_value[10], thread_str);
         strcpy(&kv_key[3], thread_str);
         err = fsst->get(kv_key, kv_buf, 12, &actual_size, 0);

--- a/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_1/main.cpp
@@ -860,7 +860,7 @@ int main()
     // Don't even start if conditions aren't appropriate for test run
     uint8_t *dummy = new (std::nothrow) uint8_t[heap_alloc_threshold_size];
     if (!dummy) {
-        printf("Not enough heap memory to run test. Test skipped.\n");
+        mbed_printf("Not enough heap memory to run test. Test skipped.\n");
         GREENTEA_TESTSUITE_RESULT(1);
         return 0;
     }
@@ -868,7 +868,7 @@ int main()
 
     bd = BlockDevice::get_default_instance();
     if (!bd) {
-        printf("No default instance for this target. Test skipped.\n");
+        mbed_printf("No default instance for this target. Test skipped.\n");
         GREENTEA_TESTSUITE_RESULT(1);
         return 0;
     }
@@ -883,7 +883,7 @@ int main()
     for (int kv = 0; kv < NumKVs; kv++) {
         for (size_t i = 0; i < num_cases; i++) {
             char desc[128], *desc_ptr;
-            sprintf(desc, "%s%s", kv_prefix[kv], template_cases[i].description);
+            mbed_sprintf(desc, "%s%s", kv_prefix[kv], template_cases[i].description);
             desc_ptr = new char[strlen(desc) + 1];
             strcpy(desc_ptr, desc);
             new (&cases[total_num_cases]) Case((const char *) desc_ptr, template_cases[i].case_handler,

--- a/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
+++ b/features/storage/TESTS/kvstore/general_tests_phase_2/main.cpp
@@ -841,7 +841,7 @@ int main()
     // Don't even start if conditions aren't appropriate for test run
     uint8_t *dummy = new (std::nothrow) uint8_t[heap_alloc_threshold_size];
     if (!dummy) {
-        printf("Not enough heap memory to run test. Test skipped.\n");
+        mbed_printf("Not enough heap memory to run test. Test skipped.\n");
         GREENTEA_TESTSUITE_RESULT(1);
         return 0;
     }
@@ -849,7 +849,7 @@ int main()
 
     bd = BlockDevice::get_default_instance();
     if (!bd) {
-        printf("No default instance for this target. Test skipped.\n");
+        mbed_printf("No default instance for this target. Test skipped.\n");
         GREENTEA_TESTSUITE_RESULT(1);
         return 0;
     }
@@ -864,7 +864,7 @@ int main()
     for (int kv = 0; kv < NumKVs; kv++) {
         for (size_t i = 0; i < num_cases; i++) {
             char desc[128], *desc_ptr;
-            sprintf(desc, "%s%s", kv_prefix[kv], template_cases[i].description);
+            mbed_sprintf(desc, "%s%s", kv_prefix[kv], template_cases[i].description);
             desc_ptr = new char[strlen(desc) + 1];
             strcpy(desc_ptr, desc);
             new (&cases[total_num_cases]) Case((const char *) desc_ptr, template_cases[i].case_handler,

--- a/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/securestore_whitebox/main.cpp
@@ -140,13 +140,13 @@ static void white_box_test()
         result = sec_kv->init();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         elapsed = timer.read_ms();
-        printf("Elapsed time for init %d ms\n", elapsed);
+        mbed_printf("Elapsed time for init %d ms\n", elapsed);
 
         timer.reset();
         result = sec_kv->reset();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         elapsed = timer.read_ms();
-        printf("Elapsed time for reset is %d ms\n", elapsed);
+        mbed_printf("Elapsed time for reset is %d ms\n", elapsed);
 
         result = sec_kv->set(key1, key1_val1, strlen(key1_val1), KVStore::REQUIRE_CONFIDENTIALITY_FLAG);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
@@ -165,7 +165,7 @@ static void white_box_test()
         timer.reset();
         result = sec_kv->set(key2, key2_val3, strlen(key2_val3), KVStore::REQUIRE_REPLAY_PROTECTION_FLAG);
         elapsed = timer.read_ms();
-        printf("Elapsed time for set is %d ms\n", elapsed);
+        mbed_printf("Elapsed time for set is %d ms\n", elapsed);
 
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
@@ -250,7 +250,7 @@ static void white_box_test()
         timer.reset();
         result = sec_kv->get(key2, get_buf, sizeof(get_buf), &actual_data_size);
         elapsed = timer.read_ms();
-        printf("Elapsed time for get is %d ms\n", elapsed);
+        mbed_printf("Elapsed time for get is %d ms\n", elapsed);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         TEST_ASSERT_EQUAL(strlen(key2_val3), actual_data_size);
         TEST_ASSERT_EQUAL_STRING_LEN(key2_val3, get_buf, strlen(key2_val3));
@@ -303,7 +303,7 @@ static void white_box_test()
         timer.reset();
         result = sec_kv->init();
         elapsed = timer.read_ms();
-        printf("Elapsed time for init is %d ms\n", elapsed);
+        mbed_printf("Elapsed time for init is %d ms\n", elapsed);
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
         result = sec_kv->get(key4, get_buf, sizeof(get_buf), &actual_data_size);
@@ -423,7 +423,7 @@ static void multi_set_test()
     timer.reset();
     result = kvs->init();
     elapsed = timer.read_ms();
-    printf("Elapsed time for initial init is %d ms\n", elapsed);
+    mbed_printf("Elapsed time for initial init is %d ms\n", elapsed);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
     key = new char[key_size + 1];
@@ -479,10 +479,10 @@ static void multi_set_test()
         total_get_time += elapsed;
     }
 
-    printf("set time: Total (%d * %d times) - %d ms, Average - %d ms, Max - %d ms\n",
+    mbed_printf("set time: Total (%d * %d times) - %d ms, Average - %d ms, Max - %d ms\n",
            set_iters, num_keys, total_set_time,
            total_set_time / (set_iters * num_keys), max_set_time);
-    printf("get time: Total (%d times)      - %d ms, Average - %d ms, Max - %d ms\n",
+    mbed_printf("get time: Total (%d times)      - %d ms, Average - %d ms, Max - %d ms\n",
            num_keys, total_get_time,
            total_get_time / num_keys, max_get_time);
 
@@ -492,7 +492,7 @@ static void multi_set_test()
     timer.reset();
     result = kvs->init();
     elapsed = timer.read_ms();
-    printf("Elapsed time for init is %d ms\n", elapsed);
+    mbed_printf("Elapsed time for init is %d ms\n", elapsed);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
     result = kvs->deinit();

--- a/features/storage/TESTS/kvstore/static_tests/main.cpp
+++ b/features/storage/TESTS/kvstore/static_tests/main.cpp
@@ -63,10 +63,10 @@ static void parse_default_kv()
 {
     const char *def_kv_temp = STR(MBED_CONF_STORAGE_DEFAULT_KV);
     def_kv = new char[3 + strlen(def_kv_temp)];
-    sprintf(def_kv, "/%s/", def_kv_temp);
+    mbed_sprintf(def_kv, "/%s/", def_kv_temp);
 
     key = new char[4 + strlen(def_kv)];
-    sprintf(key, "%skey", def_kv);
+    mbed_sprintf(key, "%skey", def_kv);
 }
 
 /*----------------initialization------------------*/

--- a/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
+++ b/features/storage/TESTS/kvstore/tdbstore_whitebox/main.cpp
@@ -131,7 +131,7 @@ static void white_box_test()
         if (!bdp->size) {
             break;
         }
-        printf("\n\nBD #%d: size %d, read %d, prog %d, erase %d\n",
+        mbed_printf("\n\nBD #%d: size %d, read %d, prog %d, erase %d\n",
                bd_num, bdp->size, bdp->read_size, bdp->prog_size, bdp->erase_size);
         HeapBlockDevice heap_bd(bdp->size, bdp->read_size, bdp->prog_size, bdp->erase_size);
         FlashSimBlockDevice flash_sim_bd(&heap_bd);
@@ -157,13 +157,13 @@ static void white_box_test()
         result = tdbs->init();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         elapsed = timer.read_ms();
-        printf("Elapsed time for init %d ms\n", elapsed);
+        mbed_printf("Elapsed time for init %d ms\n", elapsed);
 
         timer.reset();
         result = tdbs->reset();
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         elapsed = timer.read_ms();
-        printf("Elapsed time for reset is %d ms\n", elapsed);
+        mbed_printf("Elapsed time for reset is %d ms\n", elapsed);
 
         result = tdbs->reserved_data_get(get_buf, strlen(res_val1));
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_ERROR_ITEM_NOT_FOUND, result);
@@ -185,7 +185,7 @@ static void white_box_test()
         timer.reset();
         result = tdbs->set(key2, key2_val3, strlen(key2_val3), 0);
         elapsed = timer.read_ms();
-        printf("Elapsed time for set is %d ms\n", elapsed);
+        mbed_printf("Elapsed time for set is %d ms\n", elapsed);
 
         TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
@@ -255,7 +255,7 @@ static void white_box_test()
         TEST_ASSERT_EQUAL_STRING_LEN(key5_val1, get_buf, strlen(key5_val1));
 
         for (int i = 0; i < 2; i++) {
-            printf("%s deinit/init\n", i ? "After" : "Before");
+            mbed_printf("%s deinit/init\n", i ? "After" : "Before");
             result = tdbs->get(key1, get_buf, sizeof(get_buf), &actual_data_size);
             TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
             TEST_ASSERT_EQUAL(strlen(key1_val1), actual_data_size);
@@ -264,7 +264,7 @@ static void white_box_test()
             timer.reset();
             result = tdbs->get(key2, get_buf, sizeof(get_buf), &actual_data_size);
             elapsed = timer.read_ms();
-            printf("Elapsed time for get is %d ms\n", elapsed);
+            mbed_printf("Elapsed time for get is %d ms\n", elapsed);
             TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
             TEST_ASSERT_EQUAL(strlen(key2_val3), actual_data_size);
             TEST_ASSERT_EQUAL_STRING_LEN(key2_val3, get_buf, strlen(key2_val3));
@@ -319,7 +319,7 @@ static void white_box_test()
             timer.reset();
             result = tdbs->init();
             elapsed = timer.read_ms();
-            printf("Elapsed time for init is %d ms\n", elapsed);
+            mbed_printf("Elapsed time for init is %d ms\n", elapsed);
             TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
         }
 
@@ -373,7 +373,7 @@ static void multi_set_test()
     timer.reset();
     result = tdbs->init();
     elapsed = timer.read_ms();
-    printf("Elapsed time for initial init is %d ms\n", elapsed);
+    mbed_printf("Elapsed time for initial init is %d ms\n", elapsed);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
     key = new char[key_size + 1];
@@ -429,10 +429,10 @@ static void multi_set_test()
         total_get_time += elapsed;
     }
 
-    printf("set time: Total (%d * %d times) - %d ms, Average - %d ms, Max - %d ms\n",
+    mbed_printf("set time: Total (%d * %d times) - %d ms, Average - %d ms, Max - %d ms\n",
            set_iters, num_keys, total_set_time,
            total_set_time / (set_iters * num_keys), max_set_time);
-    printf("get time: Total (%d times)      - %d ms, Average - %d ms, Max - %d ms\n",
+    mbed_printf("get time: Total (%d times)      - %d ms, Average - %d ms, Max - %d ms\n",
            num_keys, total_get_time,
            total_get_time / num_keys, max_get_time);
 
@@ -442,7 +442,7 @@ static void multi_set_test()
     timer.reset();
     result = tdbs->init();
     elapsed = timer.read_ms();
-    printf("Elapsed time for init is %d ms\n", elapsed);
+    mbed_printf("Elapsed time for init is %d ms\n", elapsed);
     TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, result);
 
     result = tdbs->deinit();

--- a/features/storage/blockdevice/HeapBlockDevice.h
+++ b/features/storage/blockdevice/HeapBlockDevice.h
@@ -51,7 +51,7 @@ namespace mbed {
  *     bd.erase(0, BLOCK_SIZE);
  *     bd.program(block, 0, BLOCK_SIZE);
  *     bd.read(block, 0, BLOCK_SIZE);
- *     printf("%s", block);
+ *     mbed_printf("%s", block);
  *     bd.deinit();
  * }
  * @endcode

--- a/features/storage/filesystem/littlefs/README.md
+++ b/features/storage/filesystem/littlefs/README.md
@@ -75,7 +75,7 @@ int main() {
     fs.unmount();
 
     // Print the boot count
-    printf("boot_count: %ld\n", boot_count);
+    mbed_printf("boot_count: %ld\n", boot_count);
 }
 ```
 

--- a/features/storage/filesystem/littlefs/TESTS/COMMON/atomic_usage.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/COMMON/atomic_usage.cpp
@@ -177,7 +177,7 @@ static int file_printf(File *file, const char *format, ...)
     uint8_t buf[BUFFER_SIZE];
     va_list args;
     va_start(args, format);
-    int size = vsprintf((char *)buf, format, args);
+    int size = mbed_vsprintf((char *)buf, format, args);
     va_end(args);
     TEST_ASSERT_OR_EXIT((size >= 0) && (size <= (int)sizeof(buf)));
 
@@ -300,7 +300,7 @@ static void setup_file_rename_replace(FileSystem *fs)
     uint32_t count = 0;
     uint8_t buf[BUFFER_SIZE];
     memset(buf, 0, sizeof(buf));
-    const int length = sprintf((char *)buf, FILE_RENAME_REPLACE_FMT, count);
+    const int length = mbed_sprintf((char *)buf, FILE_RENAME_REPLACE_FMT, count);
     TEST_ASSERT_OR_EXIT(length > 0);
 
     res = file.write(buf, length);

--- a/features/storage/filesystem/littlefs/TESTS/filesystem/dirs/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem/dirs/main.cpp
@@ -300,7 +300,7 @@ void test_multi_block_directory()
         res = fs.mkdir("cactus", 0777);
         TEST_ASSERT_EQUAL(0, res);
         for (int i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "cactus/test%d", i);
+            mbed_sprintf((char *)buffer, "cactus/test%d", i);
             res = fs.mkdir((char *)buffer, 0777);
             TEST_ASSERT_EQUAL(0, res);
         }
@@ -326,7 +326,7 @@ void test_multi_block_directory()
         res = ent.d_type;
         TEST_ASSERT_EQUAL(DT_DIR, res);
         for (int i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "test%d", i);
+            mbed_sprintf((char *)buffer, "test%d", i);
             res = dir[0].read(&ent);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ent.d_name, (char *)buffer);

--- a/features/storage/filesystem/littlefs/TESTS/filesystem/seek/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem/seek/main.cpp
@@ -94,7 +94,7 @@ void test_seek_tests()
         res = fs.mkdir("hello", 0777);
         TEST_ASSERT_EQUAL(0, res);
         for (int i = 0; i < 132; i++) {
-            sprintf((char *)buffer, "hello/kitty%d", i);
+            mbed_sprintf((char *)buffer, "hello/kitty%d", i);
             res = file[0].open(&fs, (char *)buffer,
                                O_WRONLY | O_CREAT | O_APPEND);
             TEST_ASSERT_EQUAL(0, res);
@@ -137,7 +137,7 @@ void test_simple_dir_seek()
         off_t pos;
         int i;
         for (i = 0; i < 4; i++) {
-            sprintf((char *)buffer, "kitty%d", i);
+            mbed_sprintf((char *)buffer, "kitty%d", i);
             res = dir[0].read(&ent);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ent.d_name, (char *)buffer);
@@ -148,14 +148,14 @@ void test_simple_dir_seek()
         TEST_ASSERT_EQUAL(1, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].rewind();
-        sprintf((char *)buffer, "kitty%d", 0);
+        mbed_sprintf((char *)buffer, "kitty%d", 0);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, ".");
@@ -170,7 +170,7 @@ void test_simple_dir_seek()
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);
@@ -207,7 +207,7 @@ void test_large_dir_seek()
         off_t pos;
         int i;
         for (i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "kitty%d", i);
+            mbed_sprintf((char *)buffer, "kitty%d", i);
             res = dir[0].read(&ent);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ent.d_name, (char *)buffer);
@@ -218,14 +218,14 @@ void test_large_dir_seek()
         TEST_ASSERT_EQUAL(1, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].rewind();
-        sprintf((char *)buffer, "kitty%d", 0);
+        mbed_sprintf((char *)buffer, "kitty%d", 0);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, ".");
@@ -240,7 +240,7 @@ void test_large_dir_seek()
         TEST_ASSERT_EQUAL(0, res);
 
         dir[0].seek(pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = dir[0].read(&ent);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ent.d_name, (char *)buffer);

--- a/features/storage/filesystem/littlefs/TESTS/filesystem_recovery/resilience/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem_recovery/resilience/main.cpp
@@ -78,12 +78,12 @@ void test_resilience()
     observer.attach(check_atomic_operations);
 
     // Perform operations
-    printf("Performing %i operations on flash\n", MBED_TEST_CYCLES);
+    mbed_printf("Performing %i operations on flash\n", MBED_TEST_CYCLES);
     for (int i = 1; i <= MBED_TEST_CYCLES; i++) {
         int64_t ret = perform_atomic_operations(&observer);
         TEST_ASSERT_EQUAL(i, ret);
     }
-    printf("No errors detected\n");
+    mbed_printf("No errors detected\n");
 }
 
 Case cases[] = {

--- a/features/storage/filesystem/littlefs/TESTS/filesystem_recovery/wear_leveling/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem_recovery/wear_leveling/main.cpp
@@ -65,7 +65,7 @@ static uint32_t test_wear_leveling_size(uint32_t block_count)
     SlicingBlockDevice slice(&bd, 0, block_count * block_size);
     ExhaustibleBlockDevice ebd(&slice, MBED_TEST_ERASE_CYCLES);
 
-    printf("Testing size %llu bytes (%lux%llu) blocks\n",
+    mbed_printf("Testing size %llu bytes (%lux%llu) blocks\n",
            block_count * block_size, block_count, block_size);
     setup_atomic_operations(&ebd, true);
 
@@ -81,7 +81,7 @@ static uint32_t test_wear_leveling_size(uint32_t block_count)
 
     }
 
-    printf("  Simulated flash lasted %lli cylces\n", cycles);
+    mbed_printf("  Simulated flash lasted %lli cylces\n", cycles);
     return cycles;
 }
 

--- a/features/storage/filesystem/littlefs/TESTS/filesystem_retarget/dirs/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem_retarget/dirs/main.cpp
@@ -301,7 +301,7 @@ void test_multi_block_directory()
         res = mkdir("/fs/" "cactus", 0777);
         TEST_ASSERT_EQUAL(0, res);
         for (int i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "/fs/" "cactus/test%d", i);
+            mbed_sprintf((char *)buffer, "/fs/" "cactus/test%d", i);
             res = mkdir((char *)buffer, 0777);
             TEST_ASSERT_EQUAL(0, res);
         }
@@ -327,7 +327,7 @@ void test_multi_block_directory()
         res = ed->d_type;
         TEST_ASSERT_EQUAL(DT_DIR, res);
         for (int i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "test%d", i);
+            mbed_sprintf((char *)buffer, "test%d", i);
             res = ((ed = readdir(dd[0])) != NULL);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ed->d_name, (char *)buffer);

--- a/features/storage/filesystem/littlefs/TESTS/filesystem_retarget/seek/main.cpp
+++ b/features/storage/filesystem/littlefs/TESTS/filesystem_retarget/seek/main.cpp
@@ -94,7 +94,7 @@ void test_seek_tests()
         res = mkdir("/fs/" "hello", 0777);
         TEST_ASSERT_EQUAL(0, res);
         for (int i = 0; i < 132; i++) {
-            sprintf((char *)buffer, "/fs/" "hello/kitty%d", i);
+            mbed_sprintf((char *)buffer, "/fs/" "hello/kitty%d", i);
             res = !((fd[0] = fopen((char *)buffer,
                                    "ab")) != NULL);
             TEST_ASSERT_EQUAL(0, res);
@@ -137,7 +137,7 @@ void test_simple_dir_seek()
         off_t pos;
         int i;
         for (i = 0; i < 4; i++) {
-            sprintf((char *)buffer, "kitty%d", i);
+            mbed_sprintf((char *)buffer, "kitty%d", i);
             res = ((ed = readdir(dd[0])) != NULL);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ed->d_name, (char *)buffer);
@@ -148,14 +148,14 @@ void test_simple_dir_seek()
         TEST_ASSERT_EQUAL(1, res);
 
         seekdir(dd[0], pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = ((ed = readdir(dd[0])) != NULL);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ed->d_name, (char *)buffer);
         TEST_ASSERT_EQUAL(0, res);
 
         rewinddir(dd[0]);
-        sprintf((char *)buffer, "kitty%d", 0);
+        mbed_sprintf((char *)buffer, "kitty%d", 0);
         res = ((ed = readdir(dd[0])) != NULL);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ed->d_name, ".");
@@ -170,7 +170,7 @@ void test_simple_dir_seek()
         TEST_ASSERT_EQUAL(0, res);
 
         seekdir(dd[0], pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = ((ed = readdir(dd[0])) != NULL);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ed->d_name, (char *)buffer);
@@ -207,7 +207,7 @@ void test_large_dir_seek()
         off_t pos;
         int i;
         for (i = 0; i < 128; i++) {
-            sprintf((char *)buffer, "kitty%d", i);
+            mbed_sprintf((char *)buffer, "kitty%d", i);
             res = ((ed = readdir(dd[0])) != NULL);
             TEST_ASSERT_EQUAL(1, res);
             res = strcmp(ed->d_name, (char *)buffer);
@@ -218,14 +218,14 @@ void test_large_dir_seek()
         TEST_ASSERT_EQUAL(1, res);
 
         seekdir(dd[0], pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = ((ed = readdir(dd[0])) != NULL);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ed->d_name, (char *)buffer);
         TEST_ASSERT_EQUAL(0, res);
 
         rewinddir(dd[0]);
-        sprintf((char *)buffer, "kitty%d", 0);
+        mbed_sprintf((char *)buffer, "kitty%d", 0);
         res = ((ed = readdir(dd[0])) != NULL);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ed->d_name, ".");
@@ -240,7 +240,7 @@ void test_large_dir_seek()
         TEST_ASSERT_EQUAL(0, res);
 
         seekdir(dd[0], pos);
-        sprintf((char *)buffer, "kitty%d", i);
+        mbed_sprintf((char *)buffer, "kitty%d", i);
         res = ((ed = readdir(dd[0])) != NULL);
         TEST_ASSERT_EQUAL(1, res);
         res = strcmp(ed->d_name, (char *)buffer);

--- a/features/storage/filesystem/littlefs/littlefs/README.md
+++ b/features/storage/filesystem/littlefs/littlefs/README.md
@@ -81,7 +81,7 @@ int main(void) {
     lfs_unmount(&lfs);
 
     // print the boot count
-    printf("boot_count: %d\n", boot_count);
+    mbed_printf("boot_count: %d\n", boot_count);
 }
 ```
 

--- a/features/storage/filesystem/littlefs/littlefs/emubd/lfs_emubd.c
+++ b/features/storage/filesystem/littlefs/littlefs/emubd/lfs_emubd.c
@@ -46,7 +46,7 @@ int lfs_emubd_create(const struct lfs_config *cfg, const char *path) {
     }
 
     // Load stats to continue incrementing
-    snprintf(emu->child, LFS_NAME_MAX, "stats");
+    mbed_snprintf(emu->child, LFS_NAME_MAX, "stats");
 
     FILE *f = fopen(emu->path, "r");
     if (!f && errno != ENOENT) {
@@ -91,7 +91,7 @@ int lfs_emubd_read(const struct lfs_config *cfg, lfs_block_t block,
     memset(data, 0, size);
 
     // Read data
-    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
+    mbed_snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
 
     FILE *f = fopen(emu->path, "rb");
     if (!f && errno != ENOENT) {
@@ -130,7 +130,7 @@ int lfs_emubd_prog(const struct lfs_config *cfg, lfs_block_t block,
     assert(block < cfg->block_count);
 
     // Program data
-    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
+    mbed_snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
 
     FILE *f = fopen(emu->path, "r+b");
     if (!f) {
@@ -177,7 +177,7 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     assert(block < cfg->block_count);
 
     // Erase the block
-    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
+    mbed_snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
     struct stat st;
     int err = stat(emu->path, &st);
     if (err && errno != ENOENT) {
@@ -211,7 +211,7 @@ int lfs_emubd_sync(const struct lfs_config *cfg) {
     lfs_emubd_t *emu = cfg->context;
 
     // Just write out info/stats for later lookup
-    snprintf(emu->child, LFS_NAME_MAX, "config");
+    mbed_snprintf(emu->child, LFS_NAME_MAX, "config");
     FILE *f = fopen(emu->path, "w");
     if (!f) {
         return -errno;
@@ -227,7 +227,7 @@ int lfs_emubd_sync(const struct lfs_config *cfg) {
         return -errno;
     }
 
-    snprintf(emu->child, LFS_NAME_MAX, "stats");
+    mbed_snprintf(emu->child, LFS_NAME_MAX, "stats");
     f = fopen(emu->path, "w");
     if (!f) {
         return -errno;

--- a/features/storage/filesystem/littlefs/littlefs/lfs_util.h
+++ b/features/storage/filesystem/littlefs/littlefs/lfs_util.h
@@ -59,7 +59,7 @@ extern "C"
 
 // Logging functions
 #if !defined(LFS_NO_INFO) && MBED_LFS_ENABLE_INFO
-#define LFS_INFO(fmt, ...)  printf("lfs info:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#define LFS_INFO(fmt, ...)  mbed_printf("lfs info:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #elif !defined(LFS_NO_INFO) && !defined(MBED_LFS_ENABLE_INFO)
 #define LFS_INFO(fmt, ...)  debug("lfs info:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
@@ -67,7 +67,7 @@ extern "C"
 #endif
 
 #if !defined(LFS_NO_DEBUG) && MBED_LFS_ENABLE_DEBUG
-#define LFS_DEBUG(fmt, ...) printf("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#define LFS_DEBUG(fmt, ...) mbed_printf("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #elif !defined(LFS_NO_DEBUG) && !defined(MBED_LFS_ENABLE_DEBUG)
 #define LFS_DEBUG(fmt, ...) debug("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
@@ -75,7 +75,7 @@ extern "C"
 #endif
 
 #if !defined(LFS_NO_WARN) && MBED_LFS_ENABLE_WARN
-#define LFS_WARN(fmt, ...)  printf("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#define LFS_WARN(fmt, ...)  mbed_printf("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #elif !defined(LFS_NO_WARN) && !defined(MBED_LFS_ENABLE_WARN)
 #define LFS_WARN(fmt, ...)  debug("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
@@ -83,7 +83,7 @@ extern "C"
 #endif
 
 #if !defined(LFS_NO_ERROR) && MBED_LFS_ENABLE_ERROR
-#define LFS_ERROR(fmt, ...) printf("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#define LFS_ERROR(fmt, ...) mbed_printf("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #elif !defined(LFS_NO_ERROR) && !defined(MBED_LFS_ENABLE_ERROR)
 #define LFS_ERROR(fmt, ...) debug("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else

--- a/features/storage/filesystem/littlefs/littlefs/tests/template.fmt
+++ b/features/storage/filesystem/littlefs/littlefs/tests/template.fmt
@@ -8,7 +8,7 @@
 
 // test stuff
 static void test_log(const char *s, uintmax_t v) {{
-    printf("%s: %jd\n", s, v);
+    mbed_printf("%s: %jd\n", s, v);
 }}
 
 static void test_assert(const char *file, unsigned line,
@@ -27,7 +27,7 @@ static void test_assert(const char *file, unsigned line,
     }}
 
     if (v != e) {{
-        fprintf(stderr, "\033[31m%s:%u: assert %s failed with %jd, "
+        mbed_fprintf(stderr, "\033[31m%s:%u: assert %s failed with %jd, "
                 "expected %jd\033[0m\n", file, line, s, v, e);
         exit(-2);
     }}

--- a/features/storage/filesystem/littlefs/littlefs/tests/test_alloc.sh
+++ b/features/storage/filesystem/littlefs/littlefs/tests/test_alloc.sh
@@ -33,7 +33,7 @@ tests/test.py << TEST
     const char *names[] = {"bacon", "eggs", "pancakes"};
     lfs_mount(&lfs, &cfg) => 0;
     for (unsigned n = 0; n < sizeof(names)/sizeof(names[0]); n++) {
-        sprintf((char*)buffer, "$1/%s", names[n]);
+        mbed_sprintf((char*)buffer, "$1/%s", names[n]);
         lfs_file_open(&lfs, &file[n], (char*)buffer,
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
     }
@@ -245,7 +245,7 @@ tests/test.py << TEST
     lfs_file_close(&lfs, &file[0]) => 0;
 
     for (int i = 0; i < 9; i++) {
-        sprintf((char*)buffer, "dirwithanexhaustivelylongnameforpadding%d", i);
+        mbed_sprintf((char*)buffer, "dirwithanexhaustivelylongnameforpadding%d", i);
         lfs_mkdir(&lfs, (char*)buffer) => 0;
     }
 

--- a/features/storage/filesystem/littlefs/littlefs/tests/test_dirs.sh
+++ b/features/storage/filesystem/littlefs/littlefs/tests/test_dirs.sh
@@ -100,7 +100,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, "cactus") => 0;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "cactus/test%d", i);
+        mbed_sprintf((char*)buffer, "cactus/test%d", i);
         lfs_mkdir(&lfs, (char*)buffer) => 0;
     }
     lfs_unmount(&lfs) => 0;
@@ -115,7 +115,7 @@ tests/test.py << TEST
     strcmp(info.name, "..") => 0;
     info.type => LFS_TYPE_DIR;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "test%d", i);
+        mbed_sprintf((char*)buffer, "test%d", i);
         lfs_dir_read(&lfs, &dir[0], &info) => 1;
         strcmp(info.name, (char*)buffer) => 0;
         info.type => LFS_TYPE_DIR;
@@ -330,8 +330,8 @@ echo "--- Multi-block rename ---"
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "cactus/test%d", i);
-        sprintf((char*)wbuffer, "cactus/tedd%d", i);
+        mbed_sprintf((char*)buffer, "cactus/test%d", i);
+        mbed_sprintf((char*)wbuffer, "cactus/tedd%d", i);
         lfs_rename(&lfs, (char*)buffer, (char*)wbuffer) => 0;
     }
     lfs_unmount(&lfs) => 0;
@@ -346,7 +346,7 @@ tests/test.py << TEST
     strcmp(info.name, "..") => 0;
     info.type => LFS_TYPE_DIR;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "tedd%d", i);
+        mbed_sprintf((char*)buffer, "tedd%d", i);
         lfs_dir_read(&lfs, &dir[0], &info) => 1;
         strcmp(info.name, (char*)buffer) => 0;
         info.type => LFS_TYPE_DIR;
@@ -361,7 +361,7 @@ tests/test.py << TEST
     lfs_remove(&lfs, "cactus") => LFS_ERR_NOTEMPTY;
 
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "cactus/tedd%d", i);
+        mbed_sprintf((char*)buffer, "cactus/tedd%d", i);
         lfs_remove(&lfs, (char*)buffer) => 0;
     }
 
@@ -390,7 +390,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, "prickly-pear") => 0;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "prickly-pear/test%d", i);
+        mbed_sprintf((char*)buffer, "prickly-pear/test%d", i);
         lfs_file_open(&lfs, &file[0], (char*)buffer,
                 LFS_O_WRONLY | LFS_O_CREAT) => 0;
         size = 6;
@@ -410,7 +410,7 @@ tests/test.py << TEST
     strcmp(info.name, "..") => 0;
     info.type => LFS_TYPE_DIR;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "test%d", i);
+        mbed_sprintf((char*)buffer, "test%d", i);
         lfs_dir_read(&lfs, &dir[0], &info) => 1;
         strcmp(info.name, (char*)buffer) => 0;
         info.type => LFS_TYPE_REG;
@@ -424,8 +424,8 @@ echo "--- Multi-block rename with files ---"
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "prickly-pear/test%d", i);
-        sprintf((char*)wbuffer, "prickly-pear/tedd%d", i);
+        mbed_sprintf((char*)buffer, "prickly-pear/test%d", i);
+        mbed_sprintf((char*)wbuffer, "prickly-pear/tedd%d", i);
         lfs_rename(&lfs, (char*)buffer, (char*)wbuffer) => 0;
     }
     lfs_unmount(&lfs) => 0;
@@ -440,7 +440,7 @@ tests/test.py << TEST
     strcmp(info.name, "..") => 0;
     info.type => LFS_TYPE_DIR;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "tedd%d", i);
+        mbed_sprintf((char*)buffer, "tedd%d", i);
         lfs_dir_read(&lfs, &dir[0], &info) => 1;
         strcmp(info.name, (char*)buffer) => 0;
         info.type => LFS_TYPE_REG;
@@ -456,7 +456,7 @@ tests/test.py << TEST
     lfs_remove(&lfs, "prickly-pear") => LFS_ERR_NOTEMPTY;
 
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "prickly-pear/tedd%d", i);
+        mbed_sprintf((char*)buffer, "prickly-pear/tedd%d", i);
         lfs_remove(&lfs, (char*)buffer) => 0;
     }
 

--- a/features/storage/filesystem/littlefs/littlefs/tests/test_files.sh
+++ b/features/storage/filesystem/littlefs/littlefs/tests/test_files.sh
@@ -144,7 +144,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, "directory") => 0;
     for (unsigned i = 0; i < 300; i++) {
-        snprintf((char*)buffer, sizeof(buffer), "file_%03d", i);
+        mbed_snprintf((char*)buffer, sizeof(buffer), "file_%03d", i);
         lfs_file_open(&lfs, &file[0], (char*)buffer, LFS_O_WRONLY | LFS_O_CREAT) => 0;
         size = 6;
         memcpy(wbuffer, "Hello", size);

--- a/features/storage/filesystem/littlefs/littlefs/tests/test_seek.sh
+++ b/features/storage/filesystem/littlefs/littlefs/tests/test_seek.sh
@@ -12,7 +12,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, "hello") => 0;
     for (int i = 0; i < $LARGESIZE; i++) {
-        sprintf((char*)buffer, "hello/kitty%d", i);
+        mbed_sprintf((char*)buffer, "hello/kitty%d", i);
         lfs_file_open(&lfs, &file[0], (char*)buffer,
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
 
@@ -39,7 +39,7 @@ tests/test.py << TEST
     lfs_soff_t pos;
     int i;
     for (i = 0; i < $SMALLSIZE; i++) {
-        sprintf((char*)buffer, "kitty%d", i);
+        mbed_sprintf((char*)buffer, "kitty%d", i);
         lfs_dir_read(&lfs, &dir[0], &info) => 1;
         strcmp(info.name, (char*)buffer) => 0;
         pos = lfs_dir_tell(&lfs, &dir[0]);
@@ -47,12 +47,12 @@ tests/test.py << TEST
     pos >= 0 => 1;
 
     lfs_dir_seek(&lfs, &dir[0], pos) => 0;
-    sprintf((char*)buffer, "kitty%d", i);
+    mbed_sprintf((char*)buffer, "kitty%d", i);
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
     strcmp(info.name, (char*)buffer) => 0;
 
     lfs_dir_rewind(&lfs, &dir[0]) => 0;
-    sprintf((char*)buffer, "kitty%d", 0);
+    mbed_sprintf((char*)buffer, "kitty%d", 0);
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
     strcmp(info.name, ".") => 0;
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
@@ -61,7 +61,7 @@ tests/test.py << TEST
     strcmp(info.name, (char*)buffer) => 0;
 
     lfs_dir_seek(&lfs, &dir[0], pos) => 0;
-    sprintf((char*)buffer, "kitty%d", i);
+    mbed_sprintf((char*)buffer, "kitty%d", i);
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
     strcmp(info.name, (char*)buffer) => 0;
 
@@ -81,7 +81,7 @@ tests/test.py << TEST
     lfs_soff_t pos;
     int i;
     for (i = 0; i < $MEDIUMSIZE; i++) {
-        sprintf((char*)buffer, "kitty%d", i);
+        mbed_sprintf((char*)buffer, "kitty%d", i);
         lfs_dir_read(&lfs, &dir[0], &info) => 1;
         strcmp(info.name, (char*)buffer) => 0;
         pos = lfs_dir_tell(&lfs, &dir[0]);
@@ -89,12 +89,12 @@ tests/test.py << TEST
     pos >= 0 => 1;
 
     lfs_dir_seek(&lfs, &dir[0], pos) => 0;
-    sprintf((char*)buffer, "kitty%d", i);
+    mbed_sprintf((char*)buffer, "kitty%d", i);
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
     strcmp(info.name, (char*)buffer) => 0;
 
     lfs_dir_rewind(&lfs, &dir[0]) => 0;
-    sprintf((char*)buffer, "kitty%d", 0);
+    mbed_sprintf((char*)buffer, "kitty%d", 0);
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
     strcmp(info.name, ".") => 0;
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
@@ -103,7 +103,7 @@ tests/test.py << TEST
     strcmp(info.name, (char*)buffer) => 0;
 
     lfs_dir_seek(&lfs, &dir[0], pos) => 0;
-    sprintf((char*)buffer, "kitty%d", i);
+    mbed_sprintf((char*)buffer, "kitty%d", i);
     lfs_dir_read(&lfs, &dir[0], &info) => 1;
     strcmp(info.name, (char*)buffer) => 0;
 

--- a/features/storage/filesystem/littlefs/littlefs/tests/test_truncate.sh
+++ b/features/storage/filesystem/littlefs/littlefs/tests/test_truncate.sh
@@ -24,7 +24,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
 
     for (unsigned i = 0; i < sizeof(startsizes)/sizeof(startsizes[0]); i++) {
-        sprintf((char*)buffer, "hairyhead%d", i);
+        mbed_sprintf((char*)buffer, "hairyhead%d", i);
         lfs_file_open(&lfs, &file[0], (const char*)buffer,
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC) => 0;
 
@@ -56,7 +56,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
 
     for (unsigned i = 0; i < sizeof(startsizes)/sizeof(startsizes[0]); i++) {
-        sprintf((char*)buffer, "hairyhead%d", i);
+        mbed_sprintf((char*)buffer, "hairyhead%d", i);
         lfs_file_open(&lfs, &file[0], (const char*)buffer, LFS_O_RDWR) => 0;
         lfs_file_size(&lfs, &file[0]) => hotsizes[i];
 
@@ -88,7 +88,7 @@ tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
 
     for (unsigned i = 0; i < sizeof(startsizes)/sizeof(startsizes[0]); i++) {
-        sprintf((char*)buffer, "hairyhead%d", i);
+        mbed_sprintf((char*)buffer, "hairyhead%d", i);
         lfs_file_open(&lfs, &file[0], (const char*)buffer, LFS_O_RDONLY) => 0;
         lfs_file_size(&lfs, &file[0]) => coldsizes[i];
 

--- a/hal/pinmap.h
+++ b/hal/pinmap.h
@@ -92,7 +92,7 @@ uint32_t pinmap_find_function(PinName pin, const PinMap *map);
  *         &ssel
  *     };
  *     if (pinmap_find_peripheral_pins(pins_ff, pins_avoid, per, maps, pins, sizeof(maps) / sizeof(maps[0]))) {
- *         printf("Found SPI pins to test instance %i with:\n"
+ *         mbed_printf("Found SPI pins to test instance %i with:\n"
  *                "  mosi=%s\n"
  *                "  miso=%s\n"
  *                "  sclk=%s\n"
@@ -102,7 +102,7 @@ uint32_t pinmap_find_function(PinName pin, const PinMap *map);
  *                pinmap_ff_default_pin_to_string(sclk),
  *                pinmap_ff_default_pin_to_string(ssel));
  *     } else {
- *         printf("Could not find SPI combination to test %i\n", per);
+ *         mbed_printf("Could not find SPI combination to test %i\n", per);
  *     }
  *     return 0;
  * }

--- a/mbed.h
+++ b/mbed.h
@@ -48,6 +48,7 @@
 #include "platform/mbed_interface.h"
 #include "platform/mbed_assert.h"
 #include "platform/mbed_debug.h"
+#include "platform/mbed_printf.h"
 
 // mbed Peripheral components
 #include "drivers/DigitalIn.h"

--- a/platform/CallChain.h
+++ b/platform/CallChain.h
@@ -48,17 +48,17 @@ class CallChainLink;
  * CallChain chain;
  *
  * void first(void) {
- *     printf("'first' function.\n");
+ *     mbed_printf("'first' function.\n");
  * }
  *
  * void second(void) {
- *     printf("'second' function.\n");
+ *     mbed_printf("'second' function.\n");
  * }
  *
  * class Test {
  * public:
  *     void f(void) {
- *         printf("A::f (class member).\n");
+ *         mbed_printf("A::f (class member).\n");
  *     }
  * };
  *

--- a/platform/LocalFileSystem.h
+++ b/platform/LocalFileSystem.h
@@ -82,14 +82,14 @@ protected:
  *
  * int main() {
  *     FILE *fp = fopen("/local/out.txt", "w");  // Open "out.txt" on the local file system for writing
- *     fprintf(fp, "Hello World!");
+ *     mbed_fprintf(fp, "Hello World!");
  *     fclose(fp);
  *     remove("/local/out.txt");                 // Removes the file "out.txt" from the local file system
  *
  *     DIR *d = opendir("/local");               // Opens the root directory of the local file system
  *     struct dirent *p;
  *     while((p = readdir(d)) != NULL) {         // Print the names of the files in the local file system
- *       printf("%s\n", p->d_name);              // to stdout.
+ *       mbed_printf("%s\n", p->d_name);         // to stdout.
  *     }
  *     closedir(d);
  * }

--- a/platform/mbed_debug.h
+++ b/platform/mbed_debug.h
@@ -21,6 +21,7 @@
 #include <stdarg.h>
 #endif
 #include "platform/mbed_toolchain.h"
+#include "platform/mbed_printf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,7 @@ static inline void debug(const char *format, ...)
 #if DEVICE_STDIO_MESSAGES && !defined(NDEBUG)
     va_list args;
     va_start(args, format);
-    vfprintf(stderr, format, args);
+    mbed_vfprintf(stderr, format, args);
     va_end(args);
 #endif
 }
@@ -66,7 +67,7 @@ static inline void debug_if(int condition, const char *format, ...)
     if (condition) {
         va_list args;
         va_start(args, format);
-        vfprintf(stderr, format, args);
+        mbed_vfprintf(stderr, format, args);
         va_end(args);
     }
 #endif

--- a/platform/mbed_printf.h
+++ b/platform/mbed_printf.h
@@ -24,6 +24,42 @@
 extern "C" {
 #endif
 
+/** \addtogroup platform-public-api */
+/** @{*/
+
+/**
+ * \defgroup platform_printf Mbed printf family functions
+ *
+ * Library supports both printf and snprintf in 1252 bytes of flash.
+ *
+ * Prints directly to stdio/UART without using malloc. All flags and precision modifiers are ignored.
+ * There is no error handling if a writing error occurs.
+ *
+ * Supports:
+ * * %d: signed integer [h, hh, (none), l, ll, z, j, t].
+ * * %i: signed integer [h, hh, (none), l, ll, z, j, t].
+ * * %u: unsigned integer [h, hh, (none), l, ll, z, j, t].
+ * * %x: unsigned integer [h, hh, (none), l, ll, z, j, t], printed as hexadecimal number (e.g., ff).
+ * * %X: unsigned integer [h, hh, (none), l, ll, z, j, t], printed as hexadecimal number (e.g., FF).
+ * * %f: floating point (enabled by default).
+ * * %F: floating point (enabled by default, treated as %f).
+ * * %g: floating point (enabled by default, treated as %f).
+ * * %G: floating point (enabled by default, treated as %f).
+ * * %c: character.
+ * * %s: string.
+ * * %p: pointer (e.g. 0x00123456).
+ *
+ * Unrecognized format specifiers are treated as ordinary characters.
+ *
+ * Floating point limitations:
+ * * All floating points are treated as %f.
+ * * No support for inf, infinity or nan
+ *
+ * For more information have a look at mbed-os/platform/source/minimal-printf/README.md
+ *
+ * @{
+ */
+
 /**
  * Minimal printf
  *
@@ -60,6 +96,13 @@ int mbed_vprintf(const char *format, va_list arguments);
 int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list arguments);
 
 /**
+ * Minimal sprintf
+ *
+ * Prints directly to buffer without using malloc.
+ */
+int mbed_vsprintf(char *buffer, const char *format, va_list arguments);
+
+/**
  * Minimal fprintf
  *
  * Prints directly to file stream without using malloc.
@@ -72,6 +115,10 @@ int mbed_fprintf(FILE *stream, const char *format, ...);
  * Prints directly to file stream without using malloc.
  */
 int mbed_vfprintf(FILE *stream, const char *format, va_list arguments);
+
+/**@}*/
+
+/**@}*/
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_rtc_time.h
+++ b/platform/mbed_rtc_time.h
@@ -56,13 +56,13 @@ struct timeval {
  *     while (true) {
  *         time_t seconds = time(NULL);
  *
- *         printf("Time as seconds since January 1, 1970 = %u\n", (unsigned int)seconds);
+ *         mbed_printf("Time as seconds since January 1, 1970 = %u\n", (unsigned int)seconds);
  *
- *         printf("Time as a basic string = %s", ctime(&seconds));
+ *         mbed_printf("Time as a basic string = %s", ctime(&seconds));
  *
  *         char buffer[32];
  *         strftime(buffer, 32, "%I:%M %p\n", localtime(&seconds));
- *         printf("Time as a custom formatted string = %s", buffer);
+ *         mbed_printf("Time as a custom formatted string = %s", buffer);
  *
  *         wait(1);
  *     }

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -424,7 +424,7 @@
  * @code
  * #include "mbed_toolchain.h"
  *
- * printf("This function was called from %p", MBED_CALLER_ADDR());
+ * mbed_printf("This function was called from %p", MBED_CALLER_ADDR());
  * @endcode
  *
  * @return Address of the calling function

--- a/platform/source/ATCmdParser.cpp
+++ b/platform/source/ATCmdParser.cpp
@@ -22,6 +22,7 @@
 #include "ATCmdParser.h"
 #include "mbed_poll.h"
 #include "mbed_debug.h"
+#include "mbed_printf.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -111,7 +112,7 @@ int ATCmdParser::read(char *data, int size)
 int ATCmdParser::vprintf(const char *format, std::va_list args)
 {
 
-    if (vsprintf(_buffer, format, args) < 0) {
+    if (mbed_vsprintf(_buffer, format, args) < 0) {
         return false;
     }
 
@@ -128,7 +129,7 @@ int ATCmdParser::vprintf(const char *format, std::va_list args)
 bool ATCmdParser::vsend(const char *command, std::va_list args)
 {
     // Create and send command
-    if (vsprintf(_buffer, command, args) < 0) {
+    if (mbed_vsprintf(_buffer, command, args) < 0) {
         return false;
     }
 
@@ -319,7 +320,7 @@ int ATCmdParser::printf(const char *format, ...)
 {
     std::va_list args;
     va_start(args, format);
-    int res = vprintf(format, args);
+    int res = mbed_vprintf(format, args);
     va_end(args);
     return res;
 }

--- a/platform/source/ATCmdParser.cpp
+++ b/platform/source/ATCmdParser.cpp
@@ -320,7 +320,7 @@ int ATCmdParser::printf(const char *format, ...)
 {
     std::va_list args;
     va_start(args, format);
-    int res = mbed_vprintf(format, args);
+    int res = vprintf(format, args);
     va_end(args);
     return res;
 }

--- a/platform/source/Stream.cpp
+++ b/platform/source/Stream.cpp
@@ -16,6 +16,7 @@
  */
 #include "platform/Stream.h"
 #include "platform/mbed_error.h"
+#include "platform/mbed_printf.h"
 #include <errno.h>
 
 namespace mbed {
@@ -160,7 +161,7 @@ int Stream::printf(const char *format, ...)
     std::va_list arg;
     va_start(arg, format);
     std::fseek(_file, 0, SEEK_CUR);
-    int r = vfprintf(_file, format, arg);
+    int r = mbed_vfprintf(_file, format, arg);
     va_end(arg);
     unlock();
     return r;
@@ -182,7 +183,7 @@ int Stream::vprintf(const char *format, std::va_list args)
 {
     lock();
     std::fseek(_file, 0, SEEK_CUR);
-    int r = vfprintf(_file, format, args);
+    int r = mbed_vfprintf(_file, format, args);
     unlock();
     return r;
 }

--- a/platform/source/mbed_board.c
+++ b/platform/source/mbed_board.c
@@ -22,6 +22,7 @@
 #include "platform/mbed_interface.h"
 #include "platform/mbed_retarget.h"
 #include "platform/mbed_critical.h"
+#include "platform/mbed_printf.h"
 
 WEAK MBED_NORETURN void mbed_die(void)
 {
@@ -59,7 +60,7 @@ void mbed_error_printf(const char *format, ...)
 void mbed_error_vprintf(const char *format, va_list arg)
 {
     char buffer[132];
-    int size = vsnprintf(buffer, sizeof buffer, format, arg);
+    int size = mbed_vsnprintf(buffer, sizeof buffer, format, arg);
     if ((unsigned int)size >= sizeof buffer) {
         /* Output was truncated - indicate by overwriting tail of buffer
          * with ellipsis, newline and null terminator.

--- a/platform/source/mbed_error.c
+++ b/platform/source/mbed_error.c
@@ -26,6 +26,7 @@
 #include "platform/mbed_interface.h"
 #include "platform/mbed_power_mgmt.h"
 #include "platform/mbed_stats.h"
+#include "platform/mbed_printf.h"
 #include "platform/source/TARGET_CORTEX_M/mbed_fault_handler.h"
 #include "drivers/MbedCRC.h"
 #include "mbed_rtx.h"
@@ -676,7 +677,7 @@ mbed_error_status_t mbed_save_error_hist(const char *path)
     }
 
     //First store the first and last errors
-    if (fprintf(error_log_file, "\nFirst Error: Status:0x%x ThreadId:0x%x Address:0x%x Value:0x%x\n",
+    if (mbed_fprintf(error_log_file, "\nFirst Error: Status:0x%x ThreadId:0x%x Address:0x%x Value:0x%x\n",
                 (unsigned int)first_error_ctx.error_status,
                 (unsigned int)first_error_ctx.thread_id,
                 (unsigned int)first_error_ctx.error_address,
@@ -685,7 +686,7 @@ mbed_error_status_t mbed_save_error_hist(const char *path)
         goto exit;
     }
 
-    if (fprintf(error_log_file, "\nLast Error: Status:0x%x ThreadId:0x%x Address:0x%x Value:0x%x\n",
+    if (mbed_fprintf(error_log_file, "\nLast Error: Status:0x%x ThreadId:0x%x Address:0x%x Value:0x%x\n",
                 (unsigned int)last_error_ctx.error_status,
                 (unsigned int)last_error_ctx.thread_id,
                 (unsigned int)last_error_ctx.error_address,
@@ -698,7 +699,7 @@ mbed_error_status_t mbed_save_error_hist(const char *path)
     while (--log_count >= 0) {
         mbed_error_hist_get(log_count, &ctx);
         //first line of file will be error log count
-        if (fprintf(error_log_file, "\n%d: Status:0x%x ThreadId:0x%x Address:0x%x Value:0x%x\n",
+        if (mbed_fprintf(error_log_file, "\n%d: Status:0x%x ThreadId:0x%x Address:0x%x Value:0x%x\n",
                     log_count,
                     (unsigned int)ctx.error_status,
                     (unsigned int)ctx.thread_id,

--- a/platform/source/mbed_mem_trace.cpp
+++ b/platform/source/mbed_mem_trace.cpp
@@ -21,6 +21,7 @@
 #include "platform/mbed_mem_trace.h"
 #include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
+#include "platform/mbed_printf.h"
 
 /******************************************************************************
  * Internal variables, functions and helpers
@@ -126,28 +127,28 @@ void mbed_mem_trace_default_callback(uint8_t op, void *res, void *caller, ...)
     switch (op) {
         case MBED_MEM_TRACE_MALLOC:
             temp_s1 = va_arg(va, size_t);
-            printf(MBED_MEM_DEFAULT_TRACER_PREFIX "m:%p;%p-%u\n", res, caller, temp_s1);
+            mbed_printf(MBED_MEM_DEFAULT_TRACER_PREFIX "m:%p;%p-%u\n", res, caller, temp_s1);
             break;
 
         case MBED_MEM_TRACE_REALLOC:
             temp_ptr = va_arg(va, void *);
             temp_s1 = va_arg(va, size_t);
-            printf(MBED_MEM_DEFAULT_TRACER_PREFIX "r:%p;%p-%p;%u\n", res, caller, temp_ptr, temp_s1);
+            mbed_printf(MBED_MEM_DEFAULT_TRACER_PREFIX "r:%p;%p-%p;%u\n", res, caller, temp_ptr, temp_s1);
             break;
 
         case MBED_MEM_TRACE_CALLOC:
             temp_s1 = va_arg(va, size_t);
             temp_s2 = va_arg(va, size_t);
-            printf(MBED_MEM_DEFAULT_TRACER_PREFIX "c:%p;%p-%u;%u\n", res, caller, temp_s1, temp_s2);
+            mbed_printf(MBED_MEM_DEFAULT_TRACER_PREFIX "c:%p;%p-%u;%u\n", res, caller, temp_s1, temp_s2);
             break;
 
         case MBED_MEM_TRACE_FREE:
             temp_ptr = va_arg(va, void *);
-            printf(MBED_MEM_DEFAULT_TRACER_PREFIX "f:%p;%p-%p\n", res, caller, temp_ptr);
+            mbed_printf(MBED_MEM_DEFAULT_TRACER_PREFIX "f:%p;%p-%p\n", res, caller, temp_ptr);
             break;
 
         default:
-            printf("?\n");
+            mbed_printf("?\n");
     }
     va_end(va);
 }

--- a/platform/source/minimal-printf/mbed_printf.c
+++ b/platform/source/minimal-printf/mbed_printf.c
@@ -23,7 +23,7 @@ int mbed_printf(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
+    int result = mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stdout);
     va_end(arguments);
 
     return result;
@@ -43,7 +43,7 @@ int mbed_sprintf(char *buffer, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+    int result = mbed_minimal_formatted_string(buffer, INT_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -51,7 +51,7 @@ int mbed_sprintf(char *buffer, const char *format, ...)
 
 int mbed_vprintf(const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
+    return mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stdout);
 }
 
 int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list arguments)
@@ -61,14 +61,14 @@ int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list argu
 
 int mbed_vsprintf(char *buffer, const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+    return mbed_minimal_formatted_string(buffer, INT_MAX, format, arguments, NULL);
 }
 
 int mbed_fprintf(FILE *stream, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+    int result = mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stream);
     va_end(arguments);
 
     return result;
@@ -76,5 +76,5 @@ int mbed_fprintf(FILE *stream, const char *format, ...)
 
 int mbed_vfprintf(FILE *stream, const char *format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+    return mbed_minimal_formatted_string(NULL, INT_MAX, format, arguments, stream);
 }

--- a/platform/source/minimal-printf/mbed_printf.c
+++ b/platform/source/minimal-printf/mbed_printf.c
@@ -59,6 +59,11 @@ int mbed_vsnprintf(char *buffer, size_t length, const char *format, va_list argu
     return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
 
+int mbed_vsprintf(char *buffer, const char *format, va_list arguments)
+{
+    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
+}
+
 int mbed_fprintf(FILE *stream, const char *format, ...)
 {
     va_list arguments;

--- a/rtos/ConditionVariable.h
+++ b/rtos/ConditionVariable.h
@@ -107,14 +107,14 @@ struct Waiter;
  *   mutex.lock();
  *
  *   while (done == false) {
- *     printf("Worker thread: Count: %lu\r\n", work_count);
+ *     mbed_printf("Worker thread: Count: %lu\r\n", work_count);
  *
  *     // Wait for main thread to notify the condition variable.
- *     printf("Worker thread: Waiting\r\n");
+ *     mbed_printf("Worker thread: Waiting\r\n");
  *     cv.wait();
  *   }
  *
- *   printf("Worker: Exiting\r\n");
+ *   mbed_printf("Worker: Exiting\r\n");
  *
  *   // The condition variable acquires the lock when exiting the `wait` function.
  *   // Unlock mutex when exiting the thread.
@@ -132,8 +132,8 @@ struct Waiter;
  *
  *     // Change count and notify waiters.
  *     work_count++;
- *     printf("Main thread: Set count to: %lu\r\n", work_count);
- *     printf("Main thread: Notifying worker thread\r\n");
+ *     mbed_printf("Main thread: Set count to: %lu\r\n", work_count);
+ *     mbed_printf("Main thread: Notifying worker thread\r\n");
  *     cv.notify_all();
  *
  *     // Mutex must be unlocked before the worker thread can acquire it.
@@ -150,7 +150,7 @@ struct Waiter;
  *
  *   thread.join();
  *
- *   printf("Main: Exiting\r\n");
+ *   mbed_printf("Main: Exiting\r\n");
  * }
  * @endcode
  */


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Replace stdlib printf family calls with minimal printf inside Mbed OS core. System components use printf family function in many places internally. Using minimal printf allows us to to save over 15k flash in basic use case. It doesn't affect users as by default it doesn't do mapping from mbed_printf to printf.
In users or other system component will use stdlib printf family it will pull both versions of printf, but the dependencies pulled will be reduced (depending on the explicit library printf usage) resulting in overall size decrease of around 6k.

I'm raising this PR as a work in progress RFC, because I want to start discussion to move the whole system to using minimal printf internally.

Open actions
- Should we make `mbed_printf` conditionally expand either to stdlib or minimal printf? Probably not.
- Docs
- Tests
- Think about simplifying printing/logging infrastructure. Currently we have:
```
mbed_printf
printf
debug
error
mbed_warning
mbed_error
mbed_error_printf
MBED_PRINTF
tr_debug
tr_info
tr_warn
tr_err
```
- stdlib assert pulls fiprintf. Assert is mostly used in external code like partner's SDKs
- minimal-printf by default doesn't include fp, it's a configuration choice in conflict with it's README (which states the opposite). We need to either switch it on or change the README.

**For simple RTOS example compiled in release**
Master:
```
Total Static RAM memory (data + bss): 12608(+0) bytes
Total Flash memory (text + data): 47668(+0) bytes
```
PR:
```
Total Static RAM memory (data + bss): 12624(+16) bytes
Total Flash memory (text + data): 31500(-16168) bytes
```



@kjbracey-arm @AnttiKauppila @SeppoTakalo @evedon 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

ToDo

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
