### PR TITLE
Corrected PPP debug trace flagging

### DIFF
--- a/features/netsocket/ppp/include/ppp_impl.h
+++ b/features/netsocket/ppp/include/ppp_impl.h
@@ -648,6 +648,8 @@ int  str_to_epdisc (struct epdisc *, char *); /* endpt disc. from str */
 #define multilink_master	0
 #endif
 
+#if PPP_DEBUG
+
 /* Procedures exported from utils.c. */
 void ppp_print_string(const u_char *p, int len, void (*printer) (void *, const char *, ...), void *arg);   /* Format a string for output */
 int ppp_slprintf(char *buf, int buflen, const char *fmt, ...);            /* sprintf++ */
@@ -664,6 +666,22 @@ void ppp_fatal(const char *fmt, ...);     /* log an error message and die(1) */
 void ppp_dump_packet(ppp_pcb *pcb, const char *tag, unsigned char *p, int len);
                                 /* dump packet to debug log if interesting */
 #endif /* PRINTPKT_SUPPORT */
+
+#else
+
+#define ppp_print_string(...)
+#define ppp_slprintf(...)
+#define ppp_vslprintf(...)
+#define ppp_strlcpy(...)
+#define ppp_strlcat(...)
+#define ppp_dbglog(...)
+#define ppp_info(...)
+#define ppp_notice(...)
+#define ppp_warn(...)
+#define ppp_error(...)
+#define ppp_fatal(...)
+
+#endif /* PPP_DEBUG */
 
 /*
  * Number of necessary timers analysis.

--- a/features/netsocket/ppp/source/auth.c
+++ b/features/netsocket/ppp/source/auth.c
@@ -630,12 +630,13 @@ void link_terminated(ppp_pcb *pcb) {
 #endif /* UNUSED */
 
     if (!doing_multilink) {
-	ppp_notice("Connection terminated.");
+        ppp_notice("Connection terminated.");
 #if PPP_STATS_SUPPORT
-	print_link_stats();
+        print_link_stats();
 #endif /* PPP_STATS_SUPPORT */
-    } else
-	ppp_notice("Link terminated.");
+    } else {
+        ppp_notice("Link terminated.");
+    }
 
     lcp_lowerdown(pcb);
 
@@ -1131,13 +1132,17 @@ void auth_withpeer_fail(ppp_pcb *pcb, int protocol) {
  */
 void auth_withpeer_success(ppp_pcb *pcb, int protocol, int prot_flavor) {
     int bit;
+#if PPP_DEBUG
     const char *prot = "";
+#endif
 
     switch (protocol) {
 #if CHAP_SUPPORT
     case PPP_CHAP:
 	bit = CHAP_WITHPEER;
+#if PPP_DEBUG
 	prot = "CHAP";
+#endif
 	switch (prot_flavor) {
 	case CHAP_MD5:
 	    bit |= CHAP_MD5_WITHPEER;
@@ -1158,13 +1163,17 @@ void auth_withpeer_success(ppp_pcb *pcb, int protocol, int prot_flavor) {
 #if PAP_SUPPORT
     case PPP_PAP:
 	bit = PAP_WITHPEER;
+#if PPP_DEBUG
 	prot = "PAP";
+#endif
 	break;
 #endif /* PAP_SUPPORT */
 #if EAP_SUPPORT
     case PPP_EAP:
 	bit = EAP_WITHPEER;
+#if PPP_DEBUG
 	prot = "EAP";
+#endif
 	break;
 #endif /* EAP_SUPPORT */
     default:

--- a/features/netsocket/ppp/source/chap-new.c
+++ b/features/netsocket/ppp/source/chap-new.c
@@ -205,9 +205,10 @@ void chap_auth_with_peer(ppp_pcb *pcb, const char *our_name, int digest_code) {
 		if (dp->code == digest_code)
 			break;
 
-	if (dp == NULL)
+	if (dp == NULL) {
 		ppp_fatal("CHAP digest 0x%x requested but not available",
 		      digest_code);
+	}
 
 	pcb->chap_client.digest = dp;
 	pcb->chap_client.name = our_name;
@@ -519,10 +520,11 @@ static void chap_handle_status(ppp_pcb *pcb, int code, int id,
 			msg = "CHAP authentication failed";
 	}
 	if (msg) {
-		if (len > 0)
+		if (len > 0) {
 			ppp_info("%s: %.*v", msg, len, pkt);
-		else
+		} else {
 			ppp_info("%s", msg);
+		}
 	}
 	if (code == CHAP_SUCCESS)
 		auth_withpeer_success(pcb, PPP_CHAP, pcb->chap_client.digest->code);

--- a/features/netsocket/ppp/source/fsm.c
+++ b/features/netsocket/ppp/source/fsm.c
@@ -589,8 +589,9 @@ static void fsm_rtermreq(fsm *f, int id, u_char *p, int len) {
     case PPP_FSM_OPENED:
 	if (len > 0) {
 	    ppp_info("%s terminated by peer (%0.*v)", PROTO_NAME(f), len, p);
-	} else
+	} else {
 	    ppp_info("%s terminated by peer", PROTO_NAME(f));
+	}
 	f->retransmits = 0;
 	f->state = PPP_FSM_STOPPING;
 	if (f->callbacks->down)
@@ -643,15 +644,19 @@ static void fsm_rtermack(fsm *f) {
  * fsm_rcoderej - Receive an Code-Reject.
  */
 static void fsm_rcoderej(fsm *f, u_char *inp, int len) {
+#if PPP_DEBUG
     u_char code, id;
+#endif
 
     if (len < HEADERLEN) {
 	FSMDEBUG(("fsm_rcoderej: Rcvd short Code-Reject packet!"));
 	return;
     }
+#if PPP_DEBUG
     GETCHAR(code, inp);
     GETCHAR(id, inp);
     ppp_warn("%s: Rcvd Code-Reject for code %d, id %d", PROTO_NAME(f), code, id);
+#endif
 
     if( f->state == PPP_FSM_ACKRCVD )
 	f->state = PPP_FSM_REQSENT;

--- a/features/netsocket/ppp/source/ipcp.c
+++ b/features/netsocket/ppp/source/ipcp.c
@@ -2087,13 +2087,16 @@ static void ipcp_up(fsm *f) {
 	wo->ouraddr = go->ouraddr;
 
 	ppp_notice("local  IP address %I", go->ouraddr);
-	if (ho->hisaddr != 0)
+	if (ho->hisaddr != 0) {
 	    ppp_notice("remote IP address %I", ho->hisaddr);
+	}
 #if PPP_DNS
-	if (go->dnsaddr[0])
+	if (go->dnsaddr[0]) {
 	    ppp_notice("primary   DNS address %I", go->dnsaddr[0]);
-	if (go->dnsaddr[1])
+	}
+	if (go->dnsaddr[1]) {
 	    ppp_notice("secondary DNS address %I", go->dnsaddr[1]);
+	}
 #endif /* PPP_DNS */
     }
 

--- a/features/netsocket/ppp/source/ipv6cp.c
+++ b/features/netsocket/ppp/source/ipv6cp.c
@@ -328,7 +328,9 @@ static enum script_state {
 static pid_t ipv6cp_script_pid;
 #endif /* UNUSED */
 
+#if PPP_DEBUG
 static char *llv6_ntoa(eui64_t ifaceid);
+#endif
 
 #if PPP_OPTIONS
 /*
@@ -409,6 +411,7 @@ printifaceid(opt, printer, arg)
 /*
  * Make a string representation of a network address.
  */
+#if PPP_DEBUG
 static char *
 llv6_ntoa(eui64_t ifaceid)
 {
@@ -420,7 +423,7 @@ llv6_ntoa(eui64_t ifaceid)
 
     return b;
 }
-
+#endif
 
 /*
  * ipv6cp_init - Initialize IPV6CP.
@@ -1245,6 +1248,7 @@ static void ipv6cp_up(fsm *f) {
 	    ipv6cp_close(f->pcb, "Interface configuration failed");
 	    return;
 	}
+
 #if DEMAND_SUPPORT
 	sifnpmode(f->pcb, PPP_IPV6, NPMODE_PASS);
 #endif /* DEMAND_SUPPORT */

--- a/features/netsocket/ppp/source/lcp.c
+++ b/features/netsocket/ppp/source/lcp.c
@@ -2664,8 +2664,9 @@ static void LcpEchoCheck(fsm *f) {
     /*
      * Start the timer for the next interval.
      */
-    if (pcb->lcp_echo_timer_running)
-	ppp_warn("assertion lcp_echo_timer_running==0 failed");
+    if (pcb->lcp_echo_timer_running) {
+        ppp_warn("assertion lcp_echo_timer_running==0 failed");
+    }
     TIMEOUT (LcpEchoTimeout, f, pcb->settings.lcp_echo_interval);
     pcb->lcp_echo_timer_running = 1;
 }

--- a/features/netsocket/ppp/source/utils.c
+++ b/features/netsocket/ppp/source/utils.c
@@ -30,6 +30,7 @@
 
 #include "ppp_opts.h"
 #if PPP_SUPPORT /* don't build if not configured for use in ppp_opts.h */
+#if PPP_DEBUG
 
 #if 0 /* UNUSED */
 #include <stdio.h>
@@ -955,4 +956,5 @@ unlock()
 
 #endif /* Unused */
 
+#endif /* PPP_DEBUG */
 #endif /* PPP_SUPPORT */


### PR DESCRIPTION
### Summary of changes

Some parts of PPP debug traces were enabled also on non-debug builds. Now they are correctly disabled. Corrected also compiler warnings that became visible when trace macros were flagged (if clauses without brackets).

#### Impact of changes 


#### Migration actions required 


### Documentation

None

----------------------------------------------------------------------------------------------------------------
### Pull request type 

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

---------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers 

@ARMmbed/mbed-os-wan

----------------------------------------------------------------------------------------------------------------
