### PR TITLE
Disable the cell AUX UART by default on EP_AGORA

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/ONBOARD_TELIT_ME910.cpp
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/ONBOARD_TELIT_ME910.cpp
@@ -114,7 +114,7 @@ nsapi_error_t ONBOARD_TELIT_ME910::init()
     // AT#PORTCFG=0
     // Set command allows to connect Service Access Points to the external physical ports giving a great
     // flexibility. Examples of Service Access Points: AT Parser Instance #1, #2, #3, etc..
-    _at->at_cmd_discard("#PORTCFG", "=3");
+    _at->at_cmd_discard("#PORTCFG", "=", "%d", EP_AGORA_PORT_CONFIGURATION_VARIANT);
 
     // AT&W&P
     // - AT&W: Execution command stores on profile <n> the complete configuration of the device. If

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_EP_AGORA/mbed_lib.json
@@ -5,6 +5,11 @@
             "help"                 : "Enable the cell module on the EP_AGORA board",
             "macro_name"           : "EP_AGORA_ENABLE_CELL",
             "value"                : true
+        },
+        "port-configuration-variant" : {
+            "help"                 : "Telit ME910C1 AT#PORTCFG Variant value",
+            "macro_name"           : "EP_AGORA_PORT_CONFIGURATION_VARIANT",
+            "value"                : 0
         }
     },
     "target_overrides": {


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Disables the auxiliary UART of the cell module on the `EP_AGORA` target by default. This was causing issues in the [`mbed-os-example-pelion`](https://github.com/ARMmbed/mbed-os-example-pelion) example because the auxiliary UART is muxed with the default standard output UART. Therefore, if the auxiliary UART on the cell module is enabled, it has the undesired effect of receiving and attempting to parse the debug output as an AT command. When the parsing fails, it echoes back an error in the form:
```
<input string> + CME ERROR: unknown
```
In the `mbed-os-example-pelion` example, this would result in undesired characters being received via standard input and subsequently undesired application behavior.

So, the best path forward is to disable the auxiliary UART by default and let a user enable it if/when needed.

From the [Telit ME910C1 AT command reference guide](https://y1cj3stn5fbwhv73k0ipk1eg-wpengine.netdna-ssl.com/wp-content/uploads/2019/06/Telit_ME910C1_NE910C1_ML865C1_AT_Commands_Reference_Guide_r9-1.pdf), for the `AT#PORTCFG` command (page 76) a `Variant` value of `0` enables the main cell module UART and 2 USB interfaces and does not enable the auxiliary UART (`USIF1`):
```
#PORTCFG: Variant=0: AT= USIF0 USB0 USB1
#PORTCFG: Variant=3: AT= USIF0 USIF1 USB0
#PORTCFG: Variant=8: AT= USB0 USB1
#PORTCFG: Variant=13: AT= USIF0 USB0; CMUX
```
Therefore, changing from a `Variant` value of `3` to a value of `0` should effectively disable the auxiliary UART.

NOTE: As stated in the AT command reference guide, this setting change does not take effect until the cell module is rebooted, but should only ever have to be configured once.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
The auxiliary UART of the cell module is disabled by default.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
None.

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@linlingao 

----------------------------------------------------------------------------------------------------------------
