### PR TITLE
Make cypress psoc64 TFM ready and also add TF-M initialization

### DIFF
--- a/features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_mbed_boot.c
+++ b/features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_mbed_boot.c
@@ -1,0 +1,67 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed_error.h"
+#include "tfm_multi_core_api.h"
+#include "tfm_ns_mailbox.h"
+#include "platform_multicore.h"
+#include "tfm_ns_interface.h"
+
+static struct ns_mailbox_queue_t ns_mailbox_queue;
+
+void mbed_tfm_init(void)
+{
+    /*
+     * In case the of dual CPU, we need to initialize IPC, mailbox
+     * and NS interface after the RTOS has started to enable
+     * communication from Secure and Non-Secure cores.
+     */
+    int32_t ret;
+
+    ret = tfm_ns_wait_for_s_cpu_ready();
+    /*
+     * Normally would expect "TFM_SUCCESS" returned here by TF-M, as this
+     * isn't a mailbox function. There may be some platforms other than PSoC6,
+     * which doesn't require tfm_ns_wait_for_s_cpu_ready() implementation.
+     * "PLATFORM_MAILBOX_SUCCESS" is a low-level error code and should be
+     * replaced by "TFM_SUCCESS".
+     * As the function definition has been imported from the TF-M, therefore
+     * a issue has been raised - https://developer.trustedfirmware.org/T660
+     */
+    if (ret != PLATFORM_MAILBOX_SUCCESS) {
+        /* Avoid undefined behavior after multi-core sync-up failed */
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM,
+                                   MBED_ERROR_CODE_INITIALIZATION_FAILED),
+                   "Failed to sync-up multi-core");
+    }
+
+    ret = tfm_ns_mailbox_init(&ns_mailbox_queue);
+    if (ret != MAILBOX_SUCCESS) {
+        /* Avoid undefined behavior after NS mailbox initialization failed */
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM,
+                                   MBED_ERROR_CODE_INITIALIZATION_FAILED),
+                   "Failed to initialize NS mailbox");
+    }
+
+    ret = tfm_ns_interface_init();
+    if (ret != TFM_SUCCESS) {
+        /* Avoid undefined behavior after NS interface initialization failed */
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM,
+                                   MBED_ERROR_CODE_INITIALIZATION_FAILED),
+                   "Failed to initialize NS interface");
+    }
+}

--- a/features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_V8M/src/tfm_mbed_boot.c
+++ b/features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_V8M/src/tfm_mbed_boot.c
@@ -1,0 +1,37 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed_error.h"
+#include "tfm_ns_interface.h"
+
+void mbed_tfm_init(void)
+{
+    /*
+     * In case of V8-M, we need to initialize NS interface
+     * after the RTOS has started to enable
+     * communication from Secure and Non-Secure cores.
+     */
+    int32_t ret;
+
+    ret = tfm_ns_interface_init();
+    if (ret != TFM_SUCCESS) {
+        /* Avoid undefined behavior after NS interface initialization failed */
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM,
+                                   MBED_ERROR_CODE_INITIALIZATION_FAILED),
+                   "Failed to initialize NS interface");
+    }
+}

--- a/rtos/source/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/source/TARGET_CORTEX/mbed_boot.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2016 ARM Limited
+ * Copyright (c) 2006-2020 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,6 +95,7 @@ void mbed_init(void)
 void mbed_start(void)
 {
     mbed_toolchain_init();
+    mbed_tfm_init();
     mbed_main();
     mbed_error_initialize();
     main();
@@ -106,6 +107,11 @@ MBED_WEAK void mbed_sdk_init(void)
 }
 
 MBED_WEAK void software_init_hook_rtos()
+{
+    // Nothing by default
+}
+
+MBED_WEAK void mbed_tfm_init(void)
 {
     // Nothing by default
 }

--- a/rtos/source/TARGET_CORTEX/mbed_boot.h
+++ b/rtos/source/TARGET_CORTEX/mbed_boot.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2018-2019 ARM Limited
+ * Copyright (c) 2018-2020 ARM Limited
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,7 @@ extern "C" {
  *      - Start scheduler
  *      - main thread calls start mbed
  * 4. Start mbed
+ *      - Call mbed_tfm_init
  *      - Call mbed_main
  *      - Call main
  *
@@ -150,6 +151,20 @@ void mbed_toolchain_init(void);
 void mbed_sdk_init(void);
 
 /**
+ * TF-M specific application hook for running code before mbed_main
+ *
+ * This is a weak function which can be overridden by an application
+ * to allow code to run before mbed_main is called.
+ * Some TF-M supported platforms require synchronization between
+ * Secure and Non-Secure cores, therefore these tasks are done here.
+ *
+ * Preconditions:
+ * - The RTOS has been started by a call to mbed_rtos_start
+ * - The toolchain has been initialized by a call to mbed_toolchain_init
+ */
+void mbed_tfm_init(void);
+
+/**
  * Application hook for running code before main
  *
  * This is a weak function which can be overridden by an application
@@ -157,6 +172,7 @@ void mbed_sdk_init(void);
  *
  * Preconditions:
  * - The RTOS has been started by a call to mbed_rtos_start
+ * - TFM support has been initialized by a call to mbed_tfm_init.
  * - The toolchain has been initialized by a call to mbed_toolchain_init
  */
 void mbed_main(void);

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4.sct
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_ARM/cyb06xxa_cm4.sct
@@ -27,6 +27,7 @@
 ;*******************************************************************************
 ;* \copyright
 ;* Copyright 2016-2019 Cypress Semiconductor Corporation
+;* Copyright 2020 Arm Limited
 ;* SPDX-License-Identifier: Apache-2.0
 ;*
 ;* Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,8 +43,10 @@
 ;* limitations under the License.
 ;******************************************************************************/
 
+#include "../../../partition/region_defs.h"
+
 #if !defined(MBED_ROM_START)
-  #define MBED_ROM_START    0x10000000
+  #define MBED_ROM_START    NS_CODE_START
 #endif
 
 ;* MBED_APP_START is being  used by the bootloader build script and
@@ -55,7 +58,7 @@
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-  #define MBED_ROM_SIZE     0x001D0000
+  #define MBED_ROM_SIZE     NS_CODE_SIZE
 #endif
 
 ;* MBED_APP_SIZE is being  used by the bootloader build script and
@@ -67,19 +70,19 @@
 #endif
 
 #if !defined(MBED_RAM_START)
-  #define MBED_RAM_START    0x08000000
+  #define MBED_RAM_START    NS_DATA_START
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-  #define MBED_RAM_SIZE     0x000EA000
+  #define MBED_RAM_SIZE     NS_DATA_SIZE
 #endif
 
 #if !defined(MBED_BOOT_STACK_SIZE)
-  #define MBED_BOOT_STACK_SIZE 0x400
+  #define MBED_BOOT_STACK_SIZE NS_MSP_STACK_SIZE
 #endif
 
-; The size of the stack section at the end of CM4 SRAM
-#define STACK_SIZE MBED_BOOT_STACK_SIZE
+; Shared memory area between Non-secure and Secure
+#define MBED_DATA_SHARED_SIZE  NS_DATA_SHARED_SIZE
 
 ; The defines below describe the location and size of blocks of memory in the target.
 ; Use these defines to specify the memory regions available for allocation.
@@ -91,9 +94,6 @@
 ; Flash
 #define FLASH_START             MBED_APP_START
 #define FLASH_SIZE              MBED_APP_SIZE
-
-; The size of the MCU boot header area at the start of FLASH
-#define BOOT_HEADER_SIZE        0x00000400
 
 ; The following defines describe a 32K flash region used for EEPROM emulation.
 ; This region can also be used as the general purpose flash.
@@ -136,7 +136,7 @@
 ; Cortex-M4 application flash area
 LR_IROM1 FLASH_START FLASH_SIZE
 {
-    ER_FLASH_VECTORS +BOOT_HEADER_SIZE
+    ER_FLASH_VECTORS +0
     {
         * (RESET, +FIRST)
     }
@@ -166,15 +166,27 @@ LR_IROM1 FLASH_START FLASH_SIZE
     }
 
     ; Application heap area (HEAP)
-    ARM_LIB_HEAP  +0 EMPTY RAM_START+RAM_SIZE-STACK_SIZE-ImageLimit(RW_IRAM1)
-    { 
-    }
-    
-    ; Stack region growing down
-    ARM_LIB_STACK RAM_START+RAM_SIZE EMPTY -STACK_SIZE 
+    ARM_LIB_HEAP  +0 ALIGN 4 EMPTY RAM_START+RAM_SIZE-MBED_BOOT_STACK_SIZE-MBED_DATA_SHARED_SIZE-ImageLimit(RW_IRAM1)
     {
-    }    
-    
+    }
+
+    ; Stack region growing down
+    ARM_LIB_STACK RAM_START+RAM_SIZE-MBED_DATA_SHARED_SIZE ALIGN 4 EMPTY -MBED_BOOT_STACK_SIZE
+    {
+    }
+
+    ; Stack area overflowed within RAM
+    ScatterAssert(ImageBase(ARM_LIB_STACK) + ImageLength(ARM_LIB_STACK) == RAM_START+RAM_SIZE-MBED_DATA_SHARED_SIZE)
+
+    ; Shared region
+    ARM_LIB_SHARED RAM_START+RAM_SIZE-MBED_DATA_SHARED_SIZE ALIGN 4 EMPTY MBED_DATA_SHARED_SIZE
+    {
+    }
+
+    ; Shared area overflowed within RAM
+    ScatterAssert(ImageBase(ARM_LIB_SHARED) + ImageLength(ARM_LIB_SHARED) == RAM_START+RAM_SIZE)
+
+
     ; Used for the digital signature of the secure application and the
     ; Bootloader SDK application. The size of the section depends on the required
     ; data size.

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4.ld
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/TOOLCHAIN_GCC_ARM/cyb06xxa_cm4.ld
@@ -20,6 +20,7 @@
 ********************************************************************************
 * \copyright
 * Copyright 2016-2019 Cypress Semiconductor Corporation
+* Copyright 2020 Arm Limited
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,8 +41,10 @@ SEARCH_DIR(.)
 GROUP(-lgcc -lc -lnosys)
 ENTRY(Reset_Handler)
 
+#include "../../../partition/region_defs.h"
+
 #if !defined(MBED_ROM_START)
-  #define MBED_ROM_START    0x10000000
+  #define MBED_ROM_START    NS_CODE_START
 #endif
 
 /* MBED_APP_START is being  used by the bootloader build script and
@@ -49,11 +52,11 @@ ENTRY(Reset_Handler)
 * is equal to MBED_ROM_START
 */
 #if !defined(MBED_APP_START)
-  #define MBED_APP_START MBED_ROM_START
+  #define MBED_APP_START    MBED_ROM_START
 #endif
 
 #if !defined(MBED_ROM_SIZE)
-  #define MBED_ROM_SIZE     0x001D0000
+  #define MBED_ROM_SIZE     NS_CODE_SIZE
 #endif
 
 /* MBED_APP_SIZE is being  used by the bootloader build script and
@@ -61,26 +64,24 @@ ENTRY(Reset_Handler)
 * is equal to MBED_ROM_SIZE
 */
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE MBED_ROM_SIZE
+  #define MBED_APP_SIZE     MBED_ROM_SIZE
 #endif
 
 #if !defined(MBED_RAM_START)
-  #define MBED_RAM_START    0x08000000
+  #define MBED_RAM_START    NS_DATA_START
 #endif
 
 #if !defined(MBED_RAM_SIZE)
-  #define MBED_RAM_SIZE     0x000EA000
+  #define MBED_RAM_SIZE     NS_DATA_SIZE
 #endif
 
+/* Size of the stack section in CM4 SRAM area */
 #if !defined(MBED_BOOT_STACK_SIZE)
-    #define MBED_BOOT_STACK_SIZE 0x400
+  #define MBED_BOOT_STACK_SIZE NS_MSP_STACK_SIZE
 #endif
 
-/* The size of the stack section at the end of CM4 SRAM */
-STACK_SIZE = MBED_BOOT_STACK_SIZE;
-
-/* The size of the MCU boot header area at the start of FLASH */
-BOOT_HEADER_SIZE = 0x400;
+/* Shared memory area between Non-Secure and Secure */
+#define MBED_DATA_SHARED_SIZE  NS_DATA_SHARED_SIZE
 
 /* Force symbol to be entered in the output file as an undefined symbol. Doing
 * this may, for example, trigger linking of additional modules from standard
@@ -157,7 +158,7 @@ GROUP(libgcc.a libc.a libm.a libnosys.a)
 SECTIONS
 {
     /* Cortex-M4 application flash area */
-    .text ORIGIN(flash) + BOOT_HEADER_SIZE :
+    .text ORIGIN(flash) :
     {
         /* Cortex-M4 flash vector table */
         . = ALIGN(4);
@@ -330,20 +331,26 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        . = ORIGIN(ram) + LENGTH(ram) - STACK_SIZE;
+        . = ORIGIN(ram) + LENGTH(ram) - MBED_BOOT_STACK_SIZE - MBED_DATA_SHARED_SIZE;
+        . = ALIGN(4);
+        __StackLimit = .;
         __HeapLimit = .;
     } > ram
 
 
-    /* Set stack top to end of RAM, and stack limit move down by
-     * size of stack_dummy section */
-    __StackTop = ORIGIN(ram) + LENGTH(ram);
-    __StackLimit = __StackTop - STACK_SIZE;
+    __StackTop = (__StackLimit + MBED_BOOT_STACK_SIZE + 3) & 0xFFFFFFFC;
     PROVIDE(__stack = __StackTop);
 
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+    .shared __StackTop (NOLOAD):
+    {
+        __SharedStart = .;
+        . += MBED_DATA_SHARED_SIZE;
+        KEEP(*(.shared*))
+        __SharedLimit = .;
+    } > ram
 
+    /* Check if Shared area overflowed within RAM */
+    ASSERT(__SharedLimit == ORIGIN(ram) + LENGTH(ram), "Shared area overflowed within RAM")
 
     /* Used for the digital signature of the secure application and the Bootloader SDK application.
     * The size of the section depends on the required data size. */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/device_cfg.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/device_cfg.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017-2018 Arm Limited
+ * Copyright (c) 2020, Cypress Semiconductor Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ARM_LTD_DEVICE_CFG_H__
+#define __ARM_LTD_DEVICE_CFG_H__
+
+#ifdef TFM_MULTI_CORE_MULTI_CLIENT_CALL
+#define NUM_MAILBOX_QUEUE_SLOT      4
+#endif
+
+#endif  /* __ARM_LTD_DEVICE_CFG_H__ */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/partition/flash_layout.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/partition/flash_layout.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2017-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2019, Cypress Semiconductor Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FLASH_LAYOUT_H__
+#define __FLASH_LAYOUT_H__
+
+/* Flash layout with BL2:
+ *
+ * Not supported
+ *
+ * Flash layout if BL2 not defined:
+ *
+ * 0x1000_0000 Secure     image primary (320 KB)
+ * 0x1005_0000 Non-secure image primary (1152 KB)
+ * 0x1017_0000 Secure     image secondary (320 KB)
+ * 0x101c_0000 - 0x101f_ffff Reserved
+ *  0x101c_0000 Secure Storage Area (20 KB)
+ *  0x101c_5000 Internal Trusted Storage Area (16 KB)
+ *  0x101c_9000 NV counters area (512 Bytes)
+ *  0x101c_9200 Scratch area (27.5 KB)
+ *  0x101d_0000 Reserved (192 KB)
+ * 0x101f_ffff End of Flash
+ *
+ */
+
+#define MAX(X, Y)                       (((X) > (Y)) ? (X) : (Y))
+
+/* This header file is included from linker scatter file as well, where only a
+ * limited C constructs are allowed. Therefore it is not possible to include
+ * here the platform_base_address.h to access flash related defines. To resolve
+ * this some of the values are redefined here with different names, these are
+ * marked with comment.
+ */
+
+/* The size of S partition */
+#define FLASH_S_PARTITION_SIZE          0x50000      /* 320 KB */
+/* The size of NS partition */
+#define FLASH_NS_PARTITION_SIZE         0x120000     /* 1152 KB */
+
+/* Sector size of the flash hardware; same as FLASH0_SECTOR_SIZE */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE    (0x200)      /* 512 B */
+/* Same as FLASH0_SIZE */
+#define FLASH_TOTAL_SIZE                (0x00200000) /* 2 MB */
+
+/* Flash layout info for BL2 bootloader */
+#define FLASH_BASE_ADDRESS              (0x10000000U) /* same as FLASH0_BASE */
+
+/* Reserved areas */
+#define FLASH_RESERVED_AREA_OFFSET      (SECURE_IMAGE_OFFSET + \
+                                         2*SECURE_IMAGE_MAX_SIZE + \
+                                         NON_SECURE_IMAGE_MAX_SIZE)
+
+/* FixMe: implement proper mcuboot partitioning for CYBL */
+
+/* Reserved for Secure Storage Area */
+#define FLASH_SST_AREA_OFFSET           (FLASH_RESERVED_AREA_OFFSET)
+#define FLASH_SST_AREA_SIZE             (0x5000)   /* 20 KB */
+
+/* Internal Trusted Storage Area */
+#define FLASH_ITS_AREA_OFFSET           (FLASH_SST_AREA_OFFSET + \
+                                         FLASH_SST_AREA_SIZE)
+#define FLASH_ITS_AREA_SIZE             (0x4000)    /* 16 KB */
+
+#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_ITS_AREA_OFFSET + \
+                                         FLASH_ITS_AREA_SIZE)
+#define FLASH_NV_COUNTERS_AREA_SIZE     (FLASH_AREA_IMAGE_SECTOR_SIZE)
+
+#ifdef BL2
+#error "BL2 configuration is not supported"
+#else /* BL2 */
+
+#define FLASH_AREA_SCRATCH_OFFSET       (FLASH_NV_COUNTERS_AREA_OFFSET + \
+                                         FLASH_NV_COUNTERS_AREA_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE         (0x6e00)   /* 27.5 KB */
+#endif /* BL2 */
+
+#define FLASH_AREA_SYSTEM_RESERVED_SIZE (0x30000) /* 192 KB */
+
+
+/* Secure and non-secure images definition in flash area */
+
+#define SECURE_IMAGE_OFFSET             0x0
+
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
+
+#define NON_SECURE_IMAGE_OFFSET         (SECURE_IMAGE_OFFSET + \
+                                         SECURE_IMAGE_MAX_SIZE)
+
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
+
+/* Check if it fits into available Flash*/
+
+#define FLASH_RESERVED_AREA_SIZE        (FLASH_SST_AREA_SIZE + \
+                                         FLASH_ITS_AREA_SIZE + \
+                                         FLASH_NV_COUNTERS_AREA_SIZE + \
+                                         FLASH_AREA_SCRATCH_SIZE + \
+                                         FLASH_AREA_SYSTEM_RESERVED_SIZE)
+
+#if (FLASH_RESERVED_AREA_OFFSET + FLASH_RESERVED_AREA_SIZE) > (FLASH_TOTAL_SIZE)
+#error "Out of Flash memory"
+#endif
+
+/* Flash device name used by BL2 and SST
+ * Name is defined in flash driver file: Driver_Flash.c
+ */
+#define FLASH_DEV_NAME Driver_FLASH0
+
+/* Secure Storage (SST) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M SST Integration Guide.
+ */
+#define SST_FLASH_DEV_NAME Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define SST_FLASH_AREA_ADDR     FLASH_SST_AREA_OFFSET
+/* Dedicated flash area for SST */
+#define SST_FLASH_AREA_SIZE     FLASH_SST_AREA_SIZE
+#define SST_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of SST_SECTOR_SIZE per block */
+#define SST_SECTORS_PER_BLOCK   0x8
+/* Specifies the smallest flash programmable unit in bytes */
+#define SST_FLASH_PROGRAM_UNIT  0x1
+/* The maximum asset size to be stored in the SST area */
+#define SST_MAX_ASSET_SIZE      2048
+/* The maximum number of assets to be stored in the SST area */
+#define SST_NUM_ASSETS          10
+
+/* Internal Trusted Storage (ITS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M ITS Integration Guide. The ITS should be in the internal flash, but is
+ * allocated in the external flash just for development platforms that don't
+ * have internal flash available.
+ */
+#define ITS_FLASH_DEV_NAME Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define ITS_FLASH_AREA_ADDR     FLASH_ITS_AREA_OFFSET
+/* Dedicated flash area for ITS */
+#define ITS_FLASH_AREA_SIZE     FLASH_ITS_AREA_SIZE
+#define ITS_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of ITS_SECTOR_SIZE per block */
+#define ITS_SECTORS_PER_BLOCK   (0x8)
+/* Specifies the smallest flash programmable unit in bytes */
+#define ITS_FLASH_PROGRAM_UNIT  (0x1)
+/* The maximum asset size to be stored in the ITS area */
+#define ITS_MAX_ASSET_SIZE      (512)
+/* The maximum number of assets to be stored in the ITS area */
+#define ITS_NUM_ASSETS          (10)
+
+/* NV Counters definitions */
+#define TFM_NV_COUNTERS_AREA_ADDR    FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_AREA_SIZE    FLASH_NV_COUNTERS_AREA_SIZE
+#define TFM_NV_COUNTERS_SECTOR_ADDR  FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_SECTOR_SIZE  MAX(FLASH_NV_COUNTERS_AREA_SIZE, \
+                                         FLASH_AREA_IMAGE_SECTOR_SIZE)
+
+/* Use Flash to store Code data */
+#define S_ROM_ALIAS_BASE  (0x10000000)
+#define NS_ROM_ALIAS_BASE (0x10000000)
+
+/* Use SRAM to store RW data */
+#define S_RAM_ALIAS_BASE  (0x08000000)
+#define NS_RAM_ALIAS_BASE (0x08000000)
+
+#endif /* __FLASH_LAYOUT_H__ */

--- a/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/partition/region_defs.h
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/partition/region_defs.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2017-2019 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_DEFS_H__
+#define __REGION_DEFS_H__
+
+#include "flash_layout.h"
+
+#define TOTAL_ROM_SIZE FLASH_TOTAL_SIZE
+/* 2KB of RAM (at the end of the SRAM) are reserved for system use. Using
+ * this memory region for other purposes will lead to unexpected behavior.
+ * 94KB of RAM (just before the memory reserved for system use) are
+ * allocated and protected by Cypress Bootloader */
+/* FixMe: confirm exact available amount of RAM based on the actual
+   system allocation */
+#define TOTAL_RAM_SIZE (0x000E8000) /* CY_SRAM_SIZE - 96KB */
+
+#define BL2_HEAP_SIZE           0x0001000
+#define BL2_MSP_STACK_SIZE      0x0001000
+
+#define S_HEAP_SIZE             0x0001000
+#define S_MSP_STACK_SIZE_INIT   0x0000400
+#define S_MSP_STACK_SIZE        0x0000800
+#define S_PSP_STACK_SIZE        0x0000800
+
+#define NS_HEAP_SIZE            0x0001000
+#define NS_MSP_STACK_SIZE       0x0000400
+#define NS_PSP_STACK_SIZE       0x0000C00
+
+/* Relocation of vectors to RAM support */
+/* #define RAM_VECTORS_SUPPORT */
+
+/*
+ * This size of buffer is big enough to store an attestation
+ * token produced by initial attestation service
+ */
+#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   0x250
+
+/*
+ * MPC granularity is 128 KB on AN519 MPS2 FPGA image. Alignment
+ * of partitions is defined in accordance with this constraint.
+ */
+
+#ifdef BL2
+#error "BL2 configuration is not supported"
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET  SECURE_IMAGE_OFFSET
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET NON_SECURE_IMAGE_OFFSET
+#endif /* BL2 */
+
+/* TFM PSoC6 CY8CKIT_064 RAM layout:
+ *
+ * 0x0800_0000 - 0x0802_FFFF Secure (192KB)
+ *    0x0800_0000 - 0x0800_FFFF Secure unprivileged data (S_UNPRIV_DATA_SIZE, 64KB)
+ *    0x0801_0000 - 0x0802_EFFF Secure priviliged data (S_PRIV_DATA_SIZE, 124KB)
+ *    0x0802_F000 - 0x0802_FFFF Secure priv code executable from RAM (S_RAM_CODE_SIZE, 4KB)
+ *
+ * 0x0803_0000 - 0x080E_7FFF Non-secure (736KB)
+ *    0x0803_0000 - 0x080E_6FFF Non-secure OS/App (732KB)
+ *    0x080E_7000 - 0x080E_7FFF Shared memory (NS_DATA_SHARED_SIZE, 4KB)
+ * 0x080E_8000 - 0x080F_FFFF System reserved memory (96KB)
+ * 0x0810_0000 End of RAM
+ */
+
+/*
+ * Boot partition structure if MCUBoot is used:
+ * 0x0_0000 Bootloader header
+ * 0x0_0400 Image area
+ * 0x1_FC00 Trailer
+ */
+/* Image code size is the space available for the software binary image.
+ * It is less than the FLASH_S_PARTITION_SIZE and FLASH_NS_PARTITION_SIZE
+ * because we reserve space for the image header and trailer introduced by the
+ * bootloader.
+ */
+#ifdef BL2
+#error "BL2 configuration is not supported"
+#else
+/* Even though TFM BL2 is excluded from the build,
+ * CY BL built externally is used and it needs offsets for header and trailer
+ * to be taken in account.
+ * */
+#define BL2_HEADER_SIZE      (0x400)
+#define BL2_TRAILER_SIZE     (0x400)
+
+#endif /* BL2 */
+
+#define IMAGE_S_CODE_SIZE \
+            (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+#define IMAGE_NS_CODE_SIZE \
+            (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+
+/* Alias definitions for secure and non-secure areas*/
+#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + (x))
+
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
+
+/* Secure regions */
+#define S_IMAGE_PRIMARY_AREA_OFFSET \
+             (S_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define S_CODE_START    (S_ROM_ALIAS(S_IMAGE_PRIMARY_AREA_OFFSET))
+#define S_CODE_SIZE     IMAGE_S_CODE_SIZE
+#define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
+
+#define S_DATA_START    (S_RAM_ALIAS(0))
+#define S_UNPRIV_DATA_SIZE  0x10000
+#define S_PRIV_DATA_SIZE    0x1F000
+/* Reserve 4KB for RAM-based executable code */
+#define S_RAM_CODE_SIZE     0x1000
+
+/* Secure data area */
+#define S_DATA_SIZE  (S_UNPRIV_DATA_SIZE + S_PRIV_DATA_SIZE + S_RAM_CODE_SIZE)
+#define S_DATA_LIMIT (S_DATA_START + S_DATA_SIZE - 1)
+
+/* We need the privileged data area to be aligned so that an SMPU
+ * region can cover it.
+ */
+/* TODO It would be nice to figure this out automatically.
+ * In theory, in the linker script, we could determine the amount
+ * of secure data space available after all the unprivileged data,
+ * round that down to a power of 2 to get the actual size we want
+ * to use for privileged data, and then determine this value from
+ * that. We'd also potentially have to update the configs for SMPU9
+ * and SMPU10.
+ * Leave the SMPU alignment check in SMPU configuration file.
+ */
+#define S_DATA_UNPRIV_OFFSET (0)
+#define S_DATA_UNPRIV_START  S_RAM_ALIAS(S_DATA_UNPRIV_OFFSET)
+
+#define S_DATA_PRIV_OFFSET   (S_DATA_UNPRIV_OFFSET + S_UNPRIV_DATA_SIZE)
+#define S_DATA_PRIV_START    S_RAM_ALIAS(S_DATA_PRIV_OFFSET)
+
+/* Reserve area for RAM-based executable code right after secure unprivilaged
+ * and privilaged data areas*/
+#define S_RAM_CODE_OFFSET    (S_DATA_PRIV_OFFSET + S_PRIV_DATA_SIZE)
+#define S_RAM_CODE_START     S_RAM_ALIAS(S_RAM_CODE_OFFSET)
+
+/* Non-secure regions */
+#define NS_IMAGE_PRIMARY_AREA_OFFSET \
+                        (NS_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define NS_CODE_START   (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_AREA_OFFSET))
+#define NS_CODE_SIZE    IMAGE_NS_CODE_SIZE
+#define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
+
+#define NS_DATA_START   (S_RAM_ALIAS(S_DATA_SIZE))
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE)
+#define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
+
+/* Shared memory */
+#define NS_DATA_SHARED_SIZE  0x1000
+#define NS_DATA_SHARED_START (NS_DATA_START + NS_DATA_SIZE - \
+                              NS_DATA_SHARED_SIZE)
+#define NS_DATA_SHARED_LIMIT (NS_DATA_SHARED_START + NS_DATA_SHARED_SIZE - 1)
+
+/* Shared variables addresses */
+/* ipcWaitMessageStc, cy_flash.c */
+#define IPC_WAIT_MESSAGE_STC_SIZE 4
+#define IPC_WAIT_MESSAGE_STC_ADDR (NS_DATA_SHARED_START + \
+                                   NS_DATA_SHARED_SIZE - \
+                                   IPC_WAIT_MESSAGE_STC_SIZE)
+
+/* NS partition information is used for MPC and SAU configuration */
+#define NS_PARTITION_START \
+            (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_PARTITION_OFFSET))
+
+#define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
+
+#ifdef BL2
+#error "BL2 configuration is not supported"
+#endif /* BL2 */
+
+/* Shared data area between bootloader and runtime firmware.
+ * Shared data area is allocated at the beginning of the privileged data area,
+ * it is overlapping with TF-M Secure code's MSP stack
+ */
+#define BOOT_TFM_SHARED_DATA_BASE (S_RAM_ALIAS(S_DATA_PRIV_OFFSET))
+#define BOOT_TFM_SHARED_DATA_SIZE 0x400
+
+#endif /* __REGION_DEFS_H__ */
+

--- a/targets/TARGET_Cypress/TARGET_PSOC6/cy_us_ticker_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/cy_us_ticker_api.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2019, Arm Limited and affiliates.
+ * Copyright (c) 2019-2020, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,23 @@ static void cy_us_ticker_irq_handler(MBED_UNUSED void *arg, MBED_UNUSED cyhal_ti
 void us_ticker_init(void)
 {
     if (!cy_us_ticker_initialized) {
+
+#ifdef TARGET_TFM
+        /* There are two timers, Timer0 and Timer1, available on the PSoC64.
+         * Timer0 has 8 channels and Timer1 has 24 channels. TF-M regression
+         * tests make use of Timer0 Channel 1 and Timer0 Channel 2. Therefore,
+         * reserve the timer channels used by TF-M. This approach can be
+         * replaced once we have a way to allocate dedicated timers for TF-M
+         * and Mbed OS. */
+        cyhal_resource_inst_t res = { CYHAL_RSC_TCPWM, 0, 0 };
+        if(CY_RSLT_SUCCESS != cyhal_hwmgr_reserve(&res)) {
+            MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_timer_init");
+        }
+        res.channel_num = 1;
+        if(CY_RSLT_SUCCESS != cyhal_hwmgr_reserve(&res)) {
+            MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_timer_init");
+        }
+#endif
         if (CY_RSLT_SUCCESS != cyhal_timer_init(&cy_us_timer, NC, NULL)) {
             MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_FAILED_OPERATION), "cyhal_timer_init");
         }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Non-secure core IPC, Mailbox and Interface init for TFM_DUALCPU and TFM_V8M targets

These changes concentrate on getting mbed-os(Non-secure) working with TF-M(secure)
Changes reflect towards any Cypress based TFM_DUALCPU targets and TFM_V8M targets at the moment and making it more generic in the near future.

Key changes:
* Init IPC, Mailbox and Non-secure Interface.
   These changes are for TFM_DUALCPU and TFM_V8M platforms.
   The initialization happens after mbed-os kernel is kicked off and
   when the thread is up and running.

   We are initializing the following for TFM_DUALCPU platforms:
   * IPC Interrupts for syncing multi-core platforms.
   * NS Mailbox to receive messages.
   * NS interface.

   We are only initializing a Non-secure interface for TFM_V8M platforms.

* Cypress: CY8CKIT_064S2_4343W: Reserve timer channels used by TF-M.
* Make CY8CKIT_064S2_4343W Cypress target TF-M compatible.

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->

This impacts CY8CKIT_064S2_4343W, TFM_V8M and TFM_DUALCPU targets.
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behavior change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

These changes are tested on 
* CY8CKIT_064S2_4343W with M0+ running TF-M Secure binary and M4 running blinky example with mbed-os non-secure binary.
* ARM_MUSCA_A1 with TFM + mbed-os binary running blinky example.

The blinky example is tested with:
```mbed compile -t ARMC6 -m CY8CKIT_064S2_4343W ```
```mbed compile -t GCC_ARM -m ARM_MUSCA_A1 ```

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@Patater @devran01 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
