### PR TITLE
Cellular: Move string_to_pdp_type method to CellularContext

### DIFF
--- a/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
+++ b/UNITTESTS/features/cellular/framework/common/util/utiltest.cpp
@@ -18,7 +18,6 @@
 #include <string.h>
 #include "CellularUtil.h"
 
-using namespace mbed;
 using namespace mbed_cellular_util;
 
 // AStyle ignored as the definition is not clear due to preprocessor usage
@@ -250,22 +249,3 @@ TEST_F(Testutil, int_to_hex_str)
     EXPECT_TRUE(buf[0] == '6');
     EXPECT_TRUE(buf[1] == '4');
 }
-
-TEST_F(Testutil, string_to_pdp_type)
-{
-    pdp_type_t type = string_to_pdp_type("IPV4V6");
-    ASSERT_EQ(type, IPV4V6_PDP_TYPE);
-
-    type = string_to_pdp_type("IPV6");
-    ASSERT_EQ(type, IPV6_PDP_TYPE);
-
-    type = string_to_pdp_type("IP");
-    ASSERT_EQ(type, IPV4_PDP_TYPE);
-
-    type = string_to_pdp_type("Non-IP");
-    ASSERT_EQ(type, NON_IP_PDP_TYPE);
-
-    type = string_to_pdp_type("diipadaapa");
-    ASSERT_EQ(type, DEFAULT_PDP_TYPE);
-}
-

--- a/UNITTESTS/features/cellular/framework/device/cellularcontext/cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellularcontext/cellularcontexttest.cpp
@@ -47,12 +47,15 @@ public:
 	{
 		_device = dev;
 		_cp_netif = new ControlPlane_netif_stub();
+
+		nonip_pdp_string = NULL;
 	}
 
 	~testContext()
 	{
 		delete _cp_netif;
 	}
+
 	int get_retry_count()
 	{
 		return _retry_count;
@@ -180,6 +183,11 @@ public:
 
 	}
 
+    const char *get_nonip_context_type_str()
+    {
+        return nonip_pdp_string;
+    }
+
 	void cp_data_received()
 	{
 		CellularContext::cp_data_received();
@@ -198,6 +206,58 @@ public:
 	{
 		CellularContext::do_connect_with_retry();
 	}
+
+	void test_string_to_pdp_type()
+	{
+	    pdp_type_t type = string_to_pdp_type("IPV4V6");
+	    ASSERT_EQ(type, IPV4V6_PDP_TYPE);
+
+	    type = string_to_pdp_type("IPV6");
+	    ASSERT_EQ(type, IPV6_PDP_TYPE);
+
+	    type = string_to_pdp_type("IP");
+	    ASSERT_EQ(type, IPV4_PDP_TYPE);
+
+	    type = string_to_pdp_type("Non-IP");
+	    ASSERT_EQ(type, NON_IP_PDP_TYPE);
+
+	    nonip_pdp_string = NULL;
+	    type = string_to_pdp_type("diipadaapa");
+	    ASSERT_EQ(type, DEFAULT_PDP_TYPE);
+	}
+
+    void test_nonip_context_type_str()
+    {
+        nonip_pdp_string = "NONIP";
+
+        pdp_type_t type = string_to_pdp_type("diipadaapa");
+        ASSERT_EQ(type, DEFAULT_PDP_TYPE);
+
+        type = string_to_pdp_type("NONIP");
+        ASSERT_EQ(type, NON_IP_PDP_TYPE);
+
+        type = string_to_pdp_type("nonip");
+        ASSERT_EQ(type, DEFAULT_PDP_TYPE);
+
+        type = string_to_pdp_type("IPV6");
+        ASSERT_EQ(type, IPV6_PDP_TYPE);
+
+        nonip_pdp_string = "testnonip";
+
+        type = string_to_pdp_type("diipadaapa");
+        ASSERT_EQ(type, DEFAULT_PDP_TYPE);
+
+        type = string_to_pdp_type("testnonip");
+        ASSERT_EQ(type, NON_IP_PDP_TYPE);
+
+        type = string_to_pdp_type("nonip");
+        ASSERT_EQ(type, DEFAULT_PDP_TYPE);
+
+        type = string_to_pdp_type("IPV6");
+        ASSERT_EQ(type, IPV6_PDP_TYPE);
+    }
+
+	const char *nonip_pdp_string;
 };
 
 static int network_cb_count = 0;
@@ -314,6 +374,20 @@ TEST_F(TestCellularContext, do_connect_with_retry_async)
     delete dev;
 }
 
+TEST_F(TestCellularContext, string_to_pdp_type)
+{
+    testContext *ctx = new testContext();
+    EXPECT_TRUE(ctx != NULL);
 
+    ctx->test_string_to_pdp_type();
+    delete ctx;
+}
 
+TEST_F(TestCellularContext, nonip_context_type_str)
+{
+    testContext *ctx = new testContext();
+    EXPECT_TRUE(ctx != NULL);
 
+    ctx->test_nonip_context_type_str();
+    delete ctx;
+}

--- a/UNITTESTS/stubs/CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/CellularContext_stub.cpp
@@ -68,4 +68,9 @@ void CellularContext::call_network_cb(nsapi_connection_status_t status)
     }
 }
 
+CellularContext::pdp_type_t CellularContext::string_to_pdp_type(const char *pdp_type)
+{
+    return IPV4V6_PDP_TYPE;
+}
+
 }

--- a/UNITTESTS/stubs/CellularUtil_stub.cpp
+++ b/UNITTESTS/stubs/CellularUtil_stub.cpp
@@ -28,7 +28,6 @@ int CellularUtil_stub::char_pos = 0;
 char *CellularUtil_stub::char_table[50] = {};
 int CellularUtil_stub::table_idx = 0;
 
-using namespace mbed;
 namespace mbed_cellular_util {
 
 #define MAX_STRING_LEN 200
@@ -132,11 +131,6 @@ int char_str_to_hex_str(const char *str, uint16_t len, char *buf, bool omit_lead
 uint16_t get_dynamic_ip_port()
 {
     return CellularUtil_stub::uint16_value;
-}
-
-pdp_type_t string_to_pdp_type(const char *pdp_type)
-{
-    return IPV4V6_PDP_TYPE;
 }
 
 } // namespace mbed_cellular_util

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -305,6 +305,14 @@ protected: // Device specific implementations might need these so protected
         OP_MAX          = 5
     };
 
+    enum pdp_type_t {
+        DEFAULT_PDP_TYPE = DEFAULT_STACK,
+        IPV4_PDP_TYPE = IPV4_STACK,
+        IPV6_PDP_TYPE = IPV6_STACK,
+        IPV4V6_PDP_TYPE = IPV4V6_STACK,
+        NON_IP_PDP_TYPE
+    };
+
     /** The CellularDevice calls the status callback function on status changes on the network or CellularDevice.
     *
     *  @param ev   event type
@@ -320,6 +328,16 @@ protected: // Device specific implementations might need these so protected
      *  active.
      */
     virtual void enable_hup(bool enable) = 0;
+
+    /** Return PDP type string for Non-IP if modem uses other than standard "Non-IP"
+     *
+     *  Some modems uses a non-standard PDP type string for non-ip (e.g. "NONIP").
+     *  In those cases modem driver must implement this method to return the PDP type string
+     *  used by the modem.
+     *
+     *  @return PDP type string used by the modem or NULL if standard ("Non-IP")
+     */
+    virtual const char *get_nonip_context_type_str() = 0;
 
     /** Triggers control plane's operations needed when control plane data is received,
      *  like socket event, for example.
@@ -347,6 +365,14 @@ protected: // Device specific implementations might need these so protected
      */
     void validate_ip_address();
 
+    /** Converts the given pdp type in char format to enum pdp_type_t
+     *
+     *  @param pdp_type     pdp type in string format
+     *  @return             converted pdp_type_t enum
+     */
+    CellularContext::pdp_type_t string_to_pdp_type(const char *pdp_type);
+
+protected:
     // member variables needed in target override methods
     NetworkStack *_stack; // must be pointer because of PPP
     pdp_type_t _pdp_type;

--- a/features/cellular/framework/common/CellularUtil.cpp
+++ b/features/cellular/framework/common/CellularUtil.cpp
@@ -25,7 +25,6 @@
 #define RANDOM_PORT_NUMBER_COUNT (RANDOM_PORT_NUMBER_END - RANDOM_PORT_NUMBER_START + 1)
 #define RANDOM_PORT_NUMBER_MAX_STEP 100
 
-using namespace mbed;
 namespace mbed_cellular_util {
 
 nsapi_version_t convert_ipv6(char *ip)
@@ -363,25 +362,6 @@ uint16_t get_dynamic_ip_port()
     port_counter %= RANDOM_PORT_NUMBER_COUNT;
 
     return (RANDOM_PORT_NUMBER_START + port_counter);
-}
-
-pdp_type_t string_to_pdp_type(const char *pdp_type_str)
-{
-    pdp_type_t pdp_type = DEFAULT_PDP_TYPE;
-    int len = strlen(pdp_type_str);
-
-    if (len == 6 && memcmp(pdp_type_str, "IPV4V6", len) == 0) {
-        pdp_type = IPV4V6_PDP_TYPE;
-    } else if (len == 4 && memcmp(pdp_type_str, "IPV6", len) == 0) {
-        pdp_type = IPV6_PDP_TYPE;
-    } else if (len == 2 && memcmp(pdp_type_str, "IP", len) == 0) {
-        pdp_type = IPV4_PDP_TYPE;
-    } else if (len == 6 && memcmp(pdp_type_str, "Non-IP", len) == 0) {
-        pdp_type = NON_IP_PDP_TYPE;
-    } else if (len == 5 && memcmp(pdp_type_str, "NONIP", len) == 0) {
-        pdp_type = NON_IP_PDP_TYPE;
-    }
-    return pdp_type;
 }
 
 } // namespace mbed_cellular_util

--- a/features/cellular/framework/common/CellularUtil.h
+++ b/features/cellular/framework/common/CellularUtil.h
@@ -22,16 +22,6 @@
 #include <inttypes.h>
 #include "nsapi_types.h"
 
-namespace mbed {
-
-typedef enum pdp_type {
-    DEFAULT_PDP_TYPE = DEFAULT_STACK,
-    IPV4_PDP_TYPE = IPV4_STACK,
-    IPV6_PDP_TYPE = IPV6_STACK,
-    IPV4V6_PDP_TYPE = IPV4V6_STACK,
-    NON_IP_PDP_TYPE
-} pdp_type_t;
-}
 namespace mbed_cellular_util {
 
 // some helper macros
@@ -138,13 +128,6 @@ uint32_t binary_str_to_uint(const char *binary_string, int binary_string_length)
  *  @return next port number above 49152
  */
 uint16_t get_dynamic_ip_port();
-
-/** Converts the given pdp type in char format to enum pdp_type_t
- *
- *  @param pdp_type     pdp type in string format
- *  @return             converted pdp_type_t enum
- */
-mbed::pdp_type_t string_to_pdp_type(const char *pdp_type);
 
 } // namespace mbed_cellular_util
 

--- a/features/cellular/framework/device/CellularContext.cpp
+++ b/features/cellular/framework/device/CellularContext.cpp
@@ -113,6 +113,27 @@ void CellularContext::validate_ip_address()
     }
 }
 
+CellularContext::pdp_type_t CellularContext::string_to_pdp_type(const char *pdp_type_str)
+{
+    pdp_type_t pdp_type = DEFAULT_PDP_TYPE;
+    int len = strlen(pdp_type_str);
+
+    if (len == 6 && memcmp(pdp_type_str, "IPV4V6", len) == 0) {
+        pdp_type = IPV4V6_PDP_TYPE;
+    } else if (len == 4 && memcmp(pdp_type_str, "IPV6", len) == 0) {
+        pdp_type = IPV6_PDP_TYPE;
+    } else if (len == 2 && memcmp(pdp_type_str, "IP", len) == 0) {
+        pdp_type = IPV4_PDP_TYPE;
+    } else if (len == 6 && memcmp(pdp_type_str, "Non-IP", len) == 0) {
+        pdp_type = NON_IP_PDP_TYPE;
+    } else if (get_nonip_context_type_str() &&
+               len == strlen(get_nonip_context_type_str()) &&
+               memcmp(pdp_type_str, get_nonip_context_type_str(), len) == 0) {
+        pdp_type = NON_IP_PDP_TYPE;
+    }
+    return pdp_type;
+}
+
 void CellularContext::do_connect_with_retry()
 {
     if (_cb_data.final_try) {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

`string_to_pdp_type` is only used in `CellularContext` classes and by having the conversion method in CellularContext it can be used also to check the non-standard Non-IP PDP type string.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None, if application uses existing cellular classes. If user has implemented own `CellularContext` class, then see migration actions required.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Classes deriving from `CellularContext` must implement new function: 
`virtual const char *get_nonip_context_type_str() = 0;`
This API has already been implemented in AT_CellularContext though, so current code does not change.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-wan 

----------------------------------------------------------------------------------------------------------------
