### PR TITLE
Cellular: Remove friend definitions from cellular state machine

### DIFF
--- a/features/cellular/framework/device/CellularStateMachine.h
+++ b/features/cellular/framework/device/CellularStateMachine.h
@@ -31,11 +31,9 @@ class CellularDevice;
  *  Finite State Machine for attaching to cellular network. Used by CellularDevice.
  */
 class CellularStateMachine {
-private:
-    // friend of CellularDevice so that it's the only way to close/delete this class.
-    friend class CellularDevice;
-    friend class AT_CellularDevice;
+public:
     friend class UT_CellularStateMachine; // for unit tests
+
     /** Constructor
      *
      * @param device    reference to CellularDevice
@@ -128,8 +126,21 @@ private:
     /** Reset the state machine to init state. After reset state machine can be used again to run to wanted state.
      */
     void reset();
-private:
+
+    /** Get retry timeout array
+     *
+     * @param timeout   Pointer to timeout array
+     * @param array_len Max lenght of the array
+     */
     void get_retry_timeout_array(uint16_t *timeout, int &array_len) const;
+
+    /** Change all cellular state timeouts
+     *
+     * @param timeout Timeout value (milliseconds)
+     */
+    void set_timeout(int timeout);
+
+private:
     bool power_on();
     bool open_sim();
     bool get_network_registration(CellularNetwork::RegistrationType type, CellularNetwork::RegistrationStatus &status, bool &is_registered);
@@ -188,8 +199,7 @@ private:
     int _state_timeout_registration;
     int _state_timeout_network;
     int _state_timeout_connect; // timeout for PS attach, PDN connect and socket operations
-    // Change all cellular state timeouts to `timeout`
-    void set_timeout(int timeout);
+
     cell_signal_quality_t _signal_quality;
 };
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Instead of defining which classes can access state machine, `CellularStateMachine`
class is now "a normal" CPP class with public API.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
This is potentially a breaking change but as `CellularStateMachine` is only used internally there shouldn't be any impact.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

None, internal change

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [X] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@ARMmbed/mbed-os-wan 

----------------------------------------------------------------------------------------------------------------
