### PR TITLE
Fix call to sorted by providing key to sort on.

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -511,7 +511,9 @@ class Config(object):
             resolver = RefResolver(uri, schema)
             validator = Draft4Validator(schema, resolver=resolver)
 
-            errors = sorted(validator.iter_errors(self.app_config_data))
+            errors = sorted(
+                validator.iter_errors(self.app_config_data), key=str
+            )
 
             if errors:
                 raise ConfigException("; ".join(
@@ -583,7 +585,7 @@ class Config(object):
             resolver = RefResolver(uri, schema_file)
             validator = Draft4Validator(schema_file, resolver=resolver)
 
-            errors = sorted(validator.iter_errors(cfg))
+            errors = sorted(validator.iter_errors(cfg), key=str)
 
             if errors:
                 raise ConfigException("; ".join(


### PR DESCRIPTION
### Summary of changes

This is a fix to the tools for running under Python 3.

This call to `sorted` does nothing in Python 2, as there is no way to sort a list of Exceptions without providing a key. It will simply return the evaluated generator as a list.

In Python 3 this call fails with `TypeError : '<' not supported between instances of 'ValidationError' and 'ValidationError'`, as there is no comparison implemented for the `jsonschema.exceptions.ValidationError Exception`.

This is fixed by providing the key `str`, which sorts by the string representation of
the Exception.

### Documentation <!-- Required -->

None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@madchutney @mark-edgeworth 

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
