### PR TITLE
MIMXRT1050: Add Watchdog support

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/watchdog_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/watchdog_api.c
@@ -1,0 +1,90 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2020 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "watchdog_api.h"
+
+#if DEVICE_WATCHDOG
+
+#include "reset_reason_api.h"
+#include "fsl_rtwdog.h"
+#include "fsl_clock.h"
+#include "platform/mbed_wait_api.h"
+
+// Platform specific watchdog definitions
+#define LPO_CLOCK_FREQUENCY 32768
+#define MAX_TIMEOUT         0xFFFFUL
+#define DELAY_TIME          100000U
+
+// Number of decrements in the timeout register per millisecond
+#define TICKS_PER_MS ((LPO_CLOCK_FREQUENCY) / 1000)
+
+// Maximum timeout that can be specified in milliseconds
+#define MAX_TIMEOUT_MS ((MAX_TIMEOUT) / (TICKS_PER_MS))
+
+watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
+{
+    uint32_t temp;
+    rtwdog_config_t cfg;
+
+    /* When system is boot up, WDOG32 is disabled. We must wait for at least 2.5
+     * periods of wdog32 clock to reconfigure wodg32. So Delay a while to wait for
+     * the previous configuration taking effect. */
+    for (temp = 0; temp < DELAY_TIME; temp++) {
+        __NOP();
+    }
+
+    RTWDOG_GetDefaultConfig(&cfg);
+
+    cfg.workMode.enableStop = true;
+    cfg.workMode.enableDebug = true;
+    cfg.timeoutValue = (TICKS_PER_MS * config->timeout_ms);
+
+    RTWDOG_Init(RTWDOG, &cfg);
+
+    return WATCHDOG_STATUS_OK;
+}
+
+void hal_watchdog_kick(void)
+{
+    RTWDOG_Refresh(RTWDOG);
+}
+
+watchdog_status_t hal_watchdog_stop(void)
+{
+    RTWDOG_Deinit(RTWDOG);
+
+    return WATCHDOG_STATUS_OK;
+}
+
+uint32_t hal_watchdog_get_reload_value(void)
+{
+    const uint32_t timeout = RTWDOG->TOVAL;
+
+    return (timeout / TICKS_PER_MS);
+}
+
+watchdog_features_t hal_watchdog_get_platform_features(void)
+{
+    watchdog_features_t features;
+    features.max_timeout = MAX_TIMEOUT_MS;
+    features.update_config = true;
+    features.disable_watchdog = true;
+    features.clock_typical_frequency = 32000;
+    features.clock_max_frequency = 32768;
+
+    return features;
+}
+
+#endif // DEVICE_WATCHDOG

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2849,7 +2849,8 @@
             "SPI",
             "SPISLAVE",
             "STDIO_MESSAGES",
-            "TRNG"
+            "TRNG",
+            "WATCHDOG"
         ],
         "release_versions": [
             "2",


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Add WatchDog support for MXRT1050 EVK

#### Impact of changes <!-- Optional -->
NONE

#### Migration actions required <!-- Optional -->
NONE

### Documentation <!-- Required -->
NONE

### Pull request type <!-- Required -->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

### Test results <!-- Required -->
    [] No Tests required for this change (E.g docs only update)
    [X] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR

 mbedgt: test case report:
| target                 | platform_name  | test suite                             | test case
|------------------------|----------------|----------------------------------------|---------------------------------
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog        | Init, 100 ms
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog        | Init, max_timeout
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog        | Platform feature max_timeout is
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog        | Stopped watchdog can be started
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog        | Update config with multiple init
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog        | Watchdog can be stopped
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_reset  | Kicking the Watchdog prevents re
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_reset  | Watchdog reset
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_reset  | Watchdog reset in deepsleep mode
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_reset  | Watchdog reset in sleep mode
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_reset  | Watchdog started again
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_timing | Timing, 1000 ms
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_timing | Timing, 200 ms
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_timing | Timing, 3000 ms
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_timing | Timing, 500 ms
| MIMXRT1050_EVK-GCC_ARM | MIMXRT1050_EVK | mbed-os-tests-mbed_hal-watchdog_timing | timeout accuracy
mbedgt: test case results: 16 OK

### Reviewers <!-- Optional -->
