### PR TITLE
NUCLEO_WB55RG - add device name "STM32WB55RGVx"

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12068,7 +12068,7 @@
             "2",
             "5"
         ],
-        "bootloader_supported": false
+        "bootloader_supported": true
     },
     "VBLUNO52": {
         "supported_form_factors": [

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -12060,6 +12060,7 @@
             "FLASH",
             "MPU"
         ],
+        "device_name": "STM32WB55RGVx",
         "features": [
             "BLE"
         ],


### PR DESCRIPTION
### Summary of changes 

Add device name for NUCLEO_WB55RG target.

Bootloader compilation will require the device to be in place,
it uses that to pick up the CMSIS-pack info from the index.json.

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

### Test results <!-- Required -->

    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
### Reviewers <!-- Optional -->

@ARMmbed/team-st-mcd  @0xc0170 

