### PR TITLE
Fix DNS multiple query hints to perform both IP4 and IP6 tests

### DIFF
--- a/TESTS/netsocket/dns/asynchronous_dns_multi_ip.cpp
+++ b/TESTS/netsocket/dns/asynchronous_dns_multi_ip.cpp
@@ -58,7 +58,7 @@ void do_getaddrinfo_async(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op
     // Create callback semaphore and data
     rtos::Semaphore semaphore;
     dns_application_data_multi_ip *data = new dns_application_data_multi_ip[op_count];
-    SocketAddress hints{{NSAPI_IPv4}, 80};
+    SocketAddress hints{{NSAPI_UNSPEC}, 80};
 
     unsigned int count = 0;
     for (unsigned int i = 0; i < op_count; i++) {

--- a/TESTS/netsocket/dns/synchronous_dns_multi_ip.cpp
+++ b/TESTS/netsocket/dns/synchronous_dns_multi_ip.cpp
@@ -42,7 +42,7 @@ void do_getaddrinfo(const char hosts[][DNS_TEST_HOST_LEN], unsigned int op_count
     (*exp_dns_failure) = 0;
     (*exp_timeout) = 0;
 
-    SocketAddress hints{{NSAPI_IPv4}, 80};
+    SocketAddress hints{{NSAPI_UNSPEC}, 80};
     for (unsigned int i = 0; i < op_count; i++) {
         SocketAddress *result;
         nsapi_error_t err = NetworkInterface::get_default_instance()->get_default_instance()->getaddrinfo(hosts[i], &hints, &result);


### PR DESCRIPTION
Multiple DNS Greentea tests  fixed

### Summary of changes <!-- Required -->
Getaddrinfo  fails with IP6 interface due to hardcoded IP4 hints.
Replaced query hints  with NSAPI_UNSPEC   to perform  both  IP4 and IP6 .

#### Impact of changes <!-- Optional -->
No impact

#### Migration actions required <!-- Optional -->
Not needed

### Documentation <!-- Required -->

 
### Pull request type <!-- Required -->

 
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

 
    [] No Tests required for this change (E.g docs only update)
    [x Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

 @AnttiKauppila 
@SeppoTakalo 
@michalpasztamobica 
----------------------------------------------------------------------------------------------------------------
