### PR TITLE
Fix baremetal heap and stack initialisation

### DIFF
--- a/platform/source/TARGET_CORTEX_M/TOOLCHAIN_IAR/cmain.S
+++ b/platform/source/TARGET_CORTEX_M/TOOLCHAIN_IAR/cmain.S
@@ -46,6 +46,7 @@
         EXTERN  exit
         EXTERN  __iar_dynamic_initialization
         EXTERN mbed_sdk_init
+        EXTWEAK __mbed_init
         EXTERN mbed_main
         EXTERN SystemInit
         
@@ -68,6 +69,9 @@ __cmain:
         FUNCALL __cmain, mbed_sdk_init
         BL      mbed_sdk_init
         MOVS    r0,#0             ;  No parameters        
+        FUNCALL __cmain, __mbed_init
+        BL      __mbed_init
+        MOVS    r0,#0             ;  No parameters
           FUNCALL __cmain, __iar_dynamic_initialization
         BL      __iar_dynamic_initialization   ; C++ dynamic initialization  
 

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -561,23 +561,6 @@ std::FILE *fdopen(FileHandle *fh, const char *mode)
 extern "C" FILEHANDLE PREFIX(_open)(const char *name, int openflags)
 {
 #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
-#if !defined(MBED_CONF_RTOS_PRESENT)
-    // valid only for mbed 2
-    // for ulib, this is invoked after RAM init, prior c++
-    // used as hook, as post stack/heap is not active there
-    extern void mbed_copy_nvic(void);
-    extern void mbed_sdk_init(void);
-
-    static int mbed_sdk_inited = 0;
-    if (!mbed_sdk_inited) {
-        mbed_copy_nvic();
-        mbed_sdk_init();
-#if DEVICE_USTICKER && MBED_CONF_TARGET_INIT_US_TICKER_AT_BOOT
-        us_ticker_init();
-#endif
-        mbed_sdk_inited = 1;
-    }
-#endif
     // Before version 5.03, we were using a patched version of microlib with proper names
     // This is the workaround that the microlib author suggested us
     static int n = 0;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixed baremetal heap and stack initialisation and enabled heap_and_stack test for baremetal.
Added a test to check that global variables are initialised.

In mbed_sdk_boot:
- Added initialisation for mbed_stack_isr_start/size and mbed_heap_start/size for all toolchains.
- ARM toolchain: 
   - Added call to mbed_toolchain_init() to initialise global variables.
   - Moved microlib initialisation code from mbed_retarget.cpp to mbed_sdk_boot.c.
- IAR toolchain: there is no equivalent to a software init hook that can be called. __low_level_init() was used but since this function is called before RAM initialisation, it cannot be used to initialize global variables. Defined a new __mbed_init() function called from IAR startup file instead.


<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

Heap & stack test is enabled in baremetal mode.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
