### PR TITLE
Test: Increase the UART flush delay

### DIFF
--- a/TESTS/mbed_drivers/reset_reason/main.cpp
+++ b/TESTS/mbed_drivers/reset_reason/main.cpp
@@ -49,7 +49,20 @@
 #define MSG_KEY_RESET_REASON "reason"
 #define MSG_KEY_DEVICE_RESET "reset"
 
-#define SERIAL_FLUSH_TIME_MS 20
+/* To prevent a loss of Greentea data, the serial buffers have to be flushed
+ * before the UART peripheral shutdown. The UART shutdown happens when the
+ * device is entering the deepsleep mode or performing a reset.
+ *
+ * With the current API, it is not possible to check if the hardware buffers
+ * are empty. However, it is possible to determine the time required for the
+ * buffers to flush.
+ *
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
+ */
+#define SERIAL_FLUSH_TIME_MS 150
 
 typedef enum {
     CMD_STATUS_CONTINUE,

--- a/TESTS/mbed_drivers/watchdog/main.cpp
+++ b/TESTS/mbed_drivers/watchdog/main.cpp
@@ -51,12 +51,12 @@
  * are empty. However, it is possible to determine the time required for the
  * buffers to flush.
  *
- * Take NUMAKER_PFM_NUC472 as an example:
- * The UART peripheral has 16-byte Tx FIFO. With a baud rate set to 9600,
- * flushing the Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 ms.
- * To be on the safe side, set the wait time to 20 ms.
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS 20
+#define SERIAL_FLUSH_TIME_MS 150
 
 int CASE_INDEX_START;
 int CASE_INDEX_CURRENT;

--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -61,12 +61,12 @@
  * are empty. However, it is possible to determine the time required for the
  * buffers to flush.
  *
- * Take NUMAKER_PFM_NUC472 as an example:
- * The UART peripheral has 16-byte Tx FIFO. With a baud rate set to 9600,
- * flushing the Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 ms.
- * To be on the safe side, set the wait time to 20 ms.
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS 20
+#define SERIAL_FLUSH_TIME_MS 150
 
 #define TIMEOUT_US (1000 * (TIMEOUT_MS))
 #define KICK_ADVANCE_US (1000 * (KICK_ADVANCE_MS))
@@ -112,10 +112,11 @@ void test_simple_reset()
 
     // Phase 1. -- run the test code.
     // Init the watchdog and wait for a device reset.
-    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
+    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS + SERIAL_FLUSH_TIME_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
         return;
     }
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     Watchdog &watchdog = Watchdog::get_instance();
     TEST_ASSERT_FALSE(watchdog.is_running());
     TEST_ASSERT_TRUE(watchdog.start(TIMEOUT_MS));
@@ -141,10 +142,11 @@ void test_sleep_reset()
     }
 
     // Phase 1. -- run the test code.
-    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
+    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS + SERIAL_FLUSH_TIME_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
         return;
     }
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     Watchdog &watchdog = Watchdog::get_instance();
     TEST_ASSERT_FALSE(watchdog.is_running());
     TEST_ASSERT_TRUE(watchdog.start(TIMEOUT_MS));
@@ -232,10 +234,11 @@ void test_restart_reset()
     // The watchdog should trigger before twice the timeout value.
     wait_us(TIMEOUT_US / 2 + TIMEOUT_US);
 
-    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
+    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS + SERIAL_FLUSH_TIME_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
         return;
     }
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     TEST_ASSERT_TRUE(watchdog.start(TIMEOUT_MS));
     TEST_ASSERT_TRUE(watchdog.is_running());
     // Watchdog should fire before twice the timeout value.
@@ -268,10 +271,11 @@ void test_kick_reset()
         wait_us(TIMEOUT_US - KICK_ADVANCE_US);
         watchdog.kick();
     }
-    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS) == false) {
+    if (send_reset_notification(&current_case, 2 * TIMEOUT_MS + SERIAL_FLUSH_TIME_MS) == false) {
         TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
         return;
     }
+    wait_us(SERIAL_FLUSH_TIME_US); // Wait for the serial buffers to flush.
     // Watchdog should fire before twice the timeout value.
     wait_us(2 * TIMEOUT_US); // Device reset expected.
 

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -47,21 +47,20 @@ ticker_irq_handler_type prev_handler;
 
 #define LP_TICKER_OV_LIMIT 4000
 
-/* Flush serial buffer before deep sleep
+/* To prevent a loss of Greentea data, the serial buffers have to be flushed
+ * before the UART peripheral shutdown. The UART shutdown happens when the
+ * device is entering the deepsleep mode or performing a reset.
  *
- * Since deepsleep() may shut down the UART peripheral, we wait for some time
- * to allow for hardware serial buffers to completely flush.
+ * With the current API, it is not possible to check if the hardware buffers
+ * are empty. However, it is possible to determine the time required for the
+ * buffers to flush.
  *
- * Take NUMAKER_PFM_NUC472 as an example:
- * Its UART peripheral has 16-byte Tx FIFO. With baud rate set to 9600, flush
- * Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 (ms). So set wait time to
- * 20ms here for safe.
- *
- * This should be replaced with a better function that checks if the
- * hardware buffers are empty. However, such an API does not exist now,
- * so we'll use the busy_wait_ms() function for now.
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS    20
+#define SERIAL_FLUSH_TIME_MS 150
 
 void busy_wait_ms(int ms)
 {

--- a/TESTS/mbed_hal/reset_reason/main.cpp
+++ b/TESTS/mbed_hal/reset_reason/main.cpp
@@ -49,19 +49,20 @@
 #define MSG_KEY_RESET_REASON "reason"
 #define MSG_KEY_DEVICE_RESET "reset"
 
-/* To prevent loss of Greentea data, flush serial buffers before the UART peripheral shutdown. The UART shutdown happens when the
+/* To prevent a loss of Greentea data, the serial buffers have to be flushed
+ * before the UART peripheral shutdown. The UART shutdown happens when the
  * device is entering the deepsleep mode or performing a reset.
  *
  * With the current API, it is not possible to check if the hardware buffers
- * are empty. However, you can determine the amount of time required for the
+ * are empty. However, it is possible to determine the time required for the
  * buffers to flush.
  *
- * For example, NUMAKER_PFM_NUC472:
- * The UART peripheral has 16-byte Tx FIFO. With a baud rate of 9600,
- * flushing the Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 ms.
- * To be on the safe side, set the wait time to 20 ms.
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS    20
+#define SERIAL_FLUSH_TIME_MS 150
 
 typedef enum {
     CMD_STATUS_CONTINUE,

--- a/TESTS/mbed_hal/sleep/sleep_test_utils.h
+++ b/TESTS/mbed_hal/sleep/sleep_test_utils.h
@@ -29,21 +29,20 @@
 #include "hal/us_ticker_api.h"
 #include "hal/lp_ticker_api.h"
 
-/* Flush serial buffer before deep sleep
+/* To prevent a loss of Greentea data, the serial buffers have to be flushed
+ * before the UART peripheral shutdown. The UART shutdown happens when the
+ * device is entering the deepsleep mode or performing a reset.
  *
- * Since deepsleep() may shut down the UART peripheral, we wait for some time
- * to allow for hardware serial buffers to completely flush.
+ * With the current API, it is not possible to check if the hardware buffers
+ * are empty. However, it is possible to determine the time required for the
+ * buffers to flush.
  *
- * Take NUMAKER_PFM_NUC472 as an example:
- * Its UART peripheral has 16-byte Tx FIFO. With baud rate set to 9600, flush
- * Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 (ms). So set wait time to
- * 20ms here for safe.
- *
- * This should be replaced with a better function that checks if the
- * hardware buffers are empty. However, such an API does not exist now,
- * so we'll use the busy_wait_ms() function for now.
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS 20
+#define SERIAL_FLUSH_TIME_MS 150
 
 #define US_PER_S 1000000
 

--- a/TESTS/mbed_hal/watchdog/main.cpp
+++ b/TESTS/mbed_hal/watchdog/main.cpp
@@ -52,12 +52,12 @@
  * are empty. However, it is possible to determine the time required for the
  * buffers to flush.
  *
- * Take NUMAKER_PFM_NUC472 as an example:
- * The UART peripheral has 16-byte Tx FIFO. With a baud rate set to 9600,
- * flushing the Tx FIFO would take: 16 * 8 * 1000 / 9600 = 13.3 ms.
- * To be on the safe side, set the wait time to 20 ms.
+ * Assuming the biggest Tx FIFO of 128 bytes (as for CY8CPROTO_062_4343W)
+ * and a default UART config (9600, 8N1), flushing the Tx FIFO wold take:
+ * (1 start_bit + 8 data_bits + 1 stop_bit) * 128 * 1000 / 9600 = 133.3 ms.
+ * To be on the safe side, set the wait time to 150 ms.
  */
-#define SERIAL_FLUSH_TIME_MS    20
+#define SERIAL_FLUSH_TIME_MS 150
 
 int CASE_INDEX_START;
 int CASE_INDEX_CURRENT;


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
* Increase the value of `SERIAL_FLUSH_TIME_MS` used to wait for the end of the greentea communication in a couple of tests. The original calculation was based on the 16-byte UART Tx FIFO assumption. This is wrong for `CY8CPROTO_062_4343W` which uses 128-byte FIFO.
* Insert UART-flush wait before watchdog reset.

This patch is based on the findings from https://github.com/ARMmbed/mbed-os/issues/11909#issuecomment-561432226.

Fixes #11909 

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->
@jamesbeyond, @dustin-crossman 

----------------------------------------------------------------------------------------------------------------
