### PR TITLE
target_test - assert if sectors keyword missing

### DIFF
--- a/tools/test/targets/target_test.py
+++ b/tools/test/targets/target_test.py
@@ -15,6 +15,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+# How to run this test?
+#
+# Note! You  must be in the mbed-os -folder!
+#
+# python -m pytest tools/test/targets/target_test.py
+#
 import os
 import sys
 import shutil
@@ -39,6 +45,7 @@ def test_device_name():
 
 def test_bl_has_sectors():
     """Assert a bootloader supporting pack has sector information"""
+    # ToDo: validity checks for the information IN the sectors!
     cache = Cache(True, True)
     named_targets = (
         target for target in TARGETS if
@@ -48,6 +55,9 @@ def test_bl_has_sectors():
         assert target.device_name in cache.index,\
             ("Target %s contains invalid device_name %s" %
              (target.name, target.device_name))
+        assert "sectors" in cache.index[target.device_name],\
+            ("Target %s does not have sectors" %
+             (target.name))
         assert cache.index[target.device_name]["sectors"],\
             ("Device name %s is misssing sector information" %
              (target.device_name))


### PR DESCRIPTION
### Summary of changes 

Assert it properly and thus give out the target name where the
issue is, rather than just error out with KeyError and leave the
poor sod wondering where exactly the issue is.

Before:
```

=================================== FAILURES ===================================
_____________________________ test_bl_has_sectors ______________________________
    def test_bl_has_sectors():
        """Assert a bootloader supporting pack has sector information"""
        cache = Cache(True, True)
        named_targets = (
            target for target in TARGETS if
            (hasattr(target, "device_name") and getattr(target, "bootloader_supported", False))
        )
        for target in named_targets:
            assert target.device_name in cache.index,\
                ("Target %s contains invalid device_name %s" %
                 (target.name, target.device_name))
>           assert cache.index[target.device_name]["sectors"],\
                ("Device name %s is misssing sector information" %
                 (target.device_name))
E           KeyError: 'sectors'
```

After

```
___________________________________________________ test_bl_has_sectors ___________________________________________________

    def test_bl_has_sectors():
        """Assert a bootloader supporting pack has sector information"""
        # ToDo: validity checks for the information IN the sectors!
        cache = Cache(True, True)
        named_targets = (
            target for target in TARGETS if
            (hasattr(target, "device_name") and getattr(target, "bootloader_supported", False))
        )
        for target in named_targets:
            assert target.device_name in cache.index,\
                ("Target %s contains invalid device_name %s" %
                 (target.name, target.device_name))
>           assert "sectors" in cache.index[target.device_name],\
                ("Target %s does not have sectors" %
                 (target.name))
E           AssertionError: Target NUCLEO_L073RZ does not have sectors
E           assert 'sectors' in {'algorithms': [{'default': True, 'file_name': 'CMSIS/Flash/STM32L0xx_192.FLM', 'ram_size': None, 'ram_start': None, ....on_secure_callable': False, 'peripheral': False, ...}, 'default': True, 'size': 196608, 'start': 134217728, ...}}, ...}

```

This helps you finding the offending target a bit faster.

Kudos to Jammu Kekkonen (jammu.kekkonen@arm.com aka @JammuKekkonen ) to figuring out how to actually run this test & the assertion.

Ref: Mbed OS issue #12219

### Pull request type <!-- Required -->

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@JammuKekkonen  @ARMmbed/mbed-os-maintainers 

----------------------------------------------------------------------------------------------------------------
