### PR TITLE
Cellular: Remove API's empty default implemetations

### DIFF
--- a/UNITTESTS/features/cellular/framework/device/cellularcontext/cellularcontexttest.cpp
+++ b/UNITTESTS/features/cellular/framework/device/cellularcontext/cellularcontexttest.cpp
@@ -111,22 +111,6 @@ public:
 	virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0)
 	{
 	}
-	nsapi_error_t get_netmask(SocketAddress *address)
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-	virtual const char *get_netmask()
-	{
-		return NULL;
-	}
-	nsapi_error_t get_gateway(SocketAddress *address)
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-	virtual const char *get_gateway()
-	{
-		return NULL;
-	}
 	virtual bool is_connected()
 	{
 		return false;

--- a/UNITTESTS/stubs/AT_CellularContext_stub.cpp
+++ b/UNITTESTS/stubs/AT_CellularContext_stub.cpp
@@ -149,26 +149,6 @@ void AT_CellularContext::set_credentials(const char *apn, const char *uname, con
 
 }
 
-nsapi_error_t AT_CellularContext::get_netmask(SocketAddress *address)
-{
-    return NSAPI_ERROR_UNSUPPORTED;
-}
-
-const char *AT_CellularContext::get_netmask()
-{
-    return NULL;
-}
-
-nsapi_error_t AT_CellularContext::get_gateway(SocketAddress *address)
-{
-    return NSAPI_ERROR_UNSUPPORTED;
-}
-
-const char *AT_CellularContext::get_gateway()
-{
-    return NULL;
-}
-
 AT_CellularDevice::CellularProperty AT_CellularContext::pdp_type_t_to_cellular_property(pdp_type_t pdp_type)
 {
     AT_CellularDevice::CellularProperty prop = AT_CellularDevice::PROPERTY_IPV4_PDP_TYPE;

--- a/UNITTESTS/stubs/CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/CellularDevice_stub.cpp
@@ -64,11 +64,6 @@ void CellularDevice::set_sim_pin(char const *)
 {
 }
 
-CellularContext *CellularDevice::get_context_list() const
-{
-    return NULL;
-}
-
 void CellularDevice::get_retry_timeout_array(uint16_t *timeout, int &array_len) const
 {
     array_len = CellularDevice_stub::retry_array_length;
@@ -127,9 +122,4 @@ nsapi_error_t CellularDevice::shutdown()
 
 void CellularDevice::cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx)
 {
-}
-
-nsapi_error_t CellularDevice::clear()
-{
-    return NSAPI_ERROR_OK;
 }

--- a/UNITTESTS/target_h/myCellularContext.h
+++ b/UNITTESTS/target_h/myCellularContext.h
@@ -135,26 +135,6 @@ public:
 
     };
 
-    nsapi_error_t get_netmask(SocketAddress *address)
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
-    const char *get_netmask()
-    {
-        return NULL;
-    };
-
-    nsapi_error_t get_gateway(SocketAddress *address)
-    {
-        return NSAPI_ERROR_UNSUPPORTED;
-    }
-
-    const char *get_gateway()
-    {
-        return NULL;
-    };
-
     bool get_context()
     {
         return true;

--- a/features/cellular/framework/API/CellularContext.h
+++ b/features/cellular/framework/API/CellularContext.h
@@ -146,12 +146,6 @@ public: // from NetworkInterface
     virtual nsapi_error_t connect(const char *sim_pin, const char *apn = 0, const char *uname = 0,
                                   const char *pwd = 0) = 0;
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0) = 0;
-    virtual nsapi_error_t get_netmask(SocketAddress *address) = 0;
-    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
-    virtual const char *get_netmask() = 0;
-    virtual nsapi_error_t get_gateway(SocketAddress *address) = 0;
-    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
-    virtual const char *get_gateway() = 0;
     virtual bool is_connected() = 0;
 
     /** Same as NetworkInterface::get_default_instance()

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -97,18 +97,6 @@ public:
 
 public: //Virtual functions
 
-    /** Clear modem to a default initial state
-     *
-     *  Clear persistent user data from the modem, such as PDP contexts.
-     *
-     *  @pre All open network services on modem, such as contexts and sockets, must be closed.
-     *  @post Modem power off/on may be needed to clear modem's runtime state.
-     *  @remark CellularStateMachine calls this on connect when `cellular.clear-on-connect: true`.
-     *
-     *  @return         NSAPI_ERROR_OK on success, otherwise modem may be need power cycling
-     */
-    virtual nsapi_error_t clear();
-
     /** Shutdown cellular device to minimum functionality.
      *
      *  Actual functionality is modem specific, for example UART may is not be responsive without
@@ -120,12 +108,6 @@ public: //Virtual functions
      *                  NSAPI_ERROR_DEVICE_ERROR on failure
      */
     virtual nsapi_error_t shutdown();
-
-    /** Get the linked list of CellularContext instances
-     *
-     *  @return Pointer to first item in linked list
-     */
-    virtual CellularContext *get_context_list() const;
 
     /** Get event queue that can be chained to main event queue.
      *  @return event queue
@@ -141,6 +123,25 @@ protected: //Virtual functions
     virtual void cellular_callback(nsapi_event_t ev, intptr_t ptr, CellularContext *ctx = NULL);
 
 public: //Pure virtual functions
+
+    /** Clear modem to a default initial state
+     *
+     *  Clear persistent user data from the modem, such as PDP contexts.
+     *
+     *  @pre All open network services on modem, such as contexts and sockets, must be closed.
+     *  @post Modem power off/on may be needed to clear modem's runtime state.
+     *  @remark CellularStateMachine calls this on connect when `cellular.clear-on-connect: true`.
+     *
+     *  @return         NSAPI_ERROR_OK on success, otherwise modem may be need power cycling
+     */
+    virtual nsapi_error_t clear() = 0;
+
+
+    /** Get the linked list of CellularContext instances
+     *
+     *  @return Pointer to first item in linked list
+     */
+    virtual CellularContext *get_context_list() const = 0;
 
     /** Sets the modem up for powering on
      *  This is equivalent to plugging in the device, i.e., attaching power and serial port.

--- a/features/cellular/framework/AT/AT_CellularContext.cpp
+++ b/features/cellular/framework/AT/AT_CellularContext.cpp
@@ -213,26 +213,6 @@ NetworkStack *AT_CellularContext::get_stack()
     return _stack;
 }
 
-nsapi_error_t AT_CellularContext::get_netmask(SocketAddress *address)
-{
-    return NSAPI_ERROR_UNSUPPORTED;
-}
-
-const char *AT_CellularContext::get_netmask()
-{
-    return NULL;
-}
-
-nsapi_error_t AT_CellularContext::get_gateway(SocketAddress *address)
-{
-    return NSAPI_ERROR_UNSUPPORTED;
-}
-
-const char *AT_CellularContext::get_gateway()
-{
-    return NULL;
-}
-
 nsapi_error_t AT_CellularContext::get_ip_address(SocketAddress *address)
 {
     if (!address) {

--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -48,10 +48,6 @@ public:
     virtual nsapi_error_t connect(const char *sim_pin, const char *apn = 0, const char *uname = 0,
                                   const char *pwd = 0);
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0);
-    virtual nsapi_error_t get_netmask(SocketAddress *address);
-    virtual const char *get_netmask();
-    virtual nsapi_error_t get_gateway(SocketAddress *address);
-    virtual const char *get_gateway();
 
 // from CellularContext
     virtual nsapi_error_t get_pdpcontext_params(pdpContextList_t &params_list);

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -74,11 +74,6 @@ events::EventQueue *CellularDevice::get_queue()
     return &_queue;
 }
 
-CellularContext *CellularDevice::get_context_list() const
-{
-    return NULL;
-}
-
 void CellularDevice::get_retry_timeout_array(uint16_t *timeout, int &array_len) const
 {
     if (_state_machine && timeout) {
@@ -260,11 +255,5 @@ void CellularDevice::set_retry_timeout_array(const uint16_t timeout[], int array
         _state_machine->set_retry_timeout_array(timeout, array_len);
     }
 }
-
-nsapi_error_t CellularDevice::clear()
-{
-    return NSAPI_ERROR_OK;
-}
-
 
 } // namespace mbed

--- a/features/netsocket/CellularInterface.h
+++ b/features/netsocket/CellularInterface.h
@@ -101,18 +101,6 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_ip_address() = 0;
 
-    /** @copydoc NetworkInterface::get_netmask */
-    virtual nsapi_error_t get_netmask(SocketAddress *address) = 0;
-
-    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
-    virtual const char *get_netmask() = 0;
-
-    /** @copydoc NetworkInterface::get_gateway */
-    virtual nsapi_error_t get_gateway(SocketAddress *address) = 0;
-
-    MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
-    virtual const char *get_gateway() = 0;
-
     /** @copydoc NetworkInterface::cellularInterface
      */
     virtual CellularInterface *cellularInterface()


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
Cleanup the Cellular API by removing empty default implementations and making them pure virtual.

Targeted for **release-version 6.0.0**.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
- Classes inheriting `CellularDevice `will have to have implementation for the new pure virtual methods:
    - `clear()`
    - `get_context_list()`  <br/><br/>
- Classes inheriting `CellularContext `do not have to have implementation for:
    - `get_netmask()`
    - `get_gateway()`  
   <br/>
    if they do not differ from the NetworkInterface's default implemetations:  

    ```
    nsapi_error_t NetworkInterface::get_netmask(SocketAddress *)
    {
        return NSAPI_ERROR_UNSUPPORTED;
    }

    nsapi_error_t NetworkInterface::get_gateway(SocketAddress *)
    {
        return NSAPI_ERROR_UNSUPPORTED;
    }
   ```

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
See **Impact of changes** section.
### Documentation <!-- Required -->
None

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [x] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
