### PR TITLE
Fixes for LPC55S69_NS TLS tests

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -557,6 +557,9 @@ nsapi_error_t ESP8266::open_tcp(int id, const char *addr, int port, int keepaliv
     static const char *type = "TCP";
     bool done = false;
 
+    if (!addr) {
+        return NSAPI_ERROR_PARAMETER;
+    }
     _smutex.lock();
 
     // process OOB so that _sock_i reflects the correct state of the socket

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_IAR/LPC55S69_cm33_core0_flash.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC55S69/TARGET_M33_NS/device/TOOLCHAIN_IAR/LPC55S69_cm33_core0_flash.icf
@@ -126,7 +126,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, alignment = 8, minimum size = __heap_size__ { };
 define block RW        { readwrite };
 define block ZI        { zi };
 


### PR DESCRIPTION
 Fixed ESP8266 nullpointer dereference.
Incerased LPC55S69_NS heap in IAR linker script for TLS purpose.
Summary of changes

Issue for IAR echotest and echotest nonblock with calloc fail.
Problem solved after increasing heap for IAR linker script LPC55S69_cm33_core0_flash.icf

TLSSOCKET_CONNECT_INVALID fail caused by null pointer dereference in ESP8266.

ESP8266 tcp_open called with uninitialized socket IP adress and port - this is purpose of test
Then ATCmdParser calls on vsprintf with null.
This change returns with NSAPI_ERROR_PARAMETER if IP sting is null instead calling ATCmdParser and vsprintf.
Impact of changes
Migration actions required

Not needed.
Documentation

Not needed.
Pull request type

[x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
[] Feature update (New feature / Functionality change / New API)
[] Major update (Breaking change E.g. Return code change / API behaviour change)

Test results

[] No Tests required for this change (E.g docs only update)
[x] Covered by existing mbed-os tests (Greentea or Unittest)
[] Tests / results supplied as part of this PR

Reviewers

@AnttiKauppila
@SeppoTakalo
@michalpasztamobica