### PR TITLE
Fix for issue #10725: disable lp-ticker for STM targets which uses RTC/LSI for lp-ticker

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3546,8 +3546,12 @@
             "CAN",
             "CRC"
         ],
-        "device_has_remove": ["LPTICKER"],
-        "release_versions": ["2"],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2"
+        ],
         "device_name": "STM32F303K8"
     },
     "NUCLEO_F303RE": {
@@ -3738,9 +3742,16 @@
             "FLASH",
             "MPU"
         ],
-        "device_has_remove": ["LPTICKER"],
-        "overrides": { "lse_available": 0 },
-        "release_versions": ["2", "5"],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "release_versions": [
+            "2",
+            "5"
+        ],
         "device_name": "STM32F401VE"
     },
     "NUCLEO_F410RB": {
@@ -3979,9 +3990,15 @@
         "overrides": {
             "lse_available": 0
         },
-        "device_has_remove": ["LPTICKER"],
-        "features_remove": ["BLE"],
-        "inherits": ["USI_WM_BN_BM_22"]
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "features_remove": [
+            "BLE"
+        ],
+        "inherits": [
+            "USI_WM_BN_BM_22"
+        ]
     },
     "MTB_ADV_WISE_1530": {
         "inherits": [
@@ -5753,7 +5770,9 @@
             "CRC",
             "MPU"
         ],
-        "device_has_remove": ["LPTICKER"],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
         "device_name": "STM32F303VC"
     },
     "DISCO_F334C8": {
@@ -5784,7 +5803,9 @@
             "CRC",
             "SERIAL_ASYNCH"
         ],
-        "device_has_remove": ["LPTICKER"],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
         "default_lib": "small",
         "release_versions": [
             "2"
@@ -5811,10 +5832,22 @@
                 "value": "USE_USB_OTG_FS"
             }
         },
-        "overrides": { "lse_available": 0 },
-        "device_has_add": ["ANALOGOUT", "TRNG", "FLASH", "MPU"],
-        "device_has_remove": ["LPTICKER"],
-        "release_versions": ["2", "5"],
+        "overrides": {
+            "lse_available": 0
+        },
+        "device_has_add": [
+            "ANALOGOUT",
+            "TRNG",
+            "FLASH",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
         "device_name": "STM32F407VG"
     },
     "OLIMEX_STM32E407_F407ZG": {
@@ -5849,8 +5882,12 @@
             "CAN",
             "USBDEVICE"
         ],
-        "device_has_remove": ["LPTICKER"],
-        "release_versions": ["5"],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "5"
+        ],
         "device_name": "STM32F407ZG"
     },
     "DISCO_F429ZI": {
@@ -5887,8 +5924,13 @@
             "FLASH",
             "MPU"
         ],
-        "device_has_remove": ["LPTICKER"],
-        "release_versions": ["2", "5"],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
         "device_name": "STM32F429ZI",
         "bootloader_supported": true
     },
@@ -6543,9 +6585,18 @@
                 "IAR"
             ]
         },
-        "device_has_add": ["MPU", "FLASH"],
-        "device_has_remove": ["SERIAL_FC", "LPTICKER"],
-        "release_versions": ["2", "5"],
+        "device_has_add": [
+            "MPU",
+            "FLASH"
+        ],
+        "device_has_remove": [
+            "SERIAL_FC",
+            "LPTICKER"
+        ],
+        "release_versions": [
+            "2",
+            "5"
+        ],
         "device_name": "STM32F411RE",
         "bootloader_supported": true
     },
@@ -6974,16 +7025,32 @@
         }
     },
     "MTB_UBLOX_ODIN_W2": {
-        "inherits": ["MODULE_UBLOX_ODIN_W2"],
-        "overrides": {"lse_available": 0},
-        "release_versions": ["5"]
+        "inherits": [
+            "MODULE_UBLOX_ODIN_W2"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "release_versions": [
+            "5"
+        ]
     },
     "OKDO_ODIN_W2": {
-        "inherits": ["MODULE_UBLOX_ODIN_W2"],
-        "device_has_remove": ["LPTICKER"],
-        "features_remove": ["BLE"],
-        "overrides": {"lse_available": 0},
-        "release_versions": ["5"]
+        "inherits": [
+            "MODULE_UBLOX_ODIN_W2"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
+        "features_remove": [
+            "BLE"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "release_versions": [
+            "5"
+        ]
     },
     "UBLOX_C030": {
         "inherits": [
@@ -7092,11 +7159,25 @@
         "core": "Cortex-M3",
         "default_toolchain": "uARM",
         "program_cycle_s": 1.5,
-        "extra_labels_add": ["STM32L1", "STM32L151RC"],
-        "overrides": { "lse_available": 0 },
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
-        "device_has_add": ["ANALOGOUT", "MPU"],
-        "device_has_remove": ["LPTICKER"],
+        "extra_labels_add": [
+            "STM32L1",
+            "STM32L151RC"
+        ],
+        "overrides": {
+            "lse_available": 0
+        },
+        "supported_toolchains": [
+            "ARM",
+            "uARM",
+            "GCC_ARM"
+        ],
+        "device_has_add": [
+            "ANALOGOUT",
+            "MPU"
+        ],
+        "device_has_remove": [
+            "LPTICKER"
+        ],
         "default_lib": "small",
         "device_name": "STM32L151RC"
     },
@@ -12545,7 +12626,10 @@
         "mbed_ram_size": "0x2000"
     },
     "NU_PFM_M2351_NS": {
-        "inherits": ["NSPE_Target", "NU_PFM_M2351"],
+        "inherits": [
+            "NSPE_Target",
+            "NU_PFM_M2351"
+        ],
         "core": "Cortex-M23-NS",
         "tfm.level": 1,
         "extra_labels_add": [
@@ -12559,7 +12643,9 @@
             "CMSIS_NVIC_VIRTUAL",
             "MBEDTLS_PSA_CRYPTO_C"
         ],
-        "components_add": ["FLASHIAP"],
+        "components_add": [
+            "FLASHIAP"
+        ],
         "post_binary_hook": {"function": "M2351Code.merge_secure"},
         "secure_image_filename": "tfm.hex",
         "overrides": {
@@ -12574,7 +12660,10 @@
         }
     },
     "NU_PFM_M2351_S": {
-        "inherits": ["SPE_Target", "NU_PFM_M2351"],
+        "inherits": [
+            "SPE_Target",
+            "NU_PFM_M2351"
+        ],
         "core": "Cortex-M23",
         "tfm.level": 1,
         "extra_labels_add": [
@@ -12582,13 +12671,20 @@
             "PSA",
             "TFM"
         ],
-        "device_has_remove": ["SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES"],
+        "device_has_remove": [
+            "SERIAL",
+            "SERIAL_ASYNCH",
+            "SERIAL_FC",
+            "STDIO_MESSAGES"
+        ],
         "macros_add": [
             "DAUTH_CHIP_DEFAULT",
             "MBEDTLS_PSA_CRYPTO_C",
             "MBEDTLS_PSA_CRYPTO_SPM"
         ],
-        "components_add": ["FLASHIAP"],
+        "components_add": [
+            "FLASHIAP"
+        ],
         "deliver_to_target": "NU_PFM_M2351_NS",
         "delivery_dir": "TARGET_NUVOTON/TARGET_M2351/TARGET_M23_NS/TARGET_NU_PFM_M2351_NS/TARGET_NU_PREBUILD_SECURE",
         "overrides": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -6975,8 +6975,6 @@
     },
     "MTB_UBLOX_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
-        "device_has_remove": ["LPTICKER"],
-        "features_remove": ["BLE"],
         "overrides": {"lse_available": 0},
         "release_versions": ["5"]
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3546,9 +3546,8 @@
             "CAN",
             "CRC"
         ],
-        "release_versions": [
-            "2"
-        ],
+        "device_has_remove": ["LPTICKER"],
+        "release_versions": ["2"],
         "device_name": "STM32F303K8"
     },
     "NUCLEO_F303RE": {
@@ -3739,13 +3738,9 @@
             "FLASH",
             "MPU"
         ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "release_versions": [
-            "2",
-            "5"
-        ],
+        "device_has_remove": ["LPTICKER"],
+        "overrides": { "lse_available": 0 },
+        "release_versions": ["2", "5"],
         "device_name": "STM32F401VE"
     },
     "NUCLEO_F410RB": {
@@ -3984,9 +3979,8 @@
         "overrides": {
             "lse_available": 0
         },
-        "inherits": [
-            "USI_WM_BN_BM_22"
-        ]
+        "device_has_remove": ["LPTICKER"],
+        "inherits": ["USI_WM_BN_BM_22"]
     },
     "MTB_ADV_WISE_1530": {
         "inherits": [
@@ -5758,6 +5752,7 @@
             "CRC",
             "MPU"
         ],
+        "device_has_remove": ["LPTICKER"],
         "device_name": "STM32F303VC"
     },
     "DISCO_F334C8": {
@@ -5788,6 +5783,7 @@
             "CRC",
             "SERIAL_ASYNCH"
         ],
+        "device_has_remove": ["LPTICKER"],
         "default_lib": "small",
         "release_versions": [
             "2"
@@ -5814,19 +5810,10 @@
                 "value": "USE_USB_OTG_FS"
             }
         },
-        "overrides": {
-            "lse_available": 0
-        },
-        "device_has_add": [
-            "ANALOGOUT",
-            "TRNG",
-            "FLASH",
-            "MPU"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
+        "overrides": { "lse_available": 0 },
+        "device_has_add": ["ANALOGOUT", "TRNG", "FLASH", "MPU"],
+        "device_has_remove": ["LPTICKER"],
+        "release_versions": ["2", "5"],
         "device_name": "STM32F407VG"
     },
     "OLIMEX_STM32E407_F407ZG": {
@@ -5861,9 +5848,8 @@
             "CAN",
             "USBDEVICE"
         ],
-        "release_versions": [
-            "5"
-        ],
+        "device_has_remove": ["LPTICKER"],
+        "release_versions": ["5"],
         "device_name": "STM32F407ZG"
     },
     "DISCO_F429ZI": {
@@ -5900,10 +5886,8 @@
             "FLASH",
             "MPU"
         ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
+        "device_has_remove": ["LPTICKER"],
+        "release_versions": ["2", "5"],
         "device_name": "STM32F429ZI",
         "bootloader_supported": true
     },
@@ -6558,17 +6542,9 @@
                 "IAR"
             ]
         },
-        "device_has_add": [
-            "MPU",
-            "FLASH"
-        ],
-        "device_has_remove": [
-            "SERIAL_FC"
-        ],
-        "release_versions": [
-            "2",
-            "5"
-        ],
+        "device_has_add": ["MPU", "FLASH"],
+        "device_has_remove": ["SERIAL_FC", "LPTICKER"],
+        "release_versions": ["2", "5"],
         "device_name": "STM32F411RE",
         "bootloader_supported": true
     },
@@ -6701,7 +6677,8 @@
             "MPU"
         ],
         "device_has_remove": [
-            "SERIAL_FC"
+            "SERIAL_FC",
+            "LPTICKER"
         ],
         "post_binary_hook": {
             "function": "MTSCode.combine_bins_mtb_mts_dragonfly",
@@ -6996,28 +6973,16 @@
         }
     },
     "MTB_UBLOX_ODIN_W2": {
-        "inherits": [
-            "MODULE_UBLOX_ODIN_W2"
-        ],
-        "device_has_add": [],
-        "overrides": {
-            "lse_available": 0
-        },
-        "release_versions": [
-            "5"
-        ]
+        "inherits": ["MODULE_UBLOX_ODIN_W2"],
+        "device_has_remove": ["LPTICKER"],
+        "overrides": {"lse_available": 0},
+        "release_versions": ["5"]
     },
     "OKDO_ODIN_W2": {
-        "inherits": [
-            "MODULE_UBLOX_ODIN_W2"
-        ],
-        "device_has_add": [],
-        "overrides": {
-            "lse_available": 0
-        },
-        "release_versions": [
-            "5"
-        ]
+        "inherits": ["MODULE_UBLOX_ODIN_W2"],
+        "device_has_remove": ["LPTICKER"],
+        "overrides": {"lse_available": 0},
+        "release_versions": ["5"]
     },
     "UBLOX_C030": {
         "inherits": [
@@ -7051,6 +7016,7 @@
             "FLASH",
             "MPU"
         ],
+        "device_has_remove": ["LPTICKER"],
         "public": false,
         "device_name": "STM32F437VG",
         "bootloader_supported": true,
@@ -7127,22 +7093,11 @@
         "core": "Cortex-M3",
         "default_toolchain": "uARM",
         "program_cycle_s": 1.5,
-        "extra_labels_add": [
-            "STM32L1",
-            "STM32L151RC"
-        ],
-        "overrides": {
-            "lse_available": 0
-        },
-        "supported_toolchains": [
-            "ARM",
-            "uARM",
-            "GCC_ARM"
-        ],
-        "device_has_add": [
-            "ANALOGOUT",
-            "MPU"
-        ],
+        "extra_labels_add": ["STM32L1", "STM32L151RC"],
+        "overrides": { "lse_available": 0 },
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "device_has_add": ["ANALOGOUT", "MPU"],
+        "device_has_remove": ["LPTICKER"],
         "default_lib": "small",
         "device_name": "STM32L151RC"
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3980,6 +3980,7 @@
             "lse_available": 0
         },
         "device_has_remove": ["LPTICKER"],
+        "features_remove": ["BLE"],
         "inherits": ["USI_WM_BN_BM_22"]
     },
     "MTB_ADV_WISE_1530": {
@@ -6975,12 +6976,14 @@
     "MTB_UBLOX_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "device_has_remove": ["LPTICKER"],
+        "features_remove": ["BLE"],
         "overrides": {"lse_available": 0},
         "release_versions": ["5"]
     },
     "OKDO_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "device_has_remove": ["LPTICKER"],
+        "features_remove": ["BLE"],
         "overrides": {"lse_available": 0},
         "release_versions": ["5"]
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7016,12 +7016,10 @@
             "FLASH",
             "MPU"
         ],
-        "device_has_remove": ["LPTICKER"],
         "public": false,
         "device_name": "STM32F437VG",
         "bootloader_supported": true,
         "overrides": {
-            "lse_available": 0,
             "network-default-interface-type": "ETHERNET"
         }
     },


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

This PR is continuation of PR https://github.com/ARMmbed/mbed-os/pull/12135 - which will be closed.

`tests-mbed_drivers-lp_timer` is failing on `UBLOX_C030_U201` (can't reproduce the failure locally).

According to the documentation of `STM32F437VG76` MCU:

The LSI RC acts as an low-power clock source that can be kept running in Stop and
Standby mode for the independent watchdog (IWDG) and Auto-wakeup unit (AWU). The
clock frequency is around 32 kHz. For more details, refer to the electrical characteristics
section of the datasheets.

It seems that typical `LSI` frequency is `32 kHz`, but it may vary from `17` to `47 kHz`!
This means that lp-timer test may fail on the same board because lp-ticker frequency is unstable.

The proposition is to disable lp-ticker for STM targets which uses `RTC/LSI` to drive lp-ticker - `LSI` is unstable and breaks accuracy requirements for low power ticker.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@jeromecoutant 

----------------------------------------------------------------------------------------------------------------
