### PR TITLE
unittests: disable coverage report filtering

### DIFF
--- a/UNITTESTS/mbed_unittest.py
+++ b/UNITTESTS/mbed_unittest.py
@@ -104,7 +104,6 @@ def _mbed_unittest_test(options, cwd, pwd):
 
             cov_api.generate_reports(outputs=outputs,
                                      excludes=excludes,
-                                     filter_regex=options.test_regex,
                                      build_path=options.build)
 
 def _mbed_unittest_new(options, pwd):


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Disable coverage report filtering because of poor results.

e.g. `mbed test --unittests -r Socket --coverage html`g
This command will run all unittests with names containing `Socket` and then create coverage report with the same scheme, filtering all source files with names containing `Socket`. 

The problem is that coverage report will be correct only when filtered test name will be the same as corresponding source file name (to be covered) - the same (-r) pattern is used to filter both test names and source file names used in coverage report

Due to described problems it was decided to disable coverage report filtering.
`-r` will only filter test names and pattern won't be passed to coverage report generator.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@jamesbeyond 
@michalpasztamobica 

----------------------------------------------------------------------------------------------------------------
