### PR TITLE
FPGA_CI_TEST_SHIELD : force all peripheral to be tested

### DIFF
--- a/TESTS/mbed_hal_fpga_ci_test_shield/pwm/main.cpp
+++ b/TESTS/mbed_hal_fpga_ci_test_shield/pwm/main.cpp
@@ -220,7 +220,11 @@ Case cases[] = {
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
+#ifdef FPGA_FORCE_ALL_PORTS
+    GREENTEA_SETUP(300, "default_auto");
+#else
     GREENTEA_SETUP(120, "default_auto");
+#endif
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
+++ b/components/testing/COMPONENT_FPGA_CI_TEST_SHIELD/test_utils.h
@@ -291,6 +291,10 @@ void all_peripherals()
 template<typename PortType, typename FormFactorType, typename PortType::TestFunctionType f>
 void one_peripheral()
 {
+#ifdef FPGA_FORCE_ALL_PORTS
+    utest_printf("*** FPGA_FORCE_ALL_PORTS ***\n");
+    all_ports<PortType, FormFactorType, f>();
+#else
     std::list<PortType> matched_ports, not_matched_ports;
     find_ports<PortType, FormFactorType>(matched_ports, not_matched_ports);
 
@@ -300,6 +304,7 @@ void one_peripheral()
     } else {
         test_peripheral<PortType, typename PortType::TestFunctionType, f>(matched_ports.front());
     }
+#endif
 }
 
 template <uint32_t N, typename PinMapType, typename FormFactorType, typename TestFunctionType>


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

Some FPGA tests are testing all peripherals,
some are testing only 1, in order to save time I suppose.

Proposition is to be able to force all peripherals tests.

#### Impact of changes <!-- Optional -->

With default configuration, there is no impact.
Impact comes only if user manually set FPGA_FORCE_ALL_PORTS macro.

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
