### PR TITLE
ESP8266: Add built-in hostname resolution handling (disabled by default)

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -609,7 +609,11 @@ nsapi_error_t ESP8266::open_tcp(int id, const char *addr, int port, int keepaliv
 bool ESP8266::dns_lookup(const char *name, char *ip)
 {
     _smutex.lock();
-    bool done = _parser.send("AT+CIPDOMAIN=\"%s\"", name) && _parser.recv("+CIPDOMAIN:%s%*[\r]%*[\n]", ip);
+    set_timeout(ESP8266_DNS_TIMEOUT);
+    bool done = _parser.send("AT+CIPDOMAIN=\"%s\"", name)
+                && _parser.recv("+CIPDOMAIN:%15[^\n]\n", ip)
+                && _parser.recv("OK\n");
+    set_timeout();
     _smutex.unlock();
 
     return done;

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -43,6 +43,9 @@
 #ifndef ESP8266_MISC_TIMEOUT
 #define ESP8266_MISC_TIMEOUT    2000
 #endif
+#ifndef ESP8266_DNS_TIMEOUT
+#define ESP8266_DNS_TIMEOUT     15000
+#endif
 
 #define ESP8266_SCAN_TIME_MIN 0     // [ms]
 #define ESP8266_SCAN_TIME_MAX 1500  // [ms]

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -652,6 +652,28 @@ int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count, scan_mode mode,
     return ret;
 }
 
+#if MBED_CONF_ESP8266_BUILT_IN_DNS
+nsapi_error_t ESP8266Interface::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version, const char *interface_name)
+{
+    char ip[NSAPI_IPv4_SIZE];
+    memset(ip, 0, NSAPI_IPv4_SIZE);
+    if (!_esp.dns_lookup(name, ip)) {
+        return NSAPI_ERROR_DNS_FAILURE;
+    }
+    if (!address->set_ip_address(ip)) {
+        return NSAPI_ERROR_DNS_FAILURE;
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+
+nsapi_error_t ESP8266Interface::add_dns_server(const SocketAddress &address, const char *interface_name)
+{
+    return NSAPI_ERROR_OK;
+}
+#endif
+
 bool ESP8266Interface::_get_firmware_ok()
 {
     ESP8266::fw_at_version at_v = _esp.at_version();

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -228,14 +228,25 @@ public:
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
      *  @return         0 on success, negative error code on failure
      */
+#if MBED_CONF_ESP8266_BUILT_IN_DNS
+    nsapi_error_t gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version, const char *interface_name);
+#else
     using NetworkInterface::gethostbyname;
+#endif
+
+    using NetworkInterface::gethostbyname_async;
+    using NetworkInterface::gethostbyname_async_cancel;
 
     /** Add a domain name server to list of servers to query
      *
      *  @param addr     Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
+#if MBED_CONF_ESP8266_BUILT_IN_DNS
+    nsapi_error_t add_dns_server(const SocketAddress &address, const char *interface_name);
+#else
     using NetworkInterface::add_dns_server;
+#endif
 
     /** @copydoc NetworkStack::setsockopt
      */

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -65,6 +65,10 @@
         "channels": {
             "help": "channel count, 13 by default",
             "value": null
+        },
+        "built-in-dns": {
+            "help": "use built-in CIPDOMAIN AT command to resolve address to IP",
+            "value": false
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes https://github.com/ARMmbed/mbed-os/issues/11982 (some routers fail to work with the UDPSocket-approach, but are proved to work when ESP uses its embedded hostname resolution AT command).

The feature is disabled by default and can be enabled in mbed_app.json with `"esp8266.built-in-dns": true`. When enabled then the synchronous hostname resolution will use the ESP's `CIPDOMAIN` AT command, but asynchronous resolution will keep on using the UDPSockets as before (no point rewriting the nsapi_dns). Also caching does not work.

I tested with the netsocket-dns testsuite. Obviously caching tests often fail, but if lucky I can get 15/16 passes.

@zhiyong80, please verify if this works with your router.

#### Impact of changes <!-- Optional -->

None, until user enables the `esp8266.built-in-dns` option.

#### Migration actions required <!-- Optional -->

None.

### Documentation <!-- Required -->

"help" section added to mbed_lib.json.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@AnttiKauppila 
@VeijoPesonen 
@SeppoTakalo 
@zhiyong80 

----------------------------------------------------------------------------------------------------------------
