### PR TITLE
Fix ARM compiler warning for microlib

### DIFF
--- a/tools/test/toolchains/test_toolchains.py
+++ b/tools/test/toolchains/test_toolchains.py
@@ -64,9 +64,7 @@ class TestArmToolchain(TestCase):
 
         self.assertIn("--library_type=microlib", arm_std_obj.flags["ld"])
         self.assertIn("--library_type=microlib", arm_micro_obj.flags["ld"])
-        self.assertIn("--library_type=microlib", arm_c6_obj.flags["ld"])
-
-        self.assertIn("-Wl,--library_type=microlib", arm_c6_obj.flags["cxx"])
+        self.assertIn("--library_type=microlib", arm_c6_obj.flags["ld"])        
         self.assertIn("--library_type=microlib", arm_c6_obj.flags["asm"])
 
     def test_arm_c_lib_std_exception(self):

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -581,10 +581,6 @@ class ARMC6(ARM_STD):
                 self.flags['common'].append("-D__MICROLIB")
             if "--library_type=microlib" not in self.flags['ld']:
                 self.flags['ld'].append("--library_type=microlib")
-            if "-Wl,--library_type=microlib" not in self.flags['c']:
-                self.flags['c'].append("-Wl,--library_type=microlib")
-            if "-Wl,--library_type=microlib" not in self.flags['cxx']:
-                self.flags['cxx'].append("-Wl,--library_type=microlib")
             if "--library_type=microlib" not in self.flags['asm']:
                 self.flags['asm'].append("--library_type=microlib")
 


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
- if the "target.c_lib": "small"  is configured in the build tool, then ARM compiler issues a warning  as `[DEBUG] Output: armclang: warning: -Wl,--library_type=microlib: 'linker' input unused [-Wunused-command-line-argument]` .
- The reported issue is solved by adding that flag only in the linker configuration as per [docs](http://www.keil.com/support/man/docs/armclang_lib/armclang_lib_chr1358938939195.htm).

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
With these changes, compiler warning about `unused command-line argument` should go away.

<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
None.
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->
None.
<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [x] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@evedon 
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
