### PR TITLE
Cellular: Move cellular event queue thread ownership to CellularDevice

### DIFF
--- a/UNITTESTS/features/cellular/framework/device/cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/device/cellulardevice/unittest.cmake
@@ -35,6 +35,7 @@ set(unittest-test-sources
   stubs/CellularContext_stub.cpp
   stubs/ConditionVariable_stub.cpp
   stubs/Mutex_stub.cpp
+  stubs/mbed_shared_queues_stub.cpp
 )
 
 set(unittest-test-flags

--- a/UNITTESTS/features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellularstatemachine/cellularstatemachinetest.cpp
@@ -222,13 +222,6 @@ TEST_F(TestCellularStateMachine, test_start_dispatch)
     ASSERT_EQ(NSAPI_ERROR_OK, err);
     ut.delete_state_machine();
 
-    Thread_stub::osStatus_value = osErrorNoMemory;
-    stm = ut.create_state_machine(*dev, *dev->get_queue(), *dev->open_network());
-    EXPECT_TRUE(stm);
-    err = ut.start_dispatch();
-    ASSERT_EQ(NSAPI_ERROR_NO_MEMORY, err);
-    ut.delete_state_machine();
-
     delete dev;
     dev = NULL;
 }

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -21,9 +21,14 @@
 #include "CellularStateMachine.h"
 #include "Callback.h"
 #include "ATHandler.h"
+
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
 #include "UARTSerial.h"
 #endif // #if DEVICE_SERIAL
+
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "Thread.h"
+#endif // MBED_CONF_RTOS_PRESENT
 
 /** @file CellularDevice.h
  * @brief Class CellularDevice
@@ -504,6 +509,10 @@ private: //Member variables
     char _sim_pin[MAX_PIN_SIZE + 1];
     char _plmn[MAX_PLMN_SIZE + 1];
     PlatformMutex _mutex;
+
+#ifdef MBED_CONF_RTOS_PRESENT
+    rtos::Thread _queue_thread;
+#endif
 };
 
 /**

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -20,6 +20,7 @@
 #include "CellularUtil.h"
 #include "CellularLog.h"
 #include "events/EventQueue.h"
+#include "mbed_shared_queues.h"
 
 namespace mbed {
 
@@ -33,16 +34,28 @@ MBED_WEAK CellularDevice *CellularDevice::get_target_default_instance()
     return NULL;
 }
 
-CellularDevice::CellularDevice(FileHandle *fh) : _network_ref_count(0),
+CellularDevice::CellularDevice(FileHandle *fh) :
+    _network_ref_count(0),
 #if MBED_CONF_CELLULAR_USE_SMS
     _sms_ref_count(0),
 #endif //MBED_CONF_CELLULAR_USE_SMS
     _info_ref_count(0), _fh(fh), _queue(10 * EVENTS_EVENT_SIZE), _state_machine(0),
     _status_cb(0), _nw(0)
+#ifdef MBED_CONF_RTOS_PRESENT
+    , _queue_thread(osPriorityNormal, 2048, NULL, "cellular_queue")
+#endif // MBED_CONF_RTOS_PRESENT
 {
     MBED_ASSERT(fh);
     set_sim_pin(NULL);
     set_plmn(NULL);
+
+#ifdef MBED_CONF_RTOS_PRESENT
+    if (_queue_thread.start(callback(&_queue, &events::EventQueue::dispatch_forever)) != osOK) {
+        tr_error("Failed to start thread");
+    }
+#else
+    _queue.chain(mbed_event_queue());
+#endif
 }
 
 CellularDevice::~CellularDevice()

--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -22,12 +22,6 @@
 #include "CellularCommon.h"
 #include "PlatformMutex.h"
 
-#ifdef MBED_CONF_RTOS_PRESENT
-namespace rtos {
-class Thread;
-}
-#endif
-
 namespace mbed {
 
 class CellularDevice;
@@ -162,11 +156,6 @@ private:
     void change_timeout(const int &timeout);
 
 private:
-
-#ifdef MBED_CONF_RTOS_PRESENT
-    rtos::Thread *_queue_thread;
-#endif
-
     CellularDevice &_cellularDevice;
     CellularState _state;
     CellularState _next_state;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->



### Summary of changes <!-- Required -->

Earlier CellularDevice has owned the event queue used by cellular (state machine and ATHandler for example), but the thread used to dispatch the queue has been owned by state machine.

This commit moves the event queue thread to CellularDevice so now the ownership of cellular event queue is in one place.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@ARMmbed/mbed-os-wan 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
