### PR TITLE
unittest: fix ATCmdParser test segfault

### DIFF
--- a/UNITTESTS/platform/ATCmdParser/test_ATCmdParser.cpp
+++ b/UNITTESTS/platform/ATCmdParser/test_ATCmdParser.cpp
@@ -189,8 +189,8 @@ TEST_F(test_ATCmdParser, test_ATCmdParser_read)
     filehandle_stub_table_pos = 0;
 
     ATCmdParser at(&fh1, ",");
-    char buf[6];
-    memset(buf, 0, 6);
+    char buf[8];
+    memset(buf, 0, 8);
 
     // TEST EMPTY BUFFER
     // Shouldn't read any byte since buffer is empty


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Fixes ATCmdParser unittest bug (causing segfault when run unittests on windows)

```
53: Test command: C:\Users\macboc01.ARM\work\mbed\dev\mbed-os\BUILD\unittests\platform-ATCmdParser.exe
53: Test timeout computed to be: 1500
53: Running main() from gmock_main.cc
53: [==========] Running 13 tests from 1 test case.
53: [----------] Global test environment set-up.
53: [----------] 13 tests from test_ATCmdParser
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_create
53: [       OK ] test_ATCmdParser.test_ATCmdParser_create (0 ms)
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_set_timeout
53: [       OK ] test_ATCmdParser.test_ATCmdParser_set_timeout (0 ms)
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_process_oob
53: [       OK ] test_ATCmdParser.test_ATCmdParser_process_oob (0 ms)
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_flush
53: [       OK ] test_ATCmdParser.test_ATCmdParser_flush (0 ms)
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_write
53: [       OK ] test_ATCmdParser.test_ATCmdParser_write (0 ms)
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_set_delimiter
53: [       OK ] test_ATCmdParser.test_ATCmdParser_set_delimiter (0 ms)
53: [ RUN      ] test_ATCmdParser.test_ATCmdParser_read
1/1 Test #53: platform-ATCmdParser .............***Exception: SegFault  1.26 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   1.28 sec

The following tests FAILED:
         53 - platform-ATCmdParser (SEGFAULT)
Errors while running CTest
mingw32-make: *** [Makefile:61: test] Error 8

```

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jamesbeyond 

----------------------------------------------------------------------------------------------------------------
