### PR TITLE
tests tickers: adapt ticker_interrupt_test() test case for high frequency tickers

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -53,7 +53,7 @@ extern "C" {
 #define TICKER_100_TICKS 100
 #define TICKER_500_TICKS 500
 
-#define MAX_FUNC_EXEC_TIME_US 30
+#define MAX_FUNC_EXEC_TIME_US 20
 #define DELTA_FUNC_EXEC_TIME_US 5
 #define NUM_OF_CALLS 100
 
@@ -61,6 +61,8 @@ extern "C" {
 
 #define US_TICKER_OV_LIMIT 35000
 #define LP_TICKER_OV_LIMIT 4000
+
+#define TICKS_TO_US(ticks, freq) ((uint32_t) ((uint64_t)ticks * US_PER_S /freq))
 
 using namespace utest::v1;
 
@@ -216,11 +218,20 @@ void ticker_info_test(void)
 /* Test that ticker interrupt fires only when the ticker counter increments to the value set by ticker_set_interrupt. */
 void ticker_interrupt_test(void)
 {
-    uint32_t ticker_timeout[] = { 100, 200, 300, 500 };
+    uint32_t ticker_timeout[] = { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200 };
+    uint8_t run_count = 0;
+    const ticker_info_t *p_ticker_info = intf->get_info();
 
     overflow_protect();
 
     for (uint32_t i = 0; i < (sizeof(ticker_timeout) / sizeof(uint32_t)); i++) {
+
+        /* Skip timeout if less than max allowed execution time of set_interrupt() - 20 us */
+        if (TICKS_TO_US(ticker_timeout[i], p_ticker_info->frequency) < (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)) {
+            continue;
+        }
+
+        run_count++;
         intFlag = 0;
         const uint32_t tick_count = intf->read();
 
@@ -251,6 +262,9 @@ void ticker_interrupt_test(void)
 
         TEST_ASSERT_EQUAL(1, intFlag);
     }
+
+    /* At least 3 sub test cases must be executed. */
+    TEST_ASSERT_MESSAGE(run_count >= 3, "At least 3 sub test cases must be executed");
 }
 
 /* Test that ticker interrupt is not triggered when ticker_set_interrupt */


### PR DESCRIPTION


<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

On some targets with very fast counters used for us ticker (e.g. 26 MHz) tested interrupt delays provided in the `ticker_timeout` array may be too short (execution of the `set_interrupt()` function takes longer than the tested delay).
We will skip tested ticker delay if the delay is less than assumed max `set_interrupt()` function execution time (`20 us`).

Also, the test array will be extended.

Tested on: `K64F`, `NUCLEO_F429ZI`, `NRF52840_DK`.
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
