### PR TITLE
psa: Ensure spaces before partition name comment

### DIFF
--- a/tools/psa/templates/psa_setup.c.tpl
+++ b/tools/psa/templates/psa_setup.c.tpl
@@ -186,7 +186,7 @@ void {{partition.name|lower}}_init(spm_partition_t *partition)
 {# -------------- spm_db_entry(partition) ----------------------------------- #}
 {% macro spm_db_entry(partition) -%}
 
-/* {{partition.name|upper}} */
+    /* {{partition.name|upper}} */
     {
         .partition_id = {{partition.name|upper}}_ID,
         .thread_id = 0,
@@ -214,7 +214,7 @@ void {{partition.name|lower}}_init(spm_partition_t *partition)
 /****************** SPM DB initialization *************************************/
 spm_partition_t g_partitions[] = {
 {% for partition in service_partitions %}
-{{spm_db_entry(partition)}}
+    {{spm_db_entry(partition)}}
 
 {% endfor %}
 #ifdef USE_PSA_TEST_PARTITIONS


### PR DESCRIPTION
### Summary of changes <!-- Required -->

The psa_setup.c.tpl jinja template would strip whitespace from before
the partition name comment when inserting non-test partition database
entries. Fix the template to generate psa_setup.c with the partition
name comment properly indented.

This will help avoid weird changes to psa_setup.c that cause it to fail AStyle checks when running release.py.

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jainvikas8 

----------------------------------------------------------------------------------------------------------------
