### PR TITLE
Nuvoton: Support dynamic heap configuration on IAR

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M251/device/TOOLCHAIN_IAR/M251.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M251/device/TOOLCHAIN_IAR/M251.icf
@@ -51,7 +51,7 @@ define symbol __ICFEDIT_region_IRAM_end__       = MBED_RAM_APP_START + MBED_RAM_
 
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__           = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_heap__             = 0x4000;
+define symbol __ICFEDIT_size_heap__             = 0x400;
 
 
 /**** End of ICF editor section. ###ICF###*/
@@ -62,7 +62,7 @@ define region ROM_region    = mem:[from __ICFEDIT_region_ROM_start__   to __ICFE
 define region IRAM_region   = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
 define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP       with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP       with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__    { };
 /* NOTE: Vector table base address is required to be 128-byte aligned at a minimum.
  *       A PE might impose further restrictions on it. */
 define block IRAMVEC    with alignment = 1024, size = 4 * (16 + 64)          { };

--- a/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_IAR/M261.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M261/device/TOOLCHAIN_IAR/M261.icf
@@ -34,7 +34,7 @@ define symbol __region_CRASH_DATA_RAM_end__  = 0x20018000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 102));
-define symbol __ICFEDIT_size_heap__   = 0x8000;
+define symbol __ICFEDIT_size_heap__   = 0x400;
 /**** End of ICF editor section. ###ICF###*/
 
 
@@ -43,8 +43,8 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
 
-define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP       with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__    { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = __ICFEDIT_size_intvec__          { };
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
@@ -13,7 +13,7 @@ define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20008000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_heap__   = 0x4000;
+define symbol __ICFEDIT_size_heap__   = 0x400;
 /**** End of ICF editor section. ###ICF###*/
 
 
@@ -21,8 +21,8 @@ define memory mem with size = 4G;
 define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
-define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP       with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__    { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 64)          { };
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -16,7 +16,7 @@ define symbol __region_CRASH_DATA_RAM_end__  = 0x20028000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
 define symbol __ICFEDIT_size_intvec__ = (4 * (16 + 96));
-define symbol __ICFEDIT_size_heap__   = 0x10000;
+define symbol __ICFEDIT_size_heap__   = 0x400;
 /**** End of ICF editor section. ###ICF###*/
 
 
@@ -25,8 +25,8 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ to __region_CRASH_DATA_RAM_end__];
 
-define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP       with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__    { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = __ICFEDIT_size_intvec__          { };
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
@@ -17,7 +17,7 @@ define symbol __ICFEDIT_region_XRAM_start__ = 0x60000000;
 define symbol __ICFEDIT_region_XRAM_end__   = 0x60100000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_heap__   = 0xC0000;
+define symbol __ICFEDIT_size_heap__   = 0x400;
 /**** End of ICF editor section. ###ICF###*/
 
 
@@ -31,8 +31,8 @@ define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ 
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
 define exported symbol __CRASH_DATA_RAM_END__ = __region_CRASH_DATA_RAM_end__;
 
-define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP       with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__    { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 142)         { };
 /* Move non-critical libraries to external SRAM while internal SRAM is insufficient. */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
@@ -15,7 +15,7 @@ define symbol __region_CRASH_DATA_RAM_start__   = 0x2000FF00;
 define symbol __region_CRASH_DATA_RAM_end__     = 0x20010000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = MBED_BOOT_STACK_SIZE;
-define symbol __ICFEDIT_size_heap__   = 0x8000;
+define symbol __ICFEDIT_size_heap__   = 0x400;
 /**** End of ICF editor section. ###ICF###*/
 
 
@@ -28,8 +28,8 @@ define region CRASH_DATA_RAM_region = mem:[from __region_CRASH_DATA_RAM_start__ 
 define exported symbol __CRASH_DATA_RAM_START__ = __region_CRASH_DATA_RAM_start__;
 define exported symbol __CRASH_DATA_RAM_END__   = __region_CRASH_DATA_RAM_end__;
 
-define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP       with expanding size, alignment = 8, minimum size = __ICFEDIT_size_heap__    { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 142)         { };
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

This PR is continuation of #12061 and supports IAR dynamic heap configuration on other Nuvoton targets. In this PR, on IAR, heap is configured to 1KiB at a minimum and expandable to available SRAM. This requires IAR 8.x.

Support targets:
-   NUMAKER_PFM_NUC472 w/ and w/o XRAM
-   NUMAKER_PFM_M453
-   NUMAKER_PFM_M487/NUMAKER_IOT_M487
-   NUMAKER_IOT_M263A
-   NUMAKER_M252KG

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
