### PR TITLE
mergify: enable for any pull request

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,6 +35,7 @@ pull_request_rules:
           - "needs: work"
         remove: 
           - "needs: review"
+          - "needs: CI"
 
   # From needs: review to needs: work - CI failure
   - name: "label needs: work when travis-ci failed"
@@ -47,6 +48,7 @@ pull_request_rules:
           - "needs: work"
         remove: 
           - "needs: review"
+          - "needs: CI"
 
   # From needs: review to needs: work - CI failure
   - name: "label needs: work when Jenkins CI failed - pr head"
@@ -59,6 +61,7 @@ pull_request_rules:
           - "needs: work"
         remove: 
           - "needs: review"
+          - "needs: CI"
 
   # From needs: review to needs: work - CI failure
   - name: "label needs: work when Jenkins CI failed - any of the pipeline"
@@ -71,6 +74,7 @@ pull_request_rules:
           - "needs: work"
         remove: 
           - "needs: review"
+          - "needs: CI"
 
   # From needs: review or needs: work to needs: CI. One approval means we should be good to start CI
   - name: "label needs: CI when at least one reviewers approval"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,6 @@ pull_request_rules:
   # From needs: review to needs: work - reviewers request
   - name: "label needs: work when changes were requested"
     conditions:
-      - base~=feature-mergify
       # Reviewers
       - "#changes-requested-reviews-by>0"
     actions:
@@ -40,7 +39,6 @@ pull_request_rules:
   # From needs: review to needs: work - CI failure
   - name: "label needs: work when travis-ci failed"
     conditions:
-      - base~=feature-mergify
       # Travis failing
       - status-failure~=continuous-integration/travis-ci/pr
     actions:
@@ -53,7 +51,6 @@ pull_request_rules:
   # From needs: review to needs: work - CI failure
   - name: "label needs: work when Jenkins CI failed - pr head"
     conditions:
-      - base~=feature-mergify
       # Jenkins CI failing
       - status-failure~=continuous-integration/jenkins/pr-head
     actions:
@@ -66,7 +63,6 @@ pull_request_rules:
   # From needs: review to needs: work - CI failure
   - name: "label needs: work when Jenkins CI failed - any of the pipeline"
     conditions:
-      - base~=feature-mergify
       # Jenkins CI failing - any of the pipeline
       - status-failure~=^jenkins-ci
     actions:
@@ -79,7 +75,6 @@ pull_request_rules:
   # From needs: review or needs: work to needs: CI. One approval means we should be good to start CI
   - name: "label needs: CI when at least one reviewers approval"
     conditions:
-      - base~=feature-mergify
       # Labels
       - "label!=needs: preceding PR"
 
@@ -103,7 +98,6 @@ pull_request_rules:
   # Conflict in the PR - needs: work and a comment to notify a user
   - name: "label needs: work when there is a conflict"
     conditions:
-      - base~=feature-mergify
       - conflict
     actions:
       label:
@@ -117,7 +111,6 @@ pull_request_rules:
 
   - name: "add label feature branch for feature branch additions"
     conditions:
-      - base~=feature-mergify
       - base~=^feature
     actions:
       label:
@@ -127,7 +120,6 @@ pull_request_rules:
   # Ready for integration. Not yet auto merge, will be enabled once carefuly tested
   - name: label "ready for merge" when ready
     conditions:
-      - base~=feature-mergify
       # Labels
       - "label!=do not merge"
       - "label=needs: CI"
@@ -152,7 +144,6 @@ pull_request_rules:
   # Clean-up after merge
   - name: remove ready for merge when merged
     conditions:
-      - base~=feature-mergify
       - merged
       - "label=ready for merge"
     actions:
@@ -162,7 +153,6 @@ pull_request_rules:
 
   - name: add "do not merge" label when WIP is in title
     conditions:
-       - base~=feature-mergify
        - title~=^(\[wip\]( |:) |\[WIP\]( |:) |wip( |:) |WIP( |:)).*
     actions:
       label:
@@ -172,7 +162,6 @@ pull_request_rules:
   # Check if version label is applied
   - name: release version is a must for merged PRs
     conditions:
-      - base~=feature-mergify
       - merged
       - -label~=^(release-version)
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -99,6 +99,15 @@ pull_request_rules:
           - "needs: review"
           - "needs: work"
 
+  # Remove reviews after the branch is updated. This yet does not allow
+  # any other action like labels, etc. See mergify-engine/issues/360
+  - name: remove outdated reviews
+    conditions: []
+    actions:
+      dismiss_reviews:
+        approved: True
+        changes_requested: True
+
   # Conflict in the PR - needs: work and a comment to notify a user
   - name: "label needs: work when there is a conflict"
     conditions:


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

Add mergify bot to all PRs (all branches). The configuration already resides on master but not yet  enabled, only been enabled for feature-mergify to test it.

 Docs: https://doc.mergify.io/

The configuration should follow our workflow. If it does not, we should fix via new pull request anytime (note: one drawback, the config is fetched from the default branch, in our case master. So even rules for non master, need to be in the config there). The auto merge is disabled, the bot does not have write access to any of the branches anyway. This bot can move labels, post comments.

To verify for each PR, use "Checks" where you can review Mergify conditions.

To disable, just revert this comment - to have all rules only on feature-mergify for instance. Hopefully, this won't be necessary and we tune the rules once we get more PRs involved (compare to few testing we did).

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [X] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

@bulislaw 
----------------------------------------------------------------------------------------------------------------
