### PR TITLE
Minimal-printf: Fix wrapping of printf functions for the ARM compiler

### DIFF
--- a/platform/source/minimal-printf/mbed_printf_armlink_overrides.c
+++ b/platform/source/minimal-printf/mbed_printf_armlink_overrides.c
@@ -66,19 +66,34 @@ int $Sub$$__2snprintf(char *buffer, size_t length, const char *format, ...)
     return result;
 }
 
-int $Sub$$__2vprintf(char *buffer, const char *format, ...)
+int $Sub$$__2vprintf(const char *format, va_list arguments)
 {
-    va_list arguments;
-    va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, stdout);
-    va_end(arguments);
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
+}
 
-    return result;
+int $Sub$$__2vsprintf(char *buffer, const char *format, va_list arguments)
+{
+    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
 }
 
 int $Sub$$__2vsnprintf(char *buffer, size_t length, const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
+}
+
+int $Sub$$__2fprintf(FILE *stream, const char *format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+    va_end(arguments);
+
+    return result;
+}
+
+int $Sub$$__2vfprintf(FILE *stream, const char *format, va_list arguments)
+{
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
 }
 
 /**

--- a/platform/source/minimal-printf/mbed_printf_wrapper.c
+++ b/platform/source/minimal-printf/mbed_printf_wrapper.c
@@ -21,46 +21,15 @@
 #include <limits.h>
 
 
-#if defined(__GNUC__)   /* GCC        */
-#define SUPER_PRINTF     __real_printf
-#define SUB_PRINTF       __wrap_printf
-#define SUPER_SPRINTF    __real_sprintf
-#define SUB_SPRINTF      __wrap_sprintf
-#define SUPER_SNPRINTF   __real_snprintf
-#define SUB_SNPRINTF     __wrap_snprintf
-#define SUPER_VPRINTF    __real_vprintf
-#define SUB_VPRINTF      __wrap_vprintf
-#define SUPER_VSPRINTF   __real_vsprintf
-#define SUB_VSPRINTF     __wrap_vsprintf
-#define SUPER_VSNPRINTF  __real_vsnprintf
-#define SUB_VSNPRINTF    __wrap_vsnprintf
-#define SUPER_FPRINTF  __real_fprintf
-#define SUB_FPRINTF    __wrap_fprintf
-#define SUPER_VFPRINTF __real_vfprintf
-#define SUB_VFPRINTF   __wrap_vfprintf
-#elif defined(TOOLCHAIN_ARM) /* ARMC5/ARMC6 */\
- || defined(__ICCARM__)      /* IAR        */
-#define SUPER_PRINTF     $Super$$printf
-#define SUB_PRINTF       $Sub$$printf
-#define SUPER_SPRINTF    $Super$$sprintf
-#define SUB_SPRINTF      $Sub$$sprintf
-#define SUPER_SNPRINTF   $Super$$snprintf
-#define SUB_SNPRINTF     $Sub$$snprintf
-#define SUPER_VPRINTF    $Super$$vprintf
-#define SUB_VPRINTF      $Sub$$vprintf
-#define SUPER_VSPRINTF   $Super$$vsprintf
-#define SUB_VSPRINTF     $Sub$$vsprintf
-#define SUPER_VSNPRINTF  $Super$$vsnprintf
-#define SUB_VSNPRINTF    $Sub$$vsnprintf
-#define SUPER_FPRINTF    $Super$$fprintf
-#define SUB_FPRINTF      $Sub$$fprintf
-#define SUPER_VFPRINTF   $Super$$vfprintf
-#define SUB_VFPRINTF     $Sub$$vfprintf
+#if defined(__ARMCC_VERSION) || defined(__ICCARM__)
+#    define PREFIX(x)    $Sub$$##x
+#elif defined(__GNUC__)
+#    define PREFIX(x)    __wrap_##x
 #else
 #warning "This compiler is not yet supported."
 #endif
 
-int SUB_PRINTF(const char *format, ...)
+int PREFIX(printf)(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
@@ -70,7 +39,7 @@ int SUB_PRINTF(const char *format, ...)
     return result;
 }
 
-int SUB_SPRINTF(char *buffer, const char *format, ...)
+int PREFIX(sprintf)(char *buffer, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
@@ -80,7 +49,7 @@ int SUB_SPRINTF(char *buffer, const char *format, ...)
     return result;
 }
 
-int SUB_SNPRINTF(char *buffer, size_t length, const char *format, ...)
+int PREFIX(snprintf)(char *buffer, size_t length, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
@@ -90,22 +59,22 @@ int SUB_SNPRINTF(char *buffer, size_t length, const char *format, ...)
     return result;
 }
 
-int SUB_VPRINTF(const char *format, va_list arguments)
+int PREFIX(vprintf)(const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stdout);
 }
 
-int SUB_VSPRINTF(char *buffer, const char *format, va_list arguments)
+int PREFIX(vsprintf)(char *buffer, const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
 }
 
-int SUB_VSNPRINTF(char *buffer, size_t length, const char *format, va_list arguments)
+int PREFIX(vsnprintf)(char *buffer, size_t length, const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
 
-int SUB_FPRINTF(FILE *stream, const char *format, ...)
+int PREFIX(fprintf)(FILE *stream, const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
@@ -115,7 +84,7 @@ int SUB_FPRINTF(FILE *stream, const char *format, ...)
     return result;
 }
 
-int SUB_VFPRINTF(FILE *stream, const char *format, va_list arguments)
+int PREFIX(vfprintf)(FILE *stream, const char *format, va_list arguments)
 {
     return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
As the ARM compiler is in GNU compatible mode, it defines __GNU__ which
(based on pre-processor condition in  mbed_printf_implentation.h)
causes the printf functions to be wrapped using _wrap_* instead of
$Sub$$*.

This commit modifies the pre-processor
conditions to check for __GNUC__last in order to correctly
substitute the printf functions depending on the toolchain in use.

It also gets rid of $Super$$* substitution as it is not needed. $Super$$
is used to identify the original unpatched functions.

Missing substitutions for ARM compiler internal optimized "printfs" are
also added.
#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@kjbracey-arm @evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
