### PR TITLE
Add get_time function to ESP8266

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -20,6 +20,7 @@
 
 #if DEVICE_SERIAL && DEVICE_INTERRUPTIN && defined(MBED_CONF_EVENTS_PRESENT) && defined(MBED_CONF_NSAPI_PRESENT) && defined(MBED_CONF_RTOS_API_PRESENT)
 #include <stdint.h>
+#include <ctime>
 
 #include "drivers/BufferedSerial.h"
 #include "features/netsocket/nsapi_types.h"
@@ -353,6 +354,47 @@ public:
     * @param func A pointer to a void function, or 0 to set as none
     */
     void attach(mbed::Callback<void()> status_cb);
+
+    /**
+     * Configure SNTP (Simple Network Time Protocol)
+     *
+     * @param enable   true to enable SNTP or false to disable it
+     * @param timezone timezone offset [-11,13] (0 by default)
+     * @param server0  optional parameter indicating the first SNTP server ("cn.ntp.org.cn" by default)
+     * @param server1  optional parameter indicating the second SNTP server ("ntp.sjtu.edu.cn" by default)
+     * @param server2  optional parameter indicating the third SNTP server ("us.pool.ntp.org" by default)
+     *
+     * @retval true if successful, false otherwise
+     */
+    bool set_sntp_config(bool enable, int timezone = 0, const char *server0 = nullptr,
+                         const char *server1 = nullptr, const char *server2 = nullptr);
+
+    /**
+     * Read out the configuration of SNTP (Simple Network Time Protocol)
+     *
+     * @param enable   true if SNTP is enabled
+     * @param timezone timezone offset [-11,13]
+     * @param server0  name of the first SNTP server
+     * @param server1  name of the second SNTP server (optional, nullptr if not set)
+     * @param server2  name of the third SNTP server (optional, nullptr if not set)
+     *
+     * @retval true if successful, false otherwise
+     */
+    bool get_sntp_config(bool *enable, int *timezone, char *server0,
+                         char *server1, char *server2);
+
+    /**
+     * Read out SNTP time from ESP8266.
+     *
+     * @param t std::tm structure to be filled in
+     * @retval true on success, false otherwise
+     *
+     * @note ESP8266 must be connected and needs a couple of seconds
+     * before returning correct time. It may return 1 Jan 1970 if it is not ready.
+     *
+     * @note esp8266.sntp-enable must be set to true in mbed_app.json file.
+     */
+    bool get_sntp_time(std::tm *t);
 
     template <typename T, typename M>
     void attach(T *obj, M method)

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -583,6 +583,12 @@ const char *ESP8266Interface::get_netmask()
     return _conn_stat != NSAPI_STATUS_DISCONNECTED ? _esp.netmask() : NULL;
 }
 
+nsapi_error_t ESP8266Interface::get_time(std::tm *t)
+{
+    _init();
+    return _esp.get_sntp_time(t) ? NSAPI_ERROR_OK : NSAPI_ERROR_TIMEOUT;
+}
+
 char *ESP8266Interface::get_interface_name(char *interface_name)
 {
     memcpy(interface_name, ESP8266_WIFI_IF_NAME, sizeof(ESP8266_WIFI_IF_NAME));
@@ -709,7 +715,13 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_esp.startup(ESP8266::WIFIMODE_STATION)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
-
+        if (!_esp.set_sntp_config(MBED_CONF_ESP8266_SNTP_ENABLE,
+                                  MBED_CONF_ESP8266_SNTP_TIMEZONE,
+                                  MBED_CONF_ESP8266_SNTP_SERVER0,
+                                  MBED_CONF_ESP8266_SNTP_SERVER1,
+                                  MBED_CONF_ESP8266_SNTP_SERVER2)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
         _initialized = true;
     }
     return NSAPI_ERROR_OK;

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -715,6 +715,7 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_esp.startup(ESP8266::WIFIMODE_STATION)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
+#if MBED_CONF_ESP8266_SNTP_ENABLE
         if (!_esp.set_sntp_config(MBED_CONF_ESP8266_SNTP_ENABLE,
                                   MBED_CONF_ESP8266_SNTP_TIMEZONE,
                                   MBED_CONF_ESP8266_SNTP_SERVER0,
@@ -722,6 +723,7 @@ nsapi_error_t ESP8266Interface::_init(void)
                                   MBED_CONF_ESP8266_SNTP_SERVER2)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
+#endif
         _initialized = true;
     }
     return NSAPI_ERROR_OK;

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -167,6 +167,15 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-5.15", "String-based APIs are deprecated")
     virtual const char *get_netmask();
 
+    /** Get the current time.
+     *
+     *  @retval          NSAPI_ERROR_UNSUPPORTED if the function is not supported
+     *  @retval          NSAPI_ERROR_OK on success
+     *
+     *  @note esp8266.sntp-enable must be set to true in mbed_app.json.
+     */
+    nsapi_error_t get_time(std::tm *t);
+
     /** Get the network interface name
      *
      *  @return         Null-terminated representation of the network interface name

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -71,7 +71,7 @@
             "value": false
         },
         "sntp-enable": {
-            "help": "Enable SNTP. This allows application to use get_sntp_time()",
+            "help": "Enable SNTP. This allows application to use get_sntp_time(). Only available from ESP8266 AT v1.5. This driver supports v1.7 and higher.",
             "value": false
         },
         "sntp-timezone": {

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -59,16 +59,36 @@
             "value": null
         },
         "channel-start": {
-            "help": "the channel number to start at, 1 by default",
+            "help": "The channel number to start at, 1 by default",
             "value": null
         },
         "channels": {
-            "help": "channel count, 13 by default",
+            "help": "Channel count, 13 by default",
             "value": null
         },
         "built-in-dns": {
             "help": "use built-in CIPDOMAIN AT command to resolve address to IP",
             "value": false
+        },
+        "sntp-enable": {
+            "help": "Enable SNTP. This allows application to use get_sntp_time()",
+            "value": false
+        },
+        "sntp-timezone": {
+            "help": "SNTP timezone",
+            "value": 0
+        },
+        "sntp-server0": {
+            "help": "First SNTP server. Empty string will let ESP8266 use its default.",
+            "value": "\"\""
+        },
+        "sntp-server1": {
+            "help": "Second SNTP server. Empty string will let ESP8266 use its default.",
+            "value": "\"\""
+        },
+        "sntp-server2": {
+            "help": "Third SNTP server. Empty string will let ESP8266 use its default.",
+            "value": "\"\""
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Summary of changes <!-- Required -->

Fixes https://github.com/ARMmbed/mbed-os/issues/12192.

`get_time()` function allows access to (S)NTP functionalities of ESP8266 module.

I considered using `std::chrono` instead of ctime's `std::tm`, but then - to convert to `chrono::time_point` we'd have to go through `std::tm` anyway or write our own parser, which I just managed to avoid.

Side note: using `std::` introduces some warnings due to `-D_LIBCPP_EXTERN_TEMPLATE(...)=` flag being used in all our compilation profiles. This flag seems obsolete and [I hope I will get it removed soon](https://github.com/ARMmbed/mbed-os/pull/12302).

I cannot really add any tests, as they are using `WifiInterface::get_instance()` to get the interface and there is no RTTI, that would allow casting to `ESP8266Interface` to call `get_time()`, but I tested the function locally and it works fine.

#### Impact of changes <!-- Optional -->

None, other than user can check time with ESP8266Interface.

#### Migration actions required <!-- Optional -->

None

### Documentation <!-- Required -->

Added doxygen functions.

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [x] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

    [x] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

@AnttiKauppila 
@VeijoPesonen 
@SeppoTakalo 
@kjbracey-arm 
@star297 

----------------------------------------------------------------------------------------------------------------
